### PR TITLE
feat: write root process instance key to audit log (when present)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
@@ -33,6 +33,7 @@ public class AuditLogEntityMapper {
         .decisionDefinitionId(auditLogDbModel.decisionDefinitionId())
         .processDefinitionKey(auditLogDbModel.processDefinitionKey())
         .processInstanceKey(auditLogDbModel.processInstanceKey())
+        .rootProcessInstanceKey(auditLogDbModel.rootProcessInstanceKey())
         .elementInstanceKey(auditLogDbModel.elementInstanceKey())
         .jobKey(auditLogDbModel.jobKey())
         .userTaskKey(auditLogDbModel.userTaskKey())

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapperTest.java
@@ -51,6 +51,7 @@ public class AuditLogEntityMapperTest {
             .decisionDefinitionId("decision-id")
             .processDefinitionKey(200L)
             .processInstanceKey(300L)
+            .rootProcessInstanceKey(312L)
             .elementInstanceKey(400L)
             .jobKey(500L)
             .userTaskKey(600L)

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
@@ -36,6 +36,7 @@ public class AuditLogEntityTransformer
         value.getProcessDefinitionId(),
         value.getProcessDefinitionKey(),
         value.getProcessInstanceKey(),
+        value.getRootProcessInstanceKey(),
         value.getElementInstanceKey(),
         value.getJobKey(),
         value.getUserTaskKey(),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -30,6 +30,7 @@ public record AuditLogEntity(
     String processDefinitionId,
     Long processDefinitionKey,
     Long processInstanceKey,
+    Long rootProcessInstanceKey,
     Long elementInstanceKey,
     Long jobKey,
     Long userTaskKey,
@@ -66,6 +67,7 @@ public record AuditLogEntity(
     private String processDefinitionId;
     private Long processDefinitionKey;
     private Long processInstanceKey;
+    private Long rootProcessInstanceKey;
     private Long elementInstanceKey;
     private Long jobKey;
     private Long userTaskKey;
@@ -163,6 +165,11 @@ public record AuditLogEntity(
       return this;
     }
 
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
+      return this;
+    }
+
     public Builder elementInstanceKey(final Long elementInstanceKey) {
       this.elementInstanceKey = elementInstanceKey;
       return this;
@@ -238,6 +245,7 @@ public record AuditLogEntity(
           processDefinitionId,
           processDefinitionKey,
           processInstanceKey,
+          rootProcessInstanceKey,
           elementInstanceKey,
           jobKey,
           userTaskKey,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
@@ -83,6 +83,7 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
             .batchOperationKey(log.getBatchOperationKey())
             .batchOperationType(mapBatchOperationType(log.getBatchOperationType()))
             .processInstanceKey(log.getProcessInstanceKey())
+            .rootProcessInstanceKey(log.getRootProcessInstanceKey())
             .entityVersion(log.getEntityVersion())
             .entityValueType(log.getEntityValueType())
             .entityOperationIntent(log.getEntityOperationIntent())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
@@ -200,6 +200,7 @@ class AuditLogExportHandlerTest {
     assertThat(entity.deploymentKey()).isEqualTo(606L);
     assertThat(entity.formKey()).isEqualTo(707L);
     assertThat(entity.resourceKey()).isEqualTo(808L);
+    assertThat(entity.rootProcessInstanceKey()).isEqualTo(909L);
     assertThat(entity.partitionId()).isEqualTo(record.getPartitionId());
   }
 }


### PR DESCRIPTION
So we can use it for cleanup later

Refs: #41660