### PR TITLE
[Backport stable/8.7] ci: disable license checks on fork PRs

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -24,6 +24,8 @@ jobs:
       actions: read
       contents: read
     runs-on: gcp-core-16-default
+    # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     timeout-minutes: 31
     strategy:


### PR DESCRIPTION
# Description
Backport of #43936 to `stable/8.7`.

relates to 