### PR TITLE
test: fix parameterization of cluster gateway/broker config tests

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/TlsClusterBrokerTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/TlsClusterBrokerTest.java
@@ -99,11 +99,11 @@ public class TlsClusterBrokerTest {
   @TestPropertySource(
       properties = {
         // legacy
-        "zeebe.broker.network.security.enabled=false",
+        "zeebe.broker.network.security.enabled=true",
         "zeebe.broker.network.security.certificateChainPath=certificateChainPathLegacy",
         "zeebe.broker.network.security.privateKeyPath=certificatePrivateKeyPathLegacy",
-        "zeebe.broker.network.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
-        "zeebe.broker.network.security.keyStore.password=certificateKeyStorePasswordLegacy",
+        "zeebe.broker.network.security.keyStore.filePath=keyStoreFilePathLegacy",
+        "zeebe.broker.network.security.keyStore.password=keyStorePasswordLegacy",
       })
   @ActiveProfiles({"broker"})
   class WithOnlyLegacySet {
@@ -116,7 +116,7 @@ public class TlsClusterBrokerTest {
     @Test
     void testCamundaBrokerProperties() {
       assertThat(brokerBasedProperties.getNetwork().getSecurity())
-          .returns(false, SecurityCfg::isEnabled)
+          .returns(true, SecurityCfg::isEnabled)
           .returns(new File("certificateChainPathLegacy"), SecurityCfg::getCertificateChainPath)
           .returns(new File("certificatePrivateKeyPathLegacy"), SecurityCfg::getPrivateKeyPath);
 

--- a/configuration/src/test/java/io/camunda/configuration/TlsClusterGatewayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/TlsClusterGatewayTest.java
@@ -110,11 +110,11 @@ public class TlsClusterGatewayTest {
   @TestPropertySource(
       properties = {
         // legacy
-        "zeebe.gateway.cluster.security.enabled=false",
+        "zeebe.gateway.cluster.security.enabled=true",
         "zeebe.gateway.cluster.security.certificateChainPath=certificateChainPathLegacy",
         "zeebe.gateway.cluster.security.privateKeyPath=certificatePrivateKeyPathLegacy",
-        "zeebe.gateway.cluster.security.keyStore.filePath=certificateKeyStoreFilePathLegacy",
-        "zeebe.gateway.cluster.security.keyStore.password=certificateKeyStorePasswordLegacy",
+        "zeebe.gateway.cluster.security.keyStore.filePath=keyStoreFilePathLegacy",
+        "zeebe.gateway.cluster.security.keyStore.password=keyStorePasswordLegacy",
       })
   class WithOnlyLegacySet {
     final GatewayBasedProperties gatewayBasedProperties;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The original tests were incorrectly parameterized/asserted in [this commit](https://github.com/camunda/camunda/pull/42503/changes/5851beb8d9c9300942946687d3aea0f41bafe3d8). This PR aligns the parameters and assertions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
