### PR TITLE
refactor: remove parameterised tests from transformer tests

### DIFF
--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class AuthorizationAuditLogTransformerTest {
 
@@ -28,17 +25,8 @@ class AuthorizationAuditLogTransformerTest {
   private final AuthorizationAuditLogTransformer transformer =
       new AuthorizationAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(AuthorizationIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(AuthorizationIntent.UPDATED, AuditLogOperationType.UPDATE),
-        Arguments.of(AuthorizationIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformAuthorizationRecord(
-      final AuthorizationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformAuthorizationRecord() {
     // given
     final AuthorizationRecordValue recordValue =
         ImmutableAuthorizationRecordValue.builder()
@@ -48,13 +36,14 @@ class AuthorizationAuditLogTransformerTest {
 
     final Record<AuthorizationRecordValue> record =
         factory.generateRecord(
-            ValueType.AUTHORIZATION, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.AUTHORIZATION,
+            r -> r.withIntent(AuthorizationIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
     transformer.transform(record, entity);
 
     // then
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformerTest.java
@@ -18,10 +18,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class BatchOperationCreationAuditLogTransformerTest {
 
@@ -29,14 +26,8 @@ class BatchOperationCreationAuditLogTransformerTest {
   private final BatchOperationCreationAuditLogTransformer transformer =
       new BatchOperationCreationAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(Arguments.of(BatchOperationIntent.CREATED, AuditLogOperationType.CREATE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformBatchOperationCreationRecord(
-      final BatchOperationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformBatchOperationCreationRecord() {
     // given
     final BatchOperationCreationRecordValue recordValue =
         ImmutableBatchOperationCreationRecordValue.builder()
@@ -46,7 +37,8 @@ class BatchOperationCreationAuditLogTransformerTest {
 
     final Record<BatchOperationCreationRecordValue> record =
         factory.generateRecord(
-            ValueType.BATCH_OPERATION_CREATION, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.BATCH_OPERATION_CREATION,
+            r -> r.withIntent(BatchOperationIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -55,6 +47,6 @@ class BatchOperationCreationAuditLogTransformerTest {
     // then
     assertThat(entity.getBatchOperationType())
         .isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class BatchOperationLifecycleManagementAuditLogTransformerTest {
 
@@ -28,20 +25,8 @@ class BatchOperationLifecycleManagementAuditLogTransformerTest {
   private final BatchOperationLifecycleManagementAuditLogTransformer transformer =
       new BatchOperationLifecycleManagementAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(BatchOperationIntent.RESUMED, AuditLogOperationType.RESUME),
-        Arguments.of(BatchOperationIntent.SUSPENDED, AuditLogOperationType.SUSPEND),
-        Arguments.of(BatchOperationIntent.CANCELED, AuditLogOperationType.CANCEL),
-        Arguments.of(BatchOperationIntent.RESUME, AuditLogOperationType.RESUME),
-        Arguments.of(BatchOperationIntent.SUSPEND, AuditLogOperationType.SUSPEND),
-        Arguments.of(BatchOperationIntent.CANCEL, AuditLogOperationType.CANCEL));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformBatchOperationLifecycleRecord(
-      final BatchOperationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformBatchOperationLifecycleRecord() {
     // given
     final BatchOperationLifecycleManagementRecordValue recordValue =
         ImmutableBatchOperationLifecycleManagementRecordValue.builder()
@@ -52,13 +37,13 @@ class BatchOperationLifecycleManagementAuditLogTransformerTest {
     final Record<BatchOperationLifecycleManagementRecordValue> record =
         factory.generateRecord(
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
-            r -> r.withIntent(intent).withValue(recordValue));
+            r -> r.withIntent(BatchOperationIntent.SUSPENDED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
     transformer.transform(record, entity);
 
     // then
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformerTest.java
@@ -17,26 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class DecisionAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final DecisionAuditLogTransformer transformer = new DecisionAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(DecisionIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(DecisionIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformDecisionRecord(
-      final DecisionIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformDecisionRecord() {
     // given
     final DecisionRecordValue recordValue =
         ImmutableDecisionRecordValue.builder()
@@ -51,7 +40,7 @@ class DecisionAuditLogTransformerTest {
 
     final Record<DecisionRecordValue> record =
         factory.generateRecord(
-            ValueType.DECISION, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.DECISION, r -> r.withIntent(DecisionIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -63,6 +52,6 @@ class DecisionAuditLogTransformerTest {
     assertThat(entity.getDecisionDefinitionKey()).isEqualTo(789L);
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("decisionRequirementsId");
     assertThat(entity.getDecisionDefinitionId()).isEqualTo("decisionId");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
@@ -17,27 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class GroupAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final GroupAuditLogTransformer transformer = new GroupAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(GroupIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(GroupIntent.UPDATED, AuditLogOperationType.UPDATE),
-        Arguments.of(GroupIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformGroupRecord(
-      final GroupIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformGroupRecord() {
     // given
     final GroupRecordValue recordValue =
         ImmutableGroupRecordValue.builder()
@@ -47,7 +35,8 @@ class GroupAuditLogTransformerTest {
             .build();
 
     final Record<GroupRecordValue> record =
-        factory.generateRecord(ValueType.GROUP, r -> r.withIntent(intent).withValue(recordValue));
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -55,6 +44,6 @@ class GroupAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-group");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
@@ -17,26 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class GroupEntityAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final GroupEntityAuditLogTransformer transformer = new GroupEntityAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(GroupIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
-        Arguments.of(GroupIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformGroupEntityRecord(
-      final GroupIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformGroupEntityRecord() {
     // given
     final GroupRecordValue recordValue =
         ImmutableGroupRecordValue.builder()
@@ -46,7 +35,8 @@ class GroupEntityAuditLogTransformerTest {
             .build();
 
     final Record<GroupRecordValue> record =
-        factory.generateRecord(ValueType.GROUP, r -> r.withIntent(intent).withValue(recordValue));
+        factory.generateRecord(
+            ValueType.GROUP, r -> r.withIntent(GroupIntent.ENTITY_ADDED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -54,6 +44,6 @@ class GroupEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-group");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class IncidentResolutionAuditLogTransformerTest {
 
@@ -28,16 +25,8 @@ class IncidentResolutionAuditLogTransformerTest {
   private final IncidentResolutionAuditLogTransformer transformer =
       new IncidentResolutionAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMapping() {
-    return Stream.of(
-        Arguments.of(IncidentIntent.RESOLVED, AuditLogOperationType.RESOLVE),
-        Arguments.of(IncidentIntent.RESOLVE, AuditLogOperationType.RESOLVE));
-  }
-
-  @ParameterizedTest(name = "Should map intent: {0} to operationType: {1}")
-  @MethodSource("getIntentMapping")
-  void shouldTransformIncidentResolutionRecord(
-      final IncidentIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformIncidentResolutionRecord() {
     // given
     final IncidentRecordValue recordValue =
         ImmutableIncidentRecordValue.builder()
@@ -52,7 +41,7 @@ class IncidentResolutionAuditLogTransformerTest {
 
     final Record<IncidentRecordValue> record =
         factory.generateRecord(
-            ValueType.INCIDENT, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -64,7 +53,7 @@ class IncidentResolutionAuditLogTransformerTest {
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
     assertThat(entity.getElementInstanceKey()).isEqualTo(789L);
     assertThat(entity.getJobKey()).isEqualTo(222L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.RESOLVE);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
@@ -17,27 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableMappingRuleRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class MappingRuleAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final MappingRuleAuditLogTransformer transformer = new MappingRuleAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(MappingRuleIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(MappingRuleIntent.UPDATED, AuditLogOperationType.UPDATE),
-        Arguments.of(MappingRuleIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformMappingRuleRecord(
-      final MappingRuleIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformMappingRuleRecord() {
     // given
     final MappingRuleRecordValue recordValue =
         ImmutableMappingRuleRecordValue.builder()
@@ -51,7 +39,8 @@ class MappingRuleAuditLogTransformerTest {
 
     final Record<MappingRuleRecordValue> record =
         factory.generateRecord(
-            ValueType.MAPPING_RULE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.MAPPING_RULE,
+            r -> r.withIntent(MappingRuleIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -59,6 +48,6 @@ class MappingRuleAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("mapping-rule-1");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class ProcessInstanceCancelAuditLogTransformerTest {
 
@@ -28,16 +25,8 @@ class ProcessInstanceCancelAuditLogTransformerTest {
   private final ProcessInstanceCancelAuditLogTransformer transformer =
       new ProcessInstanceCancelAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(ProcessInstanceIntent.CANCELING, AuditLogOperationType.CANCEL),
-        Arguments.of(ProcessInstanceIntent.CANCEL, AuditLogOperationType.CANCEL));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformProcessInstanceCancelRecord(
-      final ProcessInstanceIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformProcessInstanceCancelRecord() {
     // given
     final ProcessInstanceRecordValue recordValue =
         ImmutableProcessInstanceRecordValue.builder()
@@ -50,7 +39,8 @@ class ProcessInstanceCancelAuditLogTransformerTest {
 
     final Record<ProcessInstanceRecordValue> record =
         factory.generateRecord(
-            ValueType.PROCESS_INSTANCE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(ProcessInstanceIntent.CANCEL).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -60,7 +50,7 @@ class ProcessInstanceCancelAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmn-process-id");
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CANCEL);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreatedAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class ProcessInstanceCreatedAuditLogTransformerTest {
 
@@ -28,15 +25,8 @@ class ProcessInstanceCreatedAuditLogTransformerTest {
   private final ProcessInstanceCreationAuditLogTransformer transformer =
       new ProcessInstanceCreationAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(ProcessInstanceCreationIntent.CREATED, AuditLogOperationType.CREATE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformProcessInstanceCreationRecord(
-      final ProcessInstanceCreationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformProcessInstanceCreationRecord() {
     // given
     final ProcessInstanceCreationRecordValue recordValue =
         ImmutableProcessInstanceCreationRecordValue.builder()
@@ -49,7 +39,8 @@ class ProcessInstanceCreatedAuditLogTransformerTest {
 
     final Record<ProcessInstanceCreationRecordValue> record =
         factory.generateRecord(
-            ValueType.PROCESS_INSTANCE_CREATION, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r -> r.withIntent(ProcessInstanceCreationIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -59,7 +50,7 @@ class ProcessInstanceCreatedAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(456L);
     assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class ProcessInstanceMigrationAuditLogTransformerTest {
 
@@ -28,16 +25,8 @@ class ProcessInstanceMigrationAuditLogTransformerTest {
   private final ProcessInstanceMigrationAuditLogTransformer transformer =
       new ProcessInstanceMigrationAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(ProcessInstanceMigrationIntent.MIGRATED, AuditLogOperationType.MIGRATE),
-        Arguments.of(ProcessInstanceMigrationIntent.MIGRATE, AuditLogOperationType.MIGRATE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformProcessInstanceMigrationRecord(
-      final ProcessInstanceMigrationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformProcessInstanceMigrationRecord() {
     // given
     final ProcessInstanceMigrationRecordValue recordValue =
         ImmutableProcessInstanceMigrationRecordValue.builder()
@@ -49,7 +38,8 @@ class ProcessInstanceMigrationAuditLogTransformerTest {
 
     final Record<ProcessInstanceMigrationRecordValue> record =
         factory.generateRecord(
-            ValueType.PROCESS_INSTANCE_MIGRATION, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.PROCESS_INSTANCE_MIGRATION,
+            r -> r.withIntent(ProcessInstanceMigrationIntent.MIGRATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -58,7 +48,7 @@ class ProcessInstanceMigrationAuditLogTransformerTest {
     // then
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.MIGRATE);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModifiedAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModifiedAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class ProcessInstanceModifiedAuditLogTransformerTest {
 
@@ -28,15 +25,8 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
   private final ProcessInstanceModificationAuditLogTransformer transformer =
       new ProcessInstanceModificationAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(ProcessInstanceModificationIntent.MODIFIED, AuditLogOperationType.MODIFY));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformProcessInstanceModificationRecord(
-      final ProcessInstanceModificationIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformProcessInstanceModificationRecord() {
     // given
     final ProcessInstanceModificationRecordValue recordValue =
         ImmutableProcessInstanceModificationRecordValue.builder()
@@ -48,7 +38,7 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
     final Record<ProcessInstanceModificationRecordValue> record =
         factory.generateRecord(
             ValueType.PROCESS_INSTANCE_MODIFICATION,
-            r -> r.withIntent(intent).withValue(recordValue));
+            r -> r.withIntent(ProcessInstanceModificationIntent.MODIFIED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -56,7 +46,7 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
 
     // then
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.MODIFY);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantAuditLogTransformerTest.java
@@ -17,27 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class TenantAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final TenantAuditLogTransformer transformer = new TenantAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(TenantIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(TenantIntent.UPDATED, AuditLogOperationType.UPDATE),
-        Arguments.of(TenantIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformTenantRecord(
-      final TenantIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformTenantRecord() {
     // given
     final TenantRecordValue recordValue =
         ImmutableTenantRecordValue.builder()
@@ -47,7 +35,8 @@ class TenantAuditLogTransformerTest {
             .build();
 
     final Record<TenantRecordValue> record =
-        factory.generateRecord(ValueType.TENANT, r -> r.withIntent(intent).withValue(recordValue));
+        factory.generateRecord(
+            ValueType.TENANT, r -> r.withIntent(TenantIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -55,6 +44,6 @@ class TenantAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
@@ -17,26 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class TenantEntityAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final TenantEntityAuditLogTransformer transformer = new TenantEntityAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(TenantIntent.ENTITY_ADDED, AuditLogOperationType.ASSIGN),
-        Arguments.of(TenantIntent.ENTITY_REMOVED, AuditLogOperationType.UNASSIGN));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformTenantEntityRecord(
-      final TenantIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformTenantEntityRecord() {
     // given
     final TenantRecordValue recordValue =
         ImmutableTenantRecordValue.builder()
@@ -46,7 +35,8 @@ class TenantEntityAuditLogTransformerTest {
             .build();
 
     final Record<TenantRecordValue> record =
-        factory.generateRecord(ValueType.TENANT, r -> r.withIntent(intent).withValue(recordValue));
+        factory.generateRecord(
+            ValueType.TENANT, r -> r.withIntent(TenantIntent.ENTITY_ADDED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -54,6 +44,6 @@ class TenantEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserAuditLogTransformerTest.java
@@ -17,27 +17,15 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableUserRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class UserAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final UserAuditLogTransformer transformer = new UserAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(UserIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(UserIntent.UPDATED, AuditLogOperationType.UPDATE),
-        Arguments.of(UserIntent.DELETED, AuditLogOperationType.DELETE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformUserRecord(
-      final UserIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformUserRecord() {
     // given
     final UserRecordValue recordValue =
         ImmutableUserRecordValue.builder()
@@ -47,7 +35,8 @@ class UserAuditLogTransformerTest {
             .build();
 
     final Record<UserRecordValue> record =
-        factory.generateRecord(ValueType.USER, r -> r.withIntent(intent).withValue(recordValue));
+        factory.generateRecord(
+            ValueType.USER, r -> r.withIntent(UserIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -55,6 +44,6 @@ class UserAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("testuser");
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
@@ -17,10 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class VariableAddUpdateAuditLogTransformerTest {
 
@@ -28,16 +25,8 @@ class VariableAddUpdateAuditLogTransformerTest {
   private final VariableAddUpdateAuditLogTransformer transformer =
       new VariableAddUpdateAuditLogTransformer();
 
-  public static Stream<Arguments> getIntentMappings() {
-    return Stream.of(
-        Arguments.of(VariableIntent.CREATED, AuditLogOperationType.CREATE),
-        Arguments.of(VariableIntent.UPDATED, AuditLogOperationType.UPDATE));
-  }
-
-  @MethodSource("getIntentMappings")
-  @ParameterizedTest
-  void shouldTransformVariableRecord(
-      final VariableIntent intent, final AuditLogOperationType operationType) {
+  @Test
+  void shouldTransformVariableRecord() {
     // given
     final VariableRecordValue recordValue =
         ImmutableVariableRecordValue.builder()
@@ -51,7 +40,7 @@ class VariableAddUpdateAuditLogTransformerTest {
 
     final Record<VariableRecordValue> record =
         factory.generateRecord(
-            ValueType.VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -62,6 +51,6 @@ class VariableAddUpdateAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmn-process-id");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
     assertThat(entity.getElementInstanceKey()).isEqualTo(789L);
-    assertThat(entity.getOperationType()).isEqualTo(operationType);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Parameterised tests are no longer needed to cover the `AuditLogInfo` intent mapping checks. A single intent mapping is sufficient to test the audit log transformers. This PR removes the parameterised tests that was originally written into the transformer tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43848
