### PR TITLE
[Backport stable/8.8] fix: make ZEEBE_CLIENT_SECRET nullable

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -306,8 +306,6 @@ public final class OAuthCredentialsProviderBuilder {
           // if the keystore key alias is not set, apply the first one
           clientAssertionKeystoreKeyAlias = keyStore.aliases().nextElement();
         }
-      } else {
-        Objects.requireNonNull(clientSecret, String.format(INVALID_ARGUMENT_MSG, "client secret"));
       }
       Objects.requireNonNull(audience, String.format(INVALID_ARGUMENT_MSG, "audience"));
       Objects.requireNonNull(

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
@@ -45,21 +45,6 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
-  void shouldFailWithNoClientSecret() {
-    // given
-    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
-
-    // when
-    builder.audience("a").clientId("b").authorizationServerUrl("http://some.url");
-
-    // then
-    assertThatCode(builder::build)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageEndingWith(
-            String.format(OAuthCredentialsProviderBuilder.INVALID_ARGUMENT_MSG, "client secret"));
-  }
-
-  @Test
   void shouldFailWithMalformedServerUrl() {
     // given
     final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -482,8 +482,6 @@ public final class OAuthCredentialsProviderBuilder {
           // if the keystore key alias is not set, apply the first one
           clientAssertionKeystoreKeyAlias = keyStore.aliases().nextElement();
         }
-      } else {
-        Objects.requireNonNull(clientSecret, String.format(INVALID_ARGUMENT_MSG, "client secret"));
       }
       Objects.requireNonNull(audience, String.format(INVALID_ARGUMENT_MSG, "audience"));
       Objects.requireNonNull(

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -47,21 +47,6 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
-  void shouldFailWithNoClientSecret() {
-    // given
-    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
-
-    // when
-    builder.audience("a").clientId("b").authorizationServerUrl("http://some.url");
-
-    // then
-    assertThatCode(builder::build)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageEndingWith(
-            String.format(OAuthCredentialsProviderBuilder.INVALID_ARGUMENT_MSG, "client secret"));
-  }
-
-  @Test
   void shouldFailWithMalformedServerUrl() {
     // given
     final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();


### PR DESCRIPTION
# Description
Backport of #34164 to `stable/8.8`.

relates to camunda/camunda#34002