### PR TITLE
Optimize export variable filter

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/ElasticsearchExporterVariableFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/ElasticsearchExporterVariableFilterIT.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbConfigurator;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.http.HttpHost;
+import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+final class ElasticsearchExporterVariableFilterIT {
+
+  public static final String TEST_PREFIX = "test-prefix";
+  private static final String EXCLUSION_PROCESS = "exclusion-process";
+  private ElasticsearchContainer elasticsearchContainer;
+  private TestCamundaApplication testCamundaApplication;
+  private String esUrl;
+  private String indexPrefix;
+
+  @BeforeEach
+  void setUp() {
+    elasticsearchContainer =
+        TestSearchContainers.createDefeaultElasticsearchContainer()
+            .withEnv("action.destructive_requires_name", "false");
+    elasticsearchContainer.start();
+    esUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (testCamundaApplication != null) {
+      testCamundaApplication.stop();
+    }
+    if (elasticsearchContainer != null) {
+      elasticsearchContainer.stop();
+    }
+  }
+
+  @Test
+  void shouldNotExportVariableWhenNameDoesNotMatchInclusionFilter() {
+    // given
+    startApplicationWithVariableInclusion(List.of("included", "allowed"));
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(
+              Map.of(
+                  "excludedVariable", "value",
+                  "includedVariable", "value",
+                  "allowed", "value"))
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(
+              () -> {
+                assertThat(searchVariableCount("includedVariable")).isOne();
+                assertThat(searchVariableCount("allowed")).isOne();
+              });
+
+      assertThat(searchVariableCount("excludedVariable")).isZero();
+    }
+  }
+
+  @Test
+  void shouldExportVariableWhenInclusionFilterIsNull() {
+    // given
+    startApplicationWithVariableInclusion(null);
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(Map.of("excludedVariable", "value"))
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(() -> assertThat(searchVariableCount("excludedVariable")).isPositive());
+    }
+  }
+
+  @Test
+  void shouldFilterVariablesByExactNameInclusion() {
+    // given: only variables with exact names "includedVar" and "anotherIncluded" should be exported
+    startApplicationWithVariableNameExact(List.of("includedVar", "anotherIncluded"));
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(
+              Map.of(
+                  "includedVar", "value",
+                  "anotherIncluded", "value",
+                  "excludedVar", "value",
+                  "includedVarExtra", "value"))
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(
+              () -> {
+                assertThat(searchVariableCount("includedVar")).isOne();
+                assertThat(searchVariableCount("anotherIncluded")).isOne();
+              });
+
+      assertThat(searchVariableCount("excludedVar")).isZero();
+      assertThat(searchVariableCount("includedVarExtra")).isZero();
+    }
+  }
+
+  @Test
+  void shouldFilterVariablesByNameSuffixInclusion() {
+    // given: only variables whose names end with "_total" should be exported
+    startApplicationWithVariableNameSuffixes(List.of("_total"));
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(
+              Map.of(
+                  "order_total", "value", // should match
+                  "_total", "value", // should match
+                  "total_order", "value", // should NOT match
+                  "some_other", "value")) // should NOT match
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(
+              () -> {
+                assertThat(searchVariableCount("order_total")).isOne();
+                assertThat(searchVariableCount("_total")).isOne();
+              });
+
+      assertThat(searchVariableCount("total_order")).isZero();
+      assertThat(searchVariableCount("some_other")).isZero();
+    }
+  }
+
+  @Test
+  void shouldFilterVariablesByTypeInclusion() {
+    // given: only BOOLEAN variables should be exported
+    startApplicationWithVariableTypeFilter(List.of("BOOLEAN"), null);
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(
+              Map.of(
+                  "boolVar",
+                  true, // BOOLEAN
+                  "numVar",
+                  42, // NUMBER/DOUBLE
+                  "stringVar",
+                  "text")) // STRING
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(() -> assertThat(searchVariableCount("boolVar")).isOne());
+
+      assertThat(searchVariableCount("numVar")).isZero();
+      assertThat(searchVariableCount("stringVar")).isZero();
+    }
+  }
+
+  @Test
+  void shouldFilterVariablesByTypeExclusion() {
+    // given: exclude BOOLEAN variables, allow others
+    startApplicationWithVariableTypeFilter(null, List.of("BOOLEAN"));
+
+    try (final CamundaClient client = newCamundaClient()) {
+      deployProcess(client);
+
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(EXCLUSION_PROCESS)
+          .latestVersion()
+          .variables(
+              Map.of(
+                  "boolVar",
+                  true, // BOOLEAN
+                  "numVar",
+                  42, // NUMBER/DOUBLE
+                  "stringVar",
+                  "text")) // STRING
+          .send()
+          .join();
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(
+              () -> {
+                assertThat(searchVariableCount("numVar")).isOne();
+                assertThat(searchVariableCount("stringVar")).isOne();
+              });
+
+      assertThat(searchVariableCount("boolVar")).isZero();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Starts the application with Elasticsearch configured and an exporter whose index configuration
+   * is composed of the common settings plus whatever the customizer adds.
+   */
+  private void startApplicationWithIndexConfig(
+      final Consumer<Map<String, Object>> indexArgsCustomizer) {
+
+    testCamundaApplication = new TestCamundaApplication();
+    final var configurator = new MultiDbConfigurator(testCamundaApplication);
+    configurator.configureElasticsearchSupport(esUrl, TEST_PREFIX);
+    indexPrefix = configurator.zeebeIndexPrefix();
+
+    final Map<String, Object> indexArgs = new HashMap<>();
+    indexArgs.put("prefix", configurator.zeebeIndexPrefix());
+    indexArgs.put("variable", true);
+
+    // Let caller add specific filters (name/type, inclusion/exclusion, etc.)
+    indexArgsCustomizer.accept(indexArgs);
+
+    testCamundaApplication.withExporter(
+        ElasticsearchExporter.class.getSimpleName().toLowerCase(),
+        cfg -> {
+          cfg.setClassName(ElasticsearchExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "url", esUrl,
+                  "index", indexArgs,
+                  "bulk", Map.of("size", 1)));
+        });
+
+    testCamundaApplication.start().awaitCompleteTopology();
+  }
+
+  private void startApplicationWithVariableInclusion(final List<String> inclusion) {
+    // Keep existing semantics: key present even if value is null
+    startApplicationWithIndexConfig(
+        indexArgs -> indexArgs.put("variableNameInclusionStartWith", inclusion));
+  }
+
+  private void startApplicationWithVariableNameExact(final List<String> exactInclusion) {
+    startApplicationWithIndexConfig(
+        indexArgs -> indexArgs.put("variableNameInclusionExact", exactInclusion));
+  }
+
+  private void startApplicationWithVariableNameSuffixes(final List<String> suffixInclusion) {
+    startApplicationWithIndexConfig(
+        indexArgs -> indexArgs.put("variableNameInclusionEndWith", suffixInclusion));
+  }
+
+  private void startApplicationWithVariableTypeFilter(
+      final List<String> typeInclusion, final List<String> typeExclusion) {
+
+    startApplicationWithIndexConfig(
+        indexArgs -> {
+          if (typeInclusion != null) {
+            indexArgs.put("variableValueTypeInclusion", typeInclusion);
+          }
+          if (typeExclusion != null) {
+            indexArgs.put("variableValueTypeExclusion", typeExclusion);
+          }
+        });
+  }
+
+  private CamundaClient newCamundaClient() {
+    return testCamundaApplication.newClientBuilder().build();
+  }
+
+  private void deployProcess(final CamundaClient client) {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(EXCLUSION_PROCESS).startEvent().endEvent().done();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(process, EXCLUSION_PROCESS + ".bpmn")
+        .send()
+        .join();
+  }
+
+  private long searchVariableCount(final String variableName) {
+    final String indexPattern = indexPrefix + "-variable*";
+
+    try (final RestClient lowLevelClient = RestClient.builder(HttpHost.create(esUrl)).build();
+        final RestClientTransport transport =
+            new RestClientTransport(lowLevelClient, new JacksonJsonpMapper())) {
+
+      final ElasticsearchClient esClient = new ElasticsearchClient(transport);
+
+      final SearchResponse<Void> response =
+          esClient.search(
+              s ->
+                  s.index(indexPattern)
+                      .query(q -> q.match(m -> m.field("value.name").query(variableName))),
+              Void.class);
+
+      return response.hits().total() != null ? response.hits().total().value() : -1L;
+    } catch (final IOException e) {
+      return -1L;
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -203,11 +203,9 @@ final class ExporterContainer implements Controller {
     return context.getConfiguration().getId();
   }
 
-  private boolean acceptRecord(final RecordMetadata metadata) {
+  private boolean acceptRecord(final TypedRecord<?> typedEvent) {
     final Context.RecordFilter filter = context.getFilter();
-    return filter.acceptType(metadata.getRecordType())
-        && filter.acceptValue(metadata.getValueType())
-        && filter.acceptIntent(metadata.getIntent());
+    return filter.acceptRecord(typedEvent);
   }
 
   void configureExporter() throws Exception {
@@ -216,10 +214,10 @@ final class ExporterContainer implements Controller {
         () -> exporter.configure(context), exporter.getClass().getClassLoader());
   }
 
-  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord typedEvent) {
+  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord<?> typedEvent) {
     try {
       if (position < typedEvent.getPosition()) {
-        if (acceptRecord(rawMetadata)) {
+        if (acceptRecord(typedEvent)) {
           export(typedEvent);
         } else {
           updatePositionOnSkipIfUpToDate(typedEvent.getPosition());

--- a/zeebe/exporter-common/pom.xml
+++ b/zeebe/exporter-common/pom.xml
@@ -51,6 +51,16 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/ExportRecordFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/ExportRecordFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Applies a chain of {@link ExporterRecordFilter}s to determine whether a record should be
+ * exported.
+ *
+ * <p>Filters are evaluated in order and combined with logical AND: the first filter that returns
+ * {@code false} causes the whole chain to reject the record.
+ *
+ * <p>Filters that also implement {@link RecordVersionFilter} are only applied when the broker
+ * version of the record is greater than or equal to their {@link
+ * RecordVersionFilter#minRecordVersion()}. For older versions, those filters are skipped and the
+ * record is accepted immediately (matching the previous behavior).
+ */
+public final class ExportRecordFilter {
+
+  private final List<ExporterRecordFilter> recordFilters;
+
+  public ExportRecordFilter(final List<ExporterRecordFilter> recordFilters) {
+    this.recordFilters =
+        List.copyOf(Objects.requireNonNull(recordFilters, "recordFilters must not be null"));
+  }
+
+  /** Returns {@code true} if the record passes all configured filters. */
+  public boolean acceptRecord(final Record<?> record) {
+    for (final ExporterRecordFilter filter : recordFilters) {
+      if (filter instanceof final RecordVersionFilter versionFilter) {
+        final String minVersion = versionFilter.minRecordVersion();
+        if (!shouldApplyVersionedFilter(record, minVersion)) {
+          // For records from older brokers, skip this filter
+          continue;
+        }
+      }
+
+      if (!filter.accept(record)) {
+        // First rejecting filter short-circuits the chain.
+        return false;
+      }
+    }
+
+    // No filter rejected the record.
+    return true;
+  }
+
+  private boolean shouldApplyVersionedFilter(final Record<?> record, final String minVersion) {
+    final Optional<SemanticVersion> brokerVersion =
+        SemanticVersion.parse(record.getBrokerVersion());
+    if (brokerVersion.isEmpty()) {
+      // Unparseable broker version -> conservatively apply the filter
+      return true;
+    }
+
+    final SemanticVersion minVersionParsed = SemanticVersion.parse(minVersion).orElseThrow();
+    return brokerVersion.get().compareTo(minVersionParsed) >= 0;
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/ExporterRecordFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/ExporterRecordFilter.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+
+@FunctionalInterface
+public interface ExporterRecordFilter {
+
+  boolean accept(Record<?> record);
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/NameFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/NameFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+final class NameFilter {
+
+  private final List<Predicate<String>> includePredicates;
+  private final List<Predicate<String>> excludePredicates;
+
+  NameFilter(final List<NameRule> inclusionRules, final List<NameRule> exclusionRules) {
+
+    includePredicates = toPredicates(inclusionRules);
+    excludePredicates = toPredicates(exclusionRules);
+  }
+
+  boolean test(final String name) {
+    if (!includePredicates.isEmpty() && includePredicates.stream().noneMatch(p -> p.test(name))) {
+      return false;
+    }
+
+    return excludePredicates.isEmpty() || excludePredicates.stream().noneMatch(p -> p.test(name));
+  }
+
+  private static List<Predicate<String>> toPredicates(final List<NameRule> rules) {
+    return rules.stream().map(NameFilter::toPredicate).toList();
+  }
+
+  private static Predicate<String> toPredicate(final NameRule rule) {
+    final String pattern = rule.pattern();
+
+    return switch (rule.type()) {
+      case EXACT -> name -> name.equals(pattern);
+      case STARTS_WITH -> name -> name.startsWith(pattern);
+      case ENDS_WITH -> name -> name.endsWith(pattern);
+    };
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/NameRule.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/NameRule.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+public record NameRule(Type type, String pattern) {
+
+  public enum Type {
+    EXACT,
+    STARTS_WITH,
+    ENDS_WITH,
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RecordTypeFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RecordTypeFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/** Simple record-level filter that delegates to a {@link Predicate} over {@link RecordType}. */
+public final class RecordTypeFilter implements ExporterRecordFilter {
+
+  private final Predicate<RecordType> predicate;
+
+  public RecordTypeFilter(final Predicate<RecordType> predicate) {
+    this.predicate = Objects.requireNonNull(predicate, "predicate must not be null");
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    return predicate.test(record.getRecordType());
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RecordVersionFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RecordVersionFilter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+@FunctionalInterface
+public interface RecordVersionFilter {
+
+  String minRecordVersion();
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RequiredValueTypeFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/RequiredValueTypeFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+
+/**
+ * Record-level filter that applies the "required value types" logic based on broker version and
+ * exporter configuration.
+ *
+ * <p>It mirrors:
+ *
+ * <pre>
+ * if (configuration.getIsIncludeEnabledRecords()
+ *     || (recordVersion.major() == 8 && recordVersion.minor() < 8)) {
+ *   return configuration.shouldIndexValueType(record.getValueType());
+ * }
+ * return configuration.shouldIndexRequiredValueType(record.getValueType());
+ * </pre>
+ *
+ * The configuration is provided via functional parameters so this class can be reused by multiple
+ * exporters (e.g. Elasticsearch, Opensearch).
+ */
+public final class RequiredValueTypeFilter implements ExporterRecordFilter {
+
+  private final BooleanSupplier includeEnabledRecords;
+  private final Predicate<ValueType> shouldIndexValueType;
+  private final Predicate<ValueType> shouldIndexRequiredValueType;
+
+  public RequiredValueTypeFilter(
+      final BooleanSupplier includeEnabledRecords,
+      final Predicate<ValueType> shouldIndexValueType,
+      final Predicate<ValueType> shouldIndexRequiredValueType) {
+
+    this.includeEnabledRecords =
+        Objects.requireNonNull(includeEnabledRecords, "includeEnabledRecords must not be null");
+    this.shouldIndexValueType =
+        Objects.requireNonNull(shouldIndexValueType, "shouldIndexValueType must not be null");
+    this.shouldIndexRequiredValueType =
+        Objects.requireNonNull(
+            shouldIndexRequiredValueType, "shouldIndexRequiredValueType must not be null");
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    final SemanticVersion recordVersion = parseVersion(record.getBrokerVersion());
+
+    final boolean includeAllEnabledRecords =
+        includeEnabledRecords.getAsBoolean()
+            || (recordVersion.major() == 8 && recordVersion.minor() < 8);
+
+    if (includeAllEnabledRecords) {
+      // Old brokers or explicit include-all flag: use the normal value-type config
+      return shouldIndexValueType.test(record.getValueType());
+    }
+
+    // 8.8+ without include-all flag: only index "required" value types
+    return shouldIndexRequiredValueType.test(record.getValueType());
+  }
+
+  private static SemanticVersion parseVersion(final String brokerVersion) {
+    return SemanticVersion.parse(brokerVersion)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unsupported record broker version: ["
+                        + brokerVersion
+                        + "] Must be a semantic version."));
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableNameFilterRecord.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableNameFilterRecord.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.Collections;
+import java.util.List;
+
+public final class VariableNameFilterRecord implements ExporterRecordFilter, RecordVersionFilter {
+
+  private final NameFilter nameFilter;
+
+  public VariableNameFilterRecord(
+      final List<NameRule> inclusionRules, final List<NameRule> exclusionRules) {
+    nameFilter = new NameFilter(inclusionRules, exclusionRules);
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+
+    return nameFilter.test(variableRecordValue.getName());
+  }
+
+  public static List<NameRule> parseRules(final List<String> rawList, final NameRule.Type type) {
+
+    if (rawList == null) {
+      return Collections.emptyList();
+    }
+
+    return rawList.stream()
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(pattern -> new NameRule(type, pattern))
+        .toList();
+  }
+
+  @Override
+  public String minRecordVersion() {
+    return "8.9.0";
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilter.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 public final class VariableTypeFilter implements ExporterRecordFilter, RecordVersionFilter {
 
-  private static final String LIST_SEPARATOR = ";";
   private final ObjectMapper objectMapper;
   private final Set<VariableValueType> inclusion;
   private final Set<VariableValueType> exclusion;

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class VariableTypeFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final String LIST_SEPARATOR = ";";
+  private final ObjectMapper objectMapper;
+  private final Set<VariableValueType> inclusion;
+  private final Set<VariableValueType> exclusion;
+
+  public VariableTypeFilter(
+      final Set<VariableValueType> inclusion, final Set<VariableValueType> exclusion) {
+    this(new ObjectMapper(), inclusion, exclusion);
+  }
+
+  public VariableTypeFilter(
+      final ObjectMapper objectMapper,
+      final Set<VariableValueType> inclusion,
+      final Set<VariableValueType> exclusion) {
+    this.objectMapper = objectMapper;
+    this.inclusion = inclusion == null ? Collections.emptySet() : Set.copyOf(inclusion);
+    this.exclusion = exclusion == null ? Collections.emptySet() : Set.copyOf(exclusion);
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+
+    final VariableValueType inferredType = inferValueType(variableRecordValue.getValue());
+
+    if (!inclusion.isEmpty() && !inclusion.contains(inferredType)) {
+      return false;
+    }
+
+    return exclusion.isEmpty() || !exclusion.contains(inferredType);
+  }
+
+  /**
+   * Infers a logical type from the JSON representation of the variable value, mirroring Optimize's
+   * ZeebeVariableImportService#getVariableTypeFromJsonNode:
+   *
+   * <p>NUMBER -> DOUBLE BOOLEAN -> BOOLEAN STRING -> STRING OBJECT -> OBJECT ARRAY -> OBJECT
+   *
+   * <p>If parsing fails, falls back to STRING. Null raw value -> NULL.
+   */
+  private VariableValueType inferValueType(final String raw) {
+    if (raw == null) {
+      return VariableValueType.NULL;
+    }
+
+    try {
+      final JsonNode jsonNode = objectMapper.readTree(raw);
+      final JsonNodeType nodeType = jsonNode.getNodeType();
+
+      return switch (nodeType) {
+        case NUMBER -> VariableValueType.DOUBLE;
+        case BOOLEAN -> VariableValueType.BOOLEAN;
+        case STRING -> VariableValueType.STRING;
+        case OBJECT, ARRAY -> VariableValueType.OBJECT;
+        default -> VariableValueType.UNKNOWN;
+      };
+    } catch (final JsonProcessingException e) {
+      // If it's not valid JSON, treat as plain string
+      return VariableValueType.STRING;
+    }
+  }
+
+  public static Set<VariableValueType> parseTypes(final List<String> rawValues) {
+    if (rawValues == null || rawValues.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    final EnumSet<VariableValueType> result = EnumSet.noneOf(VariableValueType.class);
+
+    rawValues.forEach(
+        s -> {
+          final String upper = s.trim().toUpperCase(Locale.ROOT);
+          try {
+            if (upper.equals(VariableValueType.UNKNOWN.name())) {
+              return; // Skip UNKNOWN type
+            }
+            result.add(VariableValueType.valueOf(upper));
+          } catch (final IllegalArgumentException ignored) {
+            // Unknown type token: ignore silently
+          }
+        });
+
+    return result;
+  }
+
+  @Override
+  public String minRecordVersion() {
+    return "8.9.0";
+  }
+
+  /** Inferred variable value types (aligned with Optimize's JSON-node based mapping). */
+  public enum VariableValueType {
+    BOOLEAN,
+    DOUBLE,
+    STRING,
+    OBJECT,
+    NULL,
+    UNKNOWN
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/ExportRecordFilterTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/ExportRecordFilterTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+final class ExportRecordFilterTest {
+
+  @Test
+  void shouldAcceptRecordWhenNoRecordFiltersConfigured() {
+    // given
+    final var filter = new ExportRecordFilter(List.of() /* no filters */);
+
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldApplyNonVersionedFilter() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          calls.incrementAndGet();
+          return false; // actively reject
+        };
+
+    final var filter = new ExportRecordFilter(List.of(nonVersionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSkipVersionedFilterForOlderBrokerVersion() {
+    // given
+    final Record<?> record = mock(Record.class);
+    // Broker version lower than 8.9.0
+    when(record.getBrokerVersion()).thenReturn("8.8.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ false, calls);
+
+    final var filter = new ExportRecordFilter(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    // For older versions, versioned filter should be skipped; record should be accepted.
+    assertThat(accepted).isTrue();
+    assertThat(calls.get())
+        .as("Versioned filter should not be called for records below min version")
+        .isZero();
+  }
+
+  @Test
+  void shouldApplyVersionedFilterForNewerOrEqualBrokerVersion() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0"); // equal to min version
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ false, calls);
+
+    final var filter = new ExportRecordFilter(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(calls.get()).as("Versioned filter must be applied for >= min version").isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyVersionedFilterWhenBrokerVersionUnparseable() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("not-a-semver");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ true, calls);
+
+    final var filter = new ExportRecordFilter(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    // Unparseable broker version -> conservatively apply the filter
+    assertThat(accepted).isTrue();
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldShortCircuitOnFirstRejectingFilter() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final ExporterRecordFilter firstFilter =
+        r -> {
+          firstCalls.incrementAndGet();
+          return false;
+        };
+    final ExporterRecordFilter secondFilter =
+        r -> {
+          secondCalls.incrementAndGet();
+          return true;
+        };
+
+    final var filter = new ExportRecordFilter(List.of(firstFilter, secondFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(firstCalls.get()).isEqualTo(1);
+    assertThat(secondCalls.get())
+        .as("Subsequent filters should not be evaluated after first reject")
+        .isZero();
+  }
+
+  @Test
+  void shouldSkipVersionedFilterButApplyNonVersionedFilterForOlderBrokerVersion() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.8.0"); // < 8.9.0
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger versionedCalls = new AtomicInteger(0);
+    final AtomicInteger nonVersionedCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ true, versionedCalls);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          nonVersionedCalls.incrementAndGet();
+          return false; // actively reject
+        };
+
+    final var filter = new ExportRecordFilter(List.of(versionedFilter, nonVersionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    // Versioned filter skipped due to older broker version; non-versioned filter still applied
+    assertThat(accepted).isFalse();
+    assertThat(versionedCalls.get())
+        .as("Versioned filter should not be called for records below min version")
+        .isZero();
+    assertThat(nonVersionedCalls.get())
+        .as("Non-versioned filter should still be evaluated")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyOnlyQualifiedVersionedFiltersInChain() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.8.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter firstVersioned =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ true, firstCalls);
+    final TestVersionedFilter secondVersioned =
+        new TestVersionedFilter("8.8.0", /* acceptResult= */ false, secondCalls);
+
+    final var filter = new ExportRecordFilter(List.of(firstVersioned, secondVersioned));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    // First versioned filter skipped (min=8.9.0, record=8.8.0)
+    assertThat(firstCalls.get()).isZero();
+    // Second versioned filter applied (min=8.8.0, record=8.8.0) and rejects
+    assertThat(secondCalls.get()).isEqualTo(1);
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldApplyAllQualifiedVersionedFilters() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.10.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter firstVersioned =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ true, firstCalls);
+    final TestVersionedFilter secondVersioned =
+        new TestVersionedFilter("8.10.0", /* acceptResult= */ false, secondCalls);
+
+    final var filter = new ExportRecordFilter(List.of(firstVersioned, secondVersioned));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(firstCalls.get())
+        .as("First versioned filter should be applied for >= 8.9.0")
+        .isEqualTo(1);
+    assertThat(secondCalls.get())
+        .as("Second versioned filter should be applied for >= 8.10.0")
+        .isEqualTo(1);
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptWhenAllVersionedFiltersAreSkippedAndNonVersionedFilterAccepts() {
+    // given
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.7.0"); // < 8.8.0 and < 8.9.0
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger v1Calls = new AtomicInteger(0);
+    final AtomicInteger v2Calls = new AtomicInteger(0);
+    final AtomicInteger nonVersionedCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter v1 =
+        new TestVersionedFilter("8.8.0", /* acceptResult= */ false, v1Calls);
+    final TestVersionedFilter v2 =
+        new TestVersionedFilter("8.9.0", /* acceptResult= */ false, v2Calls);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          nonVersionedCalls.incrementAndGet();
+          return true; // accept
+        };
+
+    final var filter = new ExportRecordFilter(List.of(v1, v2, nonVersionedFilter));
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(v1Calls.get()).isZero();
+    assertThat(v2Calls.get()).isZero();
+    assertThat(nonVersionedCalls.get()).isEqualTo(1);
+    assertThat(accepted).isTrue();
+  }
+
+  /** Simple test implementation of a versioned filter. */
+  private static final class TestVersionedFilter
+      implements ExporterRecordFilter, RecordVersionFilter {
+
+    private final String minVersion;
+    private final boolean acceptResult;
+    private final AtomicInteger calls;
+
+    private TestVersionedFilter(
+        final String minVersion, final boolean acceptResult, final AtomicInteger calls) {
+      this.minVersion = minVersion;
+      this.acceptResult = acceptResult;
+      this.calls = calls;
+    }
+
+    @Override
+    public boolean accept(final Record<?> record) {
+      calls.incrementAndGet();
+      return acceptResult;
+    }
+
+    @Override
+    public String minRecordVersion() {
+      return minVersion;
+    }
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/NameFilterTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/NameFilterTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class NameFilterTest {
+
+  @Test
+  void shouldAcceptAllNamesWhenNoRules() {
+    // given
+    final var filter = new NameFilter(List.of(), List.of());
+
+    // when / then
+    assertThat(filter.test("foo")).isTrue();
+    assertThat(filter.test("bar")).isTrue();
+    assertThat(filter.test("any_name")).isTrue();
+  }
+
+  @Test
+  void shouldAcceptOnlyNamesMatchingExactInclusion() {
+    // given
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "foo"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.test("foo")).isTrue();
+    assertThat(filter.test("bar")).isFalse();
+    assertThat(filter.test("foobar")).isFalse();
+  }
+
+  @Test
+  void shouldApplyStartsWithInclusionRule() {
+    // given
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.STARTS_WITH, "foo"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.test("foo")).isTrue();
+    assertThat(filter.test("fooVar")).isTrue();
+    assertThat(filter.test("foobar")).isTrue();
+
+    assertThat(filter.test("barfoo")).isFalse();
+    assertThat(filter.test("other")).isFalse();
+  }
+
+  @Test
+  void shouldApplyEndsWithInclusionRule() {
+    // given
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.ENDS_WITH, "_suffix"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.test("var_suffix")).isTrue();
+    assertThat(filter.test("foo_suffix")).isTrue();
+
+    assertThat(filter.test("suffix_foo")).isFalse();
+    assertThat(filter.test("foo")).isFalse();
+  }
+
+  @Test
+  void shouldRejectWhenInclusionRulesPresentAndNoneMatch() {
+    // given
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "allowed"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.test("other")).isFalse();
+    assertThat(filter.test("allowedX")).isFalse();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingExactExclusionOnly() {
+    // given: no inclusion, only exclusion
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "secret"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.test("secret")).isFalse();
+    assertThat(filter.test("public")).isTrue();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingStartsWithExclusionOnly() {
+    // given
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.STARTS_WITH, "debug_"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.test("debug_var")).isFalse();
+    assertThat(filter.test("debug_foo")).isFalse();
+
+    assertThat(filter.test("nodebug")).isTrue();
+    assertThat(filter.test("prod_var")).isTrue();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingEndsWithExclusionOnly() {
+    // given
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.ENDS_WITH, "_tmp"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.test("var_tmp")).isFalse();
+    assertThat(filter.test("foo_tmp")).isFalse();
+
+    assertThat(filter.test("tmp_var")).isTrue();
+    assertThat(filter.test("var")).isTrue();
+  }
+
+  @Test
+  void shouldApplyInclusionThenExclusion() {
+    // given: name must start with "foo", but anything ending with "_debug" is excluded
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.STARTS_WITH, "foo"));
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.ENDS_WITH, "_debug"));
+
+    final var filter = new NameFilter(inclusionRules, exclusionRules);
+
+    // when / then
+    assertThat(filter.test("fooVar")).isTrue(); // included, not excluded
+    assertThat(filter.test("foo_debug")).isFalse(); // included AND excluded -> rejected
+    assertThat(filter.test("barVar")).isFalse(); // not included -> rejected early
+  }
+
+  @Test
+  void shouldShortCircuitOnFailedInclusionEvenIfExclusionWouldAllow() {
+    // given: include EXACT "foo"; exclude EXACT "bar"
+    final var inclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "foo"));
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "bar"));
+
+    final var filter = new NameFilter(inclusionRules, exclusionRules);
+
+    // when / then
+    // "baz" does not match inclusion -> immediately false, regardless of exclusion
+    assertThat(filter.test("baz")).isFalse();
+  }
+
+  @Test
+  void shouldAllowWhenInclusionEmptyAndNotExcluded() {
+    // given: no inclusion rules, only one exclusion
+    final var exclusionRules = List.of(new NameRule(NameRule.Type.EXACT, "forbidden"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.test("allowed")).isTrue();
+    assertThat(filter.test("forbidden")).isFalse();
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/VariableNameFilterRecordTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/VariableNameFilterRecordTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.common.filter.NameRule.Type;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class VariableNameFilterRecordTest {
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var filter = new VariableNameFilterRecord(List.of(), List.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    final ProcessInstanceRecordValue value = mock(ProcessInstanceRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldFilterVariableNamesUsingInclusionRules() {
+    // given: only variables with exact name "foo" are allowed
+    final var inclusionRules =
+        VariableNameFilterRecord.parseRules(List.of("foo"), NameRule.Type.EXACT);
+
+    final var filter = new VariableNameFilterRecord(inclusionRules, List.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> matchingRecord = mock(Record.class);
+    final VariableRecordValue matchingValue = mock(VariableRecordValue.class);
+    when(matchingRecord.getValue()).thenReturn(matchingValue);
+    when(matchingValue.getName()).thenReturn("foo");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> nonMatchingRecord = mock(Record.class);
+    final VariableRecordValue nonMatchingValue = mock(VariableRecordValue.class);
+    when(nonMatchingRecord.getValue()).thenReturn(nonMatchingValue);
+    when(nonMatchingValue.getName()).thenReturn("bar");
+
+    // when
+    final boolean matchingAccepted = filter.accept(matchingRecord);
+    final boolean nonMatchingAccepted = filter.accept(nonMatchingRecord);
+
+    // then
+    assertThat(matchingAccepted).isTrue();
+    assertThat(nonMatchingAccepted).isFalse();
+  }
+
+  @Test
+  void shouldApplyInclusionAndExclusionRulesTogether() {
+    // given:
+    //  - include names starting with "biz_"
+    //  - exclude exact name "biz_debug"
+    final var inclusionRules =
+        VariableNameFilterRecord.parseRules(List.of("biz_"), NameRule.Type.STARTS_WITH);
+    final var exclusionRules =
+        VariableNameFilterRecord.parseRules(List.of("biz_debug"), NameRule.Type.EXACT);
+
+    final var filter = new VariableNameFilterRecord(inclusionRules, exclusionRules);
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> allowedRecord = mock(Record.class);
+    final VariableRecordValue allowedValue = mock(VariableRecordValue.class);
+    when(allowedRecord.getValue()).thenReturn(allowedValue);
+    when(allowedValue.getName()).thenReturn("biz_total");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> excludedRecord = mock(Record.class);
+    final VariableRecordValue excludedValue = mock(VariableRecordValue.class);
+    when(excludedRecord.getValue()).thenReturn(excludedValue);
+    when(excludedValue.getName()).thenReturn("biz_debug");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> notIncludedRecord = mock(Record.class);
+    final VariableRecordValue notIncludedValue = mock(VariableRecordValue.class);
+    when(notIncludedRecord.getValue()).thenReturn(notIncludedValue);
+    when(notIncludedValue.getName()).thenReturn("other");
+
+    // when
+    final boolean allowedAccepted = filter.accept(allowedRecord);
+    final boolean excludedAccepted = filter.accept(excludedRecord);
+    final boolean notIncludedAccepted = filter.accept(notIncludedRecord);
+
+    // then
+    assertThat(allowedAccepted).as("name matches inclusion and not exclusion").isTrue();
+    assertThat(excludedAccepted).as("name matches inclusion and exclusion -> excluded").isFalse();
+    assertThat(notIncludedAccepted).as("name does not match inclusion -> rejected").isFalse();
+  }
+
+  @Test
+  void parseRulesShouldReturnEmptyListForNull() {
+    // when
+    final var rules = VariableNameFilterRecord.parseRules(null, Type.EXACT);
+
+    // then
+    assertThat(rules).isEmpty();
+  }
+
+  @Test
+  void parseRulesShouldTrimAndIgnoreEmptyEntries() {
+    // given
+    final var raw = List.of("  foo ", " ", "", "bar");
+
+    // when
+    final var rules = VariableNameFilterRecord.parseRules(raw, NameRule.Type.EXACT);
+
+    // then
+    assertThat(rules)
+        .hasSize(2)
+        .allSatisfy(
+            rule -> {
+              assertThat(rule.type()).isEqualTo(NameRule.Type.EXACT);
+            });
+    assertThat(rules.get(0).pattern()).isEqualTo("foo");
+    assertThat(rules.get(1).pattern()).isEqualTo("bar");
+  }
+
+  @Test
+  void shouldExposeMinRecordVersion() {
+    final var filter = new VariableNameFilterRecord(List.of(), List.of());
+    assertThat(filter.minRecordVersion()).isEqualTo("8.9.0");
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilterTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/filter/VariableTypeFilterTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.common.filter.VariableTypeFilter.VariableValueType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class VariableTypeFilterTest {
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    final ProcessInstanceRecordValue value = mock(ProcessInstanceRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferBooleanType() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.BOOLEAN), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("true"); // JSON boolean
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferDoubleTypeForNumbers() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.DOUBLE), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("42"); // JSON number
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferStringTypeForJsonString() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.STRING), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("\"hello\""); // JSON string
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferStringTypeForNonJson() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.STRING), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("not-json"); // invalid JSON → fallback STRING
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferObjectTypeForJsonObject() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.OBJECT), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("{\"foo\":1}");
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferObjectTypeForJsonArray() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.OBJECT), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn("[1,2,3]");
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldInferNullTypeWhenRawValueIsNull() {
+    // given
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.NULL), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getValue()).thenReturn(null);
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRespectInclusionOnly() {
+    // given: include only STRING
+    final var filter = new VariableTypeFilter(Set.of(VariableValueType.STRING), Set.of());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> stringRecord = mock(Record.class);
+    final VariableRecordValue stringValue = mock(VariableRecordValue.class);
+    when(stringRecord.getValue()).thenReturn(stringValue);
+    when(stringValue.getValue()).thenReturn("\"str\"");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> booleanRecord = mock(Record.class);
+    final VariableRecordValue booleanValue = mock(VariableRecordValue.class);
+    when(booleanRecord.getValue()).thenReturn(booleanValue);
+    when(booleanValue.getValue()).thenReturn("true");
+
+    // when
+    final boolean stringAccepted = filter.accept(stringRecord);
+    final boolean booleanAccepted = filter.accept(booleanRecord);
+
+    // then
+    assertThat(stringAccepted).isTrue();
+    assertThat(booleanAccepted).isFalse();
+  }
+
+  @Test
+  void shouldRespectExclusionOnly() {
+    // given: exclude BOOLEAN
+    final var filter = new VariableTypeFilter(Set.of(), Set.of(VariableValueType.BOOLEAN));
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> booleanRecord = mock(Record.class);
+    final VariableRecordValue booleanValue = mock(VariableRecordValue.class);
+    when(booleanRecord.getValue()).thenReturn(booleanValue);
+    when(booleanValue.getValue()).thenReturn("true");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> stringRecord = mock(Record.class);
+    final VariableRecordValue stringValue = mock(VariableRecordValue.class);
+    when(stringRecord.getValue()).thenReturn(stringValue);
+    when(stringValue.getValue()).thenReturn("\"str\"");
+
+    // when
+    final boolean booleanAccepted = filter.accept(booleanRecord);
+    final boolean stringAccepted = filter.accept(stringRecord);
+
+    // then
+    assertThat(booleanAccepted).isFalse();
+    assertThat(stringAccepted).isTrue();
+  }
+
+  @Test
+  void shouldRespectInclusionAndExclusionTogether() {
+    // given: include DOUBLE and BOOLEAN, but exclude BOOLEAN
+    final var filter =
+        new VariableTypeFilter(
+            Set.of(VariableValueType.DOUBLE, VariableValueType.BOOLEAN),
+            Set.of(VariableValueType.BOOLEAN));
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> doubleRecord = mock(Record.class);
+    final VariableRecordValue doubleValue = mock(VariableRecordValue.class);
+    when(doubleRecord.getValue()).thenReturn(doubleValue);
+    when(doubleValue.getValue()).thenReturn("1.5");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> booleanRecord = mock(Record.class);
+    final VariableRecordValue booleanValue = mock(VariableRecordValue.class);
+    when(booleanRecord.getValue()).thenReturn(booleanValue);
+    when(booleanValue.getValue()).thenReturn("true");
+
+    // when
+    final boolean doubleAccepted = filter.accept(doubleRecord);
+    final boolean booleanAccepted = filter.accept(booleanRecord);
+
+    // then
+    assertThat(doubleAccepted).isTrue(); // included and not excluded
+    assertThat(booleanAccepted).isFalse(); // included, but explicitly excluded
+  }
+
+  @Test
+  void parseTypesShouldHandleNullAndEmpty() {
+    assertThat(VariableTypeFilter.parseTypes(null)).isEmpty();
+    assertThat(VariableTypeFilter.parseTypes(List.of())).isEmpty();
+  }
+
+  @Test
+  void parseTypesShouldBeCaseInsensitiveAndIgnoreUnknown() {
+    // given
+    final var raw = List.of("string", "BOOLEAN", "double", "unknown", "  object  ");
+
+    // when
+    final var types = VariableTypeFilter.parseTypes(raw);
+
+    // then
+    assertThat(types)
+        .containsExactlyInAnyOrder(
+            VariableValueType.STRING,
+            VariableValueType.BOOLEAN,
+            VariableValueType.DOUBLE,
+            VariableValueType.OBJECT);
+  }
+
+  @Test
+  void shouldExposeMinRecordVersion() {
+    final var filter = new VariableTypeFilter(Set.of(), Set.of());
+    assertThat(filter.minRecordVersion()).isEqualTo("8.9.0");
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -62,7 +62,7 @@ public class ElasticsearchExporter implements Exporter {
     log = context.getLogger();
     configuration =
         context.getConfiguration().instantiate(ElasticsearchExporterConfiguration.class);
-    log.debug("Exporter configured with {}", configuration);
+    log.info("Exporter configured with {}", configuration);
 
     validate(configuration);
     pluginRepository.load(configuration.getInterceptorPlugins());

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static io.camunda.zeebe.exporter.common.filter.NameRule.Type.*;
+import static io.camunda.zeebe.exporter.common.filter.VariableNameFilterRecord.parseRules;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.common.filter.ExportRecordFilter;
+import io.camunda.zeebe.exporter.common.filter.NameRule;
+import io.camunda.zeebe.exporter.common.filter.RecordTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.RequiredValueTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.VariableNameFilterRecord;
+import io.camunda.zeebe.exporter.common.filter.VariableTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.VariableTypeFilter.VariableValueType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class ElasticsearchRecordFilter implements Context.RecordFilter {
+
+  private final ExportRecordFilter delegate;
+  private final ElasticsearchExporterConfiguration configuration;
+
+  ElasticsearchRecordFilter(final ElasticsearchExporterConfiguration configuration) {
+    this.configuration = configuration;
+    final var index = configuration.index;
+
+    final Set<VariableValueType> valueTypeInclusion =
+        VariableTypeFilter.parseTypes(index.variableValueTypeInclusion);
+    final Set<VariableValueType> valueTypeExclusion =
+        VariableTypeFilter.parseTypes(index.variableValueTypeExclusion);
+
+    final List<NameRule> nameInclusionRules = getNameInclusionRules(index);
+    final List<NameRule> nameExclusionRules = getNameExclusionRules(index);
+    delegate =
+        new ExportRecordFilter(
+            List.of(
+                new RecordTypeFilter(configuration::shouldIndexRecordType),
+                new RequiredValueTypeFilter(
+                    configuration::getIsIncludeEnabledRecords,
+                    configuration::shouldIndexValueType,
+                    configuration::shouldIndexRequiredValueType),
+                new VariableTypeFilter(valueTypeInclusion, valueTypeExclusion),
+                new VariableNameFilterRecord(nameInclusionRules, nameExclusionRules)));
+  }
+
+  private static List<NameRule> getNameExclusionRules(final IndexConfiguration index) {
+    final List<NameRule> nameExclusionRules = new ArrayList<>();
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionExact, EXACT));
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionStartWith, STARTS_WITH));
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionEndWith, ENDS_WITH));
+    return nameExclusionRules;
+  }
+
+  private static List<NameRule> getNameInclusionRules(final IndexConfiguration index) {
+    final List<NameRule> nameInclusionRules = new ArrayList<>();
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionExact, EXACT));
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionStartWith, STARTS_WITH));
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionEndWith, ENDS_WITH));
+    return nameInclusionRules;
+  }
+
+  // Still used by ExporterDirector to build ExporterEventFilter
+  @Override
+  public boolean acceptType(final RecordType recordType) {
+    return configuration.shouldIndexRecordType(recordType);
+  }
+
+  @Override
+  public boolean acceptValue(final ValueType valueType) {
+    return configuration.shouldIndexValueType(valueType);
+  }
+
+  @Override
+  public boolean acceptRecord(final Record<?> value) {
+    return delegate.acceptRecord(value);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -66,6 +68,7 @@ final class ElasticsearchExporterTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void shouldNotFailOnOpenIfElasticIsUnreachable() {
     // given
     final var exporter = new ElasticsearchExporter();
@@ -73,7 +76,9 @@ final class ElasticsearchExporterTest {
 
     // when
     exporter.open(controller);
-    final Record mockRecord = mock(Record.class);
+    final Record<ProcessInstanceRecordValue> mockRecord = mock(Record.class);
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -198,6 +203,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -215,6 +222,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -235,6 +244,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -254,6 +265,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -275,6 +288,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(valueType);
       when(recordMock.getBrokerVersion()).thenReturn(version);
       exporter.export(recordMock);
@@ -306,6 +321,8 @@ final class ElasticsearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -350,6 +367,7 @@ final class ElasticsearchExporterTest {
           ImmutableRecord.builder()
               .withPosition(10L)
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -371,6 +389,7 @@ final class ElasticsearchExporterTest {
           ImmutableRecord.builder()
               .withPosition(10L)
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -393,6 +412,7 @@ final class ElasticsearchExporterTest {
           ImmutableRecord.builder()
               .withPosition(10L)
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -414,6 +434,7 @@ final class ElasticsearchExporterTest {
           ImmutableRecord.builder()
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
               .withPosition(10L)
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -503,7 +524,6 @@ final class ElasticsearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
-    private final int position = 1;
 
     @BeforeEach
     void initExporter() {
@@ -677,6 +697,7 @@ final class ElasticsearchExporterTest {
       return ImmutableRecord.builder()
           .withBrokerVersion(VersionUtil.getVersionLowerCase())
           .withPartitionId(partitionId)
+          .withRecordType(RecordType.EVENT)
           .withValueType(valueType)
           .build();
     }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterRecordTypeTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterRecordTypeTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the record type filtering in ElasticsearchRecordFilter. */
+final class ElasticsearchRecordFilterRecordTypeTest {
+
+  @Test
+  void shouldAcceptEventWhenEventIndexingEnabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.event = true;
+    config.index.command = false;
+    config.index.rejection = false;
+
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.EVENT);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectEventWhenEventIndexingDisabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.event = false; // disable events
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.EVENT);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptCommandWhenCommandIndexingEnabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.command = true;
+    config.index.event = false;
+    config.index.rejection = false;
+
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectCommandWhenCommandIndexingDisabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.command = false;
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptCommandRejectionWhenRejectionIndexingEnabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.rejection = true;
+    config.index.event = false;
+    config.index.command = false;
+
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND_REJECTION);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectCommandRejectionWhenRejectionIndexingDisabled() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.rejection = false;
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND_REJECTION);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @ParameterizedTest(name = "recordType={0}, enabled={1} -> acceptRecord={2}")
+  @CsvSource(
+      value = {
+        // recordType | enableEvent | enableCommand | enableRejection | expectedAccepted
+        "EVENT            | true  | false | false | true",
+        "EVENT            | false | false | false | false",
+        "COMMAND          | false | true  | false | true",
+        "COMMAND          | false | false | false | false",
+        "COMMAND_REJECTION| false | false | true  | true",
+        "COMMAND_REJECTION| false | false | false | false"
+      },
+      delimiter = '|')
+  void shouldFilterRecordsByRecordTypeConfiguration(
+      final RecordType recordType,
+      final boolean enableEvent,
+      final boolean enableCommand,
+      final boolean enableRejection,
+      final boolean expectedAccepted) {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.event = enableEvent;
+    config.index.command = enableCommand;
+    config.index.rejection = enableRejection;
+
+    // keep value-type-related filters permissive by using a value type that is enabled by default
+    // (PROCESS_INSTANCE is true by default in IndexConfiguration)
+    final var filter = new ElasticsearchRecordFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(recordType);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterRequiredValueTypeTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterRequiredValueTypeTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests for the "required value type" behavior in {@link ElasticsearchRecordFilter}, which is
+ * implemented via {@link io.camunda.zeebe.exporter.common.filter.RequiredValueTypeFilter}.
+ *
+ * <p>Covered branches:
+ *
+ * <ul>
+ *   <li>Pre-8.8 brokers (major == 8, minor &lt; 8) → use {@code shouldIndexValueType}
+ *   <li>Any broker with {@code includeEnabledRecords = true} → use {@code shouldIndexValueType}
+ *   <li>8.8+ with {@code includeEnabledRecords = false} → use {@code shouldIndexRequiredValueType}
+ *   <li>Required value types honoring index flags (index.* can still disable them)
+ *   <li>Invalid broker version string → IllegalArgumentException
+ * </ul>
+ */
+final class ElasticsearchRecordFilterRequiredValueTypeTest {
+
+  private ElasticsearchRecordFilter createFilter(final ElasticsearchExporterConfiguration config) {
+    return new ElasticsearchRecordFilter(config);
+  }
+
+  @ParameterizedTest(
+      name =
+          "pre-8.8 (8.7.x), valueType={0}, enabledFlag={1} -> accepted={1} (uses shouldIndexValueType)")
+  @CsvSource(
+      value = {
+        // valueType       | enabledFlag
+        "MESSAGE          | true",
+        "MESSAGE          | false",
+        "PROCESS_INSTANCE | true",
+        "PROCESS_INSTANCE | false"
+      },
+      delimiter = '|')
+  void shouldUseNormalValueTypeConfigForPre88Brokers(
+      final ValueType valueType, final boolean enabledFlag) {
+
+    // given: includeEnabledRecords=false, but broker is 8.7.x
+    // -> includeAllEnabledRecords == true
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    // configure the normal index flags per value type
+    switch (valueType) {
+      case MESSAGE -> config.index.message = enabledFlag;
+      case PROCESS_INSTANCE -> config.index.processInstance = enabledFlag;
+      default -> throw new IllegalArgumentException("Test not set up for value type: " + valueType);
+    }
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.7.3");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT); // event is enabled by default
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: required-vs-nonrequired is ignored for pre-8.8; we follow index.* flag
+    assertThat(accepted).isEqualTo(enabledFlag);
+  }
+
+  @ParameterizedTest(
+      name = "includeEnabledRecords=true (8.9.x), valueType={0}, enabledFlag={1} -> accepted={1}")
+  @CsvSource(
+      value = {
+        // valueType       | enabledFlag
+        "MESSAGE          | true",
+        "MESSAGE          | false",
+        "PROCESS_INSTANCE | true",
+        "PROCESS_INSTANCE | false"
+      },
+      delimiter = '|')
+  void shouldUseNormalValueTypeConfigWhenIncludeEnabledRecordsIsTrue(
+      final ValueType valueType, final boolean enabledFlag) {
+
+    // given: includeEnabledRecords=true
+    // -> includeAllEnabledRecords == true for any 8.x version
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(true);
+
+    switch (valueType) {
+      case MESSAGE -> config.index.message = enabledFlag;
+      case PROCESS_INSTANCE -> config.index.processInstance = enabledFlag;
+      default -> throw new IllegalArgumentException("Test not set up for value type: " + valueType);
+    }
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: we use shouldIndexValueType, i.e. index.* flag decides
+    assertThat(accepted).isEqualTo(enabledFlag);
+  }
+
+  @ParameterizedTest(
+      name =
+          "8.9.x, includeEnabledRecords=false, valueType={0} -> accepted={1} (uses shouldIndexRequiredValueType)")
+  @CsvSource(
+      value = {
+        // Required value types (Optimize / analytics), excluding VARIABLE (handled separately)
+        "DEPLOYMENT       | true",
+        "PROCESS          | true",
+        "INCIDENT         | true",
+        "PROCESS_INSTANCE | true",
+        "USER_TASK        | true",
+        "JOB              | true",
+        // Some non-required value types
+        "MESSAGE          | false",
+        "TIMER            | false",
+        "DECISION         | false",
+        "MESSAGE_SUBSCRIPTION | false"
+      },
+      delimiter = '|')
+  void shouldFilterByRequiredValueTypesWhenIncludeEnabledRecordsDisabledOnNewBrokers(
+      final ValueType valueType, final boolean expectedAccepted) {
+
+    // given: 8.9.x broker, includeEnabledRecords=false
+    // -> includeAllEnabledRecords == false
+    // -> RequiredValueTypeFilter delegates to shouldIndexRequiredValueType
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldTreatVariableAsRequiredWhenIncludeEnabledRecordsDisabledOnNewBrokers() {
+    // given: VARIABLE is in the required set
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    final var filter = createFilter(config);
+
+    final VariableRecordValue variableValue = mock(VariableRecordValue.class);
+    when(variableValue.getName()).thenReturn("anyVariable");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldHonorIndexFlagsForRequiredValueTypesOnNewBrokers() {
+    // given: 8.9.x, includeEnabledRecords=false -> required-value branch
+    // but explicitly disable one required type (PROCESS_INSTANCE)
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+    config.index.processInstance = false; // override default
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: even though PROCESS_INSTANCE is in the "required" set, index flag wins
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldThrowOnNonSemanticBrokerVersion() {
+    // given: invalid broker version string → RequiredValueTypeFilter should throw
+    final var config = new ElasticsearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("not-a-version");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when / then
+    assertThatThrownBy(() -> filter.acceptRecord(record))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported record broker version");
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterVariableNameTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterVariableNameTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the variable name inclusion filtering in ElasticsearchRecordFilter. */
+final class ElasticsearchRecordFilterVariableNameTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+
+  @Test
+  void shouldAcceptVariableWhenNameMatchesInclusionPrefix() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldNotAcceptVariableWhenNameDoesNotMatchInclusionPrefix() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("excludedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @CsvSource(
+      value = {
+        "included | includedVariable | true",
+        "included | includedAnotherName | true",
+        "included | included | true",
+        "allowed | allowedVariable | true",
+        "allowed | allowedAnotherName | true",
+        "var | variable | true",
+        "var | anotherVar | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByNamePrefix(
+      final String inclusionPrefix, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of(inclusionPrefix);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldAcceptAllVariablesWhenInclusionIsEmpty() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of();
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("anyVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldTrimWhitespaceFromInclusionPrefixes() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of("included");
+    final var filter = createFilter(config);
+
+    final ProcessInstanceRecordValue value =
+        factory.generateObject(ProcessInstanceRecordValue.class);
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "blank inclusion -> accept variable: [{0}]")
+  @CsvSource({
+    ",", // null
+    "'',", // empty string
+    "'   '," // whitespace-only
+  })
+  void shouldAcceptAllVariablesWhenInclusionIsBlank(final String inclusion) {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variable = true;
+    config.index.variableNameInclusionExact =
+        inclusion != null ? List.of(inclusion) : null; // may be null/empty/whitespace
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("anyVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptVariablesWithCommaSeparatedPrefixes() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variable = true;
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var includedVar =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+    final var allowedVar =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("allowedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> includedRecord = mock(Record.class);
+    when(includedRecord.getBrokerVersion()).thenReturn("8.9.0");
+    when(includedRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(includedRecord.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(includedRecord.getIntent()).thenReturn(mock(Intent.class));
+    when(includedRecord.getValue()).thenReturn(includedVar);
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> allowedRecord = mock(Record.class);
+    when(allowedRecord.getBrokerVersion()).thenReturn("8.9.0");
+    when(allowedRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(allowedRecord.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(allowedRecord.getIntent()).thenReturn(mock(Intent.class));
+    when(allowedRecord.getValue()).thenReturn(allowedVar);
+
+    // when
+    final var includedAccepted = filter.acceptRecord(includedRecord);
+    final var allowedAccepted = filter.acceptRecord(allowedRecord);
+
+    // then
+    assertThat(includedAccepted).isTrue();
+    assertThat(allowedAccepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "exact inclusion={0}, name={1} -> accepted={2}")
+  @CsvSource(
+      value = {
+        "included | included       | true",
+        "included | includedVar    | false",
+        "foo      | foo            | true",
+        "foo      | bar            | false",
+        "var      | var            | true",
+        "var      | anotherVar     | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByExactName(
+      final String exactName, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of(exactName);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @ParameterizedTest(name = "suffix inclusion={0}, name={1} -> accepted={2}")
+  @CsvSource(
+      value = {
+        "_total  | order_total     | true",
+        "_total  | _total          | true",
+        "_total  | total_order     | false",
+        "_count  | item_count      | true",
+        "_count  | count_item      | false",
+        "_id     | process_id      | true",
+        "_id     | id_process      | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByNameSuffix(
+      final String inclusionSuffix, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableNameInclusionEndWith = List.of(inclusionSuffix);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  private ElasticsearchRecordFilter createFilter(final ElasticsearchExporterConfiguration config) {
+    return new ElasticsearchRecordFilter(config);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterVariableTypeTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchRecordFilterVariableTypeTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the variable type filtering in ElasticsearchRecordFilter. */
+final class ElasticsearchRecordFilterVariableTypeTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+
+  @Test
+  void shouldAcceptVariableWhenTypeMatchesInclusion() {
+    // given: only BOOLEAN variables should be accepted
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var booleanValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("true") // JSON boolean
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(booleanValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectVariableWhenTypeDoesNotMatchInclusion() {
+    // given: only BOOLEAN variables should be accepted
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var numberValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("42") // JSON number -> DOUBLE
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(numberValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldRejectVariableWhenTypeIsExcluded() {
+    // given: exclude BOOLEAN, no inclusion list
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeExclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var booleanValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("false") // JSON boolean
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(booleanValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAllowOtherTypesWhenOnlyOneTypeIsExcluded() {
+    // given: exclude BOOLEAN, but allow everything else
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeExclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var stringValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("\"hello\"") // JSON string
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(stringValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "inclusion={0}, exclusion={1}, raw={2} -> accepted={3}")
+  @CsvSource(
+      value = {
+        // inclusion-only cases
+        "BOOLEAN        |                | true         | true",
+        "BOOLEAN        |                | 42           | false",
+        "DOUBLE         |                | 42           | true",
+        "STRING         |                | '\"text\"'   | true",
+        "OBJECT         |                | '{\"a\":1}'  | true",
+        "OBJECT         |                | '[1,2,3]'    | true",
+        // exclusion-only cases
+        "               | BOOLEAN        | true         | false",
+        "               | BOOLEAN        | 42           | true",
+        // inclusion + exclusion together: include BOOLEAN & DOUBLE, but exclude BOOLEAN
+        "BOOLEAN,DOUBLE | BOOLEAN        | true         | false",
+        "BOOLEAN,DOUBLE | BOOLEAN        | 42           | true"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByInferredType(
+      final String inclusionCsv,
+      final String exclusionCsv,
+      final String rawValue,
+      final boolean expectedAccepted) {
+
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+
+    if (inclusionCsv != null && !inclusionCsv.isBlank()) {
+      config.index.variableValueTypeInclusion = List.of(inclusionCsv.trim().split("\s*,\s*"));
+    }
+    if (exclusionCsv != null && !exclusionCsv.isBlank()) {
+      config.index.variableValueTypeExclusion = List.of(exclusionCsv.trim().split("\s*,\s*"));
+    }
+
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(rawValue)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldAcceptAllVariablesWhenInclusionAndExclusionAreEmpty() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of();
+    config.index.variableValueTypeExclusion = List.of();
+    final var filter = createFilter(config);
+
+    final var anyValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("true")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(anyValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var config = new ElasticsearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final ProcessInstanceRecordValue value =
+        factory.generateObject(ProcessInstanceRecordValue.class);
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  private ElasticsearchRecordFilter createFilter(final ElasticsearchExporterConfiguration config) {
+    return new ElasticsearchRecordFilter(config);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -23,9 +23,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -63,8 +61,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -89,8 +85,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -113,8 +107,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -141,8 +133,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -166,8 +156,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -200,8 +188,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -236,10 +222,6 @@ public class RecordCounterTest {
     final Record mockRecord1 = mock(Record.class);
     final Record mockRecord2 = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord1.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord2.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord1.getIntent()).thenReturn(mock(Intent.class));
-    when(mockRecord2.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord1.getValueType()).thenReturn(valueType);
     when(mockRecord2.getValueType()).thenReturn(valueType);
     when(mockRecord1.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
@@ -269,8 +251,6 @@ public class RecordCounterTest {
     exporter.configure(context);
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     when(client.shouldFlush()).thenReturn(true);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -61,6 +63,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -85,6 +89,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -107,6 +113,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -133,6 +141,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -156,6 +166,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -188,6 +200,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -222,6 +236,10 @@ public class RecordCounterTest {
     final Record mockRecord1 = mock(Record.class);
     final Record mockRecord2 = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord1.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord2.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord1.getIntent()).thenReturn(mock(Intent.class));
+    when(mockRecord2.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord1.getValueType()).thenReturn(valueType);
     when(mockRecord2.getValueType()).thenReturn(valueType);
     when(mockRecord1.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
@@ -251,6 +269,8 @@ public class RecordCounterTest {
     exporter.configure(context);
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     when(client.shouldFlush()).thenReturn(true);

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -46,7 +46,7 @@ public class OpensearchExporter implements Exporter {
   public void configure(final Context context) {
     log = context.getLogger();
     configuration = context.getConfiguration().instantiate(OpensearchExporterConfiguration.class);
-    log.debug("Exporter configured with {}", configuration);
+    log.info("Exporter configured with {}", configuration);
 
     validate(configuration);
     pluginRepository.load(configuration.getInterceptorPlugins());

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.exporter.opensearch;
 
 import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
@@ -61,11 +60,6 @@ public class OpensearchExporterConfiguration {
         + ", interceptorPlugins="
         + interceptorPlugins
         + '}';
-  }
-
-  public boolean shouldIndexRecord(final Record<?> record) {
-    return shouldIndexRecordType(record.getRecordType())
-        && shouldIndexValueType(record.getValueType());
   }
 
   public boolean shouldIndexValueType(final ValueType valueType) {
@@ -190,6 +184,18 @@ public class OpensearchExporterConfiguration {
     public boolean variableDocument = true;
     public boolean adHocSubProcessInstruction = true;
 
+    // variable name filtering
+    public List<String> variableNameInclusionExact;
+    public List<String> variableNameInclusionStartWith;
+    public List<String> variableNameInclusionEndWith;
+    public List<String> variableNameExclusionExact;
+    public List<String> variableNameExclusionStartWith;
+    public List<String> variableNameExclusionEndWith;
+
+    // variable value type filtering
+    public List<String> variableValueTypeInclusion;
+    public List<String> variableValueTypeExclusion;
+
     public boolean checkpoint = false;
     public boolean timer = true;
     public boolean messageStartEventSubscription = true;
@@ -258,7 +264,7 @@ public class OpensearchExporterConfiguration {
     @Override
     public String toString() {
       return "IndexConfiguration{"
-          + "indexPrefix='"
+          + "prefix='"
           + prefix
           + '\''
           + ", createTemplate="
@@ -269,30 +275,34 @@ public class OpensearchExporterConfiguration {
           + event
           + ", rejection="
           + rejection
-          + ", error="
-          + error
+          + ", decision="
+          + decision
+          + ", decisionEvaluation="
+          + decisionEvaluation
+          + ", decisionRequirements="
+          + decisionRequirements
           + ", deployment="
           + deployment
-          + ", process="
-          + process
+          + ", error="
+          + error
           + ", incident="
           + incident
           + ", job="
           + job
+          + ", jobBatch="
+          + jobBatch
           + ", message="
           + message
           + ", messageBatch="
           + messageBatch
           + ", messageSubscription="
           + messageSubscription
-          + ", variable="
-          + variable
-          + ", variableDocument="
-          + variableDocument
+          + ", process="
+          + process
           + ", processInstance="
-          + processInstanceBatch
-          + ", processInstanceBatch="
           + processInstance
+          + ", processInstanceBatch="
+          + processInstanceBatch
           + ", processInstanceCreation="
           + processInstanceCreation
           + ", processInstanceMigration="
@@ -301,12 +311,10 @@ public class OpensearchExporterConfiguration {
           + processInstanceModification
           + ", processMessageSubscription="
           + processMessageSubscription
-          + ", decisionRequirements="
-          + decisionRequirements
-          + ", decision="
-          + decision
-          + ", decisionEvaluation="
-          + decisionEvaluation
+          + ", variable="
+          + variable
+          + ", variableDocument="
+          + variableDocument
           + ", checkpoint="
           + checkpoint
           + ", timer="
@@ -327,7 +335,7 @@ public class OpensearchExporterConfiguration {
           + resourceDeletion
           + ", adHocSubProcessInstruction="
           + adHocSubProcessInstruction
-          + ", recordDistribution="
+          + ", commandDistribution="
           + commandDistribution
           + ", form="
           + form
@@ -347,6 +355,24 @@ public class OpensearchExporterConfiguration {
           + conditionalSubscription
           + ", conditionalEvaluation="
           + conditionalEvaluation
+          // variable name filtering
+          + ", variableNameInclusionExact="
+          + variableNameInclusionExact
+          + ", variableNameInclusionStartWith="
+          + variableNameInclusionStartWith
+          + ", variableNameInclusionEndWith="
+          + variableNameInclusionEndWith
+          + ", variableNameExclusionExact="
+          + variableNameExclusionExact
+          + ", variableNameExclusionStartWith="
+          + variableNameExclusionStartWith
+          + ", variableNameExclusionEndWith="
+          + variableNameExclusionEndWith
+          // variable value type filtering
+          + ", variableValueTypeInclusion="
+          + variableValueTypeInclusion
+          + ", variableValueTypeExclusion="
+          + variableValueTypeExclusion
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static io.camunda.zeebe.exporter.common.filter.NameRule.Type.ENDS_WITH;
+import static io.camunda.zeebe.exporter.common.filter.NameRule.Type.EXACT;
+import static io.camunda.zeebe.exporter.common.filter.NameRule.Type.STARTS_WITH;
+import static io.camunda.zeebe.exporter.common.filter.VariableNameFilterRecord.parseRules;
+
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.common.filter.ExportRecordFilter;
+import io.camunda.zeebe.exporter.common.filter.NameRule;
+import io.camunda.zeebe.exporter.common.filter.RecordTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.RequiredValueTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.VariableNameFilterRecord;
+import io.camunda.zeebe.exporter.common.filter.VariableTypeFilter;
+import io.camunda.zeebe.exporter.common.filter.VariableTypeFilter.VariableValueType;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class OpensearchRecordFilter implements Context.RecordFilter {
+
+  private final ExportRecordFilter delegate;
+  private final OpensearchExporterConfiguration configuration;
+
+  OpensearchRecordFilter(final OpensearchExporterConfiguration configuration) {
+    this.configuration = configuration;
+    final var index = configuration.index;
+
+    final Set<VariableValueType> valueTypeInclusion =
+        VariableTypeFilter.parseTypes(index.variableValueTypeInclusion);
+    final Set<VariableValueType> valueTypeExclusion =
+        VariableTypeFilter.parseTypes(index.variableValueTypeExclusion);
+
+    final List<NameRule> nameInclusionRules = getNameInclusionRules(index);
+    final List<NameRule> nameExclusionRules = getNameExclusionRules(index);
+
+    delegate =
+        new ExportRecordFilter(
+            List.of(
+                new RecordTypeFilter(configuration::shouldIndexRecordType),
+                new RequiredValueTypeFilter(
+                    configuration::getIsIncludeEnabledRecords,
+                    configuration::shouldIndexValueType,
+                    configuration::shouldIndexRequiredValueType),
+                new VariableTypeFilter(valueTypeInclusion, valueTypeExclusion),
+                new VariableNameFilterRecord(nameInclusionRules, nameExclusionRules)));
+  }
+
+  private static List<NameRule> getNameExclusionRules(final IndexConfiguration index) {
+    final List<NameRule> nameExclusionRules = new ArrayList<>();
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionExact, EXACT));
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionStartWith, STARTS_WITH));
+    nameExclusionRules.addAll(parseRules(index.variableNameExclusionEndWith, ENDS_WITH));
+    return nameExclusionRules;
+  }
+
+  private static List<NameRule> getNameInclusionRules(final IndexConfiguration index) {
+    final List<NameRule> nameInclusionRules = new ArrayList<>();
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionExact, EXACT));
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionStartWith, STARTS_WITH));
+    nameInclusionRules.addAll(parseRules(index.variableNameInclusionEndWith, ENDS_WITH));
+    return nameInclusionRules;
+  }
+
+  // Still used by ExporterDirector to build ExporterEventFilter
+  @Override
+  public boolean acceptType(final RecordType recordType) {
+    return configuration.shouldIndexRecordType(recordType);
+  }
+
+  @Override
+  public boolean acceptValue(final ValueType valueType) {
+    return configuration.shouldIndexValueType(valueType);
+  }
+
+  @Override
+  public boolean acceptRecord(final Record<?> record) {
+    return delegate.acceptRecord(record);
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
@@ -620,15 +619,6 @@ final class OpensearchExporterIT {
     private void configureExporter(final Consumer<OpensearchExporterConfiguration> configurator) {
       // Apply caller-specific config (e.g. retention, priority)
       configurator.accept(config);
-
-      // In these index-settings tests we always want all index-enabled value types and record types
-      // to be exported; they are not about filtering semantics.
-      config.setIncludeEnabledRecords(true);
-
-      // Ensure record-type indexing is enabled for the types we may see
-      TestSupport.setIndexingForRecordType(config.index, RecordType.EVENT, true);
-      TestSupport.setIndexingForRecordType(config.index, RecordType.COMMAND, true);
-      TestSupport.setIndexingForRecordType(config.index, RecordType.COMMAND_REJECTION, true);
 
       exporter.configure(exporterTestContext);
       exporter.open(controller);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -78,8 +77,6 @@ final class OpensearchExporterTest {
     // when
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -124,8 +121,6 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
-    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -146,8 +141,6 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
-    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -169,8 +162,6 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
-    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -268,8 +259,6 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -287,8 +276,6 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -308,8 +295,6 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -329,8 +314,6 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -351,8 +334,6 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -338,39 +338,6 @@ final class OpensearchExporterTest {
       // then
       verify(client, never()).putIndexTemplate(valueType);
     }
-
-    @ParameterizedTest(name = "{0} - version: {1}")
-    @MethodSource(
-        "io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypesWithCurrentAndPreviousVersions")
-    void shouldExportOnlyRequiredRecords(final ValueType valueType, final String version) {
-      // given
-      config.index.createTemplate = true;
-      config.setIncludeEnabledRecords(false);
-      TestSupport.setIndexingForValueType(config.index, valueType, true);
-      exporter.configure(context);
-      exporter.open(controller);
-
-      // when
-      final var recordMock = mock(Record.class);
-      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
-      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
-      when(recordMock.getValueType()).thenReturn(valueType);
-      when(recordMock.getBrokerVersion()).thenReturn(version);
-      exporter.export(recordMock);
-
-      // then
-      if (valueType == ValueType.PROCESS_INSTANCE
-          || valueType == ValueType.PROCESS
-          || valueType == ValueType.VARIABLE
-          || valueType == ValueType.INCIDENT
-          || valueType == ValueType.USER_TASK
-          || valueType == ValueType.DEPLOYMENT
-          || valueType == ValueType.JOB) {
-        verify(client, times(1)).putIndexTemplate(valueType, version);
-      } else {
-        verify(client, never()).putIndexTemplate(any(), any());
-      }
-    }
   }
 
   @Nested
@@ -439,52 +406,6 @@ final class OpensearchExporterTest {
 
       // when
       exporter.export(record);
-
-      // then
-      assertThat(controller.getPosition()).isEqualTo(10L);
-    }
-
-    @Test
-    void shouldNotUpdatePositionWhenSkippingDisabledValueType() {
-      // given
-      TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
-      final var record =
-          ImmutableRecord.builder()
-              .withPosition(10L)
-              .withBrokerVersion(VersionUtil.getVersionLowerCase())
-              .withRecordType(RecordType.EVENT)
-              .withValueType(ValueType.PROCESS_INSTANCE)
-              .build();
-      exporter.configure(context);
-      exporter.open(controller);
-
-      // when
-      exporter.export(record);
-
-      // then
-      assertThat(controller.getPosition()).isEqualTo(-1);
-      verify(client, never()).index(any(), any());
-      verify(client, never()).flush();
-    }
-
-    @Test
-    void shouldUpdatePositionWhenSkippingDisabledValueTypeAndFlushingAfterwards() {
-      // given
-      TestSupport.setIndexingForValueType(config.index, ValueType.PROCESS_INSTANCE, false);
-      final var record =
-          ImmutableRecord.builder()
-              .withPosition(10L)
-              .withBrokerVersion(VersionUtil.getVersionLowerCase())
-              .withRecordType(RecordType.EVENT)
-              .withValueType(ValueType.PROCESS_INSTANCE)
-              .build();
-      exporter.configure(context);
-      exporter.open(controller);
-      exporter.export(record);
-
-      // when
-      when(client.shouldFlush()).thenReturn(true);
-      controller.runScheduledTasks(Duration.ofSeconds(10));
 
       // then
       assertThat(controller.getPosition()).isEqualTo(10L);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -77,6 +78,8 @@ final class OpensearchExporterTest {
     // when
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -121,6 +124,8 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
+    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -141,6 +146,8 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
+    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -162,6 +169,8 @@ final class OpensearchExporterTest {
 
     // when
     final var recordMock = mock(Record.class);
+    when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+    when(recordMock.getIntent()).thenReturn(mock(Intent.class));
     when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     exporter.export(recordMock);
@@ -259,6 +268,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -276,6 +287,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -295,6 +308,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -314,6 +329,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
@@ -335,6 +352,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(valueType);
       when(recordMock.getBrokerVersion()).thenReturn(version);
       exporter.export(recordMock);
@@ -365,6 +384,8 @@ final class OpensearchExporterTest {
 
       // when
       final var recordMock = mock(Record.class);
+      when(recordMock.getRecordType()).thenReturn(RecordType.EVENT);
+      when(recordMock.getIntent()).thenReturn(mock(Intent.class));
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
       when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -408,6 +429,7 @@ final class OpensearchExporterTest {
       final var record =
           ImmutableRecord.builder()
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withPosition(10L)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
@@ -430,6 +452,7 @@ final class OpensearchExporterTest {
           ImmutableRecord.builder()
               .withPosition(10L)
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -452,6 +475,7 @@ final class OpensearchExporterTest {
           ImmutableRecord.builder()
               .withPosition(10L)
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -473,6 +497,7 @@ final class OpensearchExporterTest {
           ImmutableRecord.builder()
               .withBrokerVersion(VersionUtil.getVersionLowerCase())
               .withPosition(10L)
+              .withRecordType(RecordType.EVENT)
               .withValueType(ValueType.PROCESS_INSTANCE)
               .build();
       exporter.configure(context);
@@ -706,6 +731,7 @@ final class OpensearchExporterTest {
       return ImmutableRecord.builder()
           .withBrokerVersion(VersionUtil.getVersionLowerCase())
           .withPartitionId(partitionId)
+          .withRecordType(RecordType.EVENT)
           .withValueType(valueType)
           .build();
     }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterRecordTypeTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterRecordTypeTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the record type filtering in OpensearchExporter’s RecordFilter. */
+final class OpensearchRecordFilterRecordTypeTest {
+
+  private RecordFilter createFilter(final OpensearchExporterConfiguration config) {
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("opensearch", config));
+    final var exporter = new OpensearchExporter();
+    exporter.configure(context);
+    return context.getRecordFilter();
+  }
+
+  @Test
+  void shouldAcceptEventWhenEventIndexingEnabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.event = true;
+    config.index.command = false;
+    config.index.rejection = false;
+
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.EVENT);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectEventWhenEventIndexingDisabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.event = false;
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.EVENT);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptCommandWhenCommandIndexingEnabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.command = true;
+    config.index.event = false;
+    config.index.rejection = false;
+
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectCommandWhenCommandIndexingDisabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.command = false;
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptCommandRejectionWhenRejectionIndexingEnabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.rejection = true;
+    config.index.event = false;
+    config.index.command = false;
+
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND_REJECTION);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectCommandRejectionWhenRejectionIndexingDisabled() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.rejection = false;
+    final var filter = createFilter(config);
+
+    // when
+    final var accepted = filter.acceptType(RecordType.COMMAND_REJECTION);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @ParameterizedTest(name = "recordType={0}, enabled={1} -> acceptRecord={4}")
+  @CsvSource(
+      value = {
+        // recordType | enableEvent | enableCommand | enableRejection | expectedAccepted
+        "EVENT            | true  | false | false | true",
+        "EVENT            | false | false | false | false",
+        "COMMAND          | false | true  | false | true",
+        "COMMAND          | false | false | false | false",
+        "COMMAND_REJECTION| false | false | true  | true",
+        "COMMAND_REJECTION| false | false | false | false"
+      },
+      delimiter = '|')
+  void shouldFilterRecordsByRecordTypeConfiguration(
+      final RecordType recordType,
+      final boolean enableEvent,
+      final boolean enableCommand,
+      final boolean enableRejection,
+      final boolean expectedAccepted) {
+
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.event = enableEvent;
+    config.index.command = enableCommand;
+    config.index.rejection = enableRejection;
+
+    // keep value-type side permissive: PROCESS_INSTANCE is enabled by default
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(recordType);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterRequiredValueTypeTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterRequiredValueTypeTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests for the "required value type" behavior in the OpenSearch exporter filter, which is
+ * implemented via {@link io.camunda.zeebe.exporter.common.filter.RequiredValueTypeFilter} and wired
+ * through {@link OpensearchExporter}.
+ *
+ * <p>Covered branches:
+ *
+ * <ul>
+ *   <li>Pre-8.8 brokers (major == 8, minor &lt; 8) → use {@code shouldIndexValueType}
+ *   <li>Any broker with {@code includeEnabledRecords = true} → use {@code shouldIndexValueType}
+ *   <li>8.8+ with {@code includeEnabledRecords = false} → use {@code shouldIndexRequiredValueType}
+ *   <li>Required value types honoring index flags (index.* can still disable them)
+ *   <li>Invalid broker version string → IllegalArgumentException
+ * </ul>
+ */
+final class OpensearchRecordFilterRequiredValueTypeTest {
+
+  private RecordFilter createFilter(final OpensearchExporterConfiguration config) {
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("opensearch", config));
+    final var exporter = new OpensearchExporter();
+    exporter.configure(context);
+    return context.getRecordFilter();
+  }
+
+  @ParameterizedTest(
+      name =
+          "pre-8.8 (8.7.x), valueType={0}, enabledFlag={1} -> accepted={1} (uses shouldIndexValueType)")
+  @CsvSource(
+      value = {
+        // valueType       | enabledFlag
+        "MESSAGE          | true",
+        "MESSAGE          | false",
+        "PROCESS_INSTANCE | true",
+        "PROCESS_INSTANCE | false"
+      },
+      delimiter = '|')
+  void shouldUseNormalValueTypeConfigForPre88Brokers(
+      final ValueType valueType, final boolean enabledFlag) {
+
+    // given: includeEnabledRecords=false, but broker is 8.7.x
+    // -> includeAllEnabledRecords == true
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    // configure the normal index flags per value type
+    switch (valueType) {
+      case MESSAGE -> config.index.message = enabledFlag;
+      case PROCESS_INSTANCE -> config.index.processInstance = enabledFlag;
+      default -> throw new IllegalArgumentException("Test not set up for value type: " + valueType);
+    }
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.7.3");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT); // event is enabled by default
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: required-vs-nonrequired is ignored for pre-8.8; we follow index.* flag
+    assertThat(accepted).isEqualTo(enabledFlag);
+  }
+
+  @ParameterizedTest(
+      name = "includeEnabledRecords=true (8.9.x), valueType={0}, enabledFlag={1} -> accepted={1}")
+  @CsvSource(
+      value = {
+        // valueType       | enabledFlag
+        "MESSAGE          | true",
+        "MESSAGE          | false",
+        "PROCESS_INSTANCE | true",
+        "PROCESS_INSTANCE | false"
+      },
+      delimiter = '|')
+  void shouldUseNormalValueTypeConfigWhenIncludeEnabledRecordsIsTrue(
+      final ValueType valueType, final boolean enabledFlag) {
+
+    // given: includeEnabledRecords=true
+    // -> includeAllEnabledRecords == true for any 8.x version
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(true);
+
+    switch (valueType) {
+      case MESSAGE -> config.index.message = enabledFlag;
+      case PROCESS_INSTANCE -> config.index.processInstance = enabledFlag;
+      default -> throw new IllegalArgumentException("Test not set up for value type: " + valueType);
+    }
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: we use shouldIndexValueType, i.e. index.* flag decides
+    assertThat(accepted).isEqualTo(enabledFlag);
+  }
+
+  @ParameterizedTest(
+      name =
+          "8.9.x, includeEnabledRecords=false, valueType={0} -> accepted={1} (uses shouldIndexRequiredValueType)")
+  @CsvSource(
+      value = {
+        // Required value types (Optimize / analytics), excluding VARIABLE (handled separately)
+        "DEPLOYMENT       | true",
+        "PROCESS          | true",
+        "INCIDENT         | true",
+        "PROCESS_INSTANCE | true",
+        "USER_TASK        | true",
+        "JOB              | true",
+        // Some non-required value types
+        "MESSAGE          | false",
+        "TIMER            | false",
+        "DECISION         | false",
+        "MESSAGE_SUBSCRIPTION | false"
+      },
+      delimiter = '|')
+  void shouldFilterByRequiredValueTypesWhenIncludeEnabledRecordsDisabledOnNewBrokers(
+      final ValueType valueType, final boolean expectedAccepted) {
+
+    // given: 8.9.x broker, includeEnabledRecords=false
+    // -> includeAllEnabledRecords == false
+    // -> RequiredValueTypeFilter delegates to shouldIndexRequiredValueType
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldTreatVariableAsRequiredWhenIncludeEnabledRecordsDisabledOnNewBrokers() {
+    // given: VARIABLE is in the required set
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    final var filter = createFilter(config);
+
+    final VariableRecordValue variableValue = mock(VariableRecordValue.class);
+    // Any simple name so variable-name filters, if present, don't exclude it
+    when(variableValue.getName()).thenReturn("anyVariable");
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldHonorIndexFlagsForRequiredValueTypesOnNewBrokers() {
+    // given: 8.9.x, includeEnabledRecords=false -> required-value branch
+    // but explicitly disable one required type (PROCESS_INSTANCE)
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+    config.index.processInstance = false; // override default
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then: even though PROCESS_INSTANCE is in the "required" set, index flag wins
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldThrowOnNonSemanticBrokerVersion() {
+    // given: invalid broker version string → RequiredValueTypeFilter should throw
+    final var config = new OpensearchExporterConfiguration();
+    config.setIncludeEnabledRecords(false);
+
+    final var filter = createFilter(config);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("not-a-version");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+
+    // when / then
+    assertThatThrownBy(() -> filter.acceptRecord(record))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported record broker version");
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterVariableNameTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterVariableNameTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the variable name inclusion filtering in OpensearchRecordFilter. */
+final class OpensearchRecordFilterVariableNameTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+
+  @Test
+  void shouldAcceptVariableWhenNameMatchesInclusionPrefix() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldNotAcceptVariableWhenNameDoesNotMatchInclusionPrefix() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("excludedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @CsvSource(
+      value = {
+        "included | includedVariable | true",
+        "included | includedAnotherName | true",
+        "included | included | true",
+        "allowed | allowedVariable | true",
+        "allowed | allowedAnotherName | true",
+        "var | variable | true",
+        "var | anotherVar | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByNamePrefix(
+      final String inclusionPrefix, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of(inclusionPrefix);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldAcceptAllVariablesWhenInclusionIsEmpty() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of();
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("anyVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldTrimWhitespaceFromInclusionPrefixes() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of("included");
+    final var filter = createFilter(config);
+
+    final ProcessInstanceRecordValue value =
+        factory.generateObject(ProcessInstanceRecordValue.class);
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "blank inclusion -> accept variable: [{0}]")
+  @CsvSource({
+    ",", // null
+    "'',", // empty string
+    "'   '," // whitespace-only
+  })
+  void shouldAcceptAllVariablesWhenInclusionIsBlank(final String inclusion) {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variable = true;
+    config.index.variableNameInclusionExact =
+        inclusion != null ? List.of(inclusion) : null; // may be null/empty/whitespace
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("anyVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptVariablesWithCommaSeparatedPrefixes() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variable = true;
+    config.index.variableNameInclusionStartWith = List.of("included", "allowed");
+    final var filter = createFilter(config);
+
+    final var includedVar =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("includedVariable")
+            .build();
+    final var allowedVar =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName("allowedVariable")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> includedRecord = mock(Record.class);
+    when(includedRecord.getBrokerVersion()).thenReturn("8.9.0");
+    when(includedRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(includedRecord.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(includedRecord.getIntent()).thenReturn(mock(Intent.class));
+    when(includedRecord.getValue()).thenReturn(includedVar);
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> allowedRecord = mock(Record.class);
+    when(allowedRecord.getBrokerVersion()).thenReturn("8.9.0");
+    when(allowedRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(allowedRecord.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(allowedRecord.getIntent()).thenReturn(mock(Intent.class));
+    when(allowedRecord.getValue()).thenReturn(allowedVar);
+
+    // when
+    final var includedAccepted = filter.acceptRecord(includedRecord);
+    final var allowedAccepted = filter.acceptRecord(allowedRecord);
+
+    // then
+    assertThat(includedAccepted).isTrue();
+    assertThat(allowedAccepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "exact inclusion={0}, name={1} -> accepted={2}")
+  @CsvSource(
+      value = {
+        "included | included       | true",
+        "included | includedVar    | false",
+        "foo      | foo            | true",
+        "foo      | bar            | false",
+        "var      | var            | true",
+        "var      | anotherVar     | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByExactName(
+      final String exactName, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionExact = List.of(exactName);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @ParameterizedTest(name = "suffix inclusion={0}, name={1} -> accepted={2}")
+  @CsvSource(
+      value = {
+        "_total  | order_total     | true",
+        "_total  | _total          | true",
+        "_total  | total_order     | false",
+        "_count  | item_count      | true",
+        "_count  | count_item      | false",
+        "_id     | process_id      | true",
+        "_id     | id_process      | false"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByNameSuffix(
+      final String inclusionSuffix, final String variableName, final boolean expectedAccepted) {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableNameInclusionEndWith = List.of(inclusionSuffix);
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withName(variableName)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  private OpensearchRecordFilter createFilter(final OpensearchExporterConfiguration config) {
+    return new OpensearchRecordFilter(config);
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterVariableTypeTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchRecordFilterVariableTypeTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/** Unit tests for the variable type filtering in OpensearchRecordFilter. */
+final class OpensearchRecordFilterVariableTypeTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+
+  @Test
+  void shouldAcceptVariableWhenTypeMatchesInclusion() {
+    // given: only BOOLEAN variables should be accepted
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var booleanValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("true") // JSON boolean
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(booleanValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldRejectVariableWhenTypeDoesNotMatchInclusion() {
+    // given: only BOOLEAN variables should be accepted
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var numberValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("42") // JSON number -> DOUBLE
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(numberValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldRejectVariableWhenTypeIsExcluded() {
+    // given: exclude BOOLEAN, no inclusion list
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeExclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var booleanValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("false") // JSON boolean
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(booleanValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAllowOtherTypesWhenOnlyOneTypeIsExcluded() {
+    // given: exclude BOOLEAN, but allow everything else
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeExclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final var stringValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("\"hello\"") // JSON string
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(stringValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @ParameterizedTest(name = "inclusion={0}, exclusion={1}, raw={2} -> accepted={3}")
+  @CsvSource(
+      value = {
+        // inclusion-only cases
+        "BOOLEAN        |                | true         | true",
+        "BOOLEAN        |                | 42           | false",
+        "DOUBLE         |                | 42           | true",
+        "STRING         |                | '\"text\"'   | true",
+        "OBJECT         |                | '{\"a\":1}'  | true",
+        "OBJECT         |                | '[1,2,3]'    | true",
+        // exclusion-only cases
+        "               | BOOLEAN        | true         | false",
+        "               | BOOLEAN        | 42           | true",
+        // inclusion + exclusion together: include BOOLEAN & DOUBLE, but exclude BOOLEAN
+        "BOOLEAN,DOUBLE | BOOLEAN        | true         | false",
+        "BOOLEAN,DOUBLE | BOOLEAN        | 42           | true"
+      },
+      delimiter = '|')
+  void shouldFilterVariablesByInferredType(
+      final String inclusionCsv,
+      final String exclusionCsv,
+      final String rawValue,
+      final boolean expectedAccepted) {
+
+    // given
+    final var config = new OpensearchExporterConfiguration();
+
+    if (inclusionCsv != null && !inclusionCsv.isBlank()) {
+      config.index.variableValueTypeInclusion = List.of(inclusionCsv.trim().split("\\s*,\\s*"));
+    }
+    if (exclusionCsv != null && !exclusionCsv.isBlank()) {
+      config.index.variableValueTypeExclusion = List.of(exclusionCsv.trim().split("\\s*,\\s*"));
+    }
+
+    final var filter = createFilter(config);
+
+    final var variableValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(rawValue)
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(variableValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isEqualTo(expectedAccepted);
+  }
+
+  @Test
+  void shouldAcceptAllVariablesWhenInclusionAndExclusionAreEmpty() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of();
+    config.index.variableValueTypeExclusion = List.of();
+    final var filter = createFilter(config);
+
+    final var anyValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("true")
+            .build();
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(anyValue);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var config = new OpensearchExporterConfiguration();
+    config.index.variableValueTypeInclusion = List.of("BOOLEAN");
+    final var filter = createFilter(config);
+
+    final ProcessInstanceRecordValue value =
+        factory.generateObject(ProcessInstanceRecordValue.class);
+
+    @SuppressWarnings("unchecked")
+    final Record<ProcessInstanceRecordValue> record = mock(Record.class);
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(mock(Intent.class));
+    when(record.getValue()).thenReturn(value);
+
+    // when
+    final var accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  private OpensearchRecordFilter createFilter(final OpensearchExporterConfiguration config) {
+    return new OpensearchRecordFilter(config);
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -60,6 +62,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -83,6 +87,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -105,6 +111,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -130,6 +138,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -153,6 +163,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -184,6 +196,8 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -217,6 +231,10 @@ public class RecordCounterTest {
     final Record mockRecord1 = mock(Record.class);
     final Record mockRecord2 = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord1.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord1.getIntent()).thenReturn(mock(Intent.class));
+    when(mockRecord2.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord2.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord1.getValueType()).thenReturn(valueType);
     when(mockRecord2.getValueType()).thenReturn(valueType);
     when(mockRecord1.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
@@ -245,6 +263,8 @@ public class RecordCounterTest {
     exporter.configure(context);
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
+    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     when(client.shouldFlush()).thenReturn(true);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
@@ -23,9 +23,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -62,8 +60,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -87,8 +83,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -111,8 +105,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -138,8 +130,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -163,8 +153,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -196,8 +184,6 @@ public class RecordCounterTest {
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(valueType);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
 
@@ -231,10 +217,6 @@ public class RecordCounterTest {
     final Record mockRecord1 = mock(Record.class);
     final Record mockRecord2 = mock(Record.class);
     final var valueType = ValueType.PROCESS_INSTANCE;
-    when(mockRecord1.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord1.getIntent()).thenReturn(mock(Intent.class));
-    when(mockRecord2.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord2.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord1.getValueType()).thenReturn(valueType);
     when(mockRecord2.getValueType()).thenReturn(valueType);
     when(mockRecord1.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
@@ -263,8 +245,6 @@ public class RecordCounterTest {
     exporter.configure(context);
     exporter.open(controller);
     final Record mockRecord = mock(Record.class);
-    when(mockRecord.getRecordType()).thenReturn(RecordType.EVENT);
-    when(mockRecord.getIntent()).thenReturn(mock(Intent.class));
     when(mockRecord.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
     when(mockRecord.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
     when(client.shouldFlush()).thenReturn(true);


### PR DESCRIPTION
**Description**

This PR implements a more granular variable export filter, allowing variables to be filtered by both name and value type before they are written by exporters.

**Motivation**

Exporter-side filtering was previously too coarse: it could not reliably restrict exports by both variable name and type. This made it harder for downstream systems to avoid irrelevant or large values.

**Changes**

Extend variable export filtering to support combined name + value type criteria.
Wire the new filter into the exporter pipeline so configurations gain the stricter behavior when enabled.

Add an Elasticsearch exporter acceptance test:
qa/acceptance-tests/src/test/java/io/camunda/it/exporter/ElasticsearchExporterVariableFilterIT.java.

Related issues
