### PR TITLE
test: add assign, update and complete ITs for user task audit log

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auditlog;
+
+import static io.camunda.it.auditlog.AuditLogUtils.DEFAULT_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
+import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
+import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
+import io.camunda.client.api.search.enums.AuditLogResultEnum;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class AuditLogUserTaskOperationsIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthorizationsEnabled()
+          .withAuthenticatedAccess();
+
+  private static UserTaskRecordValue userTask;
+  private static CamundaClient adminClient;
+  private static AuditLogUtils utils;
+
+  @BeforeAll
+  static void setup() {
+    utils = new AuditLogUtils(adminClient).generateDefaults();
+    userTask = utils.getUserTasks().getFirst();
+    updateUserTask(userTask);
+    completeUserTask(userTask);
+  }
+
+  @Test
+  void shouldSearchUserTaskAuditLogByKeyWithAssignOperation(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given
+    final long userTaskKey = userTask.getUserTaskKey();
+
+    // when
+    final var auditLogItems =
+        client
+            .newUserTaskAuditLogSearchRequest(userTaskKey)
+            .filter(f -> f.operationType(AuditLogOperationTypeEnum.ASSIGN))
+            .send()
+            .join();
+
+    // then
+    final var auditLog = auditLogItems.items().getFirst();
+    assertThat(auditLog).isNotNull();
+    assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+    assertThat(auditLog.getEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER_TASK);
+    assertThat(auditLog.getOperationType()).isEqualTo(AuditLogOperationTypeEnum.ASSIGN);
+    assertThat(auditLog.getCategory()).isEqualTo(AuditLogCategoryEnum.USER_TASKS);
+    assertThat(auditLog.getResult()).isEqualTo(AuditLogResultEnum.SUCCESS);
+  }
+
+  @Test
+  void shouldSearchUserTaskAuditLogByKeyWithUpdateOperation(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given
+    final long userTaskKey = userTask.getUserTaskKey();
+
+    // when
+    final var auditLogItems =
+        client
+            .newUserTaskAuditLogSearchRequest(userTaskKey)
+            .filter(f -> f.operationType(AuditLogOperationTypeEnum.UPDATE))
+            .send()
+            .join();
+
+    // then
+    final var auditLog = auditLogItems.items().getFirst();
+    assertThat(auditLog).isNotNull();
+    assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+    assertThat(auditLog.getEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER_TASK);
+    assertThat(auditLog.getOperationType()).isEqualTo(AuditLogOperationTypeEnum.UPDATE);
+    assertThat(auditLog.getCategory()).isEqualTo(AuditLogCategoryEnum.USER_TASKS);
+    assertThat(auditLog.getResult()).isEqualTo(AuditLogResultEnum.SUCCESS);
+  }
+
+  @Test
+  void shouldSearchUserTaskAuditLogByKeyWithCompleteOperation(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given
+    final long userTaskKey = userTask.getUserTaskKey();
+
+    // when
+    final var auditLogItems =
+        client
+            .newUserTaskAuditLogSearchRequest(userTaskKey)
+            .filter(f -> f.operationType(AuditLogOperationTypeEnum.COMPLETE))
+            .send()
+            .join();
+
+    // then
+    final var auditLog = auditLogItems.items().getFirst();
+    assertThat(auditLog).isNotNull();
+    assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+    assertThat(auditLog.getEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER_TASK);
+    assertThat(auditLog.getOperationType()).isEqualTo(AuditLogOperationTypeEnum.COMPLETE);
+    assertThat(auditLog.getCategory()).isEqualTo(AuditLogCategoryEnum.USER_TASKS);
+    assertThat(auditLog.getResult()).isEqualTo(AuditLogResultEnum.SUCCESS);
+  }
+
+  public static void updateUserTask(final UserTaskRecordValue userTask) {
+    adminClient.newUpdateUserTaskCommand(userTask.getUserTaskKey()).priority(99).send().join();
+
+    Awaitility.await("Audit log entry is created for the updated user task")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var auditLogItems =
+                  adminClient
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          fn ->
+                              fn.processInstanceKey(
+                                      String.valueOf(userTask.getProcessInstanceKey()))
+                                  .entityType(AuditLogEntityTypeEnum.USER_TASK)
+                                  .operationType(AuditLogOperationTypeEnum.UPDATE))
+                      .send()
+                      .join();
+              assertThat(auditLogItems.items()).hasSize(1);
+            });
+  }
+
+  public static void completeUserTask(final UserTaskRecordValue userTask) {
+    adminClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
+
+    Awaitility.await("Audit log entry is created for the completed user task")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var auditLogItems =
+                  adminClient
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          fn ->
+                              fn.processInstanceKey(
+                                      String.valueOf(userTask.getProcessInstanceKey()))
+                                  .entityType(AuditLogEntityTypeEnum.USER_TASK)
+                                  .operationType(AuditLogOperationTypeEnum.COMPLETE))
+                      .send()
+                      .join();
+              assertThat(auditLogItems.items()).hasSize(1);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUtils.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUtils.java
@@ -32,8 +32,6 @@ public class AuditLogUtils {
   public static final String TENANT_A = "tenantA";
   public static final String TENANT_B = "tenantB";
 
-  public static final long USER_TASK_KEY = 123L;
-
   public static final String PROCESS_A_ID = "processA";
   public static final BpmnModelInstance PROCESS_A =
       Bpmn.createExecutableProcess(PROCESS_A_ID)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Extends the audit log user task search ITs to check for assignment, update and delete user task audit logs separately.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #41238
