### PR TITLE
refactor: migrate multi instance related selection logic

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
@@ -25,6 +25,7 @@ import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {Incidents} from './Incidents';
 import {useElementInstancesCount} from 'modules/hooks/useElementInstancesCount';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -32,6 +33,8 @@ type Props = {
 
 const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const {data: processInstance} = useProcessInstance();
+  const {isSelectedInstanceMultiInstanceBody} =
+    useProcessInstanceElementSelection();
   const selection = flowNodeSelectionStore.state.selection;
   const elementId = selection?.flowNodeId;
   const elementInstanceKey = selection?.flowNodeInstanceId;
@@ -45,7 +48,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const {data: statistics} = useFlownodeInstancesStatistics();
 
   let elementInstancesCount = useElementInstancesCount(elementId);
-  if (selection?.isMultiInstance) {
+  if (isSelectedInstanceMultiInstanceBody) {
     elementInstancesCount = 1;
   }
   const incidentCount =

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Popover, Content, Divider} from './styled';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {observer} from 'mobx-react';
+import {flip, offset} from '@floating-ui/react-dom';
+import {Header} from './Header';
+import {Stack} from '@carbon/react';
+import {MultiIncidents} from './Incidents/multiIncidents';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useElementInstancesSearch} from 'modules/queries/elementInstances/useElementInstancesSearch';
+import {useElementInstance} from 'modules/queries/elementInstances/useElementInstance';
+import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
+import {useMemo} from 'react';
+import {Details} from './Details';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
+import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
+import {Incidents} from './Incidents';
+import {useElementInstancesCount} from 'modules/hooks/useElementInstancesCount';
+
+type Props = {
+  selectedFlowNodeRef?: SVGGraphicsElement | null;
+};
+
+const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
+  const {data: processInstance} = useProcessInstance();
+  const selection = flowNodeSelectionStore.state.selection;
+  const elementId = selection?.flowNodeId;
+  const elementInstanceKey = selection?.flowNodeInstanceId;
+
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {data} = useProcessInstanceXml({
+    processDefinitionKey,
+  });
+  const businessObject = elementId ? data?.businessObjects[elementId] : null;
+
+  const {data: statistics} = useFlownodeInstancesStatistics();
+
+  let elementInstancesCount = useElementInstancesCount(elementId);
+  if (selection?.isMultiInstance) {
+    elementInstancesCount = 1;
+  }
+  const incidentCount =
+    statistics?.items.find((stat) => stat.elementId === elementId)?.incidents ??
+    0;
+
+  const shouldFetchElementInstances =
+    elementInstancesCount === 1 &&
+    !elementInstanceKey &&
+    !!processInstance?.processInstanceKey &&
+    !!elementId;
+
+  const {data: elementInstance, isLoading: isFetchingInstance} =
+    useElementInstance(elementInstanceKey ?? '', {
+      enabled: !!elementInstanceKey && !!elementId,
+    });
+
+  const {
+    data: elementInstancesSearchResult,
+    isLoading: isSearchingElementInstances,
+  } = useElementInstancesSearch({
+    elementId: elementId ?? '',
+    processInstanceKey: processInstance?.processInstanceKey ?? '',
+    elementType: convertBpmnJsTypeToAPIType(businessObject?.$type),
+    enabled: shouldFetchElementInstances,
+  });
+
+  const elementInstanceMetadata = useMemo(() => {
+    if (elementInstanceKey && elementInstance) {
+      return elementInstance;
+    }
+
+    if (
+      !elementInstanceKey &&
+      elementInstancesCount === 1 &&
+      elementInstancesSearchResult?.items?.length === 1
+    ) {
+      return elementInstancesSearchResult.items[0];
+    }
+
+    return null;
+  }, [
+    elementInstanceKey,
+    elementInstance,
+    elementInstancesCount,
+    elementInstancesSearchResult,
+  ]);
+
+  if (
+    elementId === undefined ||
+    (shouldFetchElementInstances && isSearchingElementInstances) ||
+    (!!elementInstanceKey && isFetchingInstance)
+  ) {
+    return null;
+  }
+
+  return (
+    <Popover
+      referenceElement={selectedFlowNodeRef}
+      middlewareOptions={[
+        offset(10),
+        flip({
+          fallbackPlacements: ['top', 'right', 'left'],
+        }),
+      ]}
+      variant="arrow"
+    >
+      <Stack gap={3}>
+        {elementInstancesCount !== null &&
+          elementInstancesCount > 1 &&
+          !elementInstanceKey && (
+            <>
+              <Header
+                title={`This element instance triggered ${elementInstancesCount} times`}
+              />
+              <Content>
+                To view details for any of these, select one Instance in the
+                Instance History.
+              </Content>
+            </>
+          )}
+
+        {elementInstanceMetadata && (
+          <>
+            <Details
+              elementInstance={elementInstanceMetadata}
+              businessObject={businessObject}
+            />
+            {elementInstanceMetadata.hasIncident && (
+              <Incidents
+                elementInstanceKey={elementInstanceMetadata.elementInstanceKey}
+                elementName={elementInstanceMetadata.elementName}
+                elementId={elementId}
+              />
+            )}
+          </>
+        )}
+
+        {!elementInstanceMetadata && incidentCount > 0 && (
+          <>
+            <Divider />
+            <MultiIncidents
+              count={incidentCount}
+              onButtonClick={() => {
+                incidentsPanelStore.showIncidentsForElementId(elementId);
+              }}
+            />
+          </>
+        )}
+      </Stack>
+    </Popover>
+  );
+});
+
+export {MetadataPopover};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/indexV2.tsx
@@ -7,21 +7,15 @@
  */
 
 import {Popover, Content, Divider} from './styled';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {observer} from 'mobx-react';
 import {flip, offset} from '@floating-ui/react-dom';
 import {Header} from './Header';
 import {Stack} from '@carbon/react';
 import {MultiIncidents} from './Incidents/multiIncidents';
-import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {useElementInstancesSearch} from 'modules/queries/elementInstances/useElementInstancesSearch';
-import {useElementInstance} from 'modules/queries/elementInstances/useElementInstance';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
-import {useMemo} from 'react';
 import {Details} from './Details';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
-import {convertBpmnJsTypeToAPIType} from './convertBpmnJsTypeToAPIType';
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {Incidents} from './Incidents';
 import {useElementInstancesCount} from 'modules/hooks/useElementInstancesCount';
@@ -32,75 +26,36 @@ type Props = {
 };
 
 const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
-  const {data: processInstance} = useProcessInstance();
-  const {isSelectedInstanceMultiInstanceBody} =
-    useProcessInstanceElementSelection();
-  const selection = flowNodeSelectionStore.state.selection;
-  const elementId = selection?.flowNodeId;
-  const elementInstanceKey = selection?.flowNodeInstanceId;
-
+  const {
+    selectedElementId,
+    selectedElementInstanceKey,
+    resolvedElementInstance,
+    isFetchingElement,
+    isSelectedInstanceMultiInstanceBody,
+  } = useProcessInstanceElementSelection();
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {data} = useProcessInstanceXml({
     processDefinitionKey,
   });
-  const businessObject = elementId ? data?.businessObjects[elementId] : null;
 
+  const businessObject = selectedElementId
+    ? data?.businessObjects[selectedElementId]
+    : null;
   const {data: statistics} = useFlownodeInstancesStatistics();
+  let elementInstancesCount = useElementInstancesCount(
+    selectedElementId ?? undefined,
+  );
 
-  let elementInstancesCount = useElementInstancesCount(elementId);
   if (isSelectedInstanceMultiInstanceBody) {
     elementInstancesCount = 1;
   }
   const incidentCount =
-    statistics?.items.find((stat) => stat.elementId === elementId)?.incidents ??
-    0;
-
-  const shouldFetchElementInstances =
-    elementInstancesCount === 1 &&
-    !elementInstanceKey &&
-    !!processInstance?.processInstanceKey &&
-    !!elementId;
-
-  const {data: elementInstance, isLoading: isFetchingInstance} =
-    useElementInstance(elementInstanceKey ?? '', {
-      enabled: !!elementInstanceKey && !!elementId,
-    });
-
-  const {
-    data: elementInstancesSearchResult,
-    isLoading: isSearchingElementInstances,
-  } = useElementInstancesSearch({
-    elementId: elementId ?? '',
-    processInstanceKey: processInstance?.processInstanceKey ?? '',
-    elementType: convertBpmnJsTypeToAPIType(businessObject?.$type),
-    enabled: shouldFetchElementInstances,
-  });
-
-  const elementInstanceMetadata = useMemo(() => {
-    if (elementInstanceKey && elementInstance) {
-      return elementInstance;
-    }
-
-    if (
-      !elementInstanceKey &&
-      elementInstancesCount === 1 &&
-      elementInstancesSearchResult?.items?.length === 1
-    ) {
-      return elementInstancesSearchResult.items[0];
-    }
-
-    return null;
-  }, [
-    elementInstanceKey,
-    elementInstance,
-    elementInstancesCount,
-    elementInstancesSearchResult,
-  ]);
+    statistics?.items.find((stat) => stat.elementId === selectedElementId)
+      ?.incidents ?? 0;
 
   if (
-    elementId === undefined ||
-    (shouldFetchElementInstances && isSearchingElementInstances) ||
-    (!!elementInstanceKey && isFetchingInstance)
+    selectedElementId === null ||
+    (!!selectedElementInstanceKey && isFetchingElement)
   ) {
     return null;
   }
@@ -119,7 +74,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
       <Stack gap={3}>
         {elementInstancesCount !== null &&
           elementInstancesCount > 1 &&
-          !elementInstanceKey && (
+          !selectedElementInstanceKey && (
             <>
               <Header
                 title={`This element instance triggered ${elementInstancesCount} times`}
@@ -131,29 +86,31 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
             </>
           )}
 
-        {elementInstanceMetadata && (
+        {resolvedElementInstance && (
           <>
             <Details
-              elementInstance={elementInstanceMetadata}
+              elementInstance={resolvedElementInstance}
               businessObject={businessObject}
             />
-            {elementInstanceMetadata.hasIncident && (
+            {resolvedElementInstance.hasIncident && (
               <Incidents
-                elementInstanceKey={elementInstanceMetadata.elementInstanceKey}
-                elementName={elementInstanceMetadata.elementName}
-                elementId={elementId}
+                elementInstanceKey={resolvedElementInstance.elementInstanceKey}
+                elementName={resolvedElementInstance.elementName}
+                elementId={selectedElementId}
               />
             )}
           </>
         )}
 
-        {!elementInstanceMetadata && incidentCount > 0 && (
+        {!resolvedElementInstance && incidentCount > 0 && (
           <>
             <Divider />
             <MultiIncidents
               count={incidentCount}
               onButtonClick={() => {
-                incidentsPanelStore.showIncidentsForElementId(elementId);
+                incidentsPanelStore.showIncidentsForElementId(
+                  selectedElementId,
+                );
               }}
             />
           </>

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -30,6 +30,7 @@ import {computed} from 'mobx';
 import {type OverlayPosition} from 'bpmn-js/lib/NavigatedViewer';
 import {Diagram} from 'modules/components/Diagram';
 import {MetadataPopover} from './MetadataPopover';
+import {MetadataPopover as MetadataPopoverV2} from './MetadataPopover/indexV2';
 import {ModificationBadgeOverlay} from './ModificationBadgeOverlay';
 import {ModificationInfoBanner} from './ModificationInfoBanner';
 import {ModificationDropdown as ModificationDropdownV1} from './ModificationDropdown/indexV1';
@@ -436,7 +437,12 @@ const TopPanel: React.FC = observer(() => {
                       <ModificationDropdownV1 />
                     )
                   ) : (
-                    !isIncidentBarOpen && <MetadataPopover />
+                    !isIncidentBarOpen &&
+                    (IS_ELEMENT_SELECTION_V2 ? (
+                      <MetadataPopoverV2 />
+                    ) : (
+                      <MetadataPopover />
+                    ))
                   )
                 }
                 highlightedSequenceFlows={highlightedSequenceFlows}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Migrate MetadataPopover to v2 and remove flowNodeSelectionStore dependency
- Replace usage of `flowNodeSelectionStore.selection.isMultiInstance` by `isSelectedInstanceMultiInstanceBody`
-  Migrate `useHasMultipleInstances` to v2

:bulb: The first commit just contains a copy of MetadataPopover. Please focus on the the individual commits to see a proper file diff.

:warning: Please note that currently the metadata popover is not properly attached to the elements (when feature flag is on). This will be fixed in upcoming PRs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #41829 
