### PR TITLE
docs: document queries to explore the overflowed key space

### DIFF
--- a/debug-cli/scripts/overwrite-key/README.md
+++ b/debug-cli/scripts/overwrite-key/README.md
@@ -68,6 +68,12 @@ ES_URL="http://localhost:9200" PARTITION_ID=1 AFTER_KEY=2251799813999999 ./analy
 
 # Skip download and only analyze existing file (useful if data already downloaded)
 PARTITION_ID=1 SKIP_DOWNLOAD=true ./analyze-partition-keys.sh
+
+# Custom jump threshold (default: 1000000)
+ES_URL="http://localhost:9200" PARTITION_ID=1 JUMP_THRESHOLD=5000000 ./analyze-partition-keys.sh
+
+# Re-analyze with different threshold without re-downloading
+PARTITION_ID=1 SKIP_DOWNLOAD=true JUMP_THRESHOLD=500000 ./analyze-partition-keys.sh
 ```
 
 **Use Cases:**
@@ -76,12 +82,16 @@ PARTITION_ID=1 SKIP_DOWNLOAD=true ./analyze-partition-keys.sh
 
 - **AFTER_KEY**: If the script is interrupted during download, you can resume by setting AFTER_KEY to the last key in the file. Check the last line with `tail -1 partition_${PARTITION_ID}_keys.txt | cut -f1`.
 
+- **JUMP_THRESHOLD**: Adjust the minimum difference between consecutive keys to consider a jump. Default is 1,000,000. Use a higher value to only detect larger jumps, or lower to detect smaller anomalies.
+
 - **SKIP_DOWNLOAD**: Use this when you've already downloaded the data and just want to re-run the analysis. This is useful for:
+
   - Testing different jump thresholds without re-downloading
   - Sharing the data file with team members for offline analysis
   - Re-analyzing after manually modifying the data
 
 **Important:** If you need to re-run the analysis from scratch, manually delete the output file first:
+
 ```bash
 rm partition_${PARTITION_ID}_keys.txt
 ```
@@ -94,6 +104,7 @@ Partition Key Analysis
 ======================================
 Elasticsearch URL: http://localhost:9200
 Partition ID:      1
+Jump Threshold:    1000000
 Batch Size:        1000
 Output File:       partition_1_keys.txt
 

--- a/debug-cli/scripts/overwrite-key/README.md
+++ b/debug-cli/scripts/overwrite-key/README.md
@@ -39,7 +39,7 @@ Before starting, you need:
 
 #### Finding Key Jumps Using Elasticsearch
 
-To identify where the key jump occurred within a partition, use the provided script to query Elasticsearch and analyze `processInstanceKey` values. The script automatically handles pagination for partitions with many process instances.
+To identify where the key jump occurred within a partition, use the provided script to query Elasticsearch and analyze flow node instance keys. The script automatically handles pagination for partitions with many flow node instances.
 
 > [!NOTE]
 > The provided script should work for most scenarios, but may need adjustments for specific Elasticsearch configurations or custom requirements. If needed, you can perform manual queries by examining the Elasticsearch queries used by the script.
@@ -52,7 +52,7 @@ ES_URL="http://localhost:9200" PARTITION_ID=1 ./analyze-partition-keys.sh
 ```
 
 The script will:
-1. Query Elasticsearch for all unique processInstanceKeys in the partition (with automatic pagination)
+1. Query Elasticsearch for all unique flow node instance keys in the partition (with automatic pagination)
 2. Save results to `partition_${PARTITION_ID}_keys.txt`
 3. Analyze the keys to detect jumps > 1 million
 4. Display any jumps found with timestamps
@@ -72,18 +72,16 @@ PARTITION_ID=1 SKIP_DOWNLOAD=true ./analyze-partition-keys.sh
 
 **Use Cases:**
 
-- **BATCH_SIZE**: Use a larger batch size (e.g., 5000-10000) for faster downloads when the partition has many process instances. Smaller batch sizes are useful for slow networks.
+- **BATCH_SIZE**: Use a larger batch size (e.g., 5000-10000) for faster downloads when the partition has many flow node instances. Smaller batch sizes are useful for slow networks.
 
-- **AFTER_KEY**: If the script is interrupted during download, you can resume by setting AFTER_KEY to the last processInstanceKey in the file. Check the last line with `tail -1 partition_${PARTITION_ID}_keys.txt | cut -f1`.
+- **AFTER_KEY**: If the script is interrupted during download, you can resume by setting AFTER_KEY to the last key in the file. Check the last line with `tail -1 partition_${PARTITION_ID}_keys.txt | cut -f1`.
 
 - **SKIP_DOWNLOAD**: Use this when you've already downloaded the data and just want to re-run the analysis. This is useful for:
-
   - Testing different jump thresholds without re-downloading
   - Sharing the data file with team members for offline analysis
   - Re-analyzing after manually modifying the data
 
 **Important:** If you need to re-run the analysis from scratch, manually delete the output file first:
-
 ```bash
 rm partition_${PARTITION_ID}_keys.txt
 ```
@@ -102,7 +100,7 @@ Output File:       partition_1_keys.txt
 Testing Elasticsearch connectivity...
 ✓ Connected to Elasticsearch
 
-Fetching processInstanceKeys...
+Fetching flow node instance keys...
 Batch 1: Fetching up to 1000 keys... ✓ 1000 keys (Total: 1000)
 Batch 2: Fetching up to 1000 keys... ✓ 1000 keys (Total: 2000)
 Batch 3: Fetching up to 1000 keys... ✓ 456 keys (Total: 2456)
@@ -127,10 +125,10 @@ Results saved to:    partition_1_keys.txt
 
 Step 2 can be done using other tools if you prefer. The file `partition_${PARTITION_ID}_keys.txt` is a tab-separated text file with two columns:
 
-1. **Column 1**: `processInstanceKey` (sorted numerically)
-2. **Column 2**: `timestamp` (when the process instance started)
+1. **Column 1**: `key` (flow node instance key, sorted numerically)
+2. **Column 2**: `timestamp` (when the flow node instance started)
 
-**What to look for:** Find rows where the difference between consecutive `processInstanceKey` values is greater than a threshold (e.g. one million ). This indicates an abnormal jump.
+**What to look for:** Find rows where the difference between consecutive key values is greater than a threshold (e.g. one million). This indicates an abnormal jump.
 
 **Example file content:**
 

--- a/debug-cli/scripts/overwrite-key/analyze-partition-keys.sh
+++ b/debug-cli/scripts/overwrite-key/analyze-partition-keys.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# analyze-partition-keys.sh
+# 
+# Queries Elasticsearch to extract all processInstanceKeys for a specific partition
+# and saves them to a file for jump analysis.
+#
+# Required environment variables:
+#   PARTITION_ID  - Partition ID to analyze (e.g., 1)
+#
+# Required if SKIP_DOWNLOAD is not set:
+#   ES_URL        - Elasticsearch URL (e.g., http://localhost:9200)
+#
+# Optional environment variables:
+#   BATCH_SIZE    - Keys per batch (default: 1000, max: 10000)
+#   AFTER_KEY     - Resume from this key (for manual continuation)
+#   SKIP_DOWNLOAD - Set to "true" to skip download and only analyze existing file
+#
+# Output:
+#   partition_${PARTITION_ID}_keys.txt - Tab-separated file with keys and timestamps
+#
+# Usage:
+#   # Download and analyze:
+#   ES_URL="http://localhost:9200" PARTITION_ID=1 ./analyze-partition-keys.sh
+#   
+#   # With custom batch size:
+#   ES_URL="http://localhost:9200" PARTITION_ID=1 BATCH_SIZE=5000 ./analyze-partition-keys.sh
+#   
+#   # Resume from a specific key:
+#   ES_URL="http://localhost:9200" PARTITION_ID=1 AFTER_KEY=2251799813999999 ./analyze-partition-keys.sh
+#
+#   # Skip download and only analyze existing file:
+#   PARTITION_ID=1 SKIP_DOWNLOAD=true ./analyze-partition-keys.sh
+#
+# Make executable with: chmod +x analyze-partition-keys.sh
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Set defaults for optional parameters
+SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-false}"
+
+# Validate required parameters
+if [ -z "${PARTITION_ID:-}" ]; then
+  echo -e "${RED}Error: PARTITION_ID is required${NC}"
+  echo "Usage: ES_URL=\"http://localhost:9200\" PARTITION_ID=1 $0"
+  echo "   or: PARTITION_ID=1 SKIP_DOWNLOAD=true $0"
+  exit 1
+fi
+
+if [ "$SKIP_DOWNLOAD" != "true" ] && [ -z "${ES_URL:-}" ]; then
+  echo -e "${RED}Error: ES_URL is required (unless SKIP_DOWNLOAD=true)${NC}"
+  echo "Usage: ES_URL=\"http://localhost:9200\" PARTITION_ID=1 $0"
+  echo "   or: PARTITION_ID=1 SKIP_DOWNLOAD=true $0"
+  exit 1
+fi
+
+# Set defaults for optional parameters
+BATCH_SIZE="${BATCH_SIZE:-1000}"
+AFTER_KEY="${AFTER_KEY:-}"
+
+# Validate batch size
+if [ "$BATCH_SIZE" -gt 10000 ]; then
+  echo -e "${YELLOW}Warning: BATCH_SIZE cannot exceed 10000. Setting to 10000.${NC}"
+  BATCH_SIZE=10000
+fi
+
+OUTPUT_FILE="partition_${PARTITION_ID}_keys.txt"
+
+echo -e "${BLUE}======================================${NC}"
+echo -e "${BLUE}Partition Key Analysis${NC}"
+echo -e "${BLUE}======================================${NC}"
+if [ "$SKIP_DOWNLOAD" = "true" ]; then
+  echo "Mode:              Analysis only (SKIP_DOWNLOAD)"
+else
+  echo "Elasticsearch URL: $ES_URL"
+  echo "Batch Size:        $BATCH_SIZE"
+fi
+echo "Partition ID:      $PARTITION_ID"
+echo "Output File:       $OUTPUT_FILE"
+
+if [ "$SKIP_DOWNLOAD" = "true" ]; then
+  # Skip download mode - just check if file exists
+  if [ ! -f "$OUTPUT_FILE" ]; then
+    echo -e "${RED}======================================${NC}"
+    echo -e "${RED}ERROR: File does not exist!${NC}"
+    echo -e "${RED}======================================${NC}"
+    echo "File: $OUTPUT_FILE"
+    echo ""
+    echo "The file must exist to use SKIP_DOWNLOAD=true."
+    echo "Either download the data first, or remove SKIP_DOWNLOAD flag."
+    exit 1
+  fi
+  echo -e "${GREEN}✓ Found existing file with $(wc -l < "$OUTPUT_FILE") keys${NC}"
+else
+  # Download mode - check if output file exists
+  if [ -f "$OUTPUT_FILE" ]; then
+    if [ -z "$AFTER_KEY" ]; then
+      echo -e "${YELLOW}======================================${NC}"
+      echo -e "${YELLOW}WARNING: Output file already exists!${NC}"
+      echo -e "${YELLOW}======================================${NC}"
+      echo "File: $OUTPUT_FILE"
+      echo ""
+      echo "To start fresh, delete the file first:"
+      echo "  rm $OUTPUT_FILE"
+      echo ""
+      echo "To resume from where you left off, set AFTER_KEY to the last key in the file."
+      echo ""
+      echo "To skip download and only analyze, set SKIP_DOWNLOAD=true."
+      echo ""
+      echo -e "${RED}Aborting to prevent data loss.${NC}"
+      exit 1
+    else
+      echo -e "${YELLOW}Resuming: Will append to existing file${NC}"
+    fi
+  else
+    # Create empty file
+    > "$OUTPUT_FILE"
+  fi
+
+  # Test Elasticsearch connectivity
+  echo ""
+  echo "Testing Elasticsearch connectivity..."
+  if ! curl -sf "${ES_URL}/_cluster/health" > /dev/null 2>&1; then
+    echo -e "${RED}Error: Cannot connect to Elasticsearch at $ES_URL${NC}"
+    echo "Please verify the URL and ensure Elasticsearch is running."
+    exit 1
+  fi
+  echo -e "${GREEN}✓ Connected to Elasticsearch${NC}"
+
+  # Main pagination loop
+  echo ""
+  echo -e "${BLUE}Fetching processInstanceKeys...${NC}"
+  BATCH_NUM=1
+  TOTAL_KEYS=0
+  CURRENT_AFTER_KEY="$AFTER_KEY"
+
+  while true; do
+    # Build after parameter
+    AFTER_PARAM=""
+    if [ -n "$CURRENT_AFTER_KEY" ]; then
+      AFTER_PARAM=", \"after\": {\"processInstanceKey\": $CURRENT_AFTER_KEY}"
+    fi
+    
+    # Query Elasticsearch
+    echo -n "Batch $BATCH_NUM: Fetching up to $BATCH_SIZE keys..."
+    
+    RESPONSE=$(curl -sf "${ES_URL}/operate-list-view-*/_search" \
+      -H 'Content-Type: application/json' \
+      -d "{
+      \"size\": 0,
+      \"query\": {
+        \"term\": {
+          \"partitionId\": ${PARTITION_ID}
+        }
+      },
+      \"aggs\": {
+        \"process_instances\": {
+          \"composite\": {
+            \"size\": ${BATCH_SIZE},
+            \"sources\": [
+              {\"processInstanceKey\": {\"terms\": {\"field\": \"processInstanceKey\"}}}
+            ]
+            ${AFTER_PARAM}
+          },
+          \"aggs\": {
+            \"min_timestamp\": {\"min\": {\"field\": \"startDate\"}}
+          }
+        }
+      }
+    }") || {
+      echo -e "${RED}Failed!${NC}"
+      echo -e "${RED}Error: Failed to query Elasticsearch${NC}"
+      exit 1
+    }
+  
+  # Extract data and append to file
+  BATCH_KEYS=$(echo "$RESPONSE" | jq -r '.aggregations.process_instances.buckets[] | [.key.processInstanceKey, .min_timestamp.value_as_string // "N/A"] | @tsv' | tee -a "$OUTPUT_FILE" | wc -l)
+  
+  TOTAL_KEYS=$((TOTAL_KEYS + BATCH_KEYS))
+  echo -e " ${GREEN}✓ $BATCH_KEYS keys (Total: $TOTAL_KEYS)${NC}"
+  
+  # Check for after_key
+  CURRENT_AFTER_KEY=$(echo "$RESPONSE" | jq -r '.aggregations.process_instances.after_key.processInstanceKey // empty')
+  
+  if [ -z "$CURRENT_AFTER_KEY" ]; then
+    echo -e "${GREEN}✓ All keys fetched${NC}"
+    break
+  fi
+  
+  BATCH_NUM=$((BATCH_NUM + 1))
+done
+fi
+
+# Count total keys in file
+TOTAL_KEYS=$(wc -l < "$OUTPUT_FILE")
+
+echo ""
+echo -e "${BLUE}======================================${NC}"
+echo -e "${BLUE}Analyzing for Key Jumps...${NC}"
+echo -e "${BLUE}======================================${NC}"
+
+# Step 2: Analyze the keys to find jumps
+JUMP_THRESHOLD=1000000
+JUMP_FOUND=false
+
+prev_key=""
+prev_ts=""
+while IFS=$'\t' read -r key timestamp; do
+  if [ -n "$prev_key" ]; then
+    diff=$((key - prev_key))
+    if [ $diff -gt $JUMP_THRESHOLD ]; then
+      JUMP_FOUND=true
+      echo -e "${RED}=== JUMP DETECTED ===${NC}"
+      echo "Previous key: $prev_key (timestamp: $prev_ts)"
+      echo "Current key:  $key (timestamp: $timestamp)"
+      echo "Difference:   $diff"
+      echo ""
+    fi
+  fi
+  prev_key="$key"
+  prev_ts="$timestamp"
+done < "$OUTPUT_FILE"
+
+if [ "$JUMP_FOUND" = false ]; then
+  echo -e "${GREEN}✓ No jumps detected (all differences <= $JUMP_THRESHOLD)${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}======================================${NC}"
+echo -e "${BLUE}Analysis Complete${NC}"
+echo -e "${BLUE}======================================${NC}"
+echo "Total keys analyzed: $TOTAL_KEYS"
+echo "Results saved to:    $OUTPUT_FILE"
+echo ""
+echo "You can also analyze the file manually using:"
+echo "  - Python (see README for example)"
+echo "  - Excel/Spreadsheet (import as tab-delimited)"
+echo ""
+echo "To clean up, run:"
+echo "  rm $OUTPUT_FILE"

--- a/debug-cli/scripts/overwrite-key/analyze-partition-keys.sh
+++ b/debug-cli/scripts/overwrite-key/analyze-partition-keys.sh
@@ -11,9 +11,10 @@
 #   ES_URL        - Elasticsearch URL (e.g., http://localhost:9200)
 #
 # Optional environment variables:
-#   BATCH_SIZE    - Keys per batch (default: 1000, max: 10000)
-#   AFTER_KEY     - Resume from this key (for manual continuation)
-#   SKIP_DOWNLOAD - Set to "true" to skip download and only analyze existing file
+#   BATCH_SIZE     - Keys per batch (default: 1000, max: 10000)
+#   AFTER_KEY      - Resume from this key (for manual continuation)
+#   SKIP_DOWNLOAD  - Set to "true" to skip download and only analyze existing file
+#   JUMP_THRESHOLD - Minimum difference to consider a jump (default: 1000000)
 #
 # Output:
 #   partition_${PARTITION_ID}_keys.txt - Tab-separated file with keys and timestamps
@@ -30,6 +31,9 @@
 #
 #   # Skip download and only analyze existing file:
 #   PARTITION_ID=1 SKIP_DOWNLOAD=true ./analyze-partition-keys.sh
+#
+#   # Custom jump threshold:
+#   ES_URL="http://localhost:9200" PARTITION_ID=1 JUMP_THRESHOLD=5000000 ./analyze-partition-keys.sh
 #
 # Make executable with: chmod +x analyze-partition-keys.sh
 
@@ -63,6 +67,7 @@ fi
 # Set defaults for optional parameters
 BATCH_SIZE="${BATCH_SIZE:-1000}"
 AFTER_KEY="${AFTER_KEY:-}"
+JUMP_THRESHOLD="${JUMP_THRESHOLD:-1000000}"
 
 # Validate batch size
 if [ "$BATCH_SIZE" -gt 10000 ]; then
@@ -82,6 +87,7 @@ else
   echo "Batch Size:        $BATCH_SIZE"
 fi
 echo "Partition ID:      $PARTITION_ID"
+echo "Jump Threshold:    $JUMP_THRESHOLD"
 echo "Output File:       $OUTPUT_FILE"
 
 if [ "$SKIP_DOWNLOAD" = "true" ]; then
@@ -209,7 +215,6 @@ echo -e "${BLUE}Analyzing for Key Jumps...${NC}"
 echo -e "${BLUE}======================================${NC}"
 
 # Step 2: Analyze the keys to find jumps
-JUMP_THRESHOLD=1000000
 JUMP_FOUND=false
 
 prev_key=""


### PR DESCRIPTION
## Description
In the case an overflow occurred, we add some queries to debug if there has been a "jump" in the key for the overflowed partition.

Using curl, jq we search in operate-list-view and
operate-flownode-instances indices to identify if there is large gap (defaulted to 1 million) that would explain the jump.

A manual script `analyze-partition-keys.sh` downloads all process instance keys into a file. The file is then processed by the same script, but it can also be processed with other methods such as python, excel.

Once a range has been identified, we verify that no element exists in two indices confirming that the selection [NEW_KEY,MAX_KEY] range is safe to use.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #41871
