### PR TITLE
fix: use clock to compute job activation deadline

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
+import java.time.InstantSource;
 import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -58,14 +59,15 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final ProcessingState state,
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final InstantSource clock) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     authorizationCheckBehavior = authCheckBehavior;
     jobBatchCollector =
-        new JobBatchCollector(state, stateWriter::canWriteEventOfLength, authCheckBehavior);
+        new JobBatchCollector(state, stateWriter::canWriteEventOfLength, authCheckBehavior, clock);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -118,7 +118,8 @@ public final class JobEventProcessors {
                 processingState,
                 processingState.getKeyGenerator(),
                 jobMetrics,
-                authCheckBehavior))
+                authCheckBehavior,
+                clock))
         .withListener(
             new JobTimeoutCheckerScheduler(
                 scheduledTaskStateFactory.get().getJobState(),


### PR DESCRIPTION
## Description

This PR fixes a bug where we used to compute the deadline of a job (i.e. when it would timeout after activation) based on the time at which the original job record was written.

This worked in general, but failed with YIELD, since when yielding a job, we would store the _same_ record back. 

So if you push job 1, say, with timestamp 10, with a timeout of 30 - the deadline is timestamp 40. Then it takes a while, and the push fails, and we yield it back at timestamp 100. Say it now gets activated via polling at timestamp 200, and again with a timeout of 30 - we expect the deadline to be timestamp 230. However, it was incorrectly setting the deadline to 40, leading to it getting timed out _immediately_ and pushed out, resulting in a double activation.

The fix is to use the engine clock to compute the deadline on activation.

## Related issues

closes #42244 
