### PR TITLE
feat: implement batch operation control actions

### DIFF
--- a/operate/client/src/App/BatchOperation/OperationActions.test.tsx
+++ b/operate/client/src/App/BatchOperation/OperationActions.test.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {render, screen} from 'modules/testing-library';
+import {MemoryRouter} from 'react-router-dom';
+import {OperationsActions} from './OperationActions';
+import {mockCancelBatchOperation} from 'modules/mocks/api/v2/batchOperations/cancelBatchOperation';
+import {mockSuspendBatchOperation} from 'modules/mocks/api/v2/batchOperations/suspendBatchOperation';
+import {mockResumeBatchOperation} from 'modules/mocks/api/v2/batchOperations/resumeBatchOperation';
+import {notificationsStore} from 'modules/stores/notifications';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const BATCH_OPERATION_KEY = 'migrate-operation-123';
+
+describe('<OperationActions />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSuspendBatchOperation().withSuccess(null);
+    mockResumeBatchOperation().withSuccess(null);
+    mockCancelBatchOperation().withSuccess(null);
+  });
+
+  it('should render Suspend and Cancel actions for created state', () => {
+    render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="CREATED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByRole('button', {name: /Suspend/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Options/i})).toBeInTheDocument();
+  });
+
+  it('should call cancel mutation when Cancel is clicked', async () => {
+    const cancelSpy = vi.fn();
+    mockCancelBatchOperation().withSuccess(null, {mockResolverFn: cancelSpy});
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="CREATED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Options/i}));
+    await user.click(screen.getByText('Cancel'));
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render Suspend and Cancel actions for active state', () => {
+    render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="ACTIVE"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByRole('button', {name: /Suspend/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Options/i})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Resume/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call suspend mutation when Suspend is clicked', async () => {
+    const suspendSpy = vi.fn();
+    mockSuspendBatchOperation().withSuccess(null, {
+      mockResolverFn: suspendSpy,
+    });
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="ACTIVE"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Suspend/i}));
+
+    expect(suspendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display notification when suspend operation fails', async () => {
+    mockSuspendBatchOperation().withServerError(500);
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="ACTIVE"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Suspend/i}));
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledTimes(1);
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Operation could not be created',
+      isDismissable: true,
+    });
+  });
+
+  it('should render Resume and Cancel actions', () => {
+    render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="SUSPENDED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByRole('button', {name: /Resume/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /Options/i})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Suspend/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call resume mutation when Resume is clicked', async () => {
+    const resumeSpy = vi.fn();
+    mockResumeBatchOperation().withSuccess(null, {mockResolverFn: resumeSpy});
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="SUSPENDED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Resume/i}));
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display notification when resume operation fails', async () => {
+    mockResumeBatchOperation().withServerError(500);
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="SUSPENDED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Resume/i}));
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledTimes(1);
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Operation could not be created',
+      isDismissable: true,
+    });
+  });
+
+  it('should disable Cancel action when mutation is pending', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockCancelBatchOperation().withDelay(null);
+
+    const {user} = render(
+      <OperationsActions
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationState="SUSPENDED"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: /Options/i}));
+
+    const cancelMenuItem = screen.getByText('Cancel').closest('button');
+    expect(cancelMenuItem).toBeEnabled();
+
+    await user.click(cancelMenuItem!);
+
+    await user.click(screen.getByRole('button', {name: /Options/i}));
+    const updatedCancelMenuItem = screen.getByText('Cancel').closest('button');
+    expect(updatedCancelMenuItem).toBeDisabled();
+
+    vi.runOnlyPendingTimers();
+
+    vi.useRealTimers();
+  });
+
+  it.each(['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'CANCELED'] as const)(
+    'should not render any actions for %s state',
+    (state) => {
+      render(
+        <OperationsActions
+          batchOperationKey={BATCH_OPERATION_KEY}
+          batchOperationState={state}
+        />,
+        {wrapper: Wrapper},
+      );
+
+      expect(
+        screen.queryByRole('button', {name: /Suspend/i}),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /Resume/i}),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /Options/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+});

--- a/operate/client/src/App/BatchOperation/OperationActions.tsx
+++ b/operate/client/src/App/BatchOperation/OperationActions.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {OverflowMenu, OverflowMenuItem, Button} from '@carbon/react';
+import {Pause, Play} from '@carbon/react/icons';
+import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.8/batch-operation';
+import {useSuspendBatchOperation} from 'modules/mutations/batchOperations/useSuspendBatchOperation';
+import {useResumeBatchOperation} from 'modules/mutations/batchOperations/useResumeBatchOperation';
+import {useCancelBatchOperation} from 'modules/mutations/batchOperations/useCancelBatchOperation';
+import {ActionsContainer} from './styled';
+import {handleOperationError} from 'modules/utils/notifications';
+
+type Props = {
+  batchOperationKey: string;
+  batchOperationState: BatchOperationState;
+};
+
+type OperationAction = 'SUSPEND' | 'RESUME' | 'CANCEL';
+
+const ACTIONS_BY_STATE: Record<BatchOperationState, OperationAction[]> = {
+  CREATED: ['SUSPEND', 'CANCEL'],
+  ACTIVE: ['SUSPEND', 'CANCEL'],
+  SUSPENDED: ['RESUME', 'CANCEL'],
+  COMPLETED: [],
+  PARTIALLY_COMPLETED: [],
+  FAILED: [],
+  CANCELED: [],
+};
+
+const OperationsActions: React.FC<Props> = ({
+  batchOperationKey,
+  batchOperationState,
+}) => {
+  const suspendMutation = useSuspendBatchOperation({
+    onError: (error) => {
+      handleOperationError(error.status);
+    },
+  });
+  const resumeMutation = useResumeBatchOperation({
+    onError: (error) => {
+      handleOperationError(error.status);
+    },
+  });
+  const cancelMutation = useCancelBatchOperation({
+    onError: (error) => {
+      handleOperationError(error.status);
+    },
+  });
+
+  const allowedActions = ACTIONS_BY_STATE[batchOperationState];
+
+  return (
+    <ActionsContainer gap={2} orientation="horizontal">
+      {allowedActions.includes('SUSPEND') && (
+        <Button
+          kind="tertiary"
+          renderIcon={Pause}
+          onClick={() => {
+            suspendMutation.mutate(batchOperationKey);
+          }}
+          disabled={suspendMutation.isPending}
+        >
+          Suspend
+        </Button>
+      )}
+      {allowedActions.includes('RESUME') && (
+        <Button
+          kind="tertiary"
+          renderIcon={Play}
+          onClick={() => {
+            resumeMutation.mutate(batchOperationKey);
+          }}
+          disabled={resumeMutation.isPending}
+        >
+          Resume
+        </Button>
+      )}
+      {allowedActions.includes('CANCEL') && (
+        <OverflowMenu aria-label="overflow-menu" flipped>
+          <OverflowMenuItem
+            itemText="Cancel"
+            isDelete
+            onClick={() => cancelMutation.mutate(batchOperationKey)}
+            disabled={cancelMutation.isPending}
+          />
+        </OverflowMenu>
+      )}
+    </ActionsContainer>
+  );
+};
+
+export {OperationsActions};

--- a/operate/client/src/App/BatchOperation/OperationActions.tsx
+++ b/operate/client/src/App/BatchOperation/OperationActions.tsx
@@ -38,17 +38,17 @@ const OperationsActions: React.FC<Props> = ({
 }) => {
   const suspendMutation = useSuspendBatchOperation({
     onError: (error) => {
-      handleOperationError(error.status);
+      handleOperationError(error.response?.status);
     },
   });
   const resumeMutation = useResumeBatchOperation({
     onError: (error) => {
-      handleOperationError(error.status);
+      handleOperationError(error.response?.status);
     },
   });
   const cancelMutation = useCancelBatchOperation({
     onError: (error) => {
-      handleOperationError(error.status);
+      handleOperationError(error.response?.status);
     },
   });
 

--- a/operate/client/src/App/BatchOperation/index.test.tsx
+++ b/operate/client/src/App/BatchOperation/index.test.tsx
@@ -123,6 +123,17 @@ describe('<BatchOperation />', () => {
     expect(tiles.length).toBeGreaterThan(0);
   });
 
+  it('should render correct batch actions in active state', async () => {
+    mockGetBatchOperation().withSuccess({...operation, state: 'ACTIVE'});
+    render(<BatchOperation />, {wrapper: Wrapper});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('text-skeleton'),
+    );
+
+    expect(screen.getByRole('button', {name: /Suspend/i})).toBeInTheDocument();
+  });
+
   it('should show error notification when batch operation fails to load', async () => {
     mockGetBatchOperation().withServerError(500);
 

--- a/operate/client/src/App/BatchOperation/index.tsx
+++ b/operate/client/src/App/BatchOperation/index.tsx
@@ -27,13 +27,15 @@ import {BatchStateIndicator} from 'App/BatchOperations/BatchStateIndicator';
 import {
   PageContainer,
   ContentContainer,
-  PageHeader,
+  BreadcrumbBar,
   TilesContainer,
   Tile,
   TileLabel,
+  Header,
 } from './styled';
 import {notificationsStore} from 'modules/stores/notifications';
 import {BatchItemsTable} from './BatchItemsTable';
+import {OperationsActions} from './OperationActions';
 
 const renderWithLoading = (isLoading: boolean, content: React.ReactNode) =>
   isLoading ? <SkeletonText data-testid="text-skeleton" /> : content;
@@ -106,7 +108,7 @@ const BatchOperation: React.FC = () => {
   return (
     <PageContainer gap={5}>
       <VisuallyHiddenH1>Batch Operations</VisuallyHiddenH1>
-      <PageHeader>
+      <BreadcrumbBar>
         <Breadcrumb noTrailingSlash>
           <BreadcrumbItem>
             <Link
@@ -130,9 +132,20 @@ const BatchOperation: React.FC = () => {
             <div>{renderWithLoading(isLoading, operationType)}</div>
           </BreadcrumbItem>
         </Breadcrumb>
-      </PageHeader>
+      </BreadcrumbBar>
       <ContentContainer gap={5}>
-        <h3>{renderWithLoading(isLoading, operationType)}</h3>
+        {renderWithLoading(
+          isLoading,
+          <Header>
+            <h3>{operationType}</h3>
+            {state && (
+              <OperationsActions
+                batchOperationKey={batchOperationKey}
+                batchOperationState={state}
+              />
+            )}
+          </Header>,
+        )}
         {error && (
           <InlineNotification
             kind="error"

--- a/operate/client/src/App/BatchOperation/styled.ts
+++ b/operate/client/src/App/BatchOperation/styled.ts
@@ -26,7 +26,7 @@ const ContentContainer = styled(Stack)`
   padding: 0 var(--cds-spacing-05);
 `;
 
-const PageHeader = styled.div`
+const BreadcrumbBar = styled.div`
   width: 100%;
   border-bottom: 1px solid var(--cds-border-subtle-01);
   padding: var(--cds-spacing-04) var(--cds-spacing-05);
@@ -49,11 +49,23 @@ const TileLabel = styled.span`
   color: var(--cds-text-weak);
 `;
 
+const ActionsContainer = styled(Stack)`
+  align-items: center;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export {
   PageContainer,
   ContentContainer,
-  PageHeader,
+  BreadcrumbBar,
   TilesContainer,
   Tile,
   TileLabel,
+  ActionsContainer,
+  Header,
 };

--- a/operate/client/src/modules/api/v2/batchOperations/cancelBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/cancelBatchOperation.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+import {request} from 'modules/request';
+
+const cancelBatchOperation = async (batchOperationKey: string) => {
+  return request({
+    url: endpoints.cancelBatchOperation.getUrl({batchOperationKey}),
+    method: endpoints.cancelBatchOperation.method,
+    responseType: 'none',
+  });
+};
+
+export {cancelBatchOperation};

--- a/operate/client/src/modules/api/v2/batchOperations/cancelBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/cancelBatchOperation.ts
@@ -7,10 +7,10 @@
  */
 
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
-import {request} from 'modules/request';
+import {requestWithThrow} from 'modules/request';
 
 const cancelBatchOperation = async (batchOperationKey: string) => {
-  return request({
+  return requestWithThrow({
     url: endpoints.cancelBatchOperation.getUrl({batchOperationKey}),
     method: endpoints.cancelBatchOperation.method,
     responseType: 'none',

--- a/operate/client/src/modules/api/v2/batchOperations/resumeBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/resumeBatchOperation.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+import {request} from 'modules/request';
+
+const resumeBatchOperation = async (batchOperationKey: string) => {
+  return request({
+    url: endpoints.resumeBatchOperation.getUrl({batchOperationKey}),
+    method: endpoints.resumeBatchOperation.method,
+    responseType: 'none',
+  });
+};
+
+export {resumeBatchOperation};

--- a/operate/client/src/modules/api/v2/batchOperations/resumeBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/resumeBatchOperation.ts
@@ -7,10 +7,10 @@
  */
 
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
-import {request} from 'modules/request';
+import {requestWithThrow} from 'modules/request';
 
 const resumeBatchOperation = async (batchOperationKey: string) => {
-  return request({
+  return requestWithThrow({
     url: endpoints.resumeBatchOperation.getUrl({batchOperationKey}),
     method: endpoints.resumeBatchOperation.method,
     responseType: 'none',

--- a/operate/client/src/modules/api/v2/batchOperations/suspendBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/suspendBatchOperation.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+import {request} from 'modules/request';
+
+const suspendBatchOperation = async (batchOperationKey: string) => {
+  return request({
+    url: endpoints.suspendBatchOperation.getUrl({batchOperationKey}),
+    method: endpoints.suspendBatchOperation.method,
+    responseType: 'none',
+  });
+};
+
+export {suspendBatchOperation};

--- a/operate/client/src/modules/api/v2/batchOperations/suspendBatchOperation.ts
+++ b/operate/client/src/modules/api/v2/batchOperations/suspendBatchOperation.ts
@@ -7,10 +7,10 @@
  */
 
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
-import {request} from 'modules/request';
+import {requestWithThrow} from 'modules/request';
 
 const suspendBatchOperation = async (batchOperationKey: string) => {
-  return request({
+  return requestWithThrow({
     url: endpoints.suspendBatchOperation.getUrl({batchOperationKey}),
     method: endpoints.suspendBatchOperation.method,
     responseType: 'none',

--- a/operate/client/src/modules/mocks/api/v2/batchOperations/cancelBatchOperation.ts
+++ b/operate/client/src/modules/mocks/api/v2/batchOperations/cancelBatchOperation.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from 'modules/mocks/api/mockRequest';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockCancelBatchOperation = (batchOperationKey = ':batchOperationKey') =>
+  mockPostRequest<null>(
+    `${endpoints.cancelBatchOperation.getUrl({batchOperationKey})}`,
+  );
+
+export {mockCancelBatchOperation};

--- a/operate/client/src/modules/mocks/api/v2/batchOperations/resumeBatchOperation.ts
+++ b/operate/client/src/modules/mocks/api/v2/batchOperations/resumeBatchOperation.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from 'modules/mocks/api/mockRequest';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockResumeBatchOperation = (batchOperationKey = ':batchOperationKey') =>
+  mockPostRequest<null>(
+    `${endpoints.resumeBatchOperation.getUrl({batchOperationKey})}`,
+  );
+
+export {mockResumeBatchOperation};

--- a/operate/client/src/modules/mocks/api/v2/batchOperations/suspendBatchOperation.ts
+++ b/operate/client/src/modules/mocks/api/v2/batchOperations/suspendBatchOperation.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from 'modules/mocks/api/mockRequest';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.8';
+
+const mockSuspendBatchOperation = (batchOperationKey = ':batchOperationKey') =>
+  mockPostRequest<null>(
+    `${endpoints.suspendBatchOperation.getUrl({batchOperationKey})}`,
+  );
+
+export {mockSuspendBatchOperation};

--- a/operate/client/src/modules/mutations/batchOperations/useCancelBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useCancelBatchOperation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {cancelBatchOperation} from 'modules/api/v2/batchOperations/cancelBatchOperation';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+type CancelBatchOperationOptions = {
+  onError?: (error: {
+    status: number;
+    statusText: string;
+  }) => Promise<unknown> | unknown;
+};
+
+function useCancelBatchOperation(options?: CancelBatchOperationOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, {status: number; statusText: string}, string>({
+    mutationFn: async (batchOperationKey: string) => {
+      const response = await cancelBatchOperation(batchOperationKey);
+
+      if (!response.ok) {
+        throw {status: response.status, statusText: response.statusText};
+      }
+    },
+    onSuccess: (_, batchOperationKey) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.batchOperations.get(batchOperationKey),
+      });
+    },
+    onError: (error) => {
+      return options?.onError?.(error);
+    },
+  });
+}
+
+export {useCancelBatchOperation};

--- a/operate/client/src/modules/mutations/batchOperations/useResumeBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useResumeBatchOperation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {resumeBatchOperation} from 'modules/api/v2/batchOperations/resumeBatchOperation';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+type ResumeBatchOperationOptions = {
+  onError?: (error: {
+    status: number;
+    statusText: string;
+  }) => Promise<unknown> | unknown;
+};
+
+function useResumeBatchOperation(options?: ResumeBatchOperationOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, {status: number; statusText: string}, string>({
+    mutationFn: async (batchOperationKey: string) => {
+      const response = await resumeBatchOperation(batchOperationKey);
+
+      if (!response.ok) {
+        throw {status: response.status, statusText: response.statusText};
+      }
+    },
+    onSuccess: (_, batchOperationKey) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.batchOperations.get(batchOperationKey),
+      });
+    },
+    onError: (error) => {
+      return options?.onError?.(error);
+    },
+  });
+}
+
+export {useResumeBatchOperation};

--- a/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
@@ -9,33 +9,31 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {suspendBatchOperation} from 'modules/api/v2/batchOperations/suspendBatchOperation';
 import {queryKeys} from 'modules/queries/queryKeys';
+import type {RequestError} from 'modules/request';
 
 type SuspendBatchOperationOptions = {
-  onError?: (error: {
-    status: number;
-    statusText: string;
-  }) => Promise<unknown> | unknown;
+  onError?: (error: RequestError) => Promise<unknown> | unknown;
 };
 
 function useSuspendBatchOperation(options?: SuspendBatchOperationOptions) {
   const queryClient = useQueryClient();
 
-  return useMutation<void, {status: number; statusText: string}, string>({
+  return useMutation({
     mutationFn: async (batchOperationKey: string) => {
-      const response = await suspendBatchOperation(batchOperationKey);
+      const {response, error} = await suspendBatchOperation(batchOperationKey);
 
-      if (!response.ok) {
-        throw {status: response.status, statusText: response.statusText};
+      if (response !== null) {
+        return response;
       }
+
+      throw error;
     },
     onSuccess: (_, batchOperationKey) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.batchOperations.get(batchOperationKey),
       });
     },
-    onError: (error) => {
-      return options?.onError?.(error);
-    },
+    onError: options?.onError,
   });
 }
 

--- a/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {suspendBatchOperation} from 'modules/api/v2/batchOperations/suspendBatchOperation';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+type SuspendBatchOperationOptions = {
+  onError?: (error: {
+    status: number;
+    statusText: string;
+  }) => Promise<unknown> | unknown;
+};
+
+function useSuspendBatchOperation(options?: SuspendBatchOperationOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, {status: number; statusText: string}, string>({
+    mutationFn: async (batchOperationKey: string) => {
+      const response = await suspendBatchOperation(batchOperationKey);
+
+      if (!response.ok) {
+        throw {status: response.status, statusText: response.statusText};
+      }
+    },
+    onSuccess: (_, batchOperationKey) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.batchOperations.get(batchOperationKey),
+      });
+    },
+    onError: (error) => {
+      return options?.onError?.(error);
+    },
+  });
+}
+
+export {useSuspendBatchOperation};


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR implements batch operation control actions (suspend, resume, and cancel) for the Operate client. It adds new mutation hooks and UI components to enable users to control batch operations from the batch operation detail page.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #41689
