### PR TITLE
fix: validate conflicting pagination requests

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/SearchQueryPageRequestDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/SearchQueryPageRequestDeserializer.java
@@ -55,7 +55,8 @@ public class SearchQueryPageRequestDeserializer
       throw new DeserializationException(
           ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(getSupportedFields()));
     }
-    if (!presentFields.contains(LIMIT_PAGINATION_FIELD) && presentFields.size() > 1) {
+    if ((!presentFields.contains(LIMIT_PAGINATION_FIELD) && presentFields.size() > 1)
+        || presentFields.contains(LIMIT_PAGINATION_FIELD) && presentFields.size() > 2) {
       throw new DeserializationException(
           ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(getErrorMessageParam()));
     }


### PR DESCRIPTION
## Description

Validates pagination in V2 REST search requests regarding conflicting properties when limit is included.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43977 
