### PR TITLE
Fix profiling github workflow and related script

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -35,15 +35,15 @@ jobs:
           kubectl config set-context --current --namespace=${{ inputs.name }}
       - name: Execute profiling
         run: >
-          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.name }}-${{ inputs.pod }}
+          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.pod }}
       - uses: actions/upload-artifact@v4
         with:
           # Name of the artifact to upload.
           # Optional. Default is 'artifact'
-          name: flamegraph-${{ inputs.name }}-${{ inputs.pod }}
+          name: flamegraph-${{ inputs.pod }}
           # A file, directory or wildcard pattern that describes what to upload
           # Required.
-          path: ${{ inputs.name }}-${{ inputs.pod }}*
+          path: ${{ inputs.pod }}*
       - name: Summarize profiling
         if: success()
         run: |

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -10,7 +10,7 @@ on:
         required: true
       pod:
         description: 'Specifies the pod name of the load test to profile. Please only specify the suffix like zeebe-0, or zeebe-1, etc.'
-        default: 'zeebe-0'
+        default: 'camunda-0'
         required: false
 jobs:
   profile-load-test:
@@ -35,7 +35,7 @@ jobs:
           kubectl config set-context --current --namespace=${{ inputs.name }}
       - name: Execute profiling
         run: >
-          ./zeebe/load-tests/docs/scripts/executeProfiling.sh ${{ inputs.name }}-${{ inputs.pod }}
+          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.name }}-${{ inputs.pod }}
       - uses: actions/upload-artifact@v4
         with:
           # Name of the artifact to upload.

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -36,7 +36,7 @@ fi
 
 # Run profiling
 filename=flamegraph-$(date +%Y-%m-%d_%H-%M-%S).html
-PID=$(kubectl exec "$node" -- jps | grep Standalone | cut -d " " -f 1)
+PID=$(kubectl exec "$node" -- ps -ax | grep java | awk '{$1=$1;print}' | cut -d " " -f 1)
 kubectl exec "$node" -- ./data/asprof -e itimer -d 100 -t -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" "$PID"
 
 # Copy result

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -36,6 +36,16 @@ fi
 
 # Run profiling
 filename=flamegraph-$(date +%Y-%m-%d_%H-%M-%S).html
+# Extracting the PID:
+#
+#  $ k exec camunda-0 -it -- ps -ax
+#    PID TTY      STAT   TIME COMMAND
+#      1 ?        Ssl  570:26 /usr/lib/jvm/default-jvm/bin/java -XX:+ExitOnOutOfM
+#   5905 pts/0    Rs+    0:00 ps -ax
+#
+#   As we want to find the PID of the Java process we can use awk
+#   to check the fifth input whether it contains "/java/"
+#   If so we return the first input, which is the PID
 PID=$(kubectl exec "$node" -- ps -ax | awk '$5 ~ /java/ {print $1}')
 kubectl exec "$node" -- ./data/asprof -e itimer -d 100 -t -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" "$PID"
 

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -36,7 +36,7 @@ fi
 
 # Run profiling
 filename=flamegraph-$(date +%Y-%m-%d_%H-%M-%S).html
-PID=$(kubectl exec "$node" -- ps -ax | grep java | awk '{$1=$1;print}' | cut -d " " -f 1)
+PID=$(kubectl exec "$node" -- ps -ax | awk '$5 ~ /java/ {print $1}')
 kubectl exec "$node" -- ./data/asprof -e itimer -d 100 -t -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" "$PID"
 
 # Copy result


### PR DESCRIPTION
## Description

The GH workflow was outdated and no longer working.

 * Was referencing an outdated path from 8.8
 * Was using namespace + podname as actual podname, which is outdated
 * Script was using jps which is no longer available

All of the above is fixed.


<!-- Describe the goal and purpose of this PR. -->

## Example usage

https://github.com/camunda/camunda/actions/runs/21000055122

[flamegraph-camunda-0.zip](https://github.com/user-attachments/files/24616931/flamegraph-camunda-0.zip)

<img width="1894" height="809" alt="2026-01-14_16-45" src="https://github.com/user-attachments/assets/e589f7f0-06fe-4b08-a8c9-2285e22e345d" />



## Related issues

closes https://github.com/camunda/camunda/issues/44000
