### PR TITLE
Introduce `GLOBAL_LISTENER` record

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
@@ -10,15 +10,27 @@ package io.camunda.zeebe.broker.system.configuration.engine;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.GlobalListenerConfiguration;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import java.util.ArrayList;
 import java.util.List;
 
 public class GlobalListenerCfg implements ConfigurationEntry {
 
+  private String id;
   private List<String> eventTypes = new ArrayList<>();
   private String type;
   private String retries = String.valueOf(GlobalListenerRecord.DEFAULT_RETRIES);
   private boolean afterNonGlobal = false;
+  private int priority = GlobalListenerRecord.DEFAULT_PRIORITY;
+  private GlobalListenerType listenerType = GlobalListenerType.USER_TASK;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
 
   public List<String> getEventTypes() {
     return eventTypes;
@@ -52,7 +64,24 @@ public class GlobalListenerCfg implements ConfigurationEntry {
     this.afterNonGlobal = afterNonGlobal;
   }
 
+  public int getPriority() {
+    return priority;
+  }
+
+  public void setPriority(final int priority) {
+    this.priority = priority;
+  }
+
+  public GlobalListenerType getListenerType() {
+    return listenerType;
+  }
+
+  public void setListenerType(final GlobalListenerType listenerType) {
+    this.listenerType = listenerType;
+  }
+
   public GlobalListenerConfiguration createGlobalListenerConfiguration() {
-    return new GlobalListenerConfiguration(eventTypes, type, retries, afterNonGlobal);
+    return new GlobalListenerConfiguration(
+        id, eventTypes, type, retries, afterNonGlobal, priority, listenerType);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -925,6 +925,7 @@ final class SystemContextTest {
 
   private GlobalListenerCfg createListenerCfg(final String type, final List<String> eventTypes) {
     final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
+    listenerCfg.setId("GlobalListener_" + type);
     listenerCfg.setType(type);
     listenerCfg.setEventTypes(eventTypes);
     return listenerCfg;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
@@ -8,11 +8,18 @@
 package io.camunda.zeebe.engine;
 
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import java.util.List;
 import java.util.stream.Stream;
 
 public record GlobalListenerConfiguration(
-    List<String> eventTypes, String type, String retries, boolean afterNonGlobal) {
+    String id,
+    List<String> eventTypes,
+    String type,
+    String retries,
+    boolean afterNonGlobal,
+    int priority,
+    GlobalListenerType listenerType) {
 
   public static final String ALL_EVENT_TYPES = "all";
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -376,7 +376,8 @@ public final class EngineProcessors {
         writers,
         commandDistributionBehavior,
         config,
-        processingState);
+        processingState,
+        authCheckBehavior);
 
     ExpressionProcessors.addProcessors(
         keyGenerator,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+
+@ExcludeAuthorizationCheck
+public final class GlobalListenerCreateProcessor
+    implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final Writers writers;
+  private final CommandDistributionBehavior distributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final GlobalListenersState globalListenersState;
+
+  public GlobalListenerCreateProcessor(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ProcessingState processingState) {
+    this.keyGenerator = keyGenerator;
+    this.writers = writers;
+    this.distributionBehavior = distributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
+    globalListenersState = processingState.getGlobalListenersState();
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<GlobalListenerRecord> command) {
+    final var validRecord = validateCommand(command);
+    if (validRecord.isLeft()) {
+      final var rejection = validRecord.getLeft();
+      writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
+      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    final long key = keyGenerator.nextKey();
+    writers.state().appendFollowUpEvent(key, GlobalListenerIntent.CREATED, validRecord.get());
+
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.GLOBAL_LISTENERS.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<GlobalListenerRecord> command) {
+    writers
+        .state()
+        .appendFollowUpEvent(command.getKey(), GlobalListenerIntent.CREATED, command.getValue());
+    distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private Either<Rejection, GlobalListenerRecord> validateCommand(
+      final TypedRecord<GlobalListenerRecord> command) {
+    return Either.right(command.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+
+@ExcludeAuthorizationCheck
+public final class GlobalListenerDeleteProcessor
+    implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final Writers writers;
+  private final CommandDistributionBehavior distributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final GlobalListenersState globalListenersState;
+
+  public GlobalListenerDeleteProcessor(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ProcessingState processingState) {
+    this.keyGenerator = keyGenerator;
+    this.writers = writers;
+    this.distributionBehavior = distributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
+    globalListenersState = processingState.getGlobalListenersState();
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<GlobalListenerRecord> command) {
+    final var validRecord = validateCommand(command);
+    if (validRecord.isLeft()) {
+      final var rejection = validRecord.getLeft();
+      writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
+      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    final long key = keyGenerator.nextKey();
+    writers.state().appendFollowUpEvent(key, GlobalListenerIntent.DELETED, validRecord.get());
+
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.GLOBAL_LISTENERS.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<GlobalListenerRecord> command) {
+    writers
+        .state()
+        .appendFollowUpEvent(command.getKey(), GlobalListenerIntent.DELETED, command.getValue());
+    distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private Either<Rejection, GlobalListenerRecord> validateCommand(
+      final TypedRecord<GlobalListenerRecord> command) {
+    return Either.right(command.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+
+@ExcludeAuthorizationCheck
+public final class GlobalListenerUpdateProcessor
+    implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final Writers writers;
+  private final CommandDistributionBehavior distributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final GlobalListenersState globalListenersState;
+
+  public GlobalListenerUpdateProcessor(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ProcessingState processingState) {
+    this.keyGenerator = keyGenerator;
+    this.writers = writers;
+    this.distributionBehavior = distributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
+    globalListenersState = processingState.getGlobalListenersState();
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<GlobalListenerRecord> command) {
+    final var validRecord = validateCommand(command);
+    if (validRecord.isLeft()) {
+      final var rejection = validRecord.getLeft();
+      writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
+      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      return;
+    }
+
+    final long key = keyGenerator.nextKey();
+    writers.state().appendFollowUpEvent(key, GlobalListenerIntent.UPDATED, validRecord.get());
+
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.GLOBAL_LISTENERS.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<GlobalListenerRecord> command) {
+    writers
+        .state()
+        .appendFollowUpEvent(command.getKey(), GlobalListenerIntent.UPDATED, command.getValue());
+    distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private Either<Rejection, GlobalListenerRecord> validateCommand(
+      final TypedRecord<GlobalListenerRecord> command) {
+    return Either.right(command.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.util.Objects;
@@ -82,10 +83,14 @@ public final class GlobalListenersInitializer implements StreamProcessorLifecycl
         .map(
             listener ->
                 new GlobalListenerRecord()
+                    .setId(listener.id())
                     .setType(listener.type())
                     .setEventTypes(listener.eventTypes())
                     .setRetries(Integer.parseInt(listener.retries()))
-                    .setAfterNonGlobal(listener.afterNonGlobal()))
+                    .setAfterNonGlobal(listener.afterNonGlobal())
+                    .setPriority(listener.priority())
+                    .setSource(GlobalListenerSource.CONFIGURATION)
+                    .setListenerType(listener.listenerType()))
         .forEach(record::addTaskListener);
     return record;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersProcessors.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.engine.processing.globallistener;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class GlobalListenersProcessors {
@@ -23,12 +25,28 @@ public class GlobalListenersProcessors {
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
       final EngineConfiguration engineConfiguration,
-      final ProcessingState processingState) {
+      final ProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     typedRecordProcessors
         .onCommand(
             ValueType.GLOBAL_LISTENER_BATCH,
             GlobalListenerBatchIntent.CONFIGURE,
             new GlobalListenerBatchConfigureProcessor(keyGenerator, writers, distributionBehavior))
+        .onCommand(
+            ValueType.GLOBAL_LISTENER,
+            GlobalListenerIntent.CREATE,
+            new GlobalListenerCreateProcessor(
+                keyGenerator, writers, distributionBehavior, authCheckBehavior, processingState))
+        .onCommand(
+            ValueType.GLOBAL_LISTENER,
+            GlobalListenerIntent.UPDATE,
+            new GlobalListenerUpdateProcessor(
+                keyGenerator, writers, distributionBehavior, authCheckBehavior, processingState))
+        .onCommand(
+            ValueType.GLOBAL_LISTENER,
+            GlobalListenerIntent.DELETE,
+            new GlobalListenerDeleteProcessor(
+                keyGenerator, writers, distributionBehavior, authCheckBehavior, processingState))
         .withListener(new GlobalListenersInitializer(engineConfiguration, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
@@ -188,6 +189,9 @@ public final class EventAppliers implements EventApplier {
 
   private void registerGlobalListenersEventAppliers(final MutableProcessingState state) {
     register(GlobalListenerBatchIntent.CONFIGURED, new GlobalListenerBatchConfiguredApplier(state));
+    register(GlobalListenerIntent.CREATED, NOOP_EVENT_APPLIER);
+    register(GlobalListenerIntent.UPDATED, NOOP_EVENT_APPLIER);
+    register(GlobalListenerIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClusterVariableEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -746,7 +746,10 @@ public class CommandDistributionIdempotencyTest {
                     ENGINE
                         .globalListenerBatch()
                         .withTaskListener(
-                            new GlobalListenerRecord().setType("global1").addEventType("all"))
+                            new GlobalListenerRecord()
+                                .setId("GlobalListener_global1")
+                                .setType("global1")
+                                .addEventType("all"))
                         .configure()),
             GlobalListenerBatchConfigureProcessor.class
           },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializationTest.java
@@ -30,9 +30,14 @@ public class GlobalListenersInitializationTest {
     // given a global listener batch record containing the desired configuration
     final GlobalListenerBatchRecord record =
         new GlobalListenerBatchRecord()
-            .addTaskListener(new GlobalListenerRecord().setType("global1").addEventType("all"))
             .addTaskListener(
                 new GlobalListenerRecord()
+                    .setId("GlobalListener_global1")
+                    .setType("global1")
+                    .addEventType("all"))
+            .addTaskListener(
+                new GlobalListenerRecord()
+                    .setId("GlobalListener_global2")
                     .setType("global2")
                     .addEventType("creating")
                     .addEventType("completing")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskPinningLogicTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskPinningLogicTest.java
@@ -203,6 +203,7 @@ public class UserTaskPinningLogicTest {
     for (int i = 0; i < numberOfListeners; i++) {
       record.addTaskListener(
           new GlobalListenerRecord()
+              .setId("GlobalListener_" + i)
               .setType("global" + i)
               .setEventTypes(List.of("creating", "assigning"))
               .setRetries(i)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/globallistener/GlobalListenersStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/globallistener/GlobalListenersStateTest.java
@@ -162,6 +162,7 @@ public class GlobalListenersStateTest {
     for (int i = 0; i < numberOfListeners; i++) {
       record.addTaskListener(
           new GlobalListenerRecord()
+              .setId("GlobalListener_" + i)
               .setType("global" + i)
               .setEventTypes(List.of("creating", "assigning"))
               .setRetries(i)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.ExpressionClient;
 import io.camunda.zeebe.engine.util.client.GlobalListenerBatchClient;
+import io.camunda.zeebe.engine.util.client.GlobalListenerClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
 import io.camunda.zeebe.engine.util.client.HistoryDeletionClient;
 import io.camunda.zeebe.engine.util.client.IdentitySetupClient;
@@ -753,6 +754,10 @@ public final class EngineRule extends ExternalResource {
 
   public GlobalListenerBatchClient globalListenerBatch() {
     return new GlobalListenerBatchClient(environmentRule);
+  }
+
+  public GlobalListenerClient globalListener() {
+    return new GlobalListenerClient(environmentRule);
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.BiFunction;
+
+public final class GlobalListenerClient {
+
+  private static final BiFunction<Long, GlobalListenerIntent, Record<GlobalListenerRecordValue>>
+      SUCCESS_SUPPLIER =
+          (sourceRecordPosition, intent) ->
+              RecordingExporter.globalListenerRecords()
+                  .withIntent(intent)
+                  .withSourceRecordPosition(sourceRecordPosition)
+                  .getFirst();
+  private static final BiFunction<Long, GlobalListenerIntent, Record<GlobalListenerRecordValue>>
+      REJECTION_SUPPLIER =
+          (sourceRecordPosition, intent) ->
+              RecordingExporter.globalListenerRecords()
+                  .onlyCommandRejections()
+                  .withSourceRecordPosition(sourceRecordPosition)
+                  .getFirst();
+
+  private final GlobalListenerRecord globalListenerRecord;
+  private final CommandWriter writer;
+  private BiFunction<Long, GlobalListenerIntent, Record<GlobalListenerRecordValue>> expectation =
+      SUCCESS_SUPPLIER;
+
+  public GlobalListenerClient(final CommandWriter writer) {
+    globalListenerRecord = new GlobalListenerRecord();
+    this.writer = writer;
+  }
+
+  public GlobalListenerClient withId(final String id) {
+    globalListenerRecord.setId(id);
+    return this;
+  }
+
+  public GlobalListenerClient withType(final String type) {
+    globalListenerRecord.setType(type);
+    return this;
+  }
+
+  public GlobalListenerClient withRetries(final int retries) {
+    globalListenerRecord.setRetries(retries);
+    return this;
+  }
+
+  public GlobalListenerClient withEventType(final String eventType) {
+    globalListenerRecord.addEventType(eventType);
+    return this;
+  }
+
+  public GlobalListenerClient withAfterNonGlobal(final boolean afterNonGlobal) {
+    globalListenerRecord.setAfterNonGlobal(afterNonGlobal);
+    return this;
+  }
+
+  public GlobalListenerClient afterNonGlobal() {
+    return withAfterNonGlobal(true);
+  }
+
+  public GlobalListenerClient beforeNonGlobal() {
+    return withAfterNonGlobal(false);
+  }
+
+  public GlobalListenerClient withPriority(final int priority) {
+    globalListenerRecord.setPriority(priority);
+    return this;
+  }
+
+  public GlobalListenerClient withSource(final GlobalListenerSource source) {
+    globalListenerRecord.setSource(source);
+    return this;
+  }
+
+  public GlobalListenerClient withListenerType(final GlobalListenerType listenerType) {
+    globalListenerRecord.setListenerType(listenerType);
+    return this;
+  }
+
+  public GlobalListenerClient expectRejection() {
+    expectation = REJECTION_SUPPLIER;
+    return this;
+  }
+
+  public Record<GlobalListenerRecordValue> create() {
+    final long position = writer.writeCommand(GlobalListenerIntent.CREATE, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.CREATED);
+  }
+
+  public Record<GlobalListenerRecordValue> update() {
+    final long position = writer.writeCommand(GlobalListenerIntent.UPDATE, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.UPDATED);
+  }
+
+  public Record<GlobalListenerRecordValue> delete() {
+    final long position = writer.writeCommand(GlobalListenerIntent.DELETE, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.DELETED);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -234,8 +234,8 @@ public class ElasticsearchExporterConfiguration {
     public boolean conditionalSubscription = false;
     public boolean conditionalEvaluation = false;
 
-    public boolean globalListenerBatch = false;
-    public boolean globalListener = false;
+    public boolean globalListenerBatch = true;
+    public boolean globalListener = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -112,6 +112,7 @@ public class ElasticsearchExporterConfiguration {
       case CONDITIONAL_SUBSCRIPTION -> index.conditionalSubscription;
       case CONDITIONAL_EVALUATION -> index.conditionalEvaluation;
       case GLOBAL_LISTENER_BATCH -> index.globalListenerBatch;
+      case GLOBAL_LISTENER -> index.globalListener;
       default -> false;
     };
   }
@@ -234,6 +235,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean conditionalEvaluation = false;
 
     public boolean globalListenerBatch = false;
+    public boolean globalListener = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -199,6 +199,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.globalListenerBatch) {
         createValueIndexTemplate(ValueType.GLOBAL_LISTENER_BATCH, version);
       }
+      if (index.globalListener) {
+        createValueIndexTemplate(ValueType.GLOBAL_LISTENER, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -46,6 +46,9 @@
                 },
                 "source": {
                   "type": "keyword"
+                },
+                "listenerType": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -26,6 +26,9 @@
               "type": "nested",
               "dynamic": "strict",
               "properties": {
+                "id": {
+                  "type": "keyword"
+                },
                 "type": {
                   "type": "keyword"
                 },
@@ -37,6 +40,12 @@
                 },
                 "afterNonGlobal": {
                   "type": "boolean"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "source": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -19,6 +19,9 @@
         "value": {
           "dynamic": "strict",
           "properties": {
+            "id": {
+              "type": "keyword"
+            },
             "type": {
               "type": "keyword"
             },
@@ -30,6 +33,12 @@
             },
             "afterNonGlobal": {
               "type": "boolean"
+            },
+            "priority": {
+              "type": "integer"
+            },
+            "source": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -1,0 +1,39 @@
+{
+  "index_patterns": [
+    "zeebe-record_global-listener_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-global-listener": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "retries": {
+              "type": "integer"
+            },
+            "eventTypes": {
+              "type": "keyword"
+            },
+            "afterNonGlobal": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -39,6 +39,9 @@
             },
             "source": {
               "type": "keyword"
+            },
+            "listenerType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -79,6 +79,7 @@ final class TestSupport {
       case CONDITIONAL_SUBSCRIPTION -> config.conditionalSubscription = value;
       case CONDITIONAL_EVALUATION -> config.conditionalEvaluation = value;
       case GLOBAL_LISTENER_BATCH -> config.globalListenerBatch = value;
+      case GLOBAL_LISTENER -> config.globalListener = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -111,6 +111,7 @@ public class OpensearchExporterConfiguration {
       case CONDITIONAL_SUBSCRIPTION -> index.conditionalSubscription;
       case CONDITIONAL_EVALUATION -> index.conditionalEvaluation;
       case GLOBAL_LISTENER_BATCH -> index.globalListenerBatch;
+      case GLOBAL_LISTENER -> index.globalListener;
       default -> false;
     };
   }
@@ -225,6 +226,7 @@ public class OpensearchExporterConfiguration {
     public boolean conditionalEvaluation = false;
 
     public boolean globalListenerBatch = false;
+    public boolean globalListener = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -225,8 +225,8 @@ public class OpensearchExporterConfiguration {
     public boolean conditionalSubscription = false;
     public boolean conditionalEvaluation = false;
 
-    public boolean globalListenerBatch = false;
-    public boolean globalListener = false;
+    public boolean globalListenerBatch = true;
+    public boolean globalListener = true;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -174,6 +174,9 @@ public class OpensearchExporterSchemaManager {
       if (index.globalListenerBatch) {
         createValueIndexTemplate(ValueType.GLOBAL_LISTENER_BATCH, version);
       }
+      if (index.globalListener) {
+        createValueIndexTemplate(ValueType.GLOBAL_LISTENER, version);
+      }
     }
 
     indexTemplatesCreated.add(version);

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -46,6 +46,9 @@
                 },
                 "source": {
                   "type": "keyword"
+                },
+                "listenerType": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -26,6 +26,9 @@
               "type": "nested",
               "dynamic": "strict",
               "properties": {
+                "id": {
+                  "type": "keyword"
+                },
                 "type": {
                   "type": "keyword"
                 },
@@ -37,6 +40,12 @@
                 },
                 "afterNonGlobal": {
                   "type": "boolean"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "source": {
+                  "type": "keyword"
                 }
               }
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -19,6 +19,9 @@
         "value": {
           "dynamic": "strict",
           "properties": {
+            "id": {
+              "type": "keyword"
+            },
             "type": {
               "type": "keyword"
             },
@@ -30,6 +33,12 @@
             },
             "afterNonGlobal": {
               "type": "boolean"
+            },
+            "priority": {
+              "type": "integer"
+            },
+            "source": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -1,0 +1,39 @@
+{
+  "index_patterns": [
+    "zeebe-record_global-listener_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-global-listener": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "retries": {
+              "type": "integer"
+            },
+            "eventTypes": {
+              "type": "keyword"
+            },
+            "afterNonGlobal": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -39,6 +39,9 @@
             },
             "source": {
               "type": "keyword"
+            },
+            "listenerType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -80,6 +80,7 @@ final class TestSupport {
       case CONDITIONAL_SUBSCRIPTION -> config.conditionalSubscription = value;
       case CONDITIONAL_EVALUATION -> config.conditionalEvaluation = value;
       case GLOBAL_LISTENER_BATCH -> config.globalListenerBatch = value;
+      case GLOBAL_LISTENER -> config.globalListener = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -211,6 +212,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.MESSAGE_SUBSCRIPTION -> new MessageSubscriptionRecord();
       case ValueType.GLOBAL_LISTENER_BATCH -> new GlobalListenerBatchRecord();
       case ValueType.JOB_METRICS_BATCH -> new JobMetricsBatchRecord();
+      case ValueType.GLOBAL_LISTENER -> new GlobalListenerRecord();
       case ValueType.SBE_UNKNOWN -> null;
       case ValueType.NULL_VAL -> null;
     };

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
@@ -86,6 +87,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE, BatchOperationPartitionLifecycleRecord::new);
     RECORDS_BY_TYPE.put(ValueType.CLUSTER_VARIABLE, ClusterVariableRecord::new);
     RECORDS_BY_TYPE.put(ValueType.GLOBAL_LISTENER_BATCH, GlobalListenerBatchRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.GLOBAL_LISTENER, GlobalListenerRecord::new);
   }
 
   private final IntegerProperty partitionIdProperty = new IntegerProperty(PARTITION_ID_KEY);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -11,11 +11,13 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,20 +27,37 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
     implements GlobalListenerRecordValue {
 
   public static final int DEFAULT_RETRIES = 3;
-  private static final String EMPTY_STRING = "";
+  public static final int DEFAULT_PRIORITY = 50;
 
-  private final StringProperty typeProp = new StringProperty("type", EMPTY_STRING);
+  private final StringProperty idProp = new StringProperty("id", "");
+  private final StringProperty typeProp = new StringProperty("type", "");
   private final IntegerProperty retriesProp = new IntegerProperty("retries", DEFAULT_RETRIES);
   private final ArrayProperty<StringValue> eventTypesProp =
       new ArrayProperty<>("eventTypes", StringValue::new);
   private final BooleanProperty afterNonGlobalProp = new BooleanProperty("afterNonGlobal", false);
+  private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
+  private final EnumProperty<GlobalListenerSource> sourceProp =
+      new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
 
   public GlobalListenerRecord() {
-    super(4);
-    declareProperty(typeProp)
+    super(7);
+    declareProperty(idProp)
+        .declareProperty(typeProp)
         .declareProperty(retriesProp)
         .declareProperty(eventTypesProp)
-        .declareProperty(afterNonGlobalProp);
+        .declareProperty(afterNonGlobalProp)
+        .declareProperty(priorityProp)
+        .declareProperty(sourceProp);
+  }
+
+  @Override
+  public String getId() {
+    return bufferAsString(idProp.getValue());
+  }
+
+  public GlobalListenerRecord setId(final String id) {
+    idProp.setValue(id);
+    return this;
   }
 
   @Override
@@ -82,6 +101,26 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setAfterNonGlobal(final boolean afterNonGlobal) {
     afterNonGlobalProp.setValue(afterNonGlobal);
+    return this;
+  }
+
+  @Override
+  public int getPriority() {
+    return priorityProp.getValue();
+  }
+
+  public GlobalListenerRecord setPriority(final int priority) {
+    priorityProp.setValue(priority);
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSource getSource() {
+    return sourceProp.getValue();
+  }
+
+  public GlobalListenerRecord setSource(final GlobalListenerSource source) {
+    sourceProp.setValue(source);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -25,8 +25,9 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
     implements GlobalListenerRecordValue {
 
   public static final int DEFAULT_RETRIES = 3;
+  private static final String EMPTY_STRING = "";
 
-  private final StringProperty typeProp = new StringProperty("type");
+  private final StringProperty typeProp = new StringProperty("type", EMPTY_STRING);
   private final IntegerProperty retriesProp = new IntegerProperty("retries", DEFAULT_RETRIES);
   private final ArrayProperty<StringValue> eventTypesProp =
       new ArrayProperty<>("eventTypes", StringValue::new);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,16 +39,19 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
   private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
   private final EnumProperty<GlobalListenerSource> sourceProp =
       new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
+  private final EnumProperty<GlobalListenerType> listenerTypeProp =
+      new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
 
   public GlobalListenerRecord() {
-    super(7);
+    super(8);
     declareProperty(idProp)
         .declareProperty(typeProp)
         .declareProperty(retriesProp)
         .declareProperty(eventTypesProp)
         .declareProperty(afterNonGlobalProp)
         .declareProperty(priorityProp)
-        .declareProperty(sourceProp);
+        .declareProperty(sourceProp)
+        .declareProperty(listenerTypeProp);
   }
 
   @Override
@@ -121,6 +125,16 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setSource(final GlobalListenerSource source) {
     sourceProp.setValue(source);
+    return this;
+  }
+
+  @Override
+  public GlobalListenerType getListenerType() {
+    return listenerTypeProp.getValue();
+  }
+
+  public GlobalListenerRecord setListenerType(final GlobalListenerType listenerType) {
+    listenerTypeProp.setValue(listenerType);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4337,7 +4337,8 @@ final class JsonSerializableToJsonTest {
             "eventTypes": ["creating", "assigning"],
             "afterNonGlobal": false,
             "priority": 50,
-            "source": "CONFIGURATION"
+            "source": "CONFIGURATION",
+            "listenerType": "USER_TASK"
           },
           {
             "id": "listener2",
@@ -4346,7 +4347,8 @@ final class JsonSerializableToJsonTest {
             "eventTypes": ["all"],
             "afterNonGlobal": true,
             "priority": 10,
-            "source": "CONFIGURATION"
+            "source": "CONFIGURATION",
+            "listenerType": "USER_TASK"
           }
         ]
       }
@@ -4384,7 +4386,8 @@ final class JsonSerializableToJsonTest {
       "eventTypes": ["creating", "assigning"],
       "afterNonGlobal": true,
       "priority": 10,
-      "source": "API"
+      "source": "API",
+      "listenerType": "USER_TASK"
     }
     """
       },
@@ -4399,7 +4402,8 @@ final class JsonSerializableToJsonTest {
       "eventTypes": [],
       "afterNonGlobal": false,
       "priority": 50,
-      "source": "CONFIGURATION"
+      "source": "CONFIGURATION",
+      "listenerType": "USER_TASK"
     }
     """
       }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4351,6 +4351,38 @@ final class JsonSerializableToJsonTest {
         "taskListeners": []
       }
       """
+      },
+      //////////////////////////////////// GlobalListenerRecord ///////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "GlobalListenerRecord",
+        (Supplier<GlobalListenerRecord>)
+            () ->
+                new GlobalListenerRecord()
+                    .setType("global1")
+                    .setEventTypes(List.of("creating", "assigning"))
+                    .setRetries(5)
+                    .setAfterNonGlobal(true),
+        """
+    {
+        "type": "global1",
+        "retries": 5,
+        "eventTypes": ["creating", "assigning"],
+        "afterNonGlobal": true
+    }
+    """
+      },
+      {
+        "Empty GlobalListenerRecord",
+        (Supplier<GlobalListenerRecord>) () -> new GlobalListenerRecord(),
+        """
+    {
+        "type": "",
+        "retries": 3,
+        "eventTypes": [],
+        "afterNonGlobal": false
+    }
+    """
       }
     };
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -102,6 +102,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -4313,30 +4314,39 @@ final class JsonSerializableToJsonTest {
                     .setGlobalListenerBatchKey(1)
                     .addTaskListener(
                         new GlobalListenerRecord()
+                            .setId("listener1")
                             .setType("global1")
                             .setEventTypes(List.of("creating", "assigning"))
                             .setRetries(5))
                     .addTaskListener(
                         new GlobalListenerRecord()
+                            .setId("listener2")
                             .setType("global2")
                             .setEventTypes(List.of("all"))
                             .setRetries(3)
-                            .setAfterNonGlobal(false)),
+                            .setAfterNonGlobal(true)
+                            .setPriority(10)),
         """
       {
         "globalListenerBatchKey": 1,
         "taskListeners": [
           {
+            "id": "listener1",
             "type": "global1",
             "retries": 5,
             "eventTypes": ["creating", "assigning"],
-            "afterNonGlobal": false
+            "afterNonGlobal": false,
+            "priority": 50,
+            "source": "CONFIGURATION"
           },
           {
+            "id": "listener2",
             "type": "global2",
             "retries": 3,
             "eventTypes": ["all"],
-            "afterNonGlobal": false
+            "afterNonGlobal": true,
+            "priority": 10,
+            "source": "CONFIGURATION"
           }
         ]
       }
@@ -4359,16 +4369,22 @@ final class JsonSerializableToJsonTest {
         (Supplier<GlobalListenerRecord>)
             () ->
                 new GlobalListenerRecord()
+                    .setId("my-listener")
                     .setType("global1")
                     .setEventTypes(List.of("creating", "assigning"))
                     .setRetries(5)
-                    .setAfterNonGlobal(true),
+                    .setAfterNonGlobal(true)
+                    .setPriority(10)
+                    .setSource(GlobalListenerSource.API),
         """
     {
-        "type": "global1",
-        "retries": 5,
-        "eventTypes": ["creating", "assigning"],
-        "afterNonGlobal": true
+      "id": "my-listener",
+      "type": "global1",
+      "retries": 5,
+      "eventTypes": ["creating", "assigning"],
+      "afterNonGlobal": true,
+      "priority": 10,
+      "source": "API"
     }
     """
       },
@@ -4377,10 +4393,13 @@ final class JsonSerializableToJsonTest {
         (Supplier<GlobalListenerRecord>) () -> new GlobalListenerRecord(),
         """
     {
-        "type": "",
-        "retries": 3,
-        "eventTypes": [],
-        "afterNonGlobal": false
+      "id": "",
+      "type": "",
+      "retries": 3,
+      "eventTypes": [],
+      "afterNonGlobal": false,
+      "priority": 50,
+      "source": "CONFIGURATION"
     }
     """
       }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
@@ -5,17 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.protocol.impl.record.value.globallisteners;
+package io.camunda.zeebe.protocol.impl.record.value.globallistener;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,19 +27,37 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
     implements GlobalListenerRecordValue {
 
   public static final int DEFAULT_RETRIES = 3;
+  public static final int DEFAULT_PRIORITY = 50;
+  private static final String EMPTY_STRING = "";
 
-  private final StringProperty typeProp = new StringProperty("type");
+  private final StringProperty idProp = new StringProperty("id", EMPTY_STRING);
+  private final StringProperty typeProp = new StringProperty("type", EMPTY_STRING);
   private final IntegerProperty retriesProp = new IntegerProperty("retries", DEFAULT_RETRIES);
   private final ArrayProperty<StringValue> eventTypesProp =
       new ArrayProperty<>("eventTypes", StringValue::new);
   private final BooleanProperty afterNonGlobalProp = new BooleanProperty("afterNonGlobal", false);
+  private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
+  private final EnumProperty<GlobalListenerSource> sourceProp = new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
 
   public GlobalListenerRecord() {
-    super(4);
-    declareProperty(typeProp)
+    super(7);
+    declareProperty(idProp)
+        .declareProperty(typeProp)
         .declareProperty(retriesProp)
         .declareProperty(eventTypesProp)
-        .declareProperty(afterNonGlobalProp);
+        .declareProperty(afterNonGlobalProp)
+        .declareProperty(priorityProp)
+        .declareProperty(sourceProp);
+  }
+
+  @Override
+  public String getId() {
+    return bufferAsString(idProp.getValue());
+  }
+
+  public GlobalListenerRecord setId(final String id) {
+    idProp.setValue(id);
+    return this;
   }
 
   @Override
@@ -70,7 +90,7 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setEventTypes(final List<String> eventTypes) {
     eventTypesProp.reset();
-    eventTypes.forEach(eventType -> eventTypesProp.add().wrap(BufferUtil.wrapString(eventType)));
+    eventTypes.forEach(this::addEventType);
     return this;
   }
 
@@ -81,6 +101,31 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setAfterNonGlobal(final boolean afterNonGlobal) {
     afterNonGlobalProp.setValue(afterNonGlobal);
+    return this;
+  }
+
+  @Override
+  public int getPriority() {
+    return priorityProp.getValue();
+  }
+
+  public GlobalListenerRecord setPriority(final int priority) {
+    priorityProp.setValue(priority);
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSource getSource() {
+    return sourceProp.getValue();
+  }
+
+  public GlobalListenerRecord setSource(final GlobalListenerSource source) {
+    sourceProp.setValue(source);
+    return this;
+  }
+
+  public GlobalListenerRecord addEventType(final String eventType) {
+    eventTypesProp.add().wrap(BufferUtil.wrapString(eventType));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
@@ -18,6 +18,7 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,17 +38,21 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
       new ArrayProperty<>("eventTypes", StringValue::new);
   private final BooleanProperty afterNonGlobalProp = new BooleanProperty("afterNonGlobal", false);
   private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
-  private final EnumProperty<GlobalListenerSource> sourceProp = new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
+  private final EnumProperty<GlobalListenerSource> sourceProp =
+      new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
+  private final EnumProperty<GlobalListenerType> listenerTypeProp =
+      new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
 
   public GlobalListenerRecord() {
-    super(7);
+    super(8);
     declareProperty(idProp)
         .declareProperty(typeProp)
         .declareProperty(retriesProp)
         .declareProperty(eventTypesProp)
         .declareProperty(afterNonGlobalProp)
         .declareProperty(priorityProp)
-        .declareProperty(sourceProp);
+        .declareProperty(sourceProp)
+        .declareProperty(listenerTypeProp);
   }
 
   @Override
@@ -121,6 +126,16 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setSource(final GlobalListenerSource source) {
     sourceProp.setValue(source);
+    return this;
+  }
+
+  @Override
+  public GlobalListenerType getListenerType() {
+    return listenerTypeProp.getValue();
+  }
+
+  public GlobalListenerRecord setListenerType(final GlobalListenerType listenerType) {
+    listenerTypeProp.setValue(listenerType);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
@@ -98,6 +99,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
@@ -355,6 +357,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.JOB_METRICS_BATCH,
         new Mapping<>(JobMetricsBatchRecordValue.class, JobMetricsBatchIntent.class));
+    mapping.put(
+        ValueType.GLOBAL_LISTENER,
+        new Mapping<>(GlobalListenerRecordValue.class, GlobalListenerIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/GlobalListenerIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/GlobalListenerIntent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum GlobalListenerIntent implements Intent {
+  CREATE(0, false),
+  CREATED(1, true),
+  UPDATE(2, false),
+  UPDATED(3, true),
+  DELETE(4, false),
+  DELETED(5, true);
+
+  private final short value;
+  private final boolean event;
+
+  GlobalListenerIntent(final int value, final boolean event) {
+    this.value = (short) value;
+    this.event = event;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return event;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -59,6 +59,7 @@ public interface Intent {
     map.put(ValueType.ESCALATION, EscalationIntent.class);
     map.put(ValueType.EXPRESSION, ExpressionIntent.class);
     map.put(ValueType.FORM, FormIntent.class);
+    map.put(ValueType.GLOBAL_LISTENER, GlobalListenerIntent.class);
     map.put(ValueType.GLOBAL_LISTENER_BATCH, GlobalListenerBatchIntent.class);
     map.put(ValueType.GROUP, GroupIntent.class);
     map.put(ValueType.HISTORY_DELETION, HistoryDeletionIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
@@ -20,22 +20,104 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
 import org.immutables.value.Value;
 
+/**
+ * Represents a global listener configuration in the Zeebe protocol.
+ *
+ * <p>A global listener is notified of specific events occurring in the cluster, regardless of the
+ * process instance or scope. This record value describes the configuration and properties of such a
+ * listener.
+ */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableGlobalListenerRecordValue.Builder.class)
 public interface GlobalListenerRecordValue extends RecordValue {
+
+  /**
+   * Returns the unique identifier of the global listener.
+   *
+   * <p>This ID is used to reference and manage the listener through APIs.
+   *
+   * @return the global listener's unique identifier
+   */
   String getId();
 
+  /**
+   * Returns the job type of the global listener.
+   *
+   * <p>The type is used as a reference to specify which job workers request the respective listener
+   * job.
+   *
+   * @return the job type of the global listener
+   */
   String getType();
 
+  /**
+   * Returns the maximum number of retries allowed for this listener.
+   *
+   * <p>If the listener fails to process an event, it may be retried up to this number.
+   *
+   * @return the retry count
+   */
   int getRetries();
 
+  /**
+   * Returns the list of event types this listener is interested in.
+   *
+   * <p>The listener will be notified only for these event types.
+   *
+   * <p>For global user task listeners, valid event types include:
+   *
+   * <ul>
+   *   <li>"CREATING": when a user task is created
+   *   <li>"ASSIGNING": when a user task is assigned to a user or unassigned
+   *   <li>"UPDATING": when a user task information is updated
+   *   <li>"COMPLETING": when a user task is completed
+   *   <li>"CANCELING": when a user task is canceled
+   *   <li>"ALL": triggered by all of the above
+   * </ul>
+   *
+   * @return the list of event types
+   */
   List<String> getEventTypes();
 
+  /**
+   * Indicates whether this listener should be executed after all non-global listeners.
+   *
+   * <p>If {@code true}, the listener is invoked after non-global listeners for the same event,
+   * otherwise before them.
+   *
+   * @return {@code true} if executed after non-global listeners, otherwise {@code false}
+   */
   boolean isAfterNonGlobal();
 
+  /**
+   * Returns the priority of the listener.
+   *
+   * <p>Higher priority listeners are executed before lower priority ones.
+   *
+   * @return the priority value
+   */
   int getPriority();
 
+  /**
+   * Returns the source of the global listener.
+   *
+   * <p>The source indicates how or where the listener was registered. The possible values are:
+   *
+   * <ul>
+   *   <li>{@link GlobalListenerSource#API}: registered via API
+   *   <li>{@link GlobalListenerSource#CONFIGURATION}: registered via configuration file</
+   * </ul>
+   *
+   * @return the listener source
+   */
   GlobalListenerSource getSource();
 
+  /**
+   * Returns the listener type of the global listener.
+   *
+   * <p>Currently only global "user task" listeners are supported.
+   *
+   * @return the listener type
+   */
   GlobalListenerType getListenerType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerSource.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerSource.java
@@ -15,25 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
-import io.camunda.zeebe.protocol.record.ImmutableProtocol;
-import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.List;
-import org.immutables.value.Value;
-
-@Value.Immutable
-@ImmutableProtocol(builder = ImmutableGlobalListenerRecordValue.Builder.class)
-public interface GlobalListenerRecordValue extends RecordValue {
-  String getId();
-
-  String getType();
-
-  int getRetries();
-
-  List<String> getEventTypes();
-
-  boolean isAfterNonGlobal();
-
-  int getPriority();
-
-  GlobalListenerSource getSource();
+public enum GlobalListenerSource {
+  CONFIGURATION,
+  API;
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerType.java
@@ -15,27 +15,6 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
-import io.camunda.zeebe.protocol.record.ImmutableProtocol;
-import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.List;
-import org.immutables.value.Value;
-
-@Value.Immutable
-@ImmutableProtocol(builder = ImmutableGlobalListenerRecordValue.Builder.class)
-public interface GlobalListenerRecordValue extends RecordValue {
-  String getId();
-
-  String getType();
-
-  int getRetries();
-
-  List<String> getEventTypes();
-
-  boolean isAfterNonGlobal();
-
-  int getPriority();
-
-  GlobalListenerSource getSource();
-
-  GlobalListenerType getListenerType();
+public enum GlobalListenerType {
+  USER_TASK;
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -83,6 +83,7 @@
       <validValue name="GLOBAL_LISTENER_BATCH">65</validValue>
       <validValue name="EXPRESSION">66</validValue>
       <validValue name="JOB_METRICS_BATCH">67</validValue>
+      <validValue name="GLOBAL_LISTENER">68</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -381,6 +381,7 @@ public class GlobalUserTaskListenersTest {
   private GlobalListenerCfg createListenerConfig(
       final String type, final List<String> eventTypes, final boolean afterNonGlobal) {
     final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
+    listenerCfg.setId("GlobalListener_" + type);
     listenerCfg.setType(type);
     listenerCfg.setEventTypes(eventTypes);
     listenerCfg.setAfterNonGlobal(afterNonGlobal);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -136,6 +136,7 @@ final class GlobalListenersInitializerIT {
             .map(
                 type -> {
                   final GlobalListenerCfg listenerCfg = new GlobalListenerCfg();
+                  listenerCfg.setId("GlobalListener_" + type);
                   listenerCfg.setType(type);
                   listenerCfg.setEventTypes(List.of("all"));
                   return listenerCfg;

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -22,7 +22,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.DEPLOYMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.DEPLOYMENT_DISTRIBUTION;
 import static io.camunda.zeebe.protocol.record.ValueType.ESCALATION;
 import static io.camunda.zeebe.protocol.record.ValueType.EXPRESSION;
-import static io.camunda.zeebe.protocol.record.ValueType.GLOBAL_LISTENER_BATCH;
+import static io.camunda.zeebe.protocol.record.ValueType.GLOBAL_LISTENER;
 import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.IDENTITY_SETUP;
 import static io.camunda.zeebe.protocol.record.ValueType.MAPPING_RULE;
@@ -226,7 +226,7 @@ public class CompactRecordLogger {
           entry(EXPRESSION.name(), "EXPR"),
           entry(IDENTITY_SETUP.name(), "ID"),
           entry(CHECKPOINT.name(), "CHK"),
-          entry(GLOBAL_LISTENER_BATCH.name(), "GL_BATCH"));
+          entry(GLOBAL_LISTENER.name(), "GL"));
 
   private static final Map<RecordType, Character> RECORD_TYPE_ABBREVIATIONS =
       ofEntries(
@@ -321,6 +321,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.HISTORY_DELETION, this::summarizeHistoryDeletion);
     valueLoggers.put(ValueType.GLOBAL_LISTENER_BATCH, this::summarizeGlobalListenerBatch);
     valueLoggers.put(ValueType.JOB_METRICS_BATCH, this::summarizeJobMetricsBatch);
+    valueLoggers.put(ValueType.GLOBAL_LISTENER, this::summarizeGlobalListener);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -1810,6 +1811,11 @@ public class CompactRecordLogger {
         + shortenKey(value.getResourceKey())
         + ", Resource type: "
         + value.getResourceType();
+  }
+
+  private String summarizeGlobalListener(final Record<?> record) {
+    final var value = (GlobalListenerRecordValue) record.getValue();
+    return summarizeGlobalListener(value);
   }
 
   private String summarizeGlobalListener(final GlobalListenerRecordValue value) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/GlobalListenerRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/GlobalListenerRecordStream.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import java.util.stream.Stream;
+
+public class GlobalListenerRecordStream
+    extends ExporterRecordStream<GlobalListenerRecordValue, GlobalListenerRecordStream> {
+
+  public GlobalListenerRecordStream(final Stream<Record<GlobalListenerRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected GlobalListenerRecordStream supply(
+      final Stream<Record<GlobalListenerRecordValue>> wrappedStream) {
+    return new GlobalListenerRecordStream(wrappedStream);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
@@ -76,6 +77,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
@@ -711,6 +713,16 @@ public final class RecordingExporter implements Exporter {
   public static GlobalListenerBatchRecordStream globalListenerBatchRecords(
       final GlobalListenerBatchIntent intent) {
     return globalListenerBatchRecords().withIntent(intent);
+  }
+
+  public static GlobalListenerRecordStream globalListenerRecords() {
+    return new GlobalListenerRecordStream(
+        records(ValueType.GLOBAL_LISTENER, GlobalListenerRecordValue.class));
+  }
+
+  public static GlobalListenerRecordStream globalListenerRecords(
+      final GlobalListenerIntent intent) {
+    return globalListenerRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

This PR introduces the new `GLOBAL_LISTENER` record to handle operations on individual global listeners.
The new record re-uses the existing `GlobalListenerRecord` class extending it with the following fields:
- `id`: user-provided name, used to reference each listener via API
- `priority`: integer used to sort global listeners to execute them in the correct order (default 50)
- `source`: how the listener was defined; enum value:
  - `CONFIGURATION`: listened defined in configuration file / environment variables
  - `API`: listener created through APIs
- `listenerType`: whether the listener is a user task listener or a different kind of listener (e.g. execution listener); currently only a single value is supported:
  - `USER_TASK`

The intents for the new record type are:
- commands: `CREATE`, `UPDATE` and `DELETE`
- events: `CREATED`, `UPDATED` and `DELETED`

A draft implementation for these commands has been added, with the actual implementation to be completed in future PRs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43179
closes #43180
closes #43183