### PR TITLE
Search batch item API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -53,10 +53,6 @@ class OperateProcessesPage {
   readonly scheduledOperationsIcons: Locator;
   readonly viewParentInstanceLinkInList: Locator;
   readonly processInstanceLinkByKey: (processInstanceKey: string) => Locator;
-  readonly operationAndResultsContainer: (
-    operation: string,
-    resultCount?: number,
-  ) => Locator;
   readonly parentInstanceCell: (parentInstanceKey: string) => Locator;
   readonly versionCells: (version: string) => Locator;
   readonly calledInstanceCell: (
@@ -165,15 +161,6 @@ class OperateProcessesPage {
       page.getByRole('link', {
         name: processInstanceKey,
       });
-    this.operationAndResultsContainer = (
-      operation: string,
-      resultCount?: number,
-    ) => {
-      const pattern = resultCount
-        ? new RegExp(`${operation}.*${resultCount} results`)
-        : new RegExp(`${operation}.*\\d+ results`);
-      return page.locator('div').filter({hasText: pattern});
-    };
     this.parentInstanceCell = (parentInstanceKey: string) =>
       this.dataList.getByRole('cell', {name: parentInstanceKey});
     this.versionCells = (version: string) =>
@@ -365,7 +352,7 @@ class OperateProcessesPage {
             .locator('label');
 
           // Wait for the element to be attached and stable
-          await checkbox.waitFor({state: 'attached', timeout: 5000});
+          await checkbox.waitFor({state: 'attached', timeout: 10000});
           if (!(await checkbox.isChecked())) {
             await checkbox.click({timeout: 10000});
           }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -352,9 +352,9 @@ class OperateProcessesPage {
             .locator('label');
 
           // Wait for the element to be attached and stable
-          await checkbox.waitFor({state: 'attached', timeout: 10000});
+          await checkbox.waitFor({state: 'attached'});
           if (!(await checkbox.isChecked())) {
-            await checkbox.click({timeout: 10000});
+            await checkbox.click();
           }
           await sleep(100);
           break;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
@@ -37,7 +37,8 @@ import {
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
-test.describe.serial('Create Authorization API for client - Success and Conflict', () => {
+test.describe
+  .serial('Create Authorization API for client - Success and Conflict', () => {
   const clientId = 'client' + generateUniqueId();
   let createdAuthorizationKeys: string[] = [];
 
@@ -145,7 +146,8 @@ test.describe.serial('Create Authorization API for client - Success and Conflict
   });
 });
 
-test.describe.parallel('Create Authorization API for client - Unhappy paths', () => {
+test.describe
+  .parallel('Create Authorization API for client - Unhappy paths', () => {
   const clientId = 'client' + generateUniqueId();
 
   test('Create Authorization for client - 400 Bad Request - wrong value for ownerType', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
@@ -102,10 +102,7 @@ test.describe
       'GROUP',
       '*',
       'DECISION_DEFINITION',
-      [
-        'CREATE_DECISION_INSTANCE',
-        'READ_DECISION_DEFINITION'
-      ],
+      ['CREATE_DECISION_INSTANCE', 'READ_DECISION_DEFINITION'],
     );
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -37,7 +37,8 @@ import {
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
-test.describe.serial('Create Authorization API for Mapping Rule - Success and Conflict', () => {
+test.describe
+  .serial('Create Authorization API for Mapping Rule - Success and Conflict', () => {
   let successMappingRule: {
     mappingRuleId: string;
     claimName: string;
@@ -106,10 +107,7 @@ test.describe.serial('Create Authorization API for Mapping Rule - Success and Co
       'MAPPING_RULE',
       '*',
       'DOCUMENT',
-      [
-        'CREATE',
-        'READ'
-      ],
+      ['CREATE', 'READ'],
     );
 
     await expect(async () => {
@@ -163,7 +161,8 @@ test.describe.serial('Create Authorization API for Mapping Rule - Success and Co
   });
 });
 
-test.describe.parallel('Create Authorization API for Mapping Rule - Unhappy paths', () => {
+test.describe
+  .parallel('Create Authorization API for Mapping Rule - Unhappy paths', () => {
   let unhappyPathMappingRule: {
     mappingRuleId: string;
     claimName: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -39,7 +39,8 @@ import {
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
-test.describe.serial('Create Authorization API for role - Success and Conflict', () => {
+test.describe
+  .serial('Create Authorization API for role - Success and Conflict', () => {
   const uid = generateUniqueId();
   let successRole = {
     roleId: `role-create-authorization-${uid}`,
@@ -105,10 +106,7 @@ test.describe.serial('Create Authorization API for role - Success and Conflict',
       'ROLE',
       '*',
       'MAPPING_RULE',
-      [
-        'CREATE',
-        'READ'
-      ],
+      ['CREATE', 'READ'],
     );
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -97,10 +97,7 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
       'USER',
       '*',
       'SYSTEM',
-      [
-        'READ_USAGE_METRIC',
-        'UPDATE'
-      ],
+      ['READ_USAGE_METRIC', 'UPDATE'],
     );
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
@@ -1,0 +1,598 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  cancelProcessInstance,
+  createInstances,
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponseShape} from '../../../../json-body-assertions';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createCancellationBatch,
+  createSingleIncidentProcessInstance,
+  expectBatchState,
+  verifyIncidentsForProcessInstance,
+} from '@requestHelpers';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
+
+const SEARCH_BATCH_OPERATION_ITEMS_PATH = '/batch-operation-items/search';
+
+test.describe.parallel('Batch Operation Items Search API Tests', () => {
+  const processInstanceKeys: string[] = [];
+
+  test.beforeAll(async () => {
+    await deploy([
+      './resources/singleIncidentProcess.bpmn',
+      './resources/process_with_task_listener.bpmn',
+      './resources/processWithAnError.bpmn',
+    ]);
+  });
+
+  test.afterAll(async () => {
+    for (const processInstanceKey of processInstanceKeys) {
+      try {
+        await cancelProcessInstance(processInstanceKey);
+      } catch (error) {
+        console.warn(
+          `Failed to cancel process instance with key ${processInstanceKey}: ${error}`,
+        );
+      }
+    }
+  });
+
+  test('Search Batch Operation Items - by itemKey [incident key] - Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, unknown> = {};
+    await createSingleIncidentProcessInstance(localState, request);
+    const incidentKeys = localState['incidentKeys'] as string[];
+    const incidentKey = incidentKeys[0];
+    const processInstanceKey = localState.processInstanceKey as string;
+    processInstanceKeys.push(processInstanceKey);
+
+    await test.step('Verify that the process instance has incidents', async () => {
+      await verifyIncidentsForProcessInstance(request, processInstanceKey, 1);
+    });
+
+    await sleep(3000);
+
+    await test.step('Create Batch Operation to Resolve Incidents', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-instances/incident-resolution'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: localState.processInstanceKey,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-instances/incident-resolution',
+            method: 'POST',
+            status: '200',
+          },
+          json,
+        );
+        expect(json.batchOperationType).toBe('RESOLVE_INCIDENT');
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Batch Operation Items', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                itemKey: incidentKey,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toEqual(1);
+
+        const item = body.items[0];
+        expect(item.itemKey).toBe(incidentKey);
+        expect(item.operationType).toBe('RESOLVE_INCIDENT');
+        expect(item.state).toBeDefined();
+        expect(item.processInstanceKey).toBe(processInstanceKey);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search Batch Operation Items - by process instance key with single canceled process instance - Success', async ({
+    request,
+  }) => {
+    let processInstanceKeyToCancel: string;
+    let batchOperationKey: string;
+    await test.step('Create process instance to cancel', async () => {
+      processInstanceKeyToCancel = (
+        await createSingleInstance('processWithAnError', 1)
+      ).processInstanceKey;
+      console.log(
+        'Created process instance with key:',
+        processInstanceKeyToCancel,
+      );
+    });
+
+    await sleep(3000);
+
+    await test.step('Create a Batch Operation to Cancel Process Instance - Success', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-instances/cancellation'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToCancel,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-instances/cancellation',
+            method: 'POST',
+            status: '200',
+          },
+          json,
+        );
+        expect(json.batchOperationType).toBe('CANCEL_PROCESS_INSTANCE');
+        batchOperationKey = json.batchOperationKey;
+        console.log('Created batch operation with key:', batchOperationKey);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Poll batch status', async () => {
+      await expectBatchState(request, batchOperationKey, 'COMPLETED');
+    });
+
+    await test.step('Search Batch Operation Items - by process instance key', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToCancel,
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toEqual(1);
+
+        const item = body.items[0];
+        expect(item.itemKey).toBe(processInstanceKeyToCancel);
+        expect(item.batchOperationKey).toBe(batchOperationKey);
+        expect(item.operationType).toBe('CANCEL_PROCESS_INSTANCE');
+        expect(item.state).toBeDefined();
+        expect(item.processInstanceKey).toBe(processInstanceKeyToCancel);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search Batch Operation Items - by itemKey [process instance key] with multiple canceled process instance - Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, string[]> = {processInstanceKeys: []};
+    let processInstanceKey1: string;
+    let processInstanceKey2: string;
+    let batchOperationKey: string;
+    await test.step('Create multiple process instances to cancel', async () => {
+      const processInstances = await createInstances(
+        'process_with_task_listener',
+        1,
+        3,
+      );
+      for (const processInstance of processInstances) {
+        localState['processInstanceKeys'] = [
+          ...(localState['processInstanceKeys'] as string[]),
+          processInstance.processInstanceKey,
+        ];
+      }
+      processInstanceKey1 = localState['processInstanceKeys']![0];
+      processInstanceKey2 = localState['processInstanceKeys']![1];
+    });
+
+    await sleep(3000);
+
+    await test.step('Create a Batch Operation to Cancel Process Instances', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-instances/cancellation'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                $or: [
+                  ...localState['processInstanceKeys'].map((key) => ({
+                    processInstanceKey: key,
+                  })),
+                ],
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-instances/cancellation',
+            method: 'POST',
+            status: '200',
+          },
+          json,
+        );
+        expect(json.batchOperationType).toBe('CANCEL_PROCESS_INSTANCE');
+        batchOperationKey = json.batchOperationKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Batch Operation Items - by multiple process instance key as itemKey', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                itemKey: {
+                  $in: [processInstanceKey1, processInstanceKey2],
+                },
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+        expect(body.page.totalItems).toEqual(2);
+        expect(body.items.length).toEqual(2);
+
+        const item = body.items[0];
+        expect([processInstanceKey1, processInstanceKey2]).toContain(item.itemKey)
+        expect(item.batchOperationKey).toBe(batchOperationKey);
+        expect(item.operationType).toBe('CANCEL_PROCESS_INSTANCE');
+        expect(item.state).toBeDefined();
+        expect([processInstanceKey1, processInstanceKey2]).toContain(item.processInstanceKey);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search Batch Operation Items - by operationType - Success', async ({
+    request,
+  }) => {
+    const localState: Record<string, unknown> = {};
+    await createSingleIncidentProcessInstance(localState, request);
+    const processInstanceKey = localState.processInstanceKey as string;
+    let processInstanceKeyToCancel: string;
+    let batchOperationKey: string;
+    processInstanceKeys.push(processInstanceKey);
+
+    await test.step('Verify that the process instance has incidents', async () => {
+      await verifyIncidentsForProcessInstance(request, processInstanceKey, 1);
+    });
+
+    await sleep(3000);
+
+    await test.step('Create Batch Operation to Resolve Incidents', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-instances/incident-resolution'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: localState.processInstanceKey,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-instances/incident-resolution',
+            method: 'POST',
+            status: '200',
+          },
+          json,
+        );
+        expect(json.batchOperationType).toBe('RESOLVE_INCIDENT');
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Create process instance to cancel', async () => {
+      processInstanceKeyToCancel = (
+        await createSingleInstance('processWithAnError', 1)
+      ).processInstanceKey;
+      console.log(
+        'Created process instance with key:',
+        processInstanceKeyToCancel,
+      );
+    });
+
+    await sleep(3000);
+
+    await test.step('Create a Batch Operation to Cancel Process Instance - Success', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/process-instances/cancellation'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToCancel,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        validateResponseShape(
+          {
+            path: '/process-instances/cancellation',
+            method: 'POST',
+            status: '200',
+          },
+          json,
+        );
+        expect(json.batchOperationType).toBe('CANCEL_PROCESS_INSTANCE');
+        batchOperationKey = json.batchOperationKey;
+        console.log('Created batch operation with key:', batchOperationKey);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Poll batch status', async () => {
+      await expectBatchState(request, batchOperationKey, 'COMPLETED');
+    });
+
+    await test.step('Search Batch Operation Items - by operation type CANCEL_PROCESS_INSTANCE', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                operationType: 'CANCEL_PROCESS_INSTANCE',
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toBeGreaterThanOrEqual(1);
+
+        const item = body.items[0];
+        expect(item.operationType).toBe('CANCEL_PROCESS_INSTANCE');
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search Batch Operation Items - by operation type RESOLVE_INCIDENT', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                operationType: 'RESOLVE_INCIDENT',
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+
+        const body = await res.json();
+
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toBeGreaterThanOrEqual(1);
+
+        const item = body.items[0];
+        expect(item.operationType).toBe('RESOLVE_INCIDENT');
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search Batch Operation Items - Unauthorized Request', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+      {
+        data: {
+          filter: {
+            operationType: 'RESOLVE_INCIDENT',
+          },
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Batch Operation Items - Empty Result', async ({request}) => {
+    const notExistingProcessInstanceKey = '9999999999999999';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: notExistingProcessInstanceKey,
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: SEARCH_BATCH_OPERATION_ITEMS_PATH,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(0);
+      expect(body.items.length).toBe(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Batch Operation Items - Bad Request - invalid filter field', async ({
+    request,
+  }) => {
+    const invalidFilterValue = 'meow';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              meow: invalidFilterValue,
+            },
+          },
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        'Request property [filter.meow] cannot be parsed',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Batch Operation Items - Bad Request - invalid state filter value', async ({
+    request,
+  }) => {
+    const invalidFilterValue = 'meow';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              state: invalidFilterValue,
+            },
+          },
+        },
+      );
+
+      await assertBadRequest(
+        res,
+        "Unexpected value 'meow' for enum field 'state'. Use any of the following values: [ACTIVE, COMPLETED, CANCELED, FAILED]",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Batch Operation Items - Bad Request - invalid itemKey filter value', async ({
+    request,
+  }) => {
+    const invalidFilterValue = 'meow';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(SEARCH_BATCH_OPERATION_ITEMS_PATH),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              itemKey: invalidFilterValue,
+            },
+          },
+        },
+      );
+
+      await assertBadRequest(res, 'For input string: \"meow\"');
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
-  assertNotFoundRequest,
   assertStatusCode,
   assertUnauthorizedRequest,
   buildUrl,
@@ -25,12 +24,10 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponseShape} from '../../../../json-body-assertions';
 import {validateResponse} from '../../../../json-body-assertions';
 import {
-  createCancellationBatch,
   createSingleIncidentProcessInstance,
   expectBatchState,
   verifyIncidentsForProcessInstance,
 } from '@requestHelpers';
-import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from 'utils/sleep';
 
 const SEARCH_BATCH_OPERATION_ITEMS_PATH = '/batch-operation-items/search';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
@@ -64,9 +64,9 @@ test.describe.parallel('Create Process Instance Batch to Cancel Tests', () => {
             headers: jsonHeaders(),
             data: {
               filter: {
-                $or: [
-                  ...localState['processInstanceKeys'].map((key) => ({ processInstanceKey: key })),
-                ]
+                processInstanceKey: {
+                  $in: localState['processInstanceKeys'],
+                },
               },
             },
           },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
@@ -64,9 +64,9 @@ test.describe.parallel('Create Process Instance Batch to Cancel Tests', () => {
             headers: jsonHeaders(),
             data: {
               filter: {
-                processInstanceKey: {
-                  $in: localState['processInstanceKeys'],
-                },
+                $or: [
+                  ...localState['processInstanceKeys'].map((key) => ({ processInstanceKey: key })),
+                ]
               },
             },
           },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -232,18 +232,6 @@ test.describe('Operations', () => {
 
       await validateURL(page, /operationId=/);
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(
-            operateProcessesPage.operationAndResultsContainer('cancel', 5),
-          ).toBeVisible({
-            timeout: 30000,
-          });
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
       await Promise.all(
         instances.map((instance) =>
           expect(
@@ -279,8 +267,16 @@ test.describe('Operations', () => {
         instances.length,
       );
 
-      await expect(operationEntry).toBeVisible({timeout: 120000});
-
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operationEntry).toBeVisible({});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
+      });
+      
       await Promise.all(
         instances.map((instance) =>
           expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -269,7 +269,7 @@ test.describe('Operations', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(operationEntry).toBeVisible({});
+          await expect(operationEntry).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -173,7 +173,7 @@ test.describe('Process Instance', () => {
     });
   });
 
-  test('Cancel an instance', async ({operateProcessInstancePage}) => {
+  test('Cancel an instance', async ({operateProcessInstancePage, page}) => {
     const instanceId = instanceWithIncidentToCancel.processInstanceKey;
 
     await test.step('Navigate to process instance with incident', async () => {
@@ -197,9 +197,17 @@ test.describe('Process Instance', () => {
     });
 
     await test.step('Verify instance is canceled', async () => {
-      await expect(
-        operateProcessInstancePage.incidentBannerButton(3),
-      ).not.toBeVisible({timeout: 60000});
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.incidentBannerButton(3),
+          ).toBeHidden();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 5,
+      });
 
       await expect(operateProcessInstancePage.terminatedIcon).toBeVisible();
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -76,6 +76,7 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.selectProcess(
         'Process With Multiple Versions',
       );
+      await operateFiltersPanelPage.selectVersion('2');
       await waitForAssertion({
         assertion: async () => {
           await expect
@@ -90,6 +91,7 @@ test.describe('Process Instances Filters', () => {
           await operateFiltersPanelPage.selectProcess(
             'Process With Multiple Versions',
           );
+          await operateFiltersPanelPage.selectVersion('2');
         },
       });
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -248,8 +248,15 @@ test.describe('Processes', () => {
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );
 
-      await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled({
-        timeout: 30000,
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled({
+            timeout: 5000,
+          });
+        },
+        onFailure: async () => {
+          page.reload();
+        },
       });
 
       await expect(operateDiagramPage.diagramSpinner).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -118,11 +118,11 @@ test.describe('process page', () => {
     await waitForAssertion({
       assertion: async () => {
         await expect(
-          taskPanelPage.availableTasks.getByText('User_Task'),
-        ).toBeVisible();
+          taskPanelPage.availableTasks.getByText('User_Task').first(),
+        ).toBeVisible({timeout: 10000});
       },
       onFailure: async () => {
-        console.log('User_Task not visible yet, retrying...');
+        page.reload();
       },
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -118,8 +118,8 @@ test.describe('process page', () => {
     await waitForAssertion({
       assertion: async () => {
         await expect(
-          taskPanelPage.availableTasks.getByText('User_Task').first(),
-        ).toBeVisible({timeout: 10000});
+          taskPanelPage.availableTasks.getByText('User_Task').first())
+        .toBeVisible();
       },
       onFailure: async () => {
         page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -119,7 +119,7 @@ test.describe('process page', () => {
       assertion: async () => {
         await expect(
           taskPanelPageV1.availableTasks.getByText('User_Task').first()
-        ).toBeVisible({timeout: 10000});
+        ).toBeVisible();
       },
       onFailure: async () => {
         page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/processes-page.spec.ts
@@ -118,11 +118,11 @@ test.describe('process page', () => {
     await waitForAssertion({
       assertion: async () => {
         await expect(
-          taskPanelPageV1.availableTasks.getByText('User_Task'),
-        ).toBeVisible();
+          taskPanelPageV1.availableTasks.getByText('User_Task').first()
+        ).toBeVisible({timeout: 10000});
       },
       onFailure: async () => {
-        console.log('User_Task not visible yet, retrying...');
+        page.reload();
       },
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -625,12 +625,12 @@ test.describe('task details page', () => {
     await taskDetailsPageV1.assertFieldValue(
       'Process input variable',
       'name:"Adeel Solangi"',
-      {contains: true},
+      {partial: true},
     );
     await taskDetailsPageV1.assertFieldValue(
       'Process input variable',
       'Maecenas quis nisi nunc.", version:2.69',
-      {contains: true},
+      {partial: true},
     );
     await taskDetailsPageV1.clickCompleteTaskButton();
     await expect(taskDetailsPageV1.taskCompletedBanner).toBeVisible();
@@ -642,12 +642,12 @@ test.describe('task details page', () => {
     await taskDetailsPageV1.assertFieldValue(
       'Process input variable',
       'name:"Adeel Solangi"',
-      {contains: true},
+      {partial: true},
     );
     await taskDetailsPageV1.assertFieldValue(
       'Process input variable',
       'Maecenas quis nisi nunc.", version:2.69',
-      {contains: true},
+      {partial: true},
     );
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForAssertion.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/waitForAssertion.ts
@@ -14,7 +14,7 @@ async function waitForAssertion(options: {
   const {assertion, onFailure: fallback, maxRetries = 3} = options;
   let retries = 1;
 
-  while (retries < maxRetries) {
+  while (retries <= maxRetries) {
     try {
       await assertion();
       break;


### PR DESCRIPTION
## Description

This PR covers Batch operation items search [API](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-batch-operation-items/) with happy path:

- Search Batch Operation Items - by itemKey [incident key] - Success
- Search Batch Operation Items - by process instance key with single canceled process instance - Success
- Search Batch Operation Items - by itemKey [process instance key] with multiple canceled process instance - Success
- Search Batch Operation Items - by operationType - Success
- Search Batch Operation Items - Empty Result

and unhappy path:

- Search Batch Operation Items - Unauthorized Request
- Search Batch Operation Items - Bad Request - invalid filter field
- Search Batch Operation Items - Bad Request - invalid state filter value
- Search Batch Operation Items - Bad Request - invalid itemKey filter value'

In backport to stable/8.8 will be required to remove operation type filter test as this filter isn't present in `stable/8.8`

This PR also covers some some other updates:

- `OperateProcessPage`: remove locator for not existing UI element
- lint fix for all create authorization files
- update `waitForAsserion` function to reach maxRetries = retries; 
- `task-details.spec.ts`: change contain to existing `partial` parameter 
- and some other.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand worfklow
After 15 tries [was finally successful](https://github.com/camunda/camunda/actions/runs/21059809893)
