### PR TITLE
ci: add workflow to publish camunda-api-zod-schemas

### DIFF
--- a/.github/workflows/publish-zod-schemas.yml
+++ b/.github/workflows/publish-zod-schemas.yml
@@ -1,0 +1,85 @@
+# description: Publishes the @camunda/camunda-api-zod-schemas package to npm. This package provides Zod schemas and TypeScript types for Camunda 8 REST API. Published at: https://www.npmjs.com/package/@camunda/camunda-api-zod-schemas
+# type: CI Helper - Manual
+# owner: @camunda/core-features
+---
+name: Publish Zod Schemas to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (does not publish)'
+        required: false
+        type: boolean
+        default: true
+  push:
+    branches:
+      - main
+      - '**'  # Allow testing from any branch
+    paths:
+      - '.github/workflows/publish-zod-schemas.yml'
+      - 'client-components/packages/camunda-api-zod-schemas/**'
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  publish-zod-schemas:
+    name: "Publish @camunda/camunda-api-zod-schemas"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: client-components
+        shell: bash
+    env:
+      TEST_OWNER: Core Features
+      TEST_PRODUCT: Camunda
+      TEST_TYPE: Build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@camunda'
+          always-auth: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package (automatic triggers)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          npm run prepublishOnly
+          echo "Automatic trigger: Package built successfully but not published"
+
+      - name: Publish to npm (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          npm run prepublishOnly
+          npm publish --dry-run --tag next -w @camunda/camunda-api-zod-schemas --provenance || true
+
+      - name: Publish to npm
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
+        run: |
+          npm run publish:zod-schemas -- --provenance
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

On `push`:
- package build NOT published

On `workflow_dispatch` && `dry_run`
- publish  for release candidates

On `workflow_dispatch` && `!dry_run`
- publish