### PR TITLE
ci: prune buildx cache in docker-checks job to free space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,11 +875,12 @@ jobs:
           # push is needed for multi-arch images as buildkit does not support loading them locally
           push: true
 
-      # We need to free up some space to let the step after this block succeed.
-      # With this cleanup, at the time of measuring, we go from a 100% disk usage (73/74 GB) to a
-      # 94% (68/73 GB), on the runner ubuntu-latest. This allows the workflow to go through.
+      # Since subsequent steps of this job need a lot of disk space for downloaded
+      # database Docker images, we try to clean all unused caches and free space here.
       - name: Cleanup docker images
-        run: docker system prune -af
+        run: |
+          docker buildx prune -f
+          docker system prune -af
 
       - name: Verify Docker image
         # Skip verification on fork PRs as there public base images are used that don't match our golden labels


### PR DESCRIPTION
## Description

As we discovered in https://app.incident.io/camunda/incidents/4230 the `docker-checks` job is getting tight due to downloading large DB Docker images (Oracle 👀 ) [via here](https://github.com/camunda/camunda/blob/main/dist/src/test/java/io/camunda/application/StartStandaloneCamundaOnRdbmsDockerIT.java).

I discovered that around 4 GiB of Docker Buildx caches can be pruned (via `docker buildx prune -f`) after the `.github/actions/build-platform-docker` step (no new images will be built in later steps) which gives more headroom for the remaining job. The root cause is probably not fixed with this, but it should remove the pain for now.

Successful runs using `docker buildx prune -f`:

* https://github.com/camunda/camunda/actions/runs/20959517638/attempts/1?pr=43928
* https://github.com/camunda/camunda/actions/runs/20959517638/attempts/2?pr=43928
* https://github.com/camunda/camunda/actions/runs/20959517638/job/60237350301?pr=43928

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)) - no as `StartStandaloneCamundaOnRdbmsDockerIT.java` is not on `stable/8.8` nor older branches

## Related issues

None
