### PR TITLE
refactor: use selectedElementId and selectedAnchorElementId in TopPanel

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -297,13 +297,21 @@ const TopPanel: React.FC = observer(() => {
 
   useEffect(() => {
     if (!isModificationModeEnabled) {
-      if (selectedElementId) {
+      if (
+        IS_ELEMENT_SELECTION_V2
+          ? selectedElementId
+          : flowNodeSelection?.flowNodeId
+      ) {
         tracking.track({eventName: 'metadata-popover-opened'});
       } else {
         tracking.track({eventName: 'metadata-popover-closed'});
       }
     }
-  }, [isModificationModeEnabled, selectedElementId]);
+  }, [
+    isModificationModeEnabled,
+    selectedElementId,
+    flowNodeSelection?.flowNodeId,
+  ]);
 
   const getStatus = () => {
     if (isXmlFetching) {


### PR DESCRIPTION
## Description

- Replace `flowNodeSelection` store usage  by  selectedElementId and selectedAnchorElementId in TopPanel

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #41829
