### PR TITLE
test: fix `DynamicNodeIdIT` flakyness when not shutting down gracefully

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DataDirectoryValidatorAssertions.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DataDirectoryValidatorAssertions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.cluster.dynamicnodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryValidator;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataDirectoryValidatorAssertions implements DataDirectoryValidator {
+
+  private final boolean assertHardLinked;
+  private final AtomicInteger filesChecked = new AtomicInteger(0);
+
+  public DataDirectoryValidatorAssertions(final boolean hardLinked) {
+    assertHardLinked = hardLinked;
+  }
+
+  @Override
+  public void validate(final Path source, final Path target, final String markerFileName)
+      throws IOException {
+    // First perform standard validation to ensure files exist
+    assertFilesAreHardLinkedOrCopied(source, target, assertHardLinked);
+  }
+
+  private void assertFilesAreHardLinkedOrCopied(
+      final Path v0Dir, final Path v1Dir, final boolean assertHardLinked) throws IOException {
+    final String markerFile = "directory-initialized.json";
+
+    Files.walkFileTree(
+        v1Dir,
+        new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult preVisitDirectory(
+              final Path dir, final BasicFileAttributes attrs) {
+            // Skip runtime directories
+            if (dir.getFileName().toString().equals("runtime")) {
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult visitFile(final Path target, final BasicFileAttributes attrs)
+              throws IOException {
+            final Path relative = v1Dir.relativize(target);
+
+            // Skip marker file
+            if (relative.getFileName().toString().equals(markerFile)) {
+              return FileVisitResult.CONTINUE;
+            }
+
+            final Path source = v0Dir.resolve(relative);
+
+            // Source file should exist
+            assertThat(source).exists();
+
+            // Files should be hard-linked (same inode)
+            if (assertHardLinked) {
+              assertThat(areHardLinked(source, target))
+                  .as("File %s should be hard-linked to %s", source, target)
+                  .isTrue();
+            } else {
+              assertThat(Files.readAllBytes(target)).isEqualTo(Files.readAllBytes(source));
+            }
+
+            filesChecked.incrementAndGet();
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  public void assertFilesHaveBeenvalidated() {
+    // Ensure we actually checked some files
+    assertThat(filesChecked.get()).as("Should have verified at least some files").isGreaterThan(0);
+  }
+
+  private boolean areHardLinked(final Path file1, final Path file2) throws IOException {
+    final var key1 = Files.readAttributes(file1, BasicFileAttributes.class).fileKey();
+    final var key2 = Files.readAttributes(file2, BasicFileAttributes.class).fileKey();
+    return key1 != null && key2 != null && key1.equals(key2);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DataDirectoryValidatorAssertions.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DataDirectoryValidatorAssertions.java
@@ -74,7 +74,7 @@ public class DataDirectoryValidatorAssertions implements DataDirectoryValidator 
                   .as("File %s should be hard-linked to %s", source, target)
                   .isTrue();
             } else {
-              assertThat(Files.readAllBytes(target)).isEqualTo(Files.readAllBytes(source));
+              assertThat(target).hasSameBinaryContentAs(source);
             }
 
             filesChecked.incrementAndGet();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.nodeid.Lease;
 import io.camunda.zeebe.dynamic.nodeid.Lease.VersionMappings;
 import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
 import io.camunda.zeebe.dynamic.nodeid.Version;
+import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryValidator;
 import io.camunda.zeebe.dynamic.nodeid.fs.DirectoryInitializationInfo;
 import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -36,17 +36,12 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import oracle.net.nt.Clock;
@@ -270,10 +265,14 @@ public class DynamicNodeIdIT {
       s3Client.putObject(request, body);
     }
 
+    final var validator = new DataDirectoryValidatorAssertions(gracefulShutdown);
+    broker.withBean("dataDirectoryValidator", validator, DataDirectoryValidator.class);
     broker.start().await(TestHealthProbe.READY);
     testCluster.awaitCompleteTopology();
 
     // then - verify new version created
+    validator.assertFilesHaveBeenvalidated();
+
     final Lease leaseAfterRestart = awaitValidLease(nodeId);
     final long versionAfterRestart = leaseAfterRestart.nodeInstance().version().version();
     assertThat(versionAfterRestart).isEqualTo(2L);
@@ -288,9 +287,6 @@ public class DynamicNodeIdIT {
     assertThat(v1InitInfo.initializedAt()).isGreaterThan(0);
     assertThat(v1InitInfo.initializedFrom()).isNotNull();
     assertThat(v1InitInfo.initializedFrom().version()).isEqualTo(1L);
-
-    // Verify files are hard-linked (gracefulShutdonw) or copied otherwise
-    assertFilesAreHardLinkedOrCopied(v0Dir, v1Dir, gracefulShutdown);
 
     // Verify data continuity - complete process instance started in v0
     try (final CamundaClient client = testCluster.newClientBuilder().build()) {
@@ -332,65 +328,6 @@ public class DynamicNodeIdIT {
     final Path initFile = versionDir.resolve("directory-initialized.json");
     assertThat(initFile).exists().isRegularFile();
     return OBJECT_MAPPER.readValue(initFile.toFile(), DirectoryInitializationInfo.class);
-  }
-
-  private void assertFilesAreHardLinkedOrCopied(
-      final Path v0Dir, final Path v1Dir, final boolean assertHardLinked) throws IOException {
-    final String markerFile = "directory-initialized.json";
-    final AtomicInteger filesChecked = new AtomicInteger(0);
-
-    Files.walkFileTree(
-        v1Dir,
-        new SimpleFileVisitor<>() {
-          @Override
-          public FileVisitResult preVisitDirectory(
-              final Path dir, final BasicFileAttributes attrs) {
-            // Skip runtime directories
-            if (dir.getFileName().toString().equals("runtime")) {
-              return FileVisitResult.SKIP_SUBTREE;
-            }
-            return FileVisitResult.CONTINUE;
-          }
-
-          @Override
-          public FileVisitResult visitFile(final Path target, final BasicFileAttributes attrs)
-              throws IOException {
-            final Path relative = v1Dir.relativize(target);
-
-            // Skip marker file
-            if (relative.getFileName().toString().equals(markerFile)) {
-              return FileVisitResult.CONTINUE;
-            }
-
-            final Path source = v0Dir.resolve(relative);
-
-            // Source file should exist
-            assertThat(source).exists();
-
-            // Files should be hard-linked (same inode)
-            if (assertHardLinked) {
-              assertThat(areHardLinked(source, target))
-                  .as("File %s should be hard-linked to %s", source, target)
-                  .isTrue();
-            } else {
-              assertThat(Files.readAllBytes(target)).isEqualTo(Files.readAllBytes(source));
-            }
-
-            filesChecked.incrementAndGet();
-            return FileVisitResult.CONTINUE;
-          }
-        });
-
-    // Ensure we actually checked some files
-    assertThat(filesChecked.get())
-        .as("Should have verified at least some hard-linked files")
-        .isGreaterThan(0);
-  }
-
-  private boolean areHardLinked(final Path file1, final Path file2) throws IOException {
-    final var key1 = Files.readAttributes(file1, BasicFileAttributes.class).fileKey();
-    final var key2 = Files.readAttributes(file2, BasicFileAttributes.class).fileKey();
-    return key1 != null && key2 != null && key1.equals(key2);
   }
 
   private List<Lease> readLeases(final List<S3Object> objectsInBucket) throws IOException {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DataDirectoryCopier.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DataDirectoryCopier.java
@@ -23,7 +23,4 @@ public interface DataDirectoryCopier {
    */
   void copy(Path source, Path target, String markerFileName, boolean useHardLinks)
       throws IOException;
-
-  void validate(final Path source, final Path target, final String markerFileName)
-      throws IOException;
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DataDirectoryValidator.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DataDirectoryValidator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid.fs;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Validates that a data directory has been correctly copied/initialized. */
+public interface DataDirectoryValidator {
+
+  /**
+   * Validates that the target directory has been correctly initialized from the source directory.
+   *
+   * @param source the source data directory that was copied from
+   * @param target the target data directory that was copied to
+   * @param markerFileName a marker file name that was not copied
+   * @throws IOException if validation fails
+   */
+  void validate(Path source, Path target, String markerFileName) throws IOException;
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedNodeIdBasedDataDirectoryProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedNodeIdBasedDataDirectoryProvider.java
@@ -36,6 +36,7 @@ public class VersionedNodeIdBasedDataDirectoryProvider implements DataDirectoryP
   private final ObjectMapper objectMapper;
   private final NodeInstance nodeInstance;
   private final DataDirectoryCopier copier;
+  private final DataDirectoryValidator validator;
   private final boolean previousNodeGracefullyShutdown;
   private final int retentionCount;
   private final CompletableFuture<Void> garbageCollection = new CompletableFuture<>();
@@ -44,11 +45,13 @@ public class VersionedNodeIdBasedDataDirectoryProvider implements DataDirectoryP
       final ObjectMapper objectMapper,
       final NodeInstance nodeInstance,
       final DataDirectoryCopier copier,
+      final DataDirectoryValidator validator,
       final boolean previousNodeGracefullyShutdown,
       final int retentionCount) {
     this.objectMapper = objectMapper;
     this.nodeInstance = nodeInstance;
     this.copier = copier;
+    this.validator = validator;
     this.previousNodeGracefullyShutdown = previousNodeGracefullyShutdown;
     this.retentionCount = retentionCount;
   }
@@ -105,7 +108,7 @@ public class VersionedNodeIdBasedDataDirectoryProvider implements DataDirectoryP
             DIRECTORY_INITIALIZED_FILE,
             previousNodeGracefullyShutdown);
 
-        copier.validate(previousDataDirectory, dataDirectory, DIRECTORY_INITIALIZED_FILE);
+        validator.validate(previousDataDirectory, dataDirectory, DIRECTORY_INITIALIZED_FILE);
         layout.initializeDirectory(nodeInstance.version(), previousVersion.get());
 
         // Run garbage collection after successful validation

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedNodeIdBasedDataDirectoryProviderTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedNodeIdBasedDataDirectoryProviderTest.java
@@ -144,7 +144,7 @@ class VersionedNodeIdBasedDataDirectoryProviderTest {
     // then
     assertThat(result).isEqualTo(nodeDirectory.resolve("v3"));
     assertThat(result.resolve("file2.txt")).exists();
-    assertThat(Files.readString(result.resolve("file2.txt"))).isEqualTo("content2");
+    assertThat(result.resolve("file2.txt")).hasContent("content2");
 
     assertThat(copier.invocations()).hasSize(1);
     assertThat(copier.invocations().getFirst().source()).isEqualTo(nodeDirectory.resolve("v2"));
@@ -173,7 +173,7 @@ class VersionedNodeIdBasedDataDirectoryProviderTest {
     // then
     assertThat(result).isEqualTo(nodeDirectory.resolve("v1"));
     assertThat(result.resolve("file0.txt")).exists();
-    assertThat(Files.readString(result.resolve("file0.txt"))).isEqualTo("version 0 content");
+    assertThat(result.resolve("file0.txt")).hasContent("version 0 content");
 
     assertThat(copier.useHardLinks).isEqualTo(gracefulShutdown);
 
@@ -212,7 +212,7 @@ class VersionedNodeIdBasedDataDirectoryProviderTest {
     assertThat(result).isEqualTo(nodeDirectory.resolve("v4"));
 
     assertThat(result.resolve("file1.txt")).exists();
-    assertThat(Files.readString(result.resolve("file1.txt"))).isEqualTo("content1");
+    assertThat(result.resolve("file1.txt")).hasContent("content1");
     assertThat(result.resolve("file2.txt")).doesNotExist();
     assertThat(result.resolve("file3.txt")).doesNotExist();
 


### PR DESCRIPTION
## Description

The test case `shouldCreateNewVersionedFolderAfterRestartWithHardLinks` is flaky because we check that the files have an identical to the ones in the previous version while the broker is running.
This is not generally true as the broker may append new entries while we perform the check.

Splitting `DataDirectoryCopier` interface into two, one with `copy` and one with `validate`, we can inject a custom `DataDirectoryValidator` that overrides the default ones in tests.

This allows us to perform the validation before the broker module is even started.