### PR TITLE
feat: add latest-version filter for decision definition search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
@@ -45,4 +45,12 @@ public interface DecisionDefinitionFilter extends SearchRequestFilter {
 
   /** Filter by tenant id. */
   DecisionDefinitionFilter tenantId(final String value);
+
+  /**
+   * Filters decision definitions to only include the latest version of each decision definition.
+   *
+   * @param latestVersion whether to only return latest versions
+   * @return the updated filter
+   */
+  DecisionDefinitionFilter isLatestVersion(boolean latestVersion);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionDefinitionFilterImpl.java
@@ -85,6 +85,12 @@ public class DecisionDefinitionFilterImpl
   }
 
   @Override
+  public DecisionDefinitionFilter isLatestVersion(final boolean latestVersion) {
+    filter.setIsLatestVersion(latestVersion);
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.DecisionDefinitionFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionDefinitionTest.java
@@ -49,7 +49,8 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
                     .decisionRequirementsKey(2L)
                     .decisionRequirementsId("ddri")
                     .version(3)
-                    .tenantId("t"))
+                    .tenantId("t")
+                    .isLatestVersion(true))
         .send()
         .join();
 
@@ -63,6 +64,7 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
     assertThat(request.getFilter().getDecisionRequirementsId()).isEqualTo("ddri");
     assertThat(request.getFilter().getVersion()).isEqualTo(3);
     assertThat(request.getFilter().getTenantId()).isEqualTo("t");
+    assertThat(request.getFilter().getIsLatestVersion()).isTrue();
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -12,7 +12,8 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery">
     SELECT COUNT(*)
-    FROM ${prefix}DECISION_DEFINITION
+    FROM ${prefix}DECISION_DEFINITION t
+    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.maxVersionFilter"/>
     <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
   </select>
 
@@ -31,6 +32,7 @@
     FROM ${prefix}DECISION_DEFINITION
     <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
     ) t
+    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.maxVersionFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
@@ -136,4 +138,18 @@
     VALUES (#{decisionDefinitionKey}, #{decisionDefinitionId}, #{name},
             #{tenantId}, #{version}, #{decisionRequirementsId}, #{decisionRequirementsKey}, #{decisionRequirementsName}, #{decisionRequirementsVersion})
   </insert>
+
+  <sql id="maxVersionFilter">
+    <if test="filter.isLatestVersion != null and filter.isLatestVersion == true">
+      JOIN (
+        SELECT dd.DECISION_DEFINITION_ID AS dd_id, dd.TENANT_ID AS t_id, MAX(VERSION) AS max_version
+        FROM ${prefix}DECISION_DEFINITION dd
+        <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
+        GROUP BY dd.TENANT_ID, dd.DECISION_DEFINITION_ID
+      ) lv
+      ON t.DECISION_DEFINITION_ID = lv.dd_id
+      AND t.VERSION = lv.max_version
+      AND (t.TENANT_ID = lv.t_id OR (t.TENANT_ID IS NULL AND lv.t_id IS NULL))
+    </if>
+  </sql>
 </mapper>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -589,6 +589,7 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::decisionDefinitionKeys);
       ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::decisionDefinitionIds);
       ofNullable(filter.getName()).ifPresent(builder::names);
+      ofNullable(filter.getIsLatestVersion()).ifPresent(builder::isLatestVersion);
       ofNullable(filter.getVersion()).ifPresent(builder::versions);
       ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::decisionRequirementsIds);
       ofNullable(filter.getDecisionRequirementsKey())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers;
 
 import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
@@ -19,6 +20,7 @@ import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregatio
 import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
+import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
@@ -34,6 +36,7 @@ import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLatestVersionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
@@ -45,6 +48,7 @@ import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNod
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinitionLatestVersionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
@@ -617,6 +621,9 @@ public final class ServiceTransformers {
     mappers.put(
         IncidentProcessInstanceStatisticsByDefinitionAggregation.class,
         new IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer());
+    mappers.put(
+        DecisionDefinitionLatestVersionAggregation.class,
+        new DecisionDefinitionLatestVersionAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -647,5 +654,8 @@ public final class ServiceTransformers {
     mappers.put(
         IncidentProcessInstanceStatisticsByDefinitionAggregationResult.class,
         new IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer());
+    mappers.put(
+        DecisionDefinitionLatestVersionAggregationResult.class,
+        new DecisionDefinitionLatestVersionAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
@@ -79,4 +79,3 @@ public class DecisionDefinitionLatestVersionAggregationTransformer
     return List.of(finalAggregation);
   }
 }
-

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/DecisionDefinitionLatestVersionAggregationTransformer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_GROUP_DECISION_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_GROUP_TENANT_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_DECISION_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_DECISION_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_SOURCE_NAME_TENANT_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_TERMS_SIZE;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
+
+import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator.Builder;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.DecisionDefinitionSort;
+import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import java.util.Optional;
+
+public class DecisionDefinitionLatestVersionAggregationTransformer
+    implements AggregationTransformer<DecisionDefinitionLatestVersionAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<DecisionDefinitionLatestVersionAggregation, ServiceTransformers> value) {
+    final var aggregation = value.getLeft();
+    final var transformers = value.getRight();
+    final var page = aggregation.page();
+    final var sort = aggregation.sort();
+    final Builder<DecisionDefinitionEntity> topHits = topHits();
+
+    // get the MAX version per (decisionId, tenantId)
+    final SearchTopHitsAggregator<DecisionDefinitionEntity> maxVersionsAgg =
+        topHits
+            .name(AGGREGATION_NAME_LATEST_DEFINITION)
+            .sortOption(new DecisionDefinitionSort.Builder().version().desc().build())
+            .documentClass(DecisionDefinitionEntity.class)
+            .build();
+
+    // aggregate terms by decision id
+    final SearchTermsAggregator.Builder byDecisionIdAggSourceBuilder =
+        terms().name(AGGREGATION_SOURCE_NAME_DECISION_ID).field(AGGREGATION_GROUP_DECISION_ID);
+    Optional.ofNullable(sort)
+        .map(findSortOptionFor(AGGREGATION_GROUP_DECISION_ID, transformers))
+        .ifPresent(byDecisionIdAggSourceBuilder::sorting);
+
+    // aggregate terms by tenant id
+    final SearchTermsAggregator.Builder byTenantIdAggSourceBuilder =
+        terms().name(AGGREGATION_SOURCE_NAME_TENANT_ID).field(AGGREGATION_GROUP_TENANT_ID);
+    Optional.ofNullable(sort)
+        .map(findSortOptionFor(AGGREGATION_GROUP_TENANT_ID, transformers))
+        .ifPresent(byTenantIdAggSourceBuilder::sorting);
+
+    final var finalAggregation =
+        composite()
+            .name(AGGREGATION_NAME_BY_DECISION_ID)
+            .size(
+                Optional.ofNullable(page).map(SearchQueryPage::size).orElse(AGGREGATION_TERMS_SIZE))
+            .after(Optional.ofNullable(page).map(SearchQueryPage::after).orElse(null))
+            .sources(
+                List.of(byDecisionIdAggSourceBuilder.build(), byTenantIdAggSourceBuilder.build()))
+            .aggregations(maxVersionsAgg)
+            .build();
+
+    return List.of(finalAggregation);
+  }
+}
+

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_BY_DECISION_ID;
+import static io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation.AGGREGATION_NAME_LATEST_DEFINITION;
+
+import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTransformer;
+import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
+import java.util.Map;
+
+public class DecisionDefinitionLatestVersionAggregationResultTransformer
+    implements AggregationResultTransformer<DecisionDefinitionLatestVersionAggregationResult> {
+
+  @Override
+  public DecisionDefinitionLatestVersionAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+    return new DecisionDefinitionLatestVersionAggregationResult(
+        aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).aggregations().values().stream()
+            .flatMap(
+                aggregationResult -> {
+                  final var latestDefinition =
+                      aggregationResult.aggregations().get(AGGREGATION_NAME_LATEST_DEFINITION);
+                  return latestDefinition.hits().stream()
+                      .map(SearchQueryHit::source)
+                      .filter(DecisionDefinitionEntity.class::isInstance)
+                      .map(DecisionDefinitionEntity.class::cast)
+                      .map(new DecisionDefinitionEntityTransformer()::apply);
+                })
+            .toList(),
+        aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).endCursor());
+  }
+}
+

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/DecisionDefinitionLatestVersionAggregationResultTransformer.java
@@ -39,4 +39,3 @@ public class DecisionDefinitionLatestVersionAggregationResultTransformer
         aggregations.get(AGGREGATION_NAME_BY_DECISION_ID).endCursor());
   }
 }
-

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/DecisionDefinitionLatestVersionAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/DecisionDefinitionLatestVersionAggregation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.DecisionDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+import io.camunda.search.sort.DecisionDefinitionSort;
+
+/**
+ * Aggregation used to retrieve only the latest version per (tenantId, decisionDefinitionId).
+ *
+ * <p>See {@link io.camunda.search.aggregation.ProcessDefinitionLatestVersionAggregation} for the
+ * reference implementation.
+ */
+public record DecisionDefinitionLatestVersionAggregation(
+    DecisionDefinitionFilter filter, DecisionDefinitionSort sort, SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  public static final int AGGREGATION_TERMS_SIZE = 10000;
+
+  // Aggregation names
+  public static final String AGGREGATION_NAME_BY_DECISION_ID = "by-decision-id";
+  public static final String AGGREGATION_SOURCE_NAME_DECISION_ID = "decisionId";
+  public static final String AGGREGATION_SOURCE_NAME_TENANT_ID = "tenantId";
+  public static final String AGGREGATION_NAME_LATEST_DEFINITION = "latest_definition";
+
+  // Aggregation fields
+  public static final String AGGREGATION_GROUP_DECISION_ID = "decisionId";
+  public static final String AGGREGATION_GROUP_TENANT_ID = "tenantId";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
@@ -12,4 +12,3 @@ import java.util.List;
 
 public record DecisionDefinitionLatestVersionAggregationResult(
     List<DecisionDefinitionEntity> items, String endCursor) implements AggregationResultBase {}
-

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/DecisionDefinitionLatestVersionAggregationResult.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import java.util.List;
+
+public record DecisionDefinitionLatestVersionAggregationResult(
+    List<DecisionDefinitionEntity> items, String endCursor) implements AggregationResultBase {}
+

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
@@ -129,7 +129,6 @@ public record DecisionDefinitionFilter(
 
     @Override
     public DecisionDefinitionFilter build() {
-      // final var latest = Objects.requireNonNullElse(isLatestVersion, false);
       return new DecisionDefinitionFilter(
           Objects.requireNonNullElse(decisionDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(decisionDefinitionIds, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
@@ -24,7 +24,8 @@ public record DecisionDefinitionFilter(
     List<Long> decisionRequirementsKeys,
     List<String> decisionRequirementsNames,
     List<Integer> decisionRequirementsVersions,
-    List<String> tenantIds)
+    List<String> tenantIds,
+    Boolean isLatestVersion)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<DecisionDefinitionFilter> {
@@ -38,6 +39,7 @@ public record DecisionDefinitionFilter(
     private List<String> decisionRequirementsNames;
     private List<Integer> decisionRequirementsVersions;
     private List<String> tenantIds;
+    private Boolean isLatestVersion;
 
     public Builder decisionDefinitionKeys(final List<Long> values) {
       decisionDefinitionKeys = addValuesToList(decisionDefinitionKeys, values);
@@ -120,8 +122,14 @@ public record DecisionDefinitionFilter(
       return tenantIds(collectValuesAsList(values));
     }
 
+    public Builder isLatestVersion(final Boolean latest) {
+      isLatestVersion = latest;
+      return this;
+    }
+
     @Override
     public DecisionDefinitionFilter build() {
+      // final var latest = Objects.requireNonNullElse(isLatestVersion, false);
       return new DecisionDefinitionFilter(
           Objects.requireNonNullElse(decisionDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(decisionDefinitionIds, Collections.emptyList()),
@@ -131,7 +139,8 @@ public record DecisionDefinitionFilter(
           Objects.requireNonNullElse(decisionRequirementsKeys, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsNames, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsVersions, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          Objects.requireNonNullElse(isLatestVersion, false));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/DecisionDefinitionQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/DecisionDefinitionQuery.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.query;
 
+import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.page.SearchQueryPage;
@@ -25,6 +27,14 @@ public record DecisionDefinitionQuery(
     return fn.apply(new Builder()).build();
   }
 
+  @Override
+  public AggregationBase aggregation() {
+    if (filter.isLatestVersion()) {
+      return new DecisionDefinitionLatestVersionAggregation(filter, sort, page);
+    }
+    return null;
+  }
+
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
       implements TypedSearchQueryBuilder<
           DecisionDefinitionQuery, Builder, DecisionDefinitionFilter, DecisionDefinitionSort> {
@@ -37,8 +47,15 @@ public record DecisionDefinitionQuery(
     private DecisionDefinitionFilter filter;
     private DecisionDefinitionSort sort;
 
+    @Override
     public Builder filter(final DecisionDefinitionFilter value) {
       filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final DecisionDefinitionSort value) {
+      sort = value;
       return this;
     }
 
@@ -46,11 +63,6 @@ public record DecisionDefinitionQuery(
         final Function<DecisionDefinitionFilter.Builder, ObjectBuilder<DecisionDefinitionFilter>>
             fn) {
       return filter(FilterBuilders.decisionDefinition(fn));
-    }
-
-    public Builder sort(final DecisionDefinitionSort value) {
-      sort = value;
-      return this;
     }
 
     public Builder sort(

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -206,6 +206,12 @@ components:
         name:
           type: string
           description: The DMN name of the decision definition.
+        isLatestVersion:
+          description: |
+            Whether to only return the latest version of each decision definition.
+            When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`.
+            The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`.
+          type: boolean
         version:
           type: integer
           description: The assigned version of the decision definition.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds support for filtering decision definitions by latest version across the stack.
It includes the REST API definition, Java client support, document-based (Elasticsearch/OpenSearch) and RDBMS implementations, as well as QA acceptance and integration tests to verify correct behaviour.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #41296
