### PR TITLE
feat: audit: enable authorizations for RDBMS layer

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AuditLogAuthorizationFilter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AuditLogAuthorizationFilter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.AUDIT_LOG;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_USER_TASK;
+
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holds the authorization filter data for audit log queries. This record encapsulates the composite
+ * authorization structure for audit logs, matching the Elasticsearch implementation in {@code
+ * AuditLogFilterTransformer.toAuthorizationCheckSearchQuery}.
+ *
+ * <p>Wildcard access is determined by the presence of "*" in the respective lists, rather than
+ * using separate boolean flags.
+ *
+ * @param authorizedCategories categories authorized via AUDIT_LOG resource type
+ * @param authorizedProcessDefinitionIdsForProcessInstance process definition IDs authorized for
+ *     READ_PROCESS_INSTANCE (may contain "*" for wildcard access)
+ * @param authorizedProcessDefinitionIdsForUserTask process definition IDs authorized for
+ *     READ_USER_TASK (may contain "*" for wildcard access)
+ */
+public record AuditLogAuthorizationFilter(
+    List<String> authorizedCategories,
+    List<String> authorizedProcessDefinitionIdsForProcessInstance,
+    List<String> authorizedProcessDefinitionIdsForUserTask) {
+
+  /**
+   * Returns a filter that blocks all access. Use this as a defensive default to ensure no data is
+   * returned when authorization information is missing or invalid.
+   */
+  public static AuditLogAuthorizationFilter denyAll() {
+    return new AuditLogAuthorizationFilter(List.of(), List.of(), List.of());
+  }
+
+  public static AuditLogAuthorizationFilter allowAll() {
+    return new AuditLogAuthorizationFilter(
+        List.of(WILDCARD_CHAR), List.of(WILDCARD_CHAR), List.of(WILDCARD_CHAR));
+  }
+
+  /**
+   * Builds the authorization filter for audit log queries by extracting the composite authorization
+   * structure from AuthorizationCheck.
+   *
+   * <p>This mirrors the Elasticsearch implementation in {@code
+   * AuditLogFilterTransformer.toAuthorizationCheckSearchQuery}, supporting:
+   *
+   * <ul>
+   *   <li>AUDIT_LOG resource type: authorized categories
+   *   <li>PROCESS_DEFINITION + READ_PROCESS_INSTANCE: authorized process definition IDs or wildcard
+   *       access
+   *   <li>PROCESS_DEFINITION + READ_USER_TASK: authorized process definition IDs for user tasks or
+   *       wildcard access
+   * </ul>
+   */
+  public static AuditLogAuthorizationFilter of(final AuthorizationCheck check) {
+    if (!check.enabled()) {
+      // When authorization is disabled, grant full access via wildcards
+      return allowAll();
+    }
+
+    final List<String> authorizedCategories = new ArrayList<>();
+    final List<String> processDefIdsForProcessInstance = new ArrayList<>();
+    final List<String> processDefIdsForUserTask = new ArrayList<>();
+
+    for (final var auth : check.authorizations()) {
+      applyAuthorization(
+          auth, authorizedCategories, processDefIdsForProcessInstance, processDefIdsForUserTask);
+    }
+
+    return new AuditLogAuthorizationFilter(
+        authorizedCategories, processDefIdsForProcessInstance, processDefIdsForUserTask);
+  }
+
+  private static void applyAuthorization(
+      final Authorization<?> auth,
+      final List<String> authorizedCategories,
+      final List<String> processDefIdsForProcessInstance,
+      final List<String> processDefIdsForUserTask) {
+    if (auth == null || auth.resourceType() == null || !auth.hasAnyResourceIds()) {
+      return;
+    }
+
+    if (AUDIT_LOG.equals(auth.resourceType())) {
+      authorizedCategories.addAll(auth.resourceIds());
+    } else if (PROCESS_DEFINITION.equals(auth.resourceType())) {
+      if (READ_PROCESS_INSTANCE.equals(auth.permissionType())) {
+        processDefIdsForProcessInstance.addAll(auth.resourceIds());
+      } else if (READ_USER_TASK.equals(auth.permissionType())) {
+        processDefIdsForUserTask.addAll(auth.resourceIds());
+      }
+    }
+  }
+
+  /** Returns true if the user has wildcard access for READ_PROCESS_INSTANCE permission. */
+  public boolean hasProcessInstanceWildcard() {
+    return authorizedProcessDefinitionIdsForProcessInstance.contains(WILDCARD_CHAR);
+  }
+
+  /** Returns true if the user has wildcard access for audit log categories. */
+  public boolean hasCategoryWildcard() {
+    return authorizedCategories.contains(WILDCARD_CHAR);
+  }
+
+  /** Returns true if the user has wildcard access for READ_USER_TASK permission. */
+  public boolean hasUserTaskWildcard() {
+    return authorizedProcessDefinitionIdsForUserTask.contains(WILDCARD_CHAR);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AuditLogDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AuditLogDbQuery.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
 
 public record AuditLogDbQuery(
     AuditLogFilter filter,
-    List<String> authorizedResourceIds,
+    AuditLogAuthorizationFilter authorizationFilter,
     List<String> authorizedTenantIds,
     DbQuerySorting<AuditLogEntity> sort,
     DbQueryPage page) {
@@ -31,7 +31,7 @@ public record AuditLogDbQuery(
     private static final AuditLogFilter EMPTY_FILTER = FilterBuilders.auditLog().build();
 
     private AuditLogFilter filter;
-    private List<String> authorizedResourceIds = List.of();
+    private AuditLogAuthorizationFilter authorizationFilter;
     private List<String> authorizedTenantIds = List.of();
     private DbQuerySorting<AuditLogEntity> sort;
     private DbQueryPage page;
@@ -41,8 +41,8 @@ public record AuditLogDbQuery(
       return this;
     }
 
-    public Builder authorizedResourceIds(final List<String> authorizedResourceIds) {
-      this.authorizedResourceIds = authorizedResourceIds;
+    public Builder authorizationFilter(final AuditLogAuthorizationFilter authorizationFilter) {
+      this.authorizationFilter = authorizationFilter;
       return this;
     }
 
@@ -78,9 +78,10 @@ public record AuditLogDbQuery(
     public AuditLogDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
-      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizationFilter =
+          Objects.requireNonNullElse(authorizationFilter, AuditLogAuthorizationFilter.denyAll());
       authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
-      return new AuditLogDbQuery(filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+      return new AuditLogDbQuery(filter, authorizationFilter, authorizedTenantIds, sort, page);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -66,12 +66,57 @@
 
   <sql id="searchFilter">
     <where>
-      <!-- authorization filters -->
+      <!-- tenant authorization filter -->
       <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
         AND (TENANT_SCOPE = 'GLOBAL' OR TENANT_ID IN
         <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
           #{tenantId}
         </foreach>)
+      </if>
+      <!-- Deny all access when no authorizations are configured -->
+      <if test="authorizationFilter.authorizedCategories.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
+        AND 1 = 0
+      </if>
+      <!-- composite authorization filter (OR of all authorization checks) -->
+      <!-- Only apply this filter if there are any authorizations configured -->
+      <if test="!authorizationFilter.authorizedCategories.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
+        AND (
+          <trim prefixOverrides="OR">
+             <!-- AUDIT_LOG resource type: wildcard access to all categories -->
+            <if test="authorizationFilter.hasCategoryWildcard()">
+              OR CATEGORY IS NOT NULL
+            </if>
+            <!-- AUDIT_LOG resource type: specific authorized categories -->
+            <if test="!authorizationFilter.authorizedCategories.isEmpty() and !authorizationFilter.hasCategoryWildcard()">
+              OR CATEGORY IN
+              <foreach collection="authorizationFilter.authorizedCategories" item="category" open="(" separator="," close=")">
+                #{category}
+              </foreach>
+            </if>
+            <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: wildcard access -->
+            <if test="authorizationFilter.hasProcessInstanceWildcard()">
+              OR PROCESS_DEFINITION_ID IS NOT NULL
+            </if>
+            <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: specific process definition IDs -->
+            <if test="!authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and !authorizationFilter.hasProcessInstanceWildcard()">
+              OR PROCESS_DEFINITION_ID IN
+              <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance" item="processDefId" open="(" separator="," close=")">
+                #{processDefId}
+              </foreach>
+            </if>
+            <!-- PROCESS_DEFINITION + READ_USER_TASK: wildcard access -->
+            <if test="authorizationFilter.hasUserTaskWildcard()">
+              OR CATEGORY = 'USER_TASKS'
+            </if>
+            <!-- PROCESS_DEFINITION + READ_USER_TASK: specific process definition IDs -->
+            <if test="!authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty() and !authorizationFilter.hasUserTaskWildcard()">
+              OR (CATEGORY = 'USER_TASKS' AND PROCESS_DEFINITION_ID IN
+              <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForUserTask" item="processDefId" open="(" separator="," close=")">
+                #{processDefId}
+              </foreach>)
+            </if>
+          </trim>
+        )
       </if>
       <!-- basic filters -->
       <if test="filter.auditLogKeyOperations != null and !filter.auditLogKeyOperations.isEmpty()">

--- a/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
+++ b/security/security-core/src/main/java/io/camunda/security/reader/AuthorizationCheck.java
@@ -10,6 +10,9 @@ package io.camunda.security.reader;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.condition.AuthorizationCondition;
 import io.camunda.security.auth.condition.AuthorizationConditions;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -28,6 +31,13 @@ public record AuthorizationCheck(boolean enabled, AuthorizationCondition authori
 
   public static AuthorizationCheck disabled() {
     return new AuthorizationCheck(false, null);
+  }
+
+  /** Returns the list of authorizations, or an empty list if none are configured. */
+  public List<Authorization<?>> authorizations() {
+    return Optional.ofNullable(authorizationCondition)
+        .map(AuthorizationCondition::authorizations)
+        .orElse(Collections.emptyList());
   }
 
   public boolean hasAnyResourceAccess() {


### PR DESCRIPTION
## Description

feat: audit: enable authorizations for RDBMS layer

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44012
