### PR TITLE
[Backport stable/8.8] fix: lastHistoricalArchiverDate state collision causes incorrect archiving

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -53,8 +53,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
@@ -74,7 +76,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
-  private String lastHistoricalArchiverDate = null;
+  private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
 
   public ElasticsearchArchiverRepository(
@@ -417,6 +419,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     }
 
     final String endDate = hits.getFirst().fields().get(field).toJson().asJsonArray().getString(0);
+    final String templateIndexName = templateDescriptor.getIndexName();
+    final String lastHistoricalArchiverDate = lastHistoricalArchiverDates.get(templateIndexName);
 
     final CompletableFuture<String> dateFuture =
         (lastHistoricalArchiverDate == null)
@@ -426,9 +430,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
     return dateFuture.thenApply(
         date -> {
-          lastHistoricalArchiverDate =
+          final String nextArchiverDate =
               DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
                   endDate, date, rolloverInterval, config.getElsRolloverDateFormat());
+
+          lastHistoricalArchiverDates.put(templateIndexName, nextArchiverDate);
 
           final var ids =
               hits.stream()
@@ -443,7 +449,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                   .map(Hit::id)
                   .toList();
 
-          return new ArchiveBatch(lastHistoricalArchiverDate, ids);
+          return new ArchiveBatch(nextArchiverDate, ids);
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -34,8 +34,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
@@ -77,7 +79,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
   private final OpenSearchGenericClient genericClient;
-  private String lastHistoricalArchiverDate = null;
+  private final Map<String, String> lastHistoricalArchiverDates = new ConcurrentHashMap<>();
   private final Cache<String, String> lifeCyclePolicyApplied;
 
   public OpenSearchArchiverRepository(
@@ -528,6 +530,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       return CompletableFuture.completedFuture(new ArchiveBatch(null, List.of()));
     }
     final var endDate = hits.getFirst().fields().get(field).toJson().asJsonArray().getString(0);
+    final String templateIndexName = templateDescriptor.getIndexName();
+    final String lastHistoricalArchiverDate = lastHistoricalArchiverDates.get(templateIndexName);
 
     final CompletableFuture<String> dateFuture;
     try {
@@ -542,9 +546,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     return dateFuture.thenApply(
         date -> {
-          lastHistoricalArchiverDate =
+          final String nextArchiverDate =
               DateOfArchivedDocumentsUtil.calculateDateOfArchiveIndexForBatch(
                   endDate, date, rolloverInterval, config.getElsRolloverDateFormat());
+
+          lastHistoricalArchiverDates.put(templateIndexName, nextArchiverDate);
 
           final var ids =
               hits.stream()
@@ -559,7 +565,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                   .map(Hit::id)
                   .toList();
 
-          return new ArchiveBatch(lastHistoricalArchiverDate, ids);
+          return new ArchiveBatch(nextArchiverDate, ids);
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1124,6 +1124,48 @@ final class ElasticsearchArchiverRepositoryIT {
                     .aliases(standaloneDecisionIndex + "alias", a -> a.isWriteIndex(false)));
   }
 
+  @Test
+  void shouldMaintainSeparateArchiverDatesForDifferentTemplates() throws IOException {
+    // given
+    final var repository = createRepository();
+    config.setRolloverInterval("1d");
+
+    final var piEndDate = "2025-05-02T12:00:00.000+0000";
+    final var pi =
+        new TestProcessInstance(
+            UUID.randomUUID().toString(),
+            piEndDate,
+            ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION,
+            1);
+
+    final var batchOperationEndDate = "2025-01-02T12:00:00.000+0000";
+    final var batchOperation =
+        new TestBatchOperation(UUID.randomUUID().toString(), batchOperationEndDate);
+
+    createProcessInstanceIndex();
+    createBatchOperationIndex();
+
+    // Create historical indices
+    testClient.indices().create(i -> i.index(processInstanceIndex + "_2025-04-30"));
+    testClient.indices().create(i -> i.index(batchOperationIndex + "_2024-12-30"));
+
+    index(processInstanceIndex, pi);
+    index(batchOperationIndex, batchOperation);
+    testClient.indices().refresh(r -> r.index(processInstanceIndex, batchOperationIndex));
+
+    // when
+    // ensure PI batch is processed first to assert that both dates are maintained separately
+    final var piBatch = repository.getProcessInstancesNextBatch().join();
+    final var batchOperationBatch = repository.getBatchOperationsNextBatch().join();
+
+    // then
+    assertThat(piBatch.ids()).isNotEmpty();
+    assertThat(batchOperationBatch.ids()).isNotEmpty();
+
+    assertThat(piBatch.finishDate()).isEqualTo("2025-05-02");
+    assertThat(batchOperationBatch.finishDate()).isEqualTo("2025-01-02");
+  }
+
   private record TestDocument(String id) implements TDocument {}
 
   private record TestBatchOperation(String id, String endDate) implements TDocument {}


### PR DESCRIPTION
# Description
Backport of #43903 to `stable/8.8`.

relates to #43902