### PR TITLE
Optionally delete process instance and process definition history on process definition deletion

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -46,6 +46,7 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
   public void processRecord(final TypedRecord<HistoryDeletionRecord> command) {
     switch (command.getValue().getResourceType()) {
       case PROCESS_INSTANCE -> deleteProcessInstance(command);
+      case PROCESS_DEFINITION -> deleteProcessDefinition(command);
       default ->
           throw new UnsupportedOperationException(
               "Unsupported resource type: " + command.getValue().getResourceType());
@@ -70,6 +71,14 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
             });
+  }
+
+  private void deleteProcessDefinition(final TypedRecord<HistoryDeletionRecord> command) {
+    final var recordValue = command.getValue();
+    stateWriter.appendFollowUpEvent(
+        recordValue.getResourceKey(), HistoryDeletionIntent.DELETED, recordValue);
+    responseWriter.writeEventOnCommand(
+        recordValue.getResourceKey(), HistoryDeletionIntent.DELETED, recordValue, command);
   }
 
   private Either<Rejection, HistoryDeletionRecord> validateProcessInstanceDoesNotExist(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessDefinitionHistoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteProcessDefinitionHistoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteProcessDefinitionHistoryTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeleteProcessDefinitionHistory() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var processDefinitionKey =
+        ENGINE
+            .deployment()
+            .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    // when
+    final var deletedEvent =
+        ENGINE.historyDeletion().processDefinition(processDefinitionKey).delete();
+
+    // then
+    assertThat(deletedEvent.getValue())
+        .hasResourceKey(processDefinitionKey)
+        .hasResourceType(HistoryDeletionType.PROCESS_DEFINITION);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
@@ -42,6 +42,12 @@ public class HistoryDeletionClient {
     return this;
   }
 
+  public HistoryDeletionClient processDefinition(final long processDefinitionKey) {
+    record.setResourceType(HistoryDeletionType.PROCESS_DEFINITION);
+    record.setResourceKey(processDefinitionKey);
+    return this;
+  }
+
   public Record<HistoryDeletionRecordValue> delete() {
     final long position = writer.writeCommand(HistoryDeletionIntent.DELETE, record);
     return expectation.apply(position);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
@@ -47,6 +47,11 @@ public class ResourceDeletionClient {
     return this;
   }
 
+  public ResourceDeletionClient withDeleteHistory(final boolean deleteHistory) {
+    resourceDeletionRecord.setDeleteHistory(deleteHistory);
+    return this;
+  }
+
   public ResourceDeletionClient withAuthorizedTenantIds(final String... tenantIds) {
     authorizedTenantIds = List.of(tenantIds);
     return this;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -91,6 +91,10 @@ public class HistoryDeletionJob implements BackgroundTask {
    */
   private CompletionStage<List<String>> deleteProcessInstances(final HistoryDeletionBatch batch) {
     final var processInstanceKeys = batch.getResourceKeys(HistoryDeletionType.PROCESS_INSTANCE);
+    if (processInstanceKeys.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
     final var deletionFutures =
         processInstanceDependants.stream()
             .filter(t -> !(t instanceof OperationTemplate))
@@ -115,6 +119,9 @@ public class HistoryDeletionJob implements BackgroundTask {
   }
 
   private CompletionStage<Integer> deleteFromHistoryDeletionIndex(final List<String> ids) {
+    if (ids.isEmpty()) {
+      return CompletableFuture.completedFuture(0);
+    }
     return deleterRepository.deleteDocumentsById(historyDeletionIndex.getFullQualifiedName(), ids);
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -188,4 +188,15 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new GlobalListenerBatchRecordStream(
         filter(r -> r.getValueType() == ValueType.GLOBAL_LISTENER_BATCH).map(Record.class::cast));
   }
+
+  public BatchOperationCreationRecordStream batchOperationCreationRecords() {
+    return new BatchOperationCreationRecordStream(
+        filter(r -> r.getValueType() == ValueType.BATCH_OPERATION_CREATION)
+            .map(Record.class::cast));
+  }
+
+  public HistoryDeletionRecordStream historyDeletionRecords() {
+    return new HistoryDeletionRecordStream(
+        filter(r -> r.getValueType() == ValueType.HISTORY_DELETION).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR creates a batch operation on process defintion deletion. This is optionally done, depending on if the `deleteHistory` property is set to true.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #41955
