### PR TITLE
feat: backport user task PIM to stable/8.8

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessMigrationIT.java
@@ -27,6 +27,8 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 public class ProcessMigrationIT {
@@ -159,6 +162,173 @@ public class ProcessMigrationIT {
           assertThat(i.getProcessDefinitionId()).isEqualTo("migration-process_v1");
           assertThat(i.getState()).isEqualTo(IncidentState.RESOLVED);
         });
+  }
+
+  @Test
+  @DisabledIfSystemProperty(
+      named = "test.integration.camunda.database.type",
+      matches = "rdbms.*$",
+      disabledReason = "Job-based user tasks don't work with RDBMS")
+  void shouldMigrateProcessWithJobBasedUserTask() {
+    // given
+    final var v1 =
+        Bpmn.createExecutableProcess("migration-user-task_v1")
+            .startEvent()
+            .userTask(
+                "task1",
+                t ->
+                    t.zeebeCandidateGroups("g1,g2")
+                        .zeebeCandidateUsers("u1,u2")
+                        .zeebeDueDate("2017-07-21T19:32:28+02:00")
+                        .zeebeFollowUpDate("2017-07-22T19:32:28+02:00")
+                        .zeebeAssignee("original"))
+            .endEvent()
+            .done();
+    final var v2 =
+        Bpmn.createExecutableProcess("migration-user-task_v2")
+            .startEvent()
+            .userTask(
+                "task1",
+                t ->
+                    t.zeebeUserTask()
+                        .zeebeAssigneeExpression("varAssignee")
+                        .zeebeTaskPriorityExpression("2*varPriority"))
+            .endEvent()
+            .done();
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(v1, "migration-user-task_v1.bpmn")
+            .addProcessModel(v2, "migration-user-task_v2.bpmn")
+            .send()
+            .join();
+    final var pd2 =
+        deploymentEvent.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals("migration-user-task_v2"))
+            .findFirst()
+            .get()
+            .getProcessDefinitionKey();
+    final var processInstanceKey =
+        startProcessInstance(
+            client, "migration-user-task_v1", Map.of("varAssignee", "demo", "varPriority", 20));
+
+    // when
+    migrateProcessInstance(
+        client,
+        processInstanceKey,
+        MigrationPlan.newBuilder()
+            .withTargetProcessDefinitionKey(pd2)
+            .addMappingInstruction("task1", "task1")
+            .build());
+
+    // then
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      client
+                          .newUserTaskSearchRequest()
+                          .filter(f -> f.processDefinitionKey(pd2).assignee("demo"))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(1);
+            });
+    final var migratedTask =
+        client
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processDefinitionKey(pd2))
+            .send()
+            .join()
+            .singleItem();
+    assertThat(migratedTask.getAssignee()).isEqualTo("demo");
+    assertThat(migratedTask.getCandidateGroups()).isEqualTo(List.of("g1", "g2"));
+    assertThat(migratedTask.getCandidateUsers()).isEqualTo(List.of("u1", "u2"));
+    assertThat(migratedTask.getDueDate()).isEqualTo("2017-07-21T19:32:28+02:00");
+    assertThat(migratedTask.getFollowUpDate()).isEqualTo("2017-07-22T19:32:28+02:00");
+    assertThat(migratedTask.getPriority()).isEqualTo(40);
+  }
+
+  @Test
+  @DisabledIfSystemProperty(
+      named = "test.integration.camunda.database.type",
+      matches = "rdbms.*$",
+      disabledReason = "Job-based user tasks don't work with RDBMS")
+  void shouldMigrateProcessWithJobBasedUserTaskWithoutAssigneeAndPriority() {
+    // given
+    final var v1 =
+        Bpmn.createExecutableProcess("migration-user-task_v1")
+            .startEvent()
+            .userTask(
+                "task1",
+                t ->
+                    t.zeebeCandidateGroups("g1,g2")
+                        .zeebeCandidateUsers("u1,u2")
+                        .zeebeDueDate("2017-07-21T19:32:28+02:00")
+                        .zeebeFollowUpDate("2017-07-22T19:32:28+02:00")
+                        .zeebeAssignee("original"))
+            .endEvent()
+            .done();
+    final var v2 =
+        Bpmn.createExecutableProcess("migration-user-task_v2")
+            .startEvent()
+            .userTask("task1", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent()
+            .done();
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(v1, "migration-user-task_v1.bpmn")
+            .addProcessModel(v2, "migration-user-task_v2.bpmn")
+            .send()
+            .join();
+    final var pd2 =
+        deploymentEvent.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals("migration-user-task_v2"))
+            .findFirst()
+            .get()
+            .getProcessDefinitionKey();
+    final var processInstanceKey =
+        startProcessInstance(
+            client, "migration-user-task_v1", Map.of("varAssignee", "demo", "varPriority", 20));
+
+    // when
+    migrateProcessInstance(
+        client,
+        processInstanceKey,
+        MigrationPlan.newBuilder()
+            .withTargetProcessDefinitionKey(pd2)
+            .addMappingInstruction("task1", "task1")
+            .build());
+
+    // then
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      client
+                          .newUserTaskSearchRequest()
+                          .filter(f -> f.processDefinitionKey(pd2).assignee(a -> a.exists(false)))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(1);
+            });
+    final var migratedTask =
+        client
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processDefinitionKey(pd2))
+            .send()
+            .join()
+            .singleItem();
+    assertThat(migratedTask.getAssignee()).isNull();
+    assertThat(migratedTask.getCandidateGroups()).isEqualTo(List.of("g1", "g2"));
+    assertThat(migratedTask.getCandidateUsers()).isEqualTo(List.of("u1", "u2"));
+    assertThat(migratedTask.getDueDate()).isEqualTo("2017-07-21T19:32:28+02:00");
+    assertThat(migratedTask.getFollowUpDate()).isEqualTo("2017-07-22T19:32:28+02:00");
+    assertThat(migratedTask.getPriority()).isEqualTo(50);
   }
 
   public Long deployProcessFromClasspath(final CamundaClient client, final String classpath) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
@@ -150,7 +150,8 @@ public class UserTaskProcessInstanceMigrationIT {
                                   f.processDefinitionKey(pd2)
                                       .bpmnProcessId(TO_PROCESS_ID)
                                       .processInstanceKey(processInstanceKey)
-                                      .assignee(expectedTask.assignee))
+                                      .assignee(expectedTask.assignee)
+                                      .state(UserTaskState.CREATED))
                           // right task
                           .send()
                           .join()
@@ -178,6 +179,7 @@ public class UserTaskProcessInstanceMigrationIT {
     assertThat(migratedTask.getFormKey()).isEqualTo(expectedTask.formKey);
     assertThat(migratedTask.getExternalFormReference())
         .isEqualTo(expectedTask.externalFormReference);
+    assertThat(migratedTask.getCustomHeaders()).isEqualTo(expectedTask.headers);
 
     verifyFormOperationsWork(migratedTask.getUserTaskKey());
   }
@@ -190,7 +192,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 .zeebeCandidateUsers("u1,u2")
                 .zeebeDueDate(EXAMPLE_DUE_DATE)
                 .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
-                .zeebeAssignee("original");
+                .zeebeAssignee("original")
+                .zeebeTaskHeader("key1", "value1");
     final Consumer<UserTaskBuilder> fromWithoutAssigneeAndPriority =
         t ->
             t.zeebeCandidateGroups("g1,g2")
@@ -210,7 +213,9 @@ public class UserTaskProcessInstanceMigrationIT {
             t.zeebeAssignee("original")
                 .zeebeFormId(FORM_1)
                 .zeebeDueDate(ALTERNATIVE_DUE_DATE)
-                .zeebeFollowUpDate(ALTERNATIVE_FOLLOW_UP_DATE);
+                .zeebeFollowUpDate(ALTERNATIVE_FOLLOW_UP_DATE)
+                .zeebeTaskHeader("key2", "value2")
+                .zeebeTaskHeader("key3", "value3");
     final Consumer<UserTaskBuilder> fromExternalForm =
         t ->
             t.zeebeAssigneeExpression("varAssignee")
@@ -241,6 +246,7 @@ public class UserTaskProcessInstanceMigrationIT {
                 .zeebeCandidateUsers("u3,u4")
                 .zeebeAssignee("targetAssignee")
                 .zeebeTaskPriority("10")
+                .zeebeTaskHeader("key3", "value3")
                 .zeebeFormId(FORM_2);
 
     return Stream.of(
@@ -255,7 +261,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of("key1", "value1"))),
         Arguments.of(
             fromWithoutAssigneeAndPriority,
             toWithoutAssigneeAndPriority,
@@ -267,7 +274,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromEmbeddedForm,
             toExternalForm,
@@ -279,7 +287,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromEmbeddedForm,
             toInternalForm,
@@ -291,7 +300,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromInternalForm,
             toExternalForm,
@@ -303,7 +313,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of(),
                 List.of(),
                 ALTERNATIVE_DUE_DATE,
-                ALTERNATIVE_FOLLOW_UP_DATE)),
+                ALTERNATIVE_FOLLOW_UP_DATE,
+                Map.of("key2", "value2", "key3", "value3"))),
         Arguments.of(
             fromExternalForm,
             toExternalForm,
@@ -315,7 +326,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of(),
                 List.of(),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)));
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())));
   }
 
   private static String getForm(final String formId) {
@@ -378,5 +390,6 @@ public class UserTaskProcessInstanceMigrationIT {
       List<String> candidateGroups,
       List<String> candidateUsers,
       String dueDate,
-      String followupDate) {}
+      String followupDate,
+      Map<String, String> headers) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration;
+
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestTasklistClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Job-based user tasks don't work with RDBMS")
+public class UserTaskProcessInstanceMigrationIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication().withAuthorizationsDisabled();
+
+  private static CamundaClient client;
+  @AutoClose private static TestRestTasklistClient tasklistClient;
+
+  private static final String FROM_PROCESS_ID = "migration-user-task_v1";
+  private static final String TO_PROCESS_ID = "migration-user-task_v2";
+  private static final String TASK_ID = "task1";
+  private static final String EXAMPLE_DUE_DATE = "2017-07-21T19:32:28+02:00";
+  private static final String EXAMPLE_FOLLOW_UP_DATE = "2017-07-22T19:32:28+02:00";
+
+  private static long formKey;
+
+  @BeforeAll
+  static void setup(final CamundaClient camundaClient) {
+    tasklistClient = STANDALONE_CAMUNDA.newTasklistClient();
+    formKey =
+        client
+            .newDeployResourceCommand()
+            .addResourceStringUtf8(getForm("linkedform"), "linkedForm.form")
+            .send()
+            .join()
+            .getForm()
+            .getFirst()
+            .getFormKey();
+  }
+
+  @ParameterizedTest
+  @MethodSource("migrationTestCases")
+  void shouldMigrateProcessInstance(
+      final Consumer<UserTaskBuilder> jobWorkerUserTask,
+      final Consumer<UserTaskBuilder> camundaUserTask,
+      final ExpectedUserTask expectedTask) {
+
+    // given
+    final BpmnModelInstance jwProcess =
+        Bpmn.createExecutableProcess(FROM_PROCESS_ID)
+            .startEvent()
+            .userTask(TASK_ID, jobWorkerUserTask)
+            .endEvent()
+            .done();
+    final BpmnModelInstance cutProcess =
+        Bpmn.createExecutableProcess(TO_PROCESS_ID)
+            .startEvent()
+            .userTask(TASK_ID, camundaUserTask)
+            .endEvent()
+            .done();
+
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(jwProcess, FROM_PROCESS_ID + ".bpmn")
+            .addProcessModel(cutProcess, TO_PROCESS_ID + ".bpmn")
+            .send()
+            .join();
+    final var pd2 =
+        deploymentEvent.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals(TO_PROCESS_ID))
+            .findFirst()
+            .get()
+            .getProcessDefinitionKey();
+    final var processInstanceKey =
+        startProcessInstance(
+                client, FROM_PROCESS_ID, Map.of("varAssignee", "demo", "varPriority", 20))
+            .getProcessInstanceKey();
+    // wait for task to be exported - use V1 because V2 does not return job worker user tasks
+    waitForTaskExported(processInstanceKey);
+
+    // when
+    migrateProcessInstance(
+        client,
+        processInstanceKey,
+        MigrationPlan.newBuilder()
+            .withTargetProcessDefinitionKey(pd2)
+            .addMappingInstruction(TASK_ID, TASK_ID)
+            .build());
+
+    // then
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      client
+                          .newUserTaskSearchRequest()
+                          .filter(
+                              f ->
+                                  f.processDefinitionKey(pd2)
+                                      .bpmnProcessId(TO_PROCESS_ID)
+                                      .processInstanceKey(processInstanceKey)
+                                      .assignee(expectedTask.assignee))
+                          // right task
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(1);
+            });
+    final UserTask migratedTask =
+        client
+            .newUserTaskSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(pd2)
+                        .bpmnProcessId(TO_PROCESS_ID)
+                        .processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .singleItem();
+
+    assertThat(migratedTask.getAssignee()).isEqualTo(expectedTask.assignee);
+    assertThat(migratedTask.getCandidateGroups()).isEqualTo(List.of("g1", "g2"));
+    assertThat(migratedTask.getCandidateUsers()).isEqualTo(List.of("u1", "u2"));
+    assertThat(migratedTask.getDueDate()).isEqualTo(EXAMPLE_DUE_DATE);
+    assertThat(migratedTask.getFollowUpDate()).isEqualTo(EXAMPLE_FOLLOW_UP_DATE);
+    assertThat(migratedTask.getPriority()).isEqualTo(expectedTask.priority);
+    assertThat(migratedTask.getFormKey()).isEqualTo(expectedTask.formKey);
+    assertThat(migratedTask.getExternalFormReference())
+        .isEqualTo(expectedTask.externalFormReference);
+  }
+
+  static Stream<Arguments> migrationTestCases() {
+    // Test case with assignee and priority expressions
+    final Consumer<UserTaskBuilder> fromPriorityAndAssignee =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
+                .zeebeAssignee("original");
+    final Consumer<UserTaskBuilder> toPriorityAndAssignee =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssigneeExpression("varAssignee")
+                .zeebeTaskPriorityExpression("2*varPriority");
+
+    // Test case where assignee and priority are removed
+    final Consumer<UserTaskBuilder> fromWithoutAssigneeAndPriority =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE);
+    final Consumer<UserTaskBuilder> toWithoutAssigneeAndPriority =
+        AbstractUserTaskBuilder::zeebeUserTask;
+
+    // Test case migrating from embedded form to external form reference
+    final Consumer<UserTaskBuilder> fromEmbeddedForm =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeUserTaskForm(getForm("testform"))
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
+                .zeebeAssignee("original");
+    final Consumer<UserTaskBuilder> toExternalForm =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssigneeExpression("varAssignee")
+                .zeebeExternalFormReference("localhost:8080//example.form");
+
+    // Test case migrating from embedded form to internal form
+    final Consumer<UserTaskBuilder> toInternalForm =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssignee("targetAssignee")
+                .zeebeTaskPriority("10")
+                .zeebeFormId("linkedform");
+
+    return Stream.of(
+        Arguments.of(
+            fromPriorityAndAssignee,
+            toPriorityAndAssignee,
+            new ExpectedUserTask("demo", 40, null, null)),
+        Arguments.of(
+            fromWithoutAssigneeAndPriority,
+            toWithoutAssigneeAndPriority,
+            new ExpectedUserTask(null, 50, null, null)),
+        Arguments.of(
+            fromEmbeddedForm,
+            toExternalForm,
+            new ExpectedUserTask("demo", 50, "localhost:8080//example.form", null)),
+        Arguments.of(
+            fromEmbeddedForm,
+            toInternalForm,
+            new ExpectedUserTask("targetAssignee", 10, null, formKey)));
+  }
+
+  private static String getForm(final String formId) {
+    return "{\n"
+        + "  \"components\": [],\n"
+        + "  \"type\": \"default\",\n"
+        + "  \"id\": \""
+        + formId
+        + "\",\n"
+        + "  \"executionPlatform\": \"Camunda Cloud\",\n"
+        + "  \"executionPlatformVersion\": \"8.7.0\",\n"
+        + "  \"exporter\": {\n"
+        + "    \"name\": \"Camunda Modeler\",\n"
+        + "    \"version\": \"5.38.1\"\n"
+        + "  },\n"
+        + "  \"schemaVersion\": 19\n"
+        + "}";
+  }
+
+  private void migrateProcessInstance(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final MigrationPlan migrationPlan) {
+    client
+        .newMigrateProcessInstanceCommand(processInstanceKey)
+        .migrationPlan(migrationPlan)
+        .send()
+        .join();
+  }
+
+  private void waitForTaskExported(final Long processInstanceKey) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final TaskSearchResponse[] tasks =
+                  tasklistClient.searchAndParseTasks(processInstanceKey);
+              assertThat(tasks).hasSize(1);
+              assertThat(tasks[0].getProcessInstanceKey()).isEqualTo(processInstanceKey.toString());
+            });
+  }
+
+  record ExpectedUserTask(
+      String assignee, Integer priority, String externalFormReference, Long formKey) {}
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -34,6 +34,7 @@ import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -458,6 +459,19 @@ public final class TestHelper {
                   client.newUserTaskSearchRequest().filter(filter).send().join().items();
               assertThat(userTasks).hasSize(expectedCount);
             });
+  }
+
+  public static UserTask waitForUserTask(
+      final CamundaClient client, final Consumer<UserTaskFilter> filter) {
+    final UserTask[] migratedTask = new UserTask[1];
+    Awaitility.await("Should find user task with filter")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              migratedTask[0] =
+                  client.newUserTaskSearchRequest().filter(filter).send().join().singleItem();
+            });
+    return migratedTask[0];
   }
 
   public static void waitForBatchOperationWithCorrectTotalCount(

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>operate-webapp</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-webapp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestTasklistClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestTasklistClient.java
@@ -8,8 +8,11 @@
 package io.camunda.qa.util.cluster;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.client.CredentialsProvider;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -26,7 +29,8 @@ import java.util.function.Consumer;
 
 public class TestRestTasklistClient implements CloseableSilently {
 
-  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
 
   private final URI endpoint;
   private final HttpClient httpClient;
@@ -34,13 +38,12 @@ public class TestRestTasklistClient implements CloseableSilently {
 
   public TestRestTasklistClient(final URI endpoint) {
     this.endpoint = endpoint;
-    this.httpClient = HttpClient.newHttpClient();
+    httpClient = HttpClient.newHttpClient();
   }
 
   public TestRestTasklistClient(final URI endpoint, final CredentialsProvider credentialsProvider) {
     this(endpoint);
-    this.authenticationApplier =
-        TestRestOperateClient.applyCredentialsProvider(credentialsProvider);
+    authenticationApplier = TestRestOperateClient.applyCredentialsProvider(credentialsProvider);
   }
 
   TestRestTasklistClient(
@@ -49,7 +52,7 @@ public class TestRestTasklistClient implements CloseableSilently {
       final String username,
       final String password) {
     this(endpoint);
-    this.authenticationApplier = applyBasicAuthenticationHeader(username, password);
+    authenticationApplier = applyBasicAuthenticationHeader(username, password);
   }
 
   public HttpResponse<String> searchRequest(final String path, final String body) {
@@ -70,6 +73,12 @@ public class TestRestTasklistClient implements CloseableSilently {
         Optional.ofNullable(processInstanceKey)
             .map(a -> mapToRequestBody("processInstanceKey", a))
             .orElse(null));
+  }
+
+  public TaskSearchResponse[] searchAndParseTasks(final Long processInstanceKey)
+      throws JsonProcessingException {
+    return OBJECT_MAPPER.readValue(
+        searchTasks(processInstanceKey).body(), TaskSearchResponse[].class);
   }
 
   public HttpResponse<String> createProcessInstanceViaPublicForm(final String processDefinitionId) {

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -35,6 +35,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private JobListenerEventType jobListenerEventType;
   private Set<String> changedAttributes;
   private Set<String> tags;
+  private boolean jobToUserTaskMigration;
 
   public JobRecordValueImpl() {}
 
@@ -209,6 +210,11 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   @Override
   public Set<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public boolean isJobToUserTaskMigration() {
+    return jobToUserTaskMigration;
   }
 
   @Override

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -214,7 +214,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
 
   @Override
   public boolean isJobToUserTaskMigration() {
-    return jobToUserTaskMigration;
+    return false;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -41,8 +41,10 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,10 +132,21 @@ public final class BpmnUserTaskBehavior {
       final BpmnElementContext context,
       final ExecutableUserTask element,
       final UserTaskProperties userTaskProperties) {
+    return createNewUserTask(
+        context,
+        element.getId(),
+        userTaskProperties,
+        element.getUserTaskProperties().getTaskHeaders());
+  }
+
+  public UserTaskRecord createNewUserTask(
+      final BpmnElementContext context,
+      final DirectBuffer id,
+      final UserTaskProperties userTaskProperties,
+      final Map<String, String> headers) {
     final var userTaskKey = keyGenerator.nextKey();
 
-    final var encodedHeaders =
-        headerEncoder.encode(element.getUserTaskProperties().getTaskHeaders());
+    final var encodedHeaders = headerEncoder.encode(headers);
 
     final var userTaskRecord =
         new UserTaskRecord()
@@ -151,7 +164,7 @@ public final class BpmnUserTaskBehavior {
             .setProcessDefinitionVersion(context.getProcessVersion())
             .setProcessDefinitionKey(context.getProcessDefinitionKey())
             .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setElementId(element.getId())
+            .setElementId(id)
             .setElementInstanceKey(context.getElementInstanceKey())
             .setTenantId(context.getTenantId())
             .setPriority(userTaskProperties.getPriority())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -389,13 +389,16 @@ public class ProcessInstanceMigrationMigrateProcessor
     if (isUserTaskConversion) {
       final ProcessInstanceMigrationUserTaskBehavior migrationUserTaskBehavior =
           new ProcessInstanceMigrationUserTaskBehavior(
+              processInstanceKey,
               elementInstance,
               sourceProcessDefinition,
               targetProcessDefinition,
+              bpmnBehaviors,
               targetElementId,
+              updatedElementInstanceRecord,
               stateWriter,
               jobState);
-      migrationUserTaskBehavior.tryMigrateJobWorkerToCamundaUserTask(processInstanceKey); // TODO
+      migrationUserTaskBehavior.tryMigrateJobWorkerToCamundaUserTask();
     }
 
     if (elementInstance.getUserTaskKey() > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
@@ -49,6 +50,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -358,13 +360,18 @@ public class ProcessInstanceMigrationMigrateProcessor
                 Please report this as a bug""",
                 processInstanceKey, elementInstance.getJobKey()));
       }
-      stateWriter.appendFollowUpEvent(
-          elementInstance.getJobKey(),
-          JobIntent.MIGRATED,
-          job.setProcessDefinitionKey(targetProcessDefinition.getKey())
-              .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
-              .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
-              .setElementId(targetElementId));
+
+      if (requiresJobCancellation(job.getJobKind(), targetProcessDefinition, targetElementId)) {
+        stateWriter.appendFollowUpEvent(elementInstance.getJobKey(), JobIntent.CANCELED, job);
+      } else {
+        stateWriter.appendFollowUpEvent(
+            elementInstance.getJobKey(),
+            JobIntent.MIGRATED,
+            job.setProcessDefinitionKey(targetProcessDefinition.getKey())
+                .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
+                .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
+                .setElementId(targetElementId));
+      }
     }
 
     final long processIncidentKey =
@@ -439,6 +446,22 @@ public class ProcessInstanceMigrationMigrateProcessor
     if (updatedElementInstanceRecord.getBpmnElementType() == BpmnElementType.CALL_ACTIVITY) {
       migrateCalledSubProcessElements(elementInstance.getCalledChildInstanceKey());
     }
+  }
+
+  private boolean requiresJobCancellation(
+      final JobKind jobKind,
+      final DeployedProcess targetProcessDefinition,
+      final String targetElementId) {
+    final BpmnElementType targetElementType =
+        targetProcessDefinition.getProcess().getElementById(targetElementId).getElementType();
+    if (targetElementType != BpmnElementType.USER_TASK) {
+      return false;
+    }
+    final ExecutableUserTask targetUserTask =
+        targetProcessDefinition
+            .getProcess()
+            .getElementById(targetElementId, ExecutableUserTask.class);
+    return jobKind == JobKind.BPMN_ELEMENT && targetUserTask.getUserTaskProperties() != null;
   }
 
   private static DirectBuffer getTargetSequenceFlowId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -244,7 +244,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
-    requireSameUserTaskImplementation(
+    requireSupportedUserTaskImplementation(
         sourceProcessDefinition,
         targetProcessDefinition,
         targetElementId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -130,12 +130,11 @@ public final class ProcessInstanceMigrationPreconditions {
       but active element with id '%s' and type '%s' is mapped to \
       an element with id '%s' and different type '%s'. \
       Elements must be mapped to elements of the same type.""";
-  private static final String ERROR_USER_TASK_IMPLEMENTATION_CHANGED =
+  private static final String ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION =
       """
       Expected to migrate process instance '%s' \
       but active user task with id '%s' and implementation '%s' is mapped to \
-      an user task with id '%s' and different implementation '%s'. \
-      Elements must be mapped to elements of the same implementation.""";
+      a user task with id '%s' and deprecated implementation '%s'.""";
   private static final String ERROR_MESSAGE_ELEMENT_FLOW_SCOPE_CHANGED =
       """
       Expected to migrate process instance '%s' \
@@ -563,9 +562,8 @@ public final class ProcessInstanceMigrationPreconditions {
   }
 
   /**
-   * Since we introduce zeebe user tasks and job worker tasks has the same bpmn element type, we
-   * need to check whether the given element instance and target element has the same user task
-   * type. Throws an exception if they have different types.
+   * Checks whether the given user task implementations are supported for migration. Throws an
+   * exception if a zeebe user task is migrated to the deprecated job worker user task type.
    *
    * @param sourceProcessDefinition source process definition to retrieve the source element type
    * @param targetProcessDefinition target process definition to retrieve the target element type
@@ -573,7 +571,7 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
    */
-  public static void requireSameUserTaskImplementation(
+  public static void requireSupportedUserTaskImplementation(
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
@@ -609,10 +607,11 @@ public final class ProcessInstanceMigrationPreconditions {
             ? ZEEBE_USER_TASK_IMPLEMENTATION
             : JOB_WORKER_IMPLEMENTATION;
 
-    if (!targetUserTaskType.equals(sourceUserTaskType)) {
+    if (!sourceUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)
+        && targetUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)) {
       final String reason =
           String.format(
-              ERROR_USER_TASK_IMPLEMENTATION_CHANGED,
+              ERROR_DEPRECATED_USER_TASK_IMPLEMENTATION,
               processInstanceKey,
               elementInstanceRecord.getElementId(),
               sourceUserTaskType,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -570,8 +570,9 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param targetElementId target element id
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
+   * @return whether the migration is to a different user task implementation
    */
-  public static void requireSupportedUserTaskImplementation(
+  public static boolean requireSupportedUserTaskImplementation(
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
@@ -579,14 +580,14 @@ public final class ProcessInstanceMigrationPreconditions {
       final long processInstanceKey) {
     final ProcessInstanceRecord elementInstanceRecord = elementInstance.getValue();
     if (elementInstanceRecord.getBpmnElementType() != BpmnElementType.USER_TASK) {
-      return;
+      return false;
     }
 
     final AbstractFlowElement targetElement =
         targetProcessDefinition.getProcess().getElementById(targetElementId);
     final BpmnElementType targetElementType = targetElement.getElementType();
     if (targetElementType != BpmnElementType.USER_TASK) {
-      return;
+      return false;
     }
 
     final ExecutableUserTask targetUserTask =
@@ -620,6 +621,8 @@ public final class ProcessInstanceMigrationPreconditions {
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_STATE);
     }
+    return sourceUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)
+        && targetUserTaskType.equals(ZEEBE_USER_TASK_IMPLEMENTATION);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -586,7 +586,10 @@ public final class ProcessInstanceMigrationPreconditions {
     final AbstractFlowElement targetElement =
         targetProcessDefinition.getProcess().getElementById(targetElementId);
     final BpmnElementType targetElementType = targetElement.getElementType();
-    if (targetElementType != BpmnElementType.USER_TASK) {
+
+    if (targetElementType != BpmnElementType.USER_TASK
+        && !(targetElement instanceof final ExecutableMultiInstanceBody tmi
+            && tmi.getInnerActivity().getElementType() == BpmnElementType.USER_TASK)) {
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -7,51 +7,95 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior.UserTaskProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.ProcessInstanceMigrationPreconditionFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
 
 public class ProcessInstanceMigrationUserTaskBehavior {
 
+  private static final String ERROR_JOB_NOT_FOUND =
+      """
+                  Expected to migrate a job for process instance with key '%d', \
+                  but could not find job with key '%d'. \
+                  Please report this as a bug""";
+
+  private static final String ERROR_TARGET_FORM_EVALUATION =
+      """
+                  Expected to migrate form of user task with id '%s' \
+                  to %s form with reference '%s' \
+                  defined in target element '%s', \
+                  but reference evaluation failed with message: %s""";
+
+  private static final String WARN_EMBEDDED_FORM_MIGRATION =
+      """
+                  Migrated embedded form of user task with id '%s' \
+                  to target element '%s' with Camunda user task implementation and no form reference \
+                  for process instance with key '%s'.
+                  """;
+
+  private static final Logger LOGGER = Loggers.ENGINE_PROCESSING_LOGGER;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final long processInstanceKey;
   private final ElementInstance elementInstance;
   private final DeployedProcess sourceProcessDefinition;
   private final DeployedProcess targetProcessDefinition;
   private final String targetElementId;
+  private final ProcessInstanceRecord updatedElementInstanceRecord;
   private final StateWriter stateWriter;
+  private final BpmnUserTaskBehavior userTaskBehavior;
   private final JobState jobState;
 
   public ProcessInstanceMigrationUserTaskBehavior(
+      final long processInstanceKey,
       final ElementInstance elementInstance,
       final DeployedProcess sourceProcessDefinition,
       final DeployedProcess targetProcessDefinition,
+      final BpmnBehaviors bpmnBehaviors,
       final String targetElementId,
+      final ProcessInstanceRecord updatedElementInstanceRecord,
       final StateWriter stateWriter,
       final JobState jobState) {
+    this.processInstanceKey = processInstanceKey;
     this.elementInstance = elementInstance;
     this.sourceProcessDefinition = sourceProcessDefinition;
     this.targetProcessDefinition = targetProcessDefinition;
     this.targetElementId = targetElementId;
+    this.updatedElementInstanceRecord = updatedElementInstanceRecord;
     this.stateWriter = stateWriter;
     this.jobState = jobState;
+    userTaskBehavior = bpmnBehaviors.userTaskBehavior();
   }
 
-  public void tryMigrateJobWorkerToCamundaUserTask(final long processInstanceKey) {
+  public void tryMigrateJobWorkerToCamundaUserTask() {
     final var jobKey = elementInstance.getJobKey();
 
     final var job = jobState.getJob(jobKey);
     if (job == null) {
       throw new SafetyCheckFailedException(
-          String.format(
-              """
-                  Expected to migrate a job for process instance with key '%d', \
-                  but could not find job with key '%d'. \
-                  Please report this as a bug""",
-              processInstanceKey, jobKey));
+          String.format(ERROR_JOB_NOT_FOUND, processInstanceKey, jobKey));
     }
 
     final String elementId = elementInstance.getValue().getElementId();
@@ -64,7 +108,164 @@ public class ProcessInstanceMigrationUserTaskBehavior {
             .getProcess()
             .getElementById(targetElementId, ExecutableUserTask.class);
 
+    // Create new user task properties
+    final Map<String, String> customHeaders = job.getCustomHeaders();
+    final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+        targetProperties = targetElement.getUserTaskProperties();
+    final var userTaskProperties = mapUserTaskProperties(customHeaders, targetProperties);
+
+    // Create new Zeebe user task
+    final var context = new BpmnElementContextImpl();
+    context.init(
+        elementInstance.getKey(), updatedElementInstanceRecord, elementInstance.getState());
+
+    migrateForm(sourceElement, customHeaders, targetProperties, context, userTaskProperties);
+
+    final var userTaskRecord =
+        createNewUserTask(targetProperties, context, userTaskProperties, targetElement);
+
+    assignUser(userTaskProperties, userTaskRecord);
+
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+  }
+
+  private void assignUser(
+      final UserTaskProperties userTaskProperties, final UserTaskRecord userTaskRecord) {
+    final var assignee = userTaskProperties.getAssignee();
+    if (StringUtils.isNotEmpty(assignee)) {
+      userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
+      userTaskBehavior.userTaskAssigned(userTaskRecord, assignee);
+    }
+  }
+
+  private UserTaskRecord createNewUserTask(
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          newProperties,
+      final BpmnElementContextImpl context,
+      final UserTaskProperties userTaskProperties,
+      final ExecutableUserTask targetElement) {
+    userTaskBehavior
+        .evaluatePriorityExpression(
+            newProperties.getPriority(),
+            context.getFlowScopeKey(),
+            targetProcessDefinition.getTenantId())
+        .ifRight(userTaskProperties::priority);
+
+    final var userTaskRecord =
+        userTaskBehavior.createNewUserTask(context, targetElement, userTaskProperties);
+    userTaskBehavior.userTaskCreated(userTaskRecord);
+    elementInstance.setUserTaskKey(userTaskRecord.getUserTaskKey());
+    return userTaskRecord;
+  }
+
+  private void migrateForm(
+      final ExecutableJobWorkerElement sourceElement,
+      final Map<String, String> customHeaders,
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          targetElementProperties,
+      final BpmnElementContextImpl context,
+      final UserTaskProperties userTaskProperties) {
+    final String jobFormKey = customHeaders.get(Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
+    final Expression workerFormId = sourceElement.getJobWorkerProperties().getFormId();
+
+    if (jobFormKey != null) {
+      if (jobFormKey.toLowerCase().contains("bpmn:usertaskform")) {
+        if (targetElementProperties.getExternalFormReference() != null) {
+          // external form
+          userTaskBehavior
+              .evaluateExternalFormReferenceExpression(
+                  targetElementProperties.getExternalFormReference(),
+                  context.getFlowScopeKey(),
+                  targetProcessDefinition.getTenantId())
+              .ifRightOrLeft(
+                  userTaskProperties::externalFormReference,
+                  failure -> {
+                    throw new ProcessInstanceMigrationPreconditionFailedException(
+                        ERROR_TARGET_FORM_EVALUATION.formatted(
+                            sourceElement.getId(),
+                            "external",
+                            targetElementProperties.getExternalFormReference(),
+                            targetElementId,
+                            failure.getMessage()),
+                        RejectionType.INVALID_STATE);
+                  });
+        } else if (targetElementProperties.getFormId() != null) {
+          // internal form
+          userTaskBehavior
+              .evaluateFormIdExpressionToFormKey(
+                  targetElementProperties.getFormId(),
+                  targetElementProperties.getFormBindingType(),
+                  targetElementProperties.getFormVersionTag(),
+                  context,
+                  context.getFlowScopeKey(),
+                  targetProcessDefinition.getTenantId())
+              .ifRightOrLeft(
+                  userTaskProperties::formKey,
+                  failure -> {
+                    throw new ProcessInstanceMigrationPreconditionFailedException(
+                        ERROR_TARGET_FORM_EVALUATION.formatted(
+                            sourceElement.getId(),
+                            "internal",
+                            targetElementProperties.getFormId().getExpression(),
+                            targetElementId,
+                            failure.getMessage()),
+                        RejectionType.INVALID_STATE);
+                  });
+        } else {
+          // none
+          LOGGER.warn(
+              WARN_EMBEDDED_FORM_MIGRATION.formatted(
+                  sourceElement.getId(), targetElementId, processInstanceKey));
+        }
+      } else if (workerFormId == null) {
+        // external form
+        userTaskProperties.externalFormReference(jobFormKey);
+      } else {
+        // internal form
+        userTaskProperties.formKey(Long.parseLong(jobFormKey));
+      }
+    }
+  }
+
+  private static UserTaskProperties mapUserTaskProperties(
+      final Map<String, String> customHeaders,
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          targetProperties) {
+    final UserTaskProperties userTaskProperties = new UserTaskProperties();
+
+    if (targetProperties.getAssignee() != null) {
+      userTaskProperties.assignee(targetProperties.getAssignee().getExpression());
+    }
+    final String candidateGroups =
+        customHeaders.get(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME);
+    if (candidateGroups != null) {
+      try {
+        userTaskProperties.candidateGroups(
+            OBJECT_MAPPER.readValue(candidateGroups, new TypeReference<>() {}));
+      } catch (final JsonProcessingException e) {
+        throw new ProcessInstanceMigrationPreconditionFailedException(
+            "Failed to parse candidate groups: " + e.getMessage(), RejectionType.INVALID_STATE);
+      }
+    }
+    final String candidateUsers = customHeaders.get(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME);
+    if (candidateUsers != null) {
+      try {
+        userTaskProperties.candidateUsers(
+            OBJECT_MAPPER.readValue(candidateUsers, new TypeReference<>() {}));
+      } catch (final JsonProcessingException e) {
+        throw new ProcessInstanceMigrationPreconditionFailedException(
+            "Failed to parse candidate users: " + e.getMessage(), RejectionType.INVALID_STATE);
+      }
+    }
+    final String dueDate = customHeaders.get(Protocol.USER_TASK_DUE_DATE_HEADER_NAME);
+    if (dueDate != null) {
+      userTaskProperties.dueDate(dueDate);
+    }
+    final String followUpDate = customHeaders.get(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME);
+    if (followUpDate != null) {
+      userTaskProperties.followUpDate(followUpDate);
+    }
+    return userTaskProperties;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class ProcessInstanceMigrationUserTaskBehavior {
+
+  private final ElementInstance elementInstance;
+  private final DeployedProcess sourceProcessDefinition;
+  private final DeployedProcess targetProcessDefinition;
+  private final String targetElementId;
+  private final StateWriter stateWriter;
+  private final JobState jobState;
+
+  public ProcessInstanceMigrationUserTaskBehavior(
+      final ElementInstance elementInstance,
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final String targetElementId,
+      final StateWriter stateWriter,
+      final JobState jobState) {
+    this.elementInstance = elementInstance;
+    this.sourceProcessDefinition = sourceProcessDefinition;
+    this.targetProcessDefinition = targetProcessDefinition;
+    this.targetElementId = targetElementId;
+    this.stateWriter = stateWriter;
+    this.jobState = jobState;
+  }
+
+  public void tryMigrateJobWorkerToCamundaUserTask(final long processInstanceKey) {
+    final var jobKey = elementInstance.getJobKey();
+
+    final var job = jobState.getJob(jobKey);
+    if (job == null) {
+      throw new SafetyCheckFailedException(
+          String.format(
+              """
+                  Expected to migrate a job for process instance with key '%d', \
+                  but could not find job with key '%d'. \
+                  Please report this as a bug""",
+              processInstanceKey, jobKey));
+    }
+
+    final String elementId = elementInstance.getValue().getElementId();
+    final ExecutableJobWorkerElement sourceElement =
+        sourceProcessDefinition
+            .getProcess()
+            .getElementById(elementId, ExecutableJobWorkerElement.class);
+    final ExecutableUserTask targetElement =
+        targetProcessDefinition
+            .getProcess()
+            .getElementById(targetElementId, ExecutableUserTask.class);
+
+    // Cancel previous job worker job
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -126,6 +126,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
 
     assignUser(userTaskProperties, userTaskRecord);
 
+    job.setIsJobToUserTaskMigration(true);
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
   }
@@ -146,10 +147,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
       final UserTaskProperties userTaskProperties,
       final ExecutableUserTask targetElement) {
     userTaskBehavior
-        .evaluatePriorityExpression(
-            newProperties.getPriority(),
-            context.getFlowScopeKey(),
-            targetProcessDefinition.getTenantId())
+        .evaluatePriorityExpression(newProperties.getPriority(), context.getFlowScopeKey())
         .ifRight(userTaskProperties::priority);
 
     final var userTaskRecord =
@@ -175,9 +173,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
           // external form
           userTaskBehavior
               .evaluateExternalFormReferenceExpression(
-                  targetElementProperties.getExternalFormReference(),
-                  context.getFlowScopeKey(),
-                  targetProcessDefinition.getTenantId())
+                  targetElementProperties.getExternalFormReference(), context.getFlowScopeKey())
               .ifRightOrLeft(
                   userTaskProperties::externalFormReference,
                   failure -> {
@@ -198,8 +194,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
                   targetElementProperties.getFormBindingType(),
                   targetElementProperties.getFormVersionTag(),
                   context,
-                  context.getFlowScopeKey(),
-                  targetProcessDefinition.getTenantId())
+                  context.getFlowScopeKey())
               .ifRightOrLeft(
                   userTaskProperties::formKey,
                   failure -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -41,9 +42,10 @@ public class ProcessInstanceMigrationUserTaskBehavior {
 
   private static final String ERROR_JOB_NOT_FOUND =
       """
-                  Expected to migrate a job for process instance with key '%d', \
+                  Expected to migrate a job for user task '%s' \
+                  on process instance with key '%d', \
                   but could not find job with key '%d'. \
-                  Please report this as a bug""";
+                  Please resolve any incidents on the user task before migrating the process instance.""";
 
   private static final String ERROR_TARGET_FORM_EVALUATION =
       """
@@ -95,14 +97,14 @@ public class ProcessInstanceMigrationUserTaskBehavior {
 
   public void tryMigrateJobWorkerToCamundaUserTask() {
     final var jobKey = elementInstance.getJobKey();
+    final String elementId = elementInstance.getValue().getElementId();
 
     final var job = jobState.getJob(jobKey);
     if (job == null) {
       throw new SafetyCheckFailedException(
-          String.format(ERROR_JOB_NOT_FOUND, processInstanceKey, jobKey));
+          String.format(ERROR_JOB_NOT_FOUND, elementId, processInstanceKey, jobKey));
     }
 
-    final String elementId = elementInstance.getValue().getElementId();
     final ExecutableJobWorkerElement sourceElement =
         sourceProcessDefinition
             .getProcess()
@@ -209,7 +211,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
                   failure -> {
                     throw new ProcessInstanceMigrationPreconditionFailedException(
                         ERROR_TARGET_FORM_EVALUATION.formatted(
-                            sourceElement.getId(),
+                            BufferUtil.bufferAsString(sourceElement.getId()),
                             "external",
                             targetElementProperties.getExternalFormReference(),
                             targetElementId,
@@ -230,7 +232,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
                   failure -> {
                     throw new ProcessInstanceMigrationPreconditionFailedException(
                         ERROR_TARGET_FORM_EVALUATION.formatted(
-                            sourceElement.getId(),
+                            BufferUtil.bufferAsString(sourceElement.getId()),
                             "internal",
                             targetElementProperties.getFormId().getExpression(),
                             targetElementId,
@@ -241,7 +243,9 @@ public class ProcessInstanceMigrationUserTaskBehavior {
           // none
           LOGGER.warn(
               WARN_EMBEDDED_FORM_MIGRATION.formatted(
-                  sourceElement.getId(), targetElementId, processInstanceKey));
+                  BufferUtil.bufferAsString(sourceElement.getId()),
+                  targetElementId,
+                  processInstanceKey));
         }
       } else if (workerFormId == null) {
         // external form

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -32,7 +32,9 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.HashMap;
 import java.util.Map;
+import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 
 public class ProcessInstanceMigrationUserTaskBehavior {
@@ -129,7 +131,12 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     migrateForm(sourceElement, customHeaders, targetProperties, context, userTaskProperties);
 
     final var userTaskRecord =
-        createNewUserTask(targetProperties, context, userTaskProperties, targetUserTask);
+        createNewUserTask(
+            targetProperties,
+            context,
+            userTaskProperties,
+            targetUserTask.getId(),
+            getCustomHeaders(customHeaders));
 
     assignUser(userTaskProperties, userTaskRecord, context, targetProperties);
 
@@ -166,13 +173,15 @@ public class ProcessInstanceMigrationUserTaskBehavior {
           newProperties,
       final BpmnElementContextImpl context,
       final UserTaskProperties userTaskProperties,
-      final ExecutableUserTask targetElement) {
+      final DirectBuffer id,
+      final Map<String, String> taskHeaders) {
+
     userTaskBehavior
         .evaluatePriorityExpression(newProperties.getPriority(), context.getFlowScopeKey())
         .ifRight(userTaskProperties::priority);
 
     final var userTaskRecord =
-        userTaskBehavior.createNewUserTask(context, targetElement, userTaskProperties);
+        userTaskBehavior.createNewUserTask(context, id, userTaskProperties, taskHeaders);
     userTaskBehavior.userTaskCreated(userTaskRecord);
     elementInstance.setUserTaskKey(userTaskRecord.getUserTaskKey());
     return userTaskRecord;
@@ -277,5 +286,16 @@ public class ProcessInstanceMigrationUserTaskBehavior {
       userTaskProperties.followUpDate(followUpDate);
     }
     return userTaskProperties;
+  }
+
+  // Filter custom headers to only include non-usertask-related headers
+  private Map<String, String> getCustomHeaders(final Map<String, String> customHeaders) {
+    final Map<String, String> newMap = new HashMap<>();
+    for (final Map.Entry<String, String> entry : customHeaders.entrySet()) {
+      if (!entry.getKey().startsWith(Protocol.RESERVED_HEADER_NAME_PREFIX)) {
+        newMap.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return newMap;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -31,8 +31,8 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 public class ProcessInstanceMigrationUserTaskBehavior {
@@ -119,7 +119,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     final Map<String, String> customHeaders = job.getCustomHeaders();
     final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
         targetProperties = targetUserTask.getUserTaskProperties();
-    final var userTaskProperties = mapUserTaskProperties(customHeaders, targetProperties);
+    final var userTaskProperties = mapUserTaskProperties(customHeaders);
 
     // Create new Zeebe user task
     final var context = new BpmnElementContextImpl();
@@ -131,7 +131,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     final var userTaskRecord =
         createNewUserTask(targetProperties, context, userTaskProperties, targetUserTask);
 
-    assignUser(userTaskProperties, userTaskRecord);
+    assignUser(userTaskProperties, userTaskRecord, context, targetProperties);
 
     job.setIsJobToUserTaskMigration(true);
     // Cancel previous job worker job
@@ -139,12 +139,26 @@ public class ProcessInstanceMigrationUserTaskBehavior {
   }
 
   private void assignUser(
-      final UserTaskProperties userTaskProperties, final UserTaskRecord userTaskRecord) {
-    final var assignee = userTaskProperties.getAssignee();
-    if (StringUtils.isNotEmpty(assignee)) {
-      userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
-      userTaskBehavior.userTaskAssigned(userTaskRecord, assignee);
+      final UserTaskProperties userTaskProperties,
+      final UserTaskRecord userTaskRecord,
+      final BpmnElementContextImpl context,
+      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
+          targetProperties) {
+
+    if (targetProperties.getAssignee() != null) {
+      userTaskBehavior
+          .evaluateAssigneeExpression(targetProperties.getAssignee(), context.getFlowScopeKey())
+          .ifRight(userTaskProperties::assignee);
     }
+
+    final var assignee = userTaskProperties.getAssignee();
+    // We always need to sync the assignee because for job-based tasks the assignee value could be
+    // anything in secondary storage
+    userTaskRecord.setAssignee(assignee);
+    userTaskRecord.setAssigneeChanged();
+    stateWriter.appendFollowUpEvent(
+        userTaskRecord.getUserTaskKey(), UserTaskIntent.ASSIGNING, userTaskRecord);
+    userTaskBehavior.userTaskAssigned(userTaskRecord, assignee);
   }
 
   private UserTaskRecord createNewUserTask(
@@ -230,15 +244,9 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     }
   }
 
-  private static UserTaskProperties mapUserTaskProperties(
-      final Map<String, String> customHeaders,
-      final io.camunda.zeebe.engine.processing.deployment.model.element.UserTaskProperties
-          targetProperties) {
+  private static UserTaskProperties mapUserTaskProperties(final Map<String, String> customHeaders) {
     final UserTaskProperties userTaskProperties = new UserTaskProperties();
 
-    if (targetProperties.getAssignee() != null) {
-      userTaskProperties.assignee(targetProperties.getAssignee().getExpression());
-    }
     final String candidateGroups =
         customHeaders.get(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME);
     if (candidateGroups != null) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -556,4 +556,60 @@ public class MigrateUserTaskTest {
         .hasVersion(1)
         .hasElementId("B");
   }
+
+  @Test
+  public void shouldWriteJobCancelEventForMigrationFromJobWorkerToNative() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .zeebeUserTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long processDefinitionKey = extractProcessDefinitionKeyByProcessId(deployment, processId);
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.BPMN_ELEMENT)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that job is canceled")
+        .hasProcessDefinitionKey(processDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasElementId("A");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -629,6 +629,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -660,7 +661,7 @@ public class MigrateUserTaskTest {
         .hasCandidateUsersList("oof", "rab")
         .hasDueDate("2023-03-02T16:35+02:00")
         .hasFollowUpDate("2023-03-02T15:35+02:00")
-        .hasAssignee("\"userA\"")
+        .hasAssignee("userA")
         .hasPriority(50); // default priority
   }
 
@@ -736,6 +737,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -770,7 +772,7 @@ public class MigrateUserTaskTest {
         .hasFormKey(form.getFormKey())
         .hasCandidateGroupsList("foo", "bar")
         .hasCandidateUsersList("oof", "rab")
-        .hasAssignee("\"userA\"")
+        .hasAssignee("userA")
         .hasDueDate("2023-03-02T16:35+02:00")
         .hasFollowUpDate("2023-03-02T15:35+02:00")
         .hasPriority(80);
@@ -848,6 +850,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -883,7 +886,7 @@ public class MigrateUserTaskTest {
         .hasFormKey(-1L)
         .hasCandidateGroupsList("foo", "bar")
         .hasCandidateUsersList("oof", "rab")
-        .hasAssignee("\"userA\"")
+        .hasAssignee("userA")
         .hasDueDate("2023-03-02T16:35+02:00")
         .hasFollowUpDate("2023-03-02T15:35+02:00")
         .hasPriority(80); // target priority
@@ -942,6 +945,7 @@ public class MigrateUserTaskTest {
         .addMappingInstruction("A", "B")
         .migrate();
 
+    // then
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
                 .withProcessInstanceKey(processInstanceKey)
@@ -958,6 +962,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -991,7 +996,7 @@ public class MigrateUserTaskTest {
         .hasCandidateGroupsList("foo", "bar")
         .hasCandidateUsersList("oof", "rab")
         .hasDueDate("2023-03-02T16:35+02:00")
-        .hasAssignee("\"userA\"")
+        .hasAssignee("userA")
         .hasFollowUpDate("2023-03-02T15:35+02:00")
         .hasPriority(50); // default priority
 
@@ -1067,6 +1072,7 @@ public class MigrateUserTaskTest {
             RecordingExporter.jobRecords(JobIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.BPMN_ELEMENT)
+                .filter(r -> r.getValue().isJobToUserTaskMigration())
                 .exists())
         .describedAs("Expect that the job is canceled for the job based user task")
         .isTrue();
@@ -1096,7 +1102,7 @@ public class MigrateUserTaskTest {
         .hasExternalFormReference("test-form-1-key")
         .hasCandidateGroupsList("foo", "bar")
         .hasCandidateUsersList("oof", "rab")
-        .hasAssignee("\"userA\"")
+        .hasAssignee("userA")
         .hasDueDate("2023-03-02T16:35+02:00")
         .hasFollowUpDate("2023-03-02T15:35+02:00")
         .hasPriority(50); // default priority

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -59,6 +59,7 @@ import io.camunda.exporter.handlers.UsageMetricExportedHandler;
 import io.camunda.exporter.handlers.UserCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.UserDeletedHandler;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler;
+import io.camunda.exporter.handlers.UserTaskCreatingHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
 import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
@@ -241,9 +242,13 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),
             new EventFromProcessMessageSubscriptionHandler(
                 indexDescriptors.get(EventTemplate.class).getFullQualifiedName()),
-            new UserTaskHandler(
+            new UserTaskCreatingHandler(
                 indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 formCache,
+                processCache,
+                exporterMetadata),
+            new UserTaskHandler(
+                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 processCache,
                 exporterMetadata),
             new UserTaskJobBasedHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTaskRecordValue> {
+
+  private static final Set<UserTaskIntent> SUPPORTED_INTENTS = EnumSet.of(UserTaskIntent.CREATING);
+
+  private final String indexName;
+  private final ExporterEntityCache<String, CachedFormEntity> formCache;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ExporterMetadata exporterMetadata;
+
+  public UserTaskCreatingHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedFormEntity> formCache,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ExporterMetadata exporterMetadata) {
+    this.indexName = indexName;
+    this.formCache = formCache;
+    this.processCache = processCache;
+    this.exporterMetadata = exporterMetadata;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER_TASK;
+  }
+
+  @Override
+  public Class<TaskEntity> getEntityType() {
+    return TaskEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserTaskRecordValue> record) {
+    return SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserTaskRecordValue> record) {
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, record.getKey());
+    if (refersToPreviousVersionRecord(record.getKey())) {
+      return List.of(String.valueOf(record.getKey()));
+    }
+    return List.of(String.valueOf(record.getValue().getElementInstanceKey()));
+  }
+
+  @Override
+  public TaskEntity createNewEntity(final String id) {
+    return new TaskEntity().setId(id).setChangedAttributes(new ArrayList<>());
+  }
+
+  @Override
+  public void updateEntity(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+    createTaskEntity(entity, record);
+  }
+
+  @Override
+  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+    final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
+
+    batchRequest.addWithRouting(
+        indexName,
+        entity,
+        previousVersionRecord ? String.valueOf(entity.getKey()) : entity.getProcessInstanceId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private void createTaskEntity(final TaskEntity entity, final Record<UserTaskRecordValue> record) {
+    final var taskValue = record.getValue();
+    final var formKey = taskValue.getFormKey() > 0 ? String.valueOf(taskValue.getFormKey()) : null;
+
+    entity
+        .setKey(record.getKey())
+        .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
+        .setState(TaskState.CREATING)
+        .setFlowNodeInstanceId(String.valueOf(taskValue.getElementInstanceKey()))
+        .setProcessInstanceId(String.valueOf(taskValue.getProcessInstanceKey()))
+        .setFlowNodeBpmnId(taskValue.getElementId())
+        .setName(
+            ProcessCacheUtil.getFlowNodeName(
+                    processCache, taskValue.getProcessDefinitionKey(), taskValue.getElementId())
+                .orElse(null))
+        .setBpmnProcessId(taskValue.getBpmnProcessId())
+        .setProcessDefinitionId(String.valueOf(taskValue.getProcessDefinitionKey()))
+        .setProcessDefinitionVersion(taskValue.getProcessDefinitionVersion())
+        .setFormKey(!ExporterUtil.isEmpty(formKey) ? formKey : null)
+        .setExternalFormReference(
+            ExporterUtil.isEmpty(taskValue.getExternalFormReference())
+                ? null
+                : taskValue.getExternalFormReference())
+        .setCustomHeaders(taskValue.getCustomHeaders())
+        .setPartitionId(record.getPartitionId())
+        .setTenantId(taskValue.getTenantId())
+        .setPosition(record.getPosition())
+        .setAction(ExporterUtil.isEmpty(taskValue.getAction()) ? null : taskValue.getAction())
+        .setCreationTime(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .setDueDate(ExporterUtil.toOffsetDateTime(taskValue.getDueDate()))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(taskValue.getFollowUpDate()))
+        .setPriority(taskValue.getPriority())
+        .setCandidateGroups(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateGroupsList()))
+        .setCandidateUsers(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateUsersList()));
+
+    if (!ExporterUtil.isEmpty(formKey)) {
+      formCache
+          .get(formKey)
+          .ifPresent(c -> entity.setFormId(c.formId()).setFormVersion(c.formVersion()));
+    }
+
+    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
+    joinRelation.setName(TaskJoinRelationshipType.TASK.getType());
+    joinRelation.setParent(Long.parseLong(entity.getProcessInstanceId()));
+    entity.setJoin(joinRelation);
+  }
+
+  private boolean refersToPreviousVersionRecord(final long key) {
+    return exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK) == -1
+        || key < exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
@@ -39,7 +38,8 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskHandler.class);
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =
       EnumSet.of(
-          UserTaskIntent.CREATING,
+          // CREATING intent is handled in UserTaskCreatingHandler to support completely overwriting
+          // user task documents which is needed for user task process instance migration
           UserTaskIntent.CREATED,
           UserTaskIntent.COMPLETING,
           UserTaskIntent.COMPLETED,
@@ -56,19 +56,15 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           UserTaskIntent.COMPLETION_DENIED);
   private static final String UNMAPPED_USER_TASK_ATTRIBUTE_WARNING =
       "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}";
-
   private final String indexName;
-  private final ExporterEntityCache<String, CachedFormEntity> formCache;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
   private final ExporterMetadata exporterMetadata;
 
   public UserTaskHandler(
       final String indexName,
-      final ExporterEntityCache<String, CachedFormEntity> formCache,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
       final ExporterMetadata exporterMetadata) {
     this.indexName = indexName;
-    this.formCache = formCache;
     this.processCache = processCache;
     this.exporterMetadata = exporterMetadata;
   }
@@ -90,10 +86,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
   @Override
   public List<String> generateIds(final Record<UserTaskRecordValue> record) {
-    if (record.getIntent().equals(UserTaskIntent.CREATING)) {
-      exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, record.getKey());
-    }
-
     if (refersToPreviousVersionRecord(record.getKey())) {
       return List.of(String.valueOf(record.getKey()));
     }
@@ -112,9 +104,9 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity.setKey(record.getKey());
 
     switch ((UserTaskIntent) record.getIntent()) {
-      case UserTaskIntent.CREATING -> createTaskEntity(entity, record);
       case UserTaskIntent.CREATED, UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED -> {
         entity.setState(TaskState.CREATED);
+        entity.setCompletionTime(null);
         updateChangedAttributes(record, entity);
       }
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
@@ -178,7 +170,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     if (entity.getCompletionTime() != null) {
       updateFields.put(TaskTemplate.COMPLETION_TIME, entity.getCompletionTime());
     }
-
     if (entity.getChangedAttributes() != null && !entity.getChangedAttributes().isEmpty()) {
       updateFields.put(TaskTemplate.CHANGED_ATTRIBUTES, entity.getChangedAttributes());
     }
@@ -206,48 +197,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     }
 
     return updateFields;
-  }
-
-  private void createTaskEntity(final TaskEntity entity, final Record<UserTaskRecordValue> record) {
-    final var taskValue = record.getValue();
-    final var formKey = taskValue.getFormKey() > 0 ? String.valueOf(taskValue.getFormKey()) : null;
-
-    entity
-        .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
-        .setState(TaskState.CREATING)
-        .setFlowNodeInstanceId(String.valueOf(taskValue.getElementInstanceKey()))
-        .setProcessInstanceId(String.valueOf(taskValue.getProcessInstanceKey()))
-        .setFlowNodeBpmnId(taskValue.getElementId())
-        .setName(
-            ProcessCacheUtil.getFlowNodeName(
-                    processCache, taskValue.getProcessDefinitionKey(), taskValue.getElementId())
-                .orElse(null))
-        .setBpmnProcessId(taskValue.getBpmnProcessId())
-        .setProcessDefinitionId(String.valueOf(taskValue.getProcessDefinitionKey()))
-        .setProcessDefinitionVersion(taskValue.getProcessDefinitionVersion())
-        .setFormKey(!ExporterUtil.isEmpty(formKey) ? formKey : null)
-        .setExternalFormReference(
-            ExporterUtil.isEmpty(taskValue.getExternalFormReference())
-                ? null
-                : taskValue.getExternalFormReference())
-        .setCustomHeaders(taskValue.getCustomHeaders())
-        .setPartitionId(record.getPartitionId())
-        .setTenantId(taskValue.getTenantId())
-        .setPosition(record.getPosition())
-        .setAction(ExporterUtil.isEmpty(taskValue.getAction()) ? null : taskValue.getAction())
-        .setCreationTime(
-            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
-        .setDueDate(ExporterUtil.toOffsetDateTime(taskValue.getDueDate()))
-        .setFollowUpDate(ExporterUtil.toOffsetDateTime(taskValue.getFollowUpDate()))
-        .setPriority(taskValue.getPriority())
-        .setCandidateGroups(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateGroupsList()))
-        .setCandidateUsers(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateUsersList()));
-
-    if (!ExporterUtil.isEmpty(formKey)) {
-      formCache
-          .get(formKey)
-          .ifPresent(c -> entity.setFormId(c.formId()).setFormVersion(c.formVersion()));
-    }
   }
 
   private boolean refersToPreviousVersionRecord(final long key) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -86,7 +86,8 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
     return SUPPORTED_INTENTS.contains(record.getIntent())
-        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE);
+        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE)
+        && !record.getValue().isJobToUserTaskMigration();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.cache.TestFormCache;
+import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserTaskCreatingHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-tasklist-creating-task";
+  private final TestFormCache formCache = new TestFormCache();
+  private final TestProcessCache processCache = new TestProcessCache();
+  private final ExporterMetadata exporterMetadata =
+      new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final UserTaskCreatingHandler underTest =
+      new UserTaskCreatingHandler(indexName, formCache, processCache, exporterMetadata);
+
+  @BeforeEach
+  void resetMetadata() {
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, -1);
+  }
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER_TASK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(TaskEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.CREATING));
+    // when - then
+    assertThat(underTest.handlesRecord(userTaskRecord))
+        .describedAs("Expect to handle intent %s", UserTaskIntent.CREATING)
+        .isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdForNewVersionReferenceRecord() {
+    // given
+    /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 110;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder()
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withUserTaskKey(recordKey)
+                            .withElementInstanceKey(flowNodeInstanceKey)
+                            .build()));
+
+    // when
+    final var idList = underTest.generateIds(userTaskRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(flowNodeInstanceKey));
+  }
+
+  @Test
+  void shouldGenerateIdForPreviousVersionReferenceRecord() {
+    // given
+    /* For 8.7 Ingested records referencing 8.6 records, the recordKey has to be less than the firstIngestedUserTaskKey */
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 90;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder()
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withUserTaskKey(recordKey)
+                            .withElementInstanceKey(flowNodeInstanceKey)
+                            .build()));
+
+    // when
+    final var idList = underTest.generateIds(userTaskRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(recordKey));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlushForNewVersionReefrenceRecord() {
+    // given
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 110;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final TaskEntity inputEntity =
+        new TaskEntity()
+            .setId(String.valueOf(flowNodeInstanceKey))
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setKey(recordKey)
+            .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+
+    verify(mockRequest, times(1))
+        .addWithRouting(indexName, inputEntity, String.valueOf(processInstanceKey));
+  }
+
+  @Test
+  void shouldAddEntityOnFlushForPreviousVersionReferenceRecord() {
+    // given
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 90;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final TaskEntity inputEntity =
+        new TaskEntity()
+            .setId(String.valueOf(recordKey))
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setKey(recordKey)
+            .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+
+    verify(mockRequest, times(1)).addWithRouting(indexName, inputEntity, String.valueOf(recordKey));
+  }
+
+  @Test
+  void shouldCreateEntityFromRecord() {
+    // given
+    final long processInstanceKey = 123;
+    final long processDefinitionKey = 555;
+    final long flowNodeInstanceKey = 456;
+    final long recordKey = 110;
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 100);
+    final var dateTime = OffsetDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+    final var formKey = 456L;
+    final var elementId = "elementId";
+    final var rootProcessInstanceKey = 999L;
+    final UserTaskRecordValue taskRecordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withAssignee("")
+            .withChangedAttributes(List.of())
+            .withFollowUpDate(dateTime)
+            .withDueDate(dateTime)
+            .withCandidateGroupsList(Arrays.asList("group1", "group2"))
+            .withCandidateUsersList(Arrays.asList("user1", "user2"))
+            .withProcessInstanceKey(processInstanceKey)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withElementInstanceKey(flowNodeInstanceKey)
+            .withFormKey(formKey)
+            .withElementId(elementId)
+            .build();
+
+    final Record<UserTaskRecordValue> taskCreatingRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(taskRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    formCache.put(String.valueOf(formKey), new CachedFormEntity("my-form", 987L));
+    processCache.put(
+        processDefinitionKey,
+        new CachedProcessEntity(
+            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node")));
+
+    // when
+    final TaskEntity taskEntity =
+        new TaskEntity().setId(String.valueOf(taskRecordValue.getElementInstanceKey()));
+    underTest.updateEntity(taskCreatingRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getId())
+        .isEqualTo(String.valueOf(taskRecordValue.getElementInstanceKey()));
+    assertThat(taskEntity.getKey()).isEqualTo(taskCreatingRecord.getKey());
+    assertThat(taskEntity.getTenantId()).isEqualTo(taskRecordValue.getTenantId());
+    assertThat(taskEntity.getPartitionId()).isEqualTo(taskCreatingRecord.getPartitionId());
+    assertThat(taskEntity.getPosition()).isEqualTo(taskCreatingRecord.getPosition());
+    assertThat(taskEntity.getProcessInstanceId()).isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo(taskRecordValue.getElementId());
+    assertThat(taskEntity.getName()).isEqualTo("my-flow-node");
+    assertThat(taskEntity.getBpmnProcessId()).isEqualTo(taskRecordValue.getBpmnProcessId());
+    assertThat(taskEntity.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(taskRecordValue.getProcessDefinitionKey()));
+    assertThat(taskEntity.getProcessDefinitionVersion())
+        .isEqualTo(taskRecordValue.getProcessDefinitionVersion());
+    assertThat(taskEntity.getFormKey()).isEqualTo(String.valueOf(taskRecordValue.getFormKey()));
+    assertThat(taskEntity.getFormId()).isEqualTo("my-form");
+    assertThat(taskEntity.getFormVersion()).isEqualTo(987L);
+    assertThat(taskEntity.getExternalFormReference())
+        .isEqualTo(taskRecordValue.getExternalFormReference());
+    assertThat(taskEntity.getCustomHeaders()).isEqualTo(taskRecordValue.getCustomHeaders());
+    assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
+    assertThat(taskEntity.getAction()).isEqualTo(taskRecordValue.getAction());
+    assertThat(taskEntity.getDueDate()).isEqualTo(dateTime);
+    assertThat(taskEntity.getFollowUpDate()).isEqualTo(dateTime);
+    assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
+        .isEqualTo(taskRecordValue.getCandidateGroupsList());
+    assertThat(Arrays.stream(taskEntity.getCandidateUsers()).toList())
+        .isEqualTo(taskRecordValue.getCandidateUsersList());
+    assertThat(taskEntity.getAssignee()).isNull();
+    assertThat(taskEntity.getJoin()).isNotNull();
+    assertThat(taskEntity.getJoin().getParent()).isEqualTo(processInstanceKey);
+    assertThat(taskEntity.getJoin().getName()).isEqualTo(TaskJoinRelationshipType.TASK.getType());
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATING);
+    assertThat(taskEntity.getCreationTime())
+        .isEqualTo(
+            ExporterUtil.toZonedOffsetDateTime(
+                Instant.ofEpochMilli(taskCreatingRecord.getTimestamp())));
+    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -14,18 +14,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.TestProcessCache;
-import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
-import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
-import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -55,7 +51,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class UserTaskHandlerTest {
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =
       EnumSet.of(
-          UserTaskIntent.CREATING,
           UserTaskIntent.CREATED,
           UserTaskIntent.COMPLETING,
           UserTaskIntent.COMPLETED,
@@ -75,12 +70,11 @@ public class UserTaskHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-tasklist-task";
-  private final TestFormCache formCache = new TestFormCache();
   private final TestProcessCache processCache = new TestProcessCache();
   private final ExporterMetadata exporterMetadata =
       new ExporterMetadata(TestObjectMapper.objectMapper());
   private final UserTaskHandler underTest =
-      new UserTaskHandler(indexName, formCache, processCache, exporterMetadata);
+      new UserTaskHandler(indexName, processCache, exporterMetadata);
 
   @BeforeEach
   void resetMetadata() {
@@ -198,7 +192,7 @@ public class UserTaskHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlushForNewVersionReferenceRecord() {
+  void shouldAddEntityOnFlushForNewVersionReefrenceRecord() {
     // given
     final long firstIngestedUserTaskKey = 100;
     final long recordKey = 110;
@@ -259,104 +253,6 @@ public class UserTaskHandlerTest {
             inputEntity,
             updateFieldsMap,
             String.valueOf(recordKey));
-  }
-
-  @Test
-  void shouldCreateEntityFromRecord() {
-    // given
-    final long processInstanceKey = 123;
-    final long processDefinitionKey = 555;
-    final long flowNodeInstanceKey = 456;
-    final long recordKey = 110;
-    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 100);
-    final var dateTime = OffsetDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
-    final var formKey = 456L;
-    final var elementId = "elementId";
-    final UserTaskRecordValue taskRecordValue =
-        ImmutableUserTaskRecordValue.builder()
-            .from(factory.generateObject(UserTaskRecordValue.class))
-            .withAssignee("")
-            .withChangedAttributes(List.of())
-            .withFollowUpDate(dateTime)
-            .withDueDate(dateTime)
-            .withCandidateGroupsList(Arrays.asList("group1", "group2"))
-            .withCandidateUsersList(Arrays.asList("user1", "user2"))
-            .withProcessInstanceKey(processInstanceKey)
-            .withProcessDefinitionKey(processDefinitionKey)
-            .withElementInstanceKey(flowNodeInstanceKey)
-            .withFormKey(formKey)
-            .withElementId(elementId)
-            .build();
-
-    final Record<UserTaskRecordValue> taskCreatingRecord =
-        factory.generateRecord(
-            ValueType.USER_TASK,
-            r ->
-                r.withIntent(UserTaskIntent.CREATING)
-                    .withKey(recordKey)
-                    .withValue(taskRecordValue)
-                    .withTimestamp(System.currentTimeMillis()));
-
-    formCache.put(String.valueOf(formKey), new CachedFormEntity("my-form", 987L));
-    processCache.put(
-        processDefinitionKey,
-        new CachedProcessEntity(
-            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node")));
-
-    // when
-    final TaskEntity taskEntity =
-        new TaskEntity().setId(String.valueOf(taskRecordValue.getElementInstanceKey()));
-    underTest.updateEntity(taskCreatingRecord, taskEntity);
-
-    final Record<UserTaskRecordValue> taskCreatedRecord =
-        factory.generateRecord(
-            ValueType.USER_TASK,
-            r ->
-                r.withIntent(UserTaskIntent.CREATED)
-                    .withKey(recordKey)
-                    .withValue(taskRecordValue)
-                    .withTimestamp(System.currentTimeMillis()));
-    underTest.updateEntity(taskCreatedRecord, taskEntity);
-
-    // then
-    assertThat(taskEntity.getId())
-        .isEqualTo(String.valueOf(taskRecordValue.getElementInstanceKey()));
-    assertThat(taskEntity.getKey()).isEqualTo(taskCreatingRecord.getKey());
-    assertThat(taskEntity.getTenantId()).isEqualTo(taskRecordValue.getTenantId());
-    assertThat(taskEntity.getPartitionId()).isEqualTo(taskCreatingRecord.getPartitionId());
-    assertThat(taskEntity.getPosition()).isEqualTo(taskCreatingRecord.getPosition());
-    assertThat(taskEntity.getProcessInstanceId()).isEqualTo(String.valueOf(processInstanceKey));
-    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo(taskRecordValue.getElementId());
-    assertThat(taskEntity.getName()).isEqualTo("my-flow-node");
-    assertThat(taskEntity.getBpmnProcessId()).isEqualTo(taskRecordValue.getBpmnProcessId());
-    assertThat(taskEntity.getProcessDefinitionId())
-        .isEqualTo(String.valueOf(taskRecordValue.getProcessDefinitionKey()));
-    assertThat(taskEntity.getProcessDefinitionVersion())
-        .isEqualTo(taskRecordValue.getProcessDefinitionVersion());
-    assertThat(taskEntity.getFormKey()).isEqualTo(String.valueOf(taskRecordValue.getFormKey()));
-    assertThat(taskEntity.getFormId()).isEqualTo("my-form");
-    assertThat(taskEntity.getFormVersion()).isEqualTo(987L);
-    assertThat(taskEntity.getExternalFormReference())
-        .isEqualTo(taskRecordValue.getExternalFormReference());
-    assertThat(taskEntity.getCustomHeaders()).isEqualTo(taskRecordValue.getCustomHeaders());
-    assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
-    assertThat(taskEntity.getAction()).isEqualTo(taskRecordValue.getAction());
-    assertThat(taskEntity.getDueDate()).isEqualTo(dateTime);
-    assertThat(taskEntity.getFollowUpDate()).isEqualTo(dateTime);
-    assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
-        .isEqualTo(taskRecordValue.getCandidateGroupsList());
-    assertThat(Arrays.stream(taskEntity.getCandidateUsers()).toList())
-        .isEqualTo(taskRecordValue.getCandidateUsersList());
-    assertThat(taskEntity.getAssignee()).isNull();
-    assertThat(taskEntity.getJoin()).isNotNull();
-    assertThat(taskEntity.getJoin().getParent()).isEqualTo(processInstanceKey);
-    assertThat(taskEntity.getJoin().getName()).isEqualTo(TaskJoinRelationshipType.TASK.getType());
-    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
-    assertThat(taskEntity.getCreationTime())
-        .isEqualTo(
-            ExporterUtil.toZonedOffsetDateTime(
-                Instant.ofEpochMilli(taskCreatingRecord.getTimestamp())));
-    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
   }
 
   @Test
@@ -1125,7 +1021,7 @@ public class UserTaskHandlerTest {
    */
   private TaskState mapIntentToExpectedState(final UserTaskIntent intent) {
     return switch (intent) {
-      case CREATING -> TaskState.CREATING;
+      case CREATING -> null;
       case CREATED, ASSIGNED, ASSIGNMENT_DENIED, UPDATED, UPDATE_DENIED, COMPLETION_DENIED ->
           TaskState.CREATED;
       case ASSIGNING, CLAIMING -> TaskState.ASSIGNING;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -86,6 +86,7 @@ public class UserTaskJobBasedHandlerTest {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(false)
             .build();
 
     SUPPORTED_INTENTS.forEach(
@@ -95,6 +96,26 @@ public class UserTaskJobBasedHandlerTest {
                   ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
           // when - then
           assertThat(underTest.handlesRecord(jobRecord)).isTrue();
+        });
+  }
+
+  @Test
+  void shouldNotHandleUserTaskMigrationRecord() {
+    // given
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    SUPPORTED_INTENTS.forEach(
+        intent -> {
+          final Record<JobRecordValue> jobRecord =
+              factory.generateRecord(
+                  ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
+          // when - then
+          assertThat(underTest.handlesRecord(jobRecord)).isFalse();
         });
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -61,6 +61,7 @@ final class BulkIndexRequest implements ContentProducer {
       "decisionEvaluationInstanceKey";
   private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
   private static final String TAGS_PROPERTY = "tags";
+  private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
   private static final String RESULT_PROPERTY = "result";
   private static final String DENIED_REASON_PROPERTY = "deniedReason";
   private static final String RUNTIME_INSTRUCTIONS_PROPERTY = "runtimeInstructions";
@@ -214,7 +215,7 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
   private static final class UserTask87Mixin {}
 
-  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
+  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,6 +104,9 @@
                 "tags": {
                   "type": "keyword"
                 },
+                "jobToUserTaskMigration": {
+                  "type": "boolean"
+                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,6 +85,9 @@
             "tags": {
               "type": "keyword"
             },
+            "jobToUserTaskMigration": {
+              "type": "boolean"
+            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -340,6 +340,7 @@ final class ElasticsearchExporterIT {
               ImmutableJobRecordValue.builder()
                   .from(((ImmutableJobRecordValue) record.getValue()))
                   .withTags(List.of())
+                  .withJobToUserTaskMigration(false)
                   .resultBuilder(null)
                   .build();
           case PROCESS_INSTANCE ->
@@ -361,6 +362,7 @@ final class ElasticsearchExporterIT {
                                       ImmutableJobRecordValue.builder()
                                           .from(job)
                                           .withTags(List.of())
+                                          .withJobToUserTaskMigration(false)
                                           .resultBuilder(null)
                                           .build())
                               .toList())

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -61,6 +61,7 @@ final class BulkIndexRequest implements ContentProducer {
       "decisionEvaluationInstanceKey";
   private static final String BATCH_OPERATION_REFERENCE_PROPERTY = "batchOperationReference";
   private static final String TAGS_PROPERTY = "tags";
+  private static final String JOB_TO_USER_TASK_MIGRATION_PROPERTY = "jobToUserTaskMigration";
   private static final String RESULT_PROPERTY = "result";
   private static final String DENIED_REASON_PROPERTY = "deniedReason";
   private static final String RUNTIME_INSTRUCTIONS_PROPERTY = "runtimeInstructions";
@@ -215,7 +216,7 @@ final class BulkIndexRequest implements ContentProducer {
   @JsonIgnoreProperties({DENIED_REASON_PROPERTY})
   private static final class UserTask87Mixin {}
 
-  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY})
+  @JsonIgnoreProperties({RESULT_PROPERTY, TAGS_PROPERTY, JOB_TO_USER_TASK_MIGRATION_PROPERTY})
   private static final class Job87Mixin {}
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -104,6 +104,9 @@
                 "tags": {
                   "type": "keyword"
                 },
+                "jobToUserTaskMigration": {
+                  "type": "boolean"
+                },
                 "result": {
                   "properties": {
                     "type": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -85,6 +85,9 @@
             "tags": {
               "type": "keyword"
             },
+            "jobToUserTaskMigration": {
+              "type": "boolean"
+            },
             "result": {
               "properties": {
                 "type": {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -417,6 +417,7 @@ final class OpensearchExporterIT {
                   ImmutableJobRecordValue.builder()
                       .from(((ImmutableJobRecordValue) record.getValue()))
                       .withTags(List.of())
+                      .withJobToUserTaskMigration(false)
                       .resultBuilder(null)
                       .build();
               case PROCESS_INSTANCE ->
@@ -438,6 +439,7 @@ final class OpensearchExporterIT {
                                           ImmutableJobRecordValue.builder()
                                               .from(job)
                                               .withTags(List.of())
+                                              .withJobToUserTaskMigration(false)
                                               .resultBuilder(null)
                                               .build())
                                   .toList())

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -72,6 +73,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue CHANGED_ATTRIBUTES_KEY = new StringValue("changedAttributes");
   private static final StringValue RESULT_KEY = new StringValue("result");
   private static final StringValue TAGS = new StringValue("tags");
+  private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
+      new StringValue("isUserTaskMigration");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
 
@@ -115,9 +118,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ObjectProperty<JobResult> resultProp =
       new ObjectProperty<>(RESULT_KEY, new JobResult());
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
+  private final BooleanProperty isJobToUserTaskMigrationProp =
+      new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
 
   public JobRecord() {
-    super(23);
+    super(24);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -140,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tenantIdProp)
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(isJobToUserTaskMigrationProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -166,6 +172,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
     resultProp.getValue().wrap(record.getResult());
+    isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
   }
@@ -333,6 +340,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -426,6 +438,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {
     jobListenerEventTypeProp.setValue(jobListenerEventType);
+    return this;
+  }
+
+  public JobRecord setIsJobToUserTaskMigration(final boolean isJobToUserTaskMigration) {
+    isJobToUserTaskMigrationProp.setValue(isJobToUserTaskMigration);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -754,88 +754,90 @@ final class JsonSerializableToJsonTest {
                   .setElementInstanceKey(activityInstanceKey)
                   .setChangedAttributes(changedAttributes)
                   .setResult(result)
-                  .setTags(Set.of("tag1", "tag2"));
+                  .setTags(Set.of("tag1", "tag2"))
+                  .setIsJobToUserTaskMigration(true);
 
               return record;
             },
         """
-        {
-          "maxJobsToActivate": 1,
-          "type": "type",
-          "worker": "worker",
-          "truncated": true,
-          "jobKeys": [
-            3
-          ],
-          "jobs": [
-            {
-              "bpmnProcessId": "test-process",
-              "processDefinitionKey": 13,
-              "processDefinitionVersion": 12,
-              "processInstanceKey": 1234,
-              "elementId": "activity",
-              "elementInstanceKey": 123,
-              "type": "type",
-              "worker": "worker",
-              "variables": {
-                "foo": "bar"
-              },
-              "retries": 3,
-              "jobKind": "BPMN_ELEMENT",
-              "jobListenerEventType": "UNSPECIFIED",
-              "retryBackoff": 1002,
-              "recurringTime": 1001,
-              "errorMessage": "failed message",
-              "errorCode": "error",
-              "customHeaders": {},
-              "deadline": 1000,
-              "timeout": -1,
-              "tenantId": "<default>",
-              "changedAttributes": ["bar", "foo"],
-              "tags": ["tag1", "tag2"],
-              "result": {
-                "type": "USER_TASK",
-                "denied": true,
-                "deniedReason": "Reason to deny lifecycle transition",
-                "correctedAttributes": [
-                  "assignee",
-                  "dueDate",
-                  "followUpDate",
-                  "candidateGroupsList",
-                  "candidateUsersList",
-                  "priority"
-                ],
-                "corrections": {
-                  "assignee": "frodo",
-                  "dueDate": "today",
-                  "followUpDate": "tomorrow",
-                  "candidateGroupsList": ["fellowship", "eagles"],
-                  "candidateUsersList": ["frodo", "sam", "gollum"],
-                  "priority": 1
-                },
-               "activateElements": [
-                  {
-                    "elementId": "gandalf",
-                    "variables": {
-                      "foo": "bar"
+                {
+                  "maxJobsToActivate": 1,
+                  "type": "type",
+                  "worker": "worker",
+                  "truncated": true,
+                  "jobKeys": [
+                    3
+                  ],
+                  "jobs": [
+                    {
+                      "bpmnProcessId": "test-process",
+                      "processDefinitionKey": 13,
+                      "processDefinitionVersion": 12,
+                      "processInstanceKey": 1234,
+                      "elementId": "activity",
+                      "elementInstanceKey": 123,
+                      "type": "type",
+                      "worker": "worker",
+                      "variables": {
+                        "foo": "bar"
+                      },
+                      "retries": 3,
+                      "jobKind": "BPMN_ELEMENT",
+                      "jobListenerEventType": "UNSPECIFIED",
+                      "retryBackoff": 1002,
+                      "recurringTime": 1001,
+                      "errorMessage": "failed message",
+                      "errorCode": "error",
+                      "customHeaders": {},
+                      "deadline": 1000,
+                      "timeout": -1,
+                      "tenantId": "<default>",
+                      "changedAttributes": ["bar", "foo"],
+                      "tags": ["tag1", "tag2"],
+                      "jobToUserTaskMigration": true,
+                      "result": {
+                        "type": "USER_TASK",
+                        "denied": true,
+                        "deniedReason": "Reason to deny lifecycle transition",
+                        "correctedAttributes": [
+                          "assignee",
+                          "dueDate",
+                          "followUpDate",
+                          "candidateGroupsList",
+                          "candidateUsersList",
+                          "priority"
+                        ],
+                        "corrections": {
+                          "assignee": "frodo",
+                          "dueDate": "today",
+                          "followUpDate": "tomorrow",
+                          "candidateGroupsList": ["fellowship", "eagles"],
+                          "candidateUsersList": ["frodo", "sam", "gollum"],
+                          "priority": 1
+                        },
+                       "activateElements": [
+                          {
+                            "elementId": "gandalf",
+                            "variables": {
+                              "foo": "bar"
+                            }
+                          },
+                          {
+                            "elementId": "sauron",
+                            "variables": {
+                              "foo": "bar"
+                            }
+                          }
+                        ],
+                        "completionConditionFulfilled": true,
+                        "cancelRemainingInstances": true
+                      }
                     }
-                  },
-                  {
-                    "elementId": "sauron",
-                    "variables": {
-                      "foo": "bar"
-                    }
-                  }
-                ],
-                "completionConditionFulfilled": true,
-                "cancelRemainingInstances": true
-              }
-            }
-          ],
-          "timeout": 2,
-          "tenantIds": []
-        }
-        """
+                  ],
+                  "timeout": 2,
+                  "tenantIds": []
+                }
+                """
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty JobBatchRecord //////////////////////////////////////
@@ -935,78 +937,80 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKey(activityInstanceKey)
                       .setChangedAttributes(changedAttributes)
                       .setResult(result)
-                      .setTags(Set.of("tag1", "tag2"));
+                      .setTags(Set.of("tag1", "tag2"))
+                      .setIsJobToUserTaskMigration(true);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
             },
         """
-        {
-          "bpmnProcessId": "test-process",
-          "processDefinitionKey": 13,
-          "processDefinitionVersion": 12,
-          "processInstanceKey": 1234,
-          "elementId": "activity",
-          "elementInstanceKey": 123,
-          "worker": "myWorker",
-          "type": "myType",
-          "variables": {
-            "foo": "bar"
-          },
-          "retries": 12,
-          "jobKind": "BPMN_ELEMENT",
-          "jobListenerEventType": "UNSPECIFIED",
-          "retryBackoff": 1003,
-          "recurringTime": 1004,
-          "errorMessage": "failed message",
-          "errorCode": "error",
-          "customHeaders": {
-            "workerVersion": "42"
-          },
-          "deadline": 13,
-          "timeout": 14,
-          "tenantId": "<default>",
-          "tags": ["tag1", "tag2"],
-          "changedAttributes": ["bar", "foo"],
-          "result": {
-            "type": "AD_HOC_SUB_PROCESS",
-            "denied": true,
-            "deniedReason": "Reason to deny lifecycle transition",
-            "correctedAttributes": [
-              "assignee",
-              "dueDate",
-              "followUpDate",
-              "candidateGroupsList",
-              "candidateUsersList",
-              "priority"
-            ],
-            "corrections": {
-              "assignee": "frodo",
-              "dueDate": "today",
-              "followUpDate": "tomorrow",
-              "candidateGroupsList": ["fellowship", "eagles"],
-              "candidateUsersList": ["frodo", "sam", "gollum"],
-              "priority": 1
-            },
-            "activateElements": [
-              {
-                "elementId": "gandalf",
-                "variables": {
-                  "foo": "bar"
+                {
+                  "bpmnProcessId": "test-process",
+                  "processDefinitionKey": 13,
+                  "processDefinitionVersion": 12,
+                  "processInstanceKey": 1234,
+                  "elementId": "activity",
+                  "elementInstanceKey": 123,
+                  "worker": "myWorker",
+                  "type": "myType",
+                  "variables": {
+                    "foo": "bar"
+                  },
+                  "retries": 12,
+                  "jobKind": "BPMN_ELEMENT",
+                  "jobListenerEventType": "UNSPECIFIED",
+                  "retryBackoff": 1003,
+                  "recurringTime": 1004,
+                  "errorMessage": "failed message",
+                  "errorCode": "error",
+                  "customHeaders": {
+                    "workerVersion": "42"
+                  },
+                  "deadline": 13,
+                  "timeout": 14,
+                  "tenantId": "<default>",
+                  "tags": ["tag1", "tag2"],
+                  "jobToUserTaskMigration": true,
+                  "changedAttributes": ["bar", "foo"],
+                  "result": {
+                    "type": "AD_HOC_SUB_PROCESS",
+                    "denied": true,
+                    "deniedReason": "Reason to deny lifecycle transition",
+                    "correctedAttributes": [
+                      "assignee",
+                      "dueDate",
+                      "followUpDate",
+                      "candidateGroupsList",
+                      "candidateUsersList",
+                      "priority"
+                    ],
+                    "corrections": {
+                      "assignee": "frodo",
+                      "dueDate": "today",
+                      "followUpDate": "tomorrow",
+                      "candidateGroupsList": ["fellowship", "eagles"],
+                      "candidateUsersList": ["frodo", "sam", "gollum"],
+                      "priority": 1
+                    },
+                    "activateElements": [
+                      {
+                        "elementId": "gandalf",
+                        "variables": {
+                          "foo": "bar"
+                        }
+                      },
+                      {
+                        "elementId": "sauron",
+                        "variables": {
+                          "foo": "bar"
+                        }
+                      }
+                    ],
+                    "completionConditionFulfilled": true,
+                    "cancelRemainingInstances": true
+                  }
                 }
-              },
-              {
-                "elementId": "sauron",
-                "variables": {
-                  "foo": "bar"
-                }
-              }
-            ],
-            "completionConditionFulfilled": true,
-            "cancelRemainingInstances": true
-          }
-        }
-        """
+                """
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -1016,48 +1020,49 @@ final class JsonSerializableToJsonTest {
         "Empty JobRecord",
         (Supplier<UnifiedRecordValue>) JobRecord::new,
         """
-        {
-          "type": "",
-          "processDefinitionVersion": -1,
-          "elementId": "",
-          "bpmnProcessId": "",
-          "processDefinitionKey": -1,
-          "processInstanceKey": -1,
-          "elementInstanceKey": -1,
-          "variables": {},
-          "worker": "",
-          "retries": -1,
-          "jobKind": "BPMN_ELEMENT",
-          "jobListenerEventType": "UNSPECIFIED",
-          "retryBackoff": 0,
-          "recurringTime": -1,
-          "errorMessage": "",
-          "errorCode": "",
-          "customHeaders": {},
-          "deadline": -1,
-          "timeout": -1,
-          "tenantId": "<default>",
-          "tags": [],
-          "changedAttributes": [],
-          "result": {
-            "type": "USER_TASK",
-            "denied": false,
-            "deniedReason": "",
-            "correctedAttributes": [],
-            "corrections": {
-              "assignee": "",
-              "dueDate": "",
-              "followUpDate": "",
-              "candidateGroupsList": [],
-              "candidateUsersList": [],
-              "priority": -1
-            },
-            "activateElements": [],
-            "completionConditionFulfilled": false,
-            "cancelRemainingInstances": false
-          }
-        }
-        """
+                {
+                  "type": "",
+                  "processDefinitionVersion": -1,
+                  "elementId": "",
+                  "bpmnProcessId": "",
+                  "processDefinitionKey": -1,
+                  "processInstanceKey": -1,
+                  "elementInstanceKey": -1,
+                  "variables": {},
+                  "worker": "",
+                  "retries": -1,
+                  "jobKind": "BPMN_ELEMENT",
+                  "jobListenerEventType": "UNSPECIFIED",
+                  "retryBackoff": 0,
+                  "recurringTime": -1,
+                  "errorMessage": "",
+                  "errorCode": "",
+                  "customHeaders": {},
+                  "deadline": -1,
+                  "timeout": -1,
+                  "tenantId": "<default>",
+                  "tags": [],
+                  "jobToUserTaskMigration": false,
+                  "changedAttributes": [],
+                  "result": {
+                    "type": "USER_TASK",
+                    "denied": false,
+                    "deniedReason": "",
+                    "correctedAttributes": [],
+                    "corrections": {
+                      "assignee": "",
+                      "dueDate": "",
+                      "followUpDate": "",
+                      "candidateGroupsList": [],
+                      "candidateUsersList": [],
+                      "priority": -1
+                    },
+                    "activateElements": [],
+                    "completionConditionFulfilled": false,
+                    "cancelRemainingInstances": false
+                  }
+                }
+                """
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////////// JobRecord with nullable variable //////////////////////
@@ -1070,50 +1075,51 @@ final class JsonSerializableToJsonTest {
                     .setVariables(
                         new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{'foo':null}"))),
         """
-        {
-          "type": "",
-          "errorMessage": "",
-          "bpmnProcessId": "",
-          "processDefinitionKey": -1,
-          "processInstanceKey": -1,
-          "elementId": "",
-          "elementInstanceKey": -1,
-          "variables": {
-            "foo": null
-          },
-          "deadline": -1,
-          "timeout": -1,
-          "worker": "",
-          "retries": -1,
-          "jobKind": "BPMN_ELEMENT",
-          "jobListenerEventType": "UNSPECIFIED",
-          "retryBackoff": 0,
-          "recurringTime": -1,
-          "errorCode": "",
-          "processDefinitionVersion": -1,
-          "customHeaders": {},
-          "tenantId": "<default>",
-          "tags": [],
-          "changedAttributes": [],
-          "result": {
-            "type": "USER_TASK",
-            "denied": false,
-            "deniedReason": "",
-            "correctedAttributes": [],
-            "corrections": {
-              "assignee": "",
-              "dueDate": "",
-              "followUpDate": "",
-              "candidateGroupsList": [],
-              "candidateUsersList": [],
-              "priority": -1
-            },
-            "activateElements": [],
-            "completionConditionFulfilled": false,
-            "cancelRemainingInstances": false
-          }
-        }
-        """
+                {
+                  "type": "",
+                  "errorMessage": "",
+                  "bpmnProcessId": "",
+                  "processDefinitionKey": -1,
+                  "processInstanceKey": -1,
+                  "elementId": "",
+                  "elementInstanceKey": -1,
+                  "variables": {
+                    "foo": null
+                  },
+                  "deadline": -1,
+                  "timeout": -1,
+                  "worker": "",
+                  "retries": -1,
+                  "jobKind": "BPMN_ELEMENT",
+                  "jobListenerEventType": "UNSPECIFIED",
+                  "retryBackoff": 0,
+                  "recurringTime": -1,
+                  "errorCode": "",
+                  "processDefinitionVersion": -1,
+                  "customHeaders": {},
+                  "tenantId": "<default>",
+                  "tags": [],
+                  "jobToUserTaskMigration": false,
+                  "changedAttributes": [],
+                  "result": {
+                    "type": "USER_TASK",
+                    "denied": false,
+                    "deniedReason": "",
+                    "correctedAttributes": [],
+                    "corrections": {
+                      "assignee": "",
+                      "dueDate": "",
+                      "followUpDate": "",
+                      "candidateGroupsList": [],
+                      "candidateUsersList": [],
+                      "priority": -1
+                    },
+                    "activateElements": [],
+                    "completionConditionFulfilled": false,
+                    "cancelRemainingInstances": false
+                  }
+                }
+                """
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// MessageRecord /////////////////////////////////////////////

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -72,6 +73,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue CHANGED_ATTRIBUTES_KEY = new StringValue("changedAttributes");
   private static final StringValue RESULT_KEY = new StringValue("result");
   private static final StringValue TAGS = new StringValue("tags");
+  private static final StringValue IS_JOB_TO_USERTASK_MIGRATION_KEY =
+      new StringValue("isUserTaskMigration");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
 
@@ -115,9 +118,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ObjectProperty<JobResult> resultProp =
       new ObjectProperty<>(RESULT_KEY, new JobResult());
   private final ArrayProperty<StringValue> tagsProp = new ArrayProperty<>(TAGS, StringValue::new);
+  private final BooleanProperty isJobToUserTaskMigrationProp =
+      new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
 
   public JobRecord() {
-    super(23);
+    super(24);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -140,7 +145,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tenantIdProp)
         .declareProperty(changedAttributesProp)
         .declareProperty(resultProp)
-        .declareProperty(tagsProp);
+        .declareProperty(tagsProp)
+        .declareProperty(isJobToUserTaskMigrationProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -166,6 +172,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
     resultProp.getValue().wrap(record.getResult());
+    isJobToUserTaskMigrationProp.setValue(record.isJobToUserTaskMigration());
 
     setTags(record.getTags());
   }
@@ -333,6 +340,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  @Override
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
+  }
+
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -426,6 +438,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {
     jobListenerEventTypeProp.setValue(jobListenerEventType);
+    return this;
+  }
+
+  public JobRecord setIsJobToUserTaskMigration(final boolean isJobToUserTaskMigration) {
+    isJobToUserTaskMigrationProp.setValue(isJobToUserTaskMigration);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -136,6 +136,11 @@ public interface JobRecordValue
    */
   Set<String> getTags();
 
+  /**
+   * @return true if the job is part of a user task migration
+   */
+  boolean isJobToUserTaskMigration();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)
   interface JobResultValue {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of the backend changes for the usertask PIM feature.

Cherry picked all commits from main branch related to user task PIM implementation and resolved merge conflicts. Cleaned up history by squashing some fixes into the implementation commits.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/44181
