### PR TITLE
test: acceptance tests for retention by hierarchy

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Stop Database service
-        if: always() && inputs.database-type != 'h2'
+        if: ${{ always() && inputs.database-type != 'h2' }}
         run: docker-compose -f db/docker-compose.yml down
       - name: Analyze Test Runs
         id: analyze-test-run

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
         description: The database docker image version to be used during the tests. Will be set as env variable IMAGE_VERSION. If not set, the default value from the docker-compose file will be used.
+      maven-profiles:
+        required: false
+        type: string
+        default: "multi-db-test"
+        description: Comma-separated list of Maven profiles to activate during the test run (e.g., "multi-db-test", "history"). The profiles parallel-tests,extract-flaky-tests,skipFrontendBuild are always included.
+      test-type-label:
+        required: false
+        type: string
+        default: "Database"
+        description: Label for the test type used in artifact names and job descriptions (e.g., "Database", "History").
       notify-slack-on-failure:
         required: false
         type: boolean
@@ -58,7 +68,7 @@ jobs:
       # start the required database service
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}
-        run: docker-compose -f db/docker-compose.yml up -d ${{inputs.database-type}}
+        run: docker-compose -f db/docker-compose.yml up -d ${{ inputs.database-type }}
       # Build the platform before running the integration tests; skipping frontend
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
@@ -79,12 +89,12 @@ jobs:
           -D failsafe.rerunFailingTestsCount=3
           -D flaky.test.reportDir=failsafe-reports
           -D test.integration.camunda.database.type=${{inputs.it-database-type}}
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,${{inputs.maven-profiles}}
           -pl 'qa/acceptance-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Stop Database service
-        if: always()
+        if: always() && inputs.database-type != 'h2'
         run: docker-compose -f db/docker-compose.yml down
       - name: Analyze Test Runs
         id: analyze-test-run
@@ -96,7 +106,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[IT] Database - ${{inputs.database-type}}"
+          name: "[IT] ${{inputs.test-type-label}} - ${{inputs.database-type}}"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,44 @@ jobs:
       database-type: "h2"
       it-database-type: "rdbms_h2"
 
+  elasticsearch-history-tests:
+    name: "History Integration Tests / Elasticsearch"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "elasticsearch"
+      database-image-version: "8.18.4"
+      it-database-type: "es"
+      maven-profiles: "history"
+      test-type-label: "History"
+
+  opensearch-history-tests:
+    name: "History Integration Tests / Opensearch"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "opensearch"
+      database-image-version: "2.17.0"
+      it-database-type: "os"
+      maven-profiles: "history"
+      test-type-label: "History"
+
+  h2-history-tests:
+    name: "History Integration Tests / H2"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "h2"
+      it-database-type: "rdbms_h2"
+      maven-profiles: "history"
+      test-type-label: "History"
+
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
@@ -1220,13 +1258,16 @@ jobs:
       - commitlint
       - detect-changes
       - docker-checks
+      - elasticsearch-history-tests
       - elasticsearch-integration-tests
       - general-unit-tests
+      - h2-history-tests
       - identity-frontend-tests
       - integration-tests
       - java-checks
       - maven-spotless-linter
       - openapi-lint
+      - opensearch-history-tests
       - opensearch-integration-tests
       - operate-ci
       - optimize-ci

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -84,11 +84,6 @@ services:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx2048m"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
-        # We need to configure ILM to run more often, to make sure data is cleaned up earlier
-        # Useful for tests where we verify history clean up
-        # Default is 10m
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-settings.html
-      - indices.lifecycle.poll_interval=1s
     ulimits:
       memlock:
         soft: -1
@@ -115,13 +110,6 @@ services:
       - action.destructive_requires_name=false
         # Disabling the security to make sure we can access without tls in our tests
         # https://opensearch.org/docs/latest/security/configuration/disable-enable-security/
-        # We need to configure ISM to run more often, to make sure data is cleaned up earlier
-        # Useful for tests where we verify history clean up
-        # Default is 5 - unit is minutes
-        # https://opensearch.org/docs/latest/im-plugin/ism/settings/
-      - plugins.index_state_management.job_interval=1
-        # A randomized delay that is added to a job’s base run time to prevent a surge of activity from all indexes at the same time.
-      - plugins.index_state_management.jitter=0
       - knn.algo_param.index_thread_qty=4
     ulimits:
       memlock:

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -661,7 +661,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <groups>rdbms</groups>
-              <excludedGroups>multi-db-test, compatibility-test</excludedGroups>
+              <excludedGroups>multi-db-test, compatibility-test, history</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -686,7 +686,7 @@
             <configuration>
               <failIfNoTests>false</failIfNoTests>
               <groups>multi-db-test</groups>
-              <excludedGroups>rdbms</excludedGroups>
+              <excludedGroups>rdbms, history</excludedGroups>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
               </systemPropertyVariables>
@@ -716,9 +716,37 @@
             <configuration>
               <failIfNoTests>false</failIfNoTests>
               <groups>compatibility-test</groups>
-              <excludedGroups>rdbms</excludedGroups>
+              <excludedGroups>rdbms, history</excludedGroups>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>compatibility</camunda.test.preferred.extension>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+    This profile will run all tests annotated with @Tag("history").
+    The profile is mainly used to run history-related tests that can be executed against
+    multiple different databases.
+
+    For example against:
+    Elasticsearch, OpenSearch, H2, etc.
+    -->
+    <profile>
+      <id>history</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>history</groups>
+              <excludedGroups>rdbms</excludedGroups>
+              <systemPropertyVariables>
+                <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -18,10 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.UserTask;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.HistoryMultiDbTest;
 import java.time.Duration;
 import java.util.Objects;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +32,17 @@ public class HistoryCleanupIT {
 
   static final String RESOURCE_NAME = "process/process_with_assigned_user_task.bpmn";
   private static CamundaClient camundaClient;
+  private static DatabaseType databaseType;
+  private static Duration cleanupTimeout;
+
+  @BeforeAll
+  static void setup() {
+    cleanupTimeout =
+        switch (databaseType) {
+          case OS, AWS_OS -> Duration.ofSeconds(210); // OS cleanup can not be faster than 3min
+          default -> Duration.ofSeconds(30);
+        };
+  }
 
   @Test
   void shouldDeleteProcessesWhichAreMarkedForCleanup() {
@@ -66,7 +79,7 @@ public class HistoryCleanupIT {
 
     // and soon it should be gone
     Awaitility.await("should wait until process and tasks are deleted")
-        .atMost(Duration.ofMinutes(5))
+        .atMost(cleanupTimeout)
         .pollDelay(Duration.ofMillis(500))
         .pollInterval(Duration.ofSeconds(10))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.historycleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.worker.JobWorker;
+import io.camunda.qa.util.multidb.HistoryMultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@HistoryMultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ProcessInstanceHistoryCleanupIT {
+
+  private static CamundaClient client;
+
+  private static final String ROOT_PROCESS_ID = "rootProcess";
+  private static final String CHILD_PROCESS_ID = "childProcess";
+  private static final String DECISION_ID = "jedi_or_sith";
+  private static final String MESSAGE_NAME = "message";
+  private static final String JOB_TYPE = "job";
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration CLEANUP_TIMEOUT = Duration.ofMinutes(2);
+  private final AtomicBoolean shouldWorkerCompleteJob = new AtomicBoolean(false);
+
+  @Test
+  void shouldDeleteInstancesDataOnlyWhenRootInstancesAreCompleted() {
+    // Given
+    deployResources(client);
+
+    final long rootPiKey;
+    final long childPiKey;
+
+    try (final var ignored = openJobWorker(client)) {
+      rootPiKey = startRootProcessInstance(client);
+      childPiKey = getChildProcessInstanceKey(client, rootPiKey);
+
+      handleIncident(client, childPiKey);
+      completeUserTask(client, childPiKey);
+      publishMessage(client, childPiKey);
+
+      // Verify that child process instance is completed, but root is still active
+      assertProcessInstanceState(client, childPiKey, ProcessInstanceState.COMPLETED);
+      assertProcessInstanceState(client, rootPiKey, ProcessInstanceState.ACTIVE);
+
+      // Verify data presence for child process instances (should exist because root is active)
+      assertProcessInstanceDataIsPresent(client, childPiKey);
+
+      // When: Complete root user task to fully complete the root process instance
+      completeUserTask(client, rootPiKey);
+
+      // Then: Root is completed
+      assertProcessInstanceState(client, rootPiKey, ProcessInstanceState.COMPLETED);
+
+      // And: Data should be cleaned up for both
+      assertProcessInstanceDataIsCleanedUp(client, rootPiKey);
+      assertProcessInstanceDataIsCleanedUp(client, childPiKey);
+    }
+  }
+
+  private void assertProcessInstanceDataIsPresent(
+      final CamundaClient client, final long processInstanceKey) {
+    Awaitility.await("Wait and verify process instance data is still present")
+        .pollDelay(TIMEOUT)
+        .timeout(TIMEOUT.plusSeconds(5))
+        .untilAsserted(
+            () -> {
+              final var verifiers = getDataVerifiers(client, processInstanceKey);
+              assertThat(verifiers)
+                  .as("All verifiers should find data")
+                  .allSatisfy(
+                      (name, supplier) ->
+                          assertThat(supplier.get()).as("Data for %s", name).isNotEmpty());
+            });
+  }
+
+  private void assertProcessInstanceDataIsCleanedUp(
+      final CamundaClient client, final long processInstanceKey) {
+    Awaitility.await("Wait for process instance data cleanup")
+        .timeout(CLEANUP_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              final var verifiers = getDataVerifiers(client, processInstanceKey);
+              assertThat(verifiers)
+                  .as("All verifiers should find no data")
+                  .allSatisfy(
+                      (name, supplier) ->
+                          assertThat(supplier.get()).as("Data for %s", name).isEmpty());
+            });
+  }
+
+  private Map<String, Supplier<Collection<?>>> getDataVerifiers(
+      final CamundaClient client, final long processInstanceKey) {
+    return Map.of(
+        "process instance",
+        () ->
+            client
+                .newProcessInstanceSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "user task",
+        () ->
+            client
+                .newUserTaskSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "element instance",
+        () ->
+            client
+                .newElementInstanceSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "variable",
+        () ->
+            client
+                .newVariableSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "correlated message subscription",
+        () ->
+            client
+                .newCorrelatedMessageSubscriptionSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "incident",
+        () ->
+            client
+                .newIncidentSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "decision instance",
+        () ->
+            client
+                .newDecisionInstanceSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "job",
+        () ->
+            client
+                .newJobSearchRequest()
+                .filter(f -> f.processInstanceKey(processInstanceKey))
+                .send()
+                .join()
+                .items(),
+        "sequence flow",
+        () -> client.newProcessInstanceSequenceFlowsRequest(processInstanceKey).send().join());
+    /* TODO enable this when the audit log for process instances cleanup is implemented
+    "audit log",
+    () ->
+        client
+            .newAuditLogSearchRequest()
+            .filter(f -> f.processInstanceKey(String.valueOf(processInstanceKey)))
+            .send()
+            .join()
+            .items());
+     */
+  }
+
+  private void assertProcessInstanceState(
+      final CamundaClient client,
+      final long processInstanceKey,
+      final ProcessInstanceState expectedState) {
+    Awaitility.await("Wait for process instance state: " + expectedState)
+        .timeout(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var processInstances =
+                  client
+                      .newProcessInstanceSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(processInstances)
+                  .hasSize(1)
+                  .first()
+                  .extracting(ProcessInstance::getState)
+                  .isEqualTo(expectedState);
+            });
+  }
+
+  private long getChildProcessInstanceKey(final CamundaClient client, final long rootPiKey) {
+    return Awaitility.await()
+        .timeout(TIMEOUT)
+        .until(
+            () ->
+                client
+                    .newProcessInstanceSearchRequest()
+                    .filter(f -> f.parentProcessInstanceKey(rootPiKey))
+                    .send()
+                    .join()
+                    .items(),
+            items -> !items.isEmpty())
+        .getFirst()
+        .getProcessInstanceKey();
+  }
+
+  private JobWorker openJobWorker(final CamundaClient client) {
+    return client
+        .newWorker()
+        .jobType(JOB_TYPE)
+        .handler(
+            (c, j) -> {
+              if (shouldWorkerCompleteJob.get()) {
+                // Complete successfully after resolution
+                c.newCompleteCommand(j.getKey()).variables(Map.of("jobVar", "done")).send();
+              } else {
+                c.newFailCommand(j.getKey())
+                    .retries(0)
+                    .errorMessage("intentional failure")
+                    .send()
+                    .join();
+              }
+            })
+        .timeout(TIMEOUT)
+        .name("worker")
+        .maxJobsActive(1)
+        .open();
+  }
+
+  private void deployResources(final CamundaClient client) {
+    final BpmnModelInstance childBpmn =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+            .startEvent()
+            .sequenceFlowId("flow1")
+            .serviceTask("serviceTask", t -> t.zeebeJobType(JOB_TYPE))
+            .userTask("userTask")
+            .zeebeUserTask()
+            .intermediateCatchEvent(
+                "catchEvent",
+                c -> c.message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression("key")))
+            .businessRuleTask(
+                "decisionTask",
+                t -> t.zeebeCalledDecisionId(DECISION_ID).zeebeResultVariable("result"))
+            .endEvent()
+            .done();
+    final BpmnModelInstance rootBpmn =
+        Bpmn.createExecutableProcess(ROOT_PROCESS_ID)
+            .startEvent()
+            .callActivity("callChildProcess", b -> b.zeebeProcessId(CHILD_PROCESS_ID))
+            .userTask("rootUserTask")
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+
+    // Simple DMN
+    final String dmnXml =
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+              <decision id="%s" name="Jedi or Sith">
+                <decisionTable id="decisionTable">
+                  <input id="input1" label="Light Saber Color">
+                    <inputExpression id="inputExpression1" typeRef="string">
+                      <text>color</text>
+                    </inputExpression>
+                  </input>
+                  <output id="output1" label="Alignment" name="alignment" typeRef="string" />
+                  <rule id="rule1">
+                    <inputEntry id="inputEntry1">
+                      <text>"blue"</text>
+                    </inputEntry>
+                    <outputEntry id="outputEntry1">
+                      <text>"Jedi"</text>
+                    </outputEntry>
+                  </rule>
+                </decisionTable>
+              </decision>
+            </definitions>
+            """
+            .formatted(DECISION_ID);
+
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(childBpmn, "child-process.bpmn")
+        .addProcessModel(rootBpmn, "root-process.bpmn")
+        .addResourceStream(
+            new ByteArrayInputStream(dmnXml.getBytes(StandardCharsets.UTF_8)), "decision.dmn")
+        .send()
+        .join();
+  }
+
+  private long startRootProcessInstance(final CamundaClient client) {
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("key", "correlationKey");
+    variables.put("color", "blue"); // For DMN
+    variables.put("initialVar", "value");
+
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(ROOT_PROCESS_ID)
+        .latestVersion()
+        .variables(variables)
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private void completeUserTask(final CamundaClient client, final long processInstanceKey) {
+    // Wait for user task to appear then complete it
+    final var userTaskKey =
+        Awaitility.await()
+            .atMost(TIMEOUT)
+            .ignoreExceptions()
+            .until(
+                () ->
+                    client
+                        .newUserTaskSearchRequest()
+                        .filter(
+                            f ->
+                                f.processInstanceKey(processInstanceKey)
+                                    .state(UserTaskState.CREATED))
+                        .send()
+                        .join()
+                        .items(),
+                tasks -> !tasks.isEmpty())
+            .getFirst()
+            .getUserTaskKey();
+    client
+        .newCompleteUserTaskCommand(userTaskKey)
+        .variables(Map.of("userTaskVar", "completed"))
+        .send()
+        .join();
+  }
+
+  private void publishMessage(final CamundaClient client, final long processInstanceKey) {
+    client
+        .newPublishMessageCommand()
+        .messageName(MESSAGE_NAME)
+        .correlationKey("correlationKey")
+        .variables(Map.of("msgVar", "received"))
+        .send()
+        .join();
+    Awaitility.await()
+        .until(
+            () ->
+                !client
+                    .newCorrelatedMessageSubscriptionSearchRequest()
+                    .filter(f -> f.processInstanceKey(processInstanceKey).messageName(MESSAGE_NAME))
+                    .send()
+                    .join()
+                    .items()
+                    .isEmpty());
+  }
+
+  private void handleIncident(final CamundaClient client, final long processInstanceKey) {
+    // Wait for incident
+    Awaitility.await()
+        .atMost(TIMEOUT)
+        .ignoreExceptions()
+        .until(
+            () -> {
+              final var result =
+                  client
+                      .newIncidentSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
+              if (result.items().isEmpty()) {
+                return false;
+              }
+              final var incident = result.items().getFirst();
+              client.newUpdateJobCommand(incident.getJobKey()).updateRetries(1).send().join();
+              shouldWorkerCompleteJob.set(true);
+              client.newResolveIncidentCommand(incident.getIncidentKey()).send().join();
+              return true;
+            });
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
@@ -105,9 +105,6 @@ public class AWSOpenSearchSetupHelper extends OpenSearchSetupHelper {
 
   @Override
   public void cleanup(final String prefix) {
-    // reset cluster settings if changed
-    super.resetLifecyclePollInterval();
-
     try {
       client.indices().delete(new DeleteIndexRequest.Builder().index(prefix + "*").build());
     } catch (final IOException e) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -419,11 +419,17 @@ public class CamundaMultiDBExtension
 
     if (isHistoryRelatedTest) {
       // make sure history clean up policies are applied more often
-      final Duration pollInterval =
-          getDatabaseType(context) == DatabaseType.ES
-              ? Duration.ofSeconds(5)
-              : Duration.ofMinutes(1);
-      setupHelper.applyIndexPoliciesPollInterval(pollInterval);
+      switch (getDatabaseType(context)) {
+        case ES, LOCAL:
+          setupHelper.applyIndexPoliciesPollInterval(Duration.ofSeconds(1));
+          break;
+        case OS:
+          setupHelper.applyIndexPoliciesPollInterval(
+              Duration.ofMinutes(1)); // OpenSearch can't go lower
+          break;
+        default:
+          break;
+      }
     }
 
     // we need to close the test application before cleaning up

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -489,6 +489,7 @@ public class CamundaMultiDBExtension
     // such they are reusable and tests methods are not relying on order, etc.
     // We want to run tests in an efficient manner, and reduce setup time
     injectStaticClientField(testClass);
+    injectStaticDatabaseTypeField(testClass, context);
   }
 
   private KeycloakContainer setupKeycloak() {
@@ -728,6 +729,24 @@ public class CamundaMultiDBExtension
     }
   }
 
+  private void injectStaticDatabaseTypeField(
+      final Class<?> testClass, final ExtensionContext context) {
+    for (final Field field : testClass.getDeclaredFields()) {
+      try {
+        if (field.getType() == DatabaseType.class) {
+          if (ModifierSupport.isStatic(field)) {
+            field.setAccessible(true);
+            field.set(null, getDatabaseType(context));
+          } else {
+            fail("DatabaseType field couldn't be injected. Make sure it is static.");
+          }
+        }
+      } catch (final Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
   private void injectStaticKeycloakContainerField(
       final Class<?> testClass, final KeycloakContainer keycloakContainer) {
     for (final Field field : testClass.getDeclaredFields()) {
@@ -765,8 +784,11 @@ public class CamundaMultiDBExtension
   public boolean supportsParameter(
       final ParameterContext parameterContext, final ExtensionContext extensionContext)
       throws ParameterResolutionException {
-    return isOwner(extensionContext)
-        && parameterContext.getParameter().getType() == CamundaClient.class;
+    if (!isOwner(extensionContext)) {
+      return false;
+    }
+    final Class<?> paramType = parameterContext.getParameter().getType();
+    return paramType == CamundaClient.class || paramType == DatabaseType.class;
   }
 
   @Override
@@ -777,7 +799,14 @@ public class CamundaMultiDBExtension
       throw new ParameterResolutionException(
           "CamundaMultiDBExtension cannot resolve parameter because it did not own the test class");
     }
-    return getCamundaClient(parameterContext.getParameter().getAnnotation(Authenticated.class));
+    final Class<?> paramType = parameterContext.getParameter().getType();
+    if (paramType == CamundaClient.class) {
+      return getCamundaClient(parameterContext.getParameter().getAnnotation(Authenticated.class));
+    }
+    if (paramType == DatabaseType.class) {
+      return getDatabaseType(extensionContext);
+    }
+    throw new ParameterResolutionException("Unsupported parameter type: " + paramType);
   }
 
   private CamundaClient getCamundaClient(final Authenticated authenticated) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
@@ -11,6 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Extension of the {@link MultiDbTest} annotation, to mark a test as history related test, which
@@ -23,5 +24,6 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Tag("history")
 @MultiDbTest
 public @interface HistoryMultiDbTest {}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -99,6 +99,10 @@ public class MultiDbConfigurator {
                   Map.of(
                       "waitPeriodBeforeArchiving",
                       retentionEnabled ? "1s" : "1h", // find completed instances almost directly
+                      "delayBetweenRuns",
+                      "1000",
+                      "maxDelayBetweenRuns",
+                      "1000",
                       "retention",
                       Map.of(
                           "enabled",

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -32,17 +32,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @MultiDbTest
  * final class MyMultiDbTest {
  *
- *   private CamundaClient client;
+ *   private static CamundaClient client;
+ *   private static DatabaseType databaseType;
  *
  *   @Test
- *   void shouldMakeUseOfClient() {
- *     // given
- *     // ... set up
+ *   void shouldUseInjectedFields() {
+ *     // Fields are automatically injected
+ *     topology = client.newTopologyRequest().send().join();
+ *     assertThat(topology.getClusterSize()).isEqualTo(1);
  *
- *     // when
- *     topology = c.newTopologyRequest().send().join();
+ *     if (databaseType == DatabaseType.ES) {
+ *       // Elasticsearch-specific logic
+ *     }
+ *   }
  *
- *     // then
+ *   @Test
+ *   void shouldUseParameterInjection(CamundaClient client, DatabaseType databaseType) {
+ *     // Can also use parameter injection instead of fields
+ *     topology = client.newTopologyRequest().send().join();
  *     assertThat(topology.getClusterSize()).isEqualTo(1);
  *   }
  * }</pre>
@@ -53,7 +60,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @MultiDbTest
  * final class MyMultiDbTest {
  *
- *   private CamundaClient client;
+ *   private static CamundaClient client;
+ *   private static DatabaseType databaseType;
  *
  *   @MultiDbTestApplication
  *   private static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
@@ -65,10 +73,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *     // ... set up
  *
  *     // when
- *     topology = c.newTopologyRequest().send().join();
+ *     topology = client.newTopologyRequest().send().join();
  *
  *     // then
  *     assertThat(topology.getClusterSize()).isEqualTo(1);
+ *     // Can also use databaseType field for conditional logic
  *   }
  * }</pre>
  */

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OpenSearchSetupHelper.java
@@ -46,7 +46,7 @@ public class OpenSearchSetupHelper extends ElasticOpenSearchSetupHelper {
             "plugins.index_state_management.history.enabled",
             "false",
             "plugins.index_state_management.job_interval",
-            String.format("%d", jobInterval.toMinutes()),
+            String.valueOf(jobInterval.toMinutes()),
             "plugins.index_state_management.jitter",
             jitter));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -26,8 +26,7 @@ import org.slf4j.Logger;
  * records itself and also delegates to the repository to move dependent records (decisions, flow
  * node instances, variable updates, etc).
  */
-public class ProcessInstanceArchiverJob
-    extends ArchiverJob<ArchiveBatch.ProcessInstanceArchiveBatch> {
+public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchiveBatch> {
 
   private final ListViewTemplate processInstanceTemplate;
   private final List<ProcessInstanceDependant> processInstanceDependants;
@@ -59,7 +58,7 @@ public class ProcessInstanceArchiverJob
   }
 
   @Override
-  CompletableFuture<ArchiveBatch.ProcessInstanceArchiveBatch> getNextBatch() {
+  CompletableFuture<ProcessInstanceArchiveBatch> getNextBatch() {
     return getArchiverRepository().getProcessInstancesNextBatch();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- adds a new acceptance test for retention by hierarchy feature
- introduces a new Maven profile and CI workflow structure to support history-related integration tests across multiple database backends (run tests annotated with `@HistoryMultiDbTest`)
- Enhances `CamundaMultiDBExtension` to inject the current `DatabaseType` into static fields and as a parameter, enabling dynamic history timeout configuration in the tests. 
* Removed cluster settings reset logic from `ElasticOpenSearchSetupHelper` as it impacts the history tests that are run in parallel.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/37412
