### PR TITLE
fix: remove db docker images after test runs

### DIFF
--- a/dist/src/test/java/io/camunda/application/StartStandaloneCamundaOnRdbmsDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/StartStandaloneCamundaOnRdbmsDockerIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.testcontainers.containers.BindMode;
@@ -14,71 +15,82 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 @EnabledIfSystemProperty(named = "camunda.docker.test.enabled", matches = "true")
-public class StartStandaloneCamundaOnRdbmsDockerIT extends AbstractCamundaDockerIT {
+public class StartStandaloneCamundaOnRdbmsDockerIT {
 
-  @Test
-  public void testStartStandaloneCamundaOnPostgres() {
-    createContainer(this::createPostgresContainer).start();
+  @Nested
+  class MysqlTests extends AbstractCamundaDockerIT {
 
-    final GenericContainer<?> camundaContainer =
-        createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithPostgres());
+    @Test
+    public void testStartStandaloneCamundaOnMysqlWithMountedDriver() throws ClassNotFoundException {
+      createContainer(this::createMysqlContainer).start();
 
-    startContainer(camundaContainer);
+      final Class<?> driverClass = Class.forName("com.mysql.cj.jdbc.Driver");
+      final String jarPath =
+          driverClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+      final GenericContainer<?> camundaContainer =
+          createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithMysql())
+              .withFileSystemBind(jarPath, "/driver-lib/mysqljdbc.jar", BindMode.READ_ONLY);
+
+      startContainer(camundaContainer);
+    }
+
+    @Test
+    public void testStartStandaloneCamundaOnMysqlWithoutMountedDriver() {
+      createContainer(this::createMysqlContainer).start();
+
+      final GenericContainer<?> camundaContainer =
+          createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithMysql())
+              .waitingFor(
+                  Wait.forLogMessage(
+                      ".*Failed to load driver class com.mysql.cj.jdbc.Driver.*\\s", 1));
+
+      startContainer(camundaContainer);
+    }
   }
 
-  @Test
-  public void testStartStandaloneCamundaOnOracleWithoutMountedDriver() {
-    createContainer(this::createOracleContainer).start();
+  @Nested
+  class OracleTests extends AbstractCamundaDockerIT {
+    @Test
+    public void testStartStandaloneCamundaOnOracleWithoutMountedDriver() {
+      createContainer(this::createOracleContainer).start();
 
-    final GenericContainer<?> camundaContainer =
-        createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithOracle())
-            .waitingFor(
-                Wait.forLogMessage(
-                    ".*Failed to load driver class oracle.jdbc.OracleDriver.*\\s", 1));
+      final GenericContainer<?> camundaContainer =
+          createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithOracle())
+              .waitingFor(
+                  Wait.forLogMessage(
+                      ".*Failed to load driver class oracle.jdbc.OracleDriver.*\\s", 1));
 
-    startContainer(camundaContainer);
+      startContainer(camundaContainer);
+    }
+
+    @Test
+    public void testStartStandaloneCamundaOnOracleWithMountedDriver()
+        throws ClassNotFoundException {
+      createContainer(this::createOracleContainer).start();
+
+      final Class<?> driverClass = Class.forName("oracle.jdbc.OracleDriver");
+      final String jarPath =
+          driverClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+      final GenericContainer<?> camundaContainer =
+          createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithOracle())
+              .withFileSystemBind(jarPath, "/driver-lib/ojdbc.jar", BindMode.READ_ONLY);
+
+      startContainer(camundaContainer);
+    }
   }
 
-  @Test
-  public void testStartStandaloneCamundaOnMysqlWithoutMountedDriver() {
-    createContainer(this::createMysqlContainer).start();
+  @Nested
+  class PostgresTests extends AbstractCamundaDockerIT {
+    @Test
+    public void testStartStandaloneCamundaOnPostgres() {
+      createContainer(this::createPostgresContainer).start();
 
-    final GenericContainer<?> camundaContainer =
-        createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithMysql())
-            .waitingFor(
-                Wait.forLogMessage(
-                    ".*Failed to load driver class com.mysql.cj.jdbc.Driver.*\\s", 1));
+      final GenericContainer<?> camundaContainer =
+          createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithPostgres());
 
-    startContainer(camundaContainer);
-  }
-
-  @Test
-  public void testStartStandaloneCamundaOnOracleWithMountedDriver() throws ClassNotFoundException {
-    createContainer(this::createOracleContainer).start();
-
-    final Class<?> driverClass = Class.forName("oracle.jdbc.OracleDriver");
-    final String jarPath =
-        driverClass.getProtectionDomain().getCodeSource().getLocation().getPath();
-
-    final GenericContainer<?> camundaContainer =
-        createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithOracle())
-            .withFileSystemBind(jarPath, "/driver-lib/ojdbc.jar", BindMode.READ_ONLY);
-
-    startContainer(camundaContainer);
-  }
-
-  @Test
-  public void testStartStandaloneCamundaOnMysqlWithMountedDriver() throws ClassNotFoundException {
-    createContainer(this::createMysqlContainer).start();
-
-    final Class<?> driverClass = Class.forName("com.mysql.cj.jdbc.Driver");
-    final String jarPath =
-        driverClass.getProtectionDomain().getCodeSource().getLocation().getPath();
-
-    final GenericContainer<?> camundaContainer =
-        createContainer(() -> createUnauthenticatedUnifiedConfigCamundaContainerWithMysql())
-            .withFileSystemBind(jarPath, "/driver-lib/mysqljdbc.jar", BindMode.READ_ONLY);
-
-    startContainer(camundaContainer);
+      startContainer(camundaContainer);
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Remove db docker images after tests are run to avoid running out of disk space.

See https://camunda.slack.com/archives/C0A8H916U12/p1768326790621569

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
