### PR TITLE
fix: add sanity check against negative-sized import batches

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/exceptions/OperateFatalException.java
+++ b/operate/common/src/main/java/io/camunda/operate/exceptions/OperateFatalException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.exceptions;
+
+public class OperateFatalException extends RuntimeException {
+
+  public OperateFatalException() {}
+
+  public OperateFatalException(final String message) {
+    super(message);
+  }
+
+  public OperateFatalException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public OperateFatalException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/elasticsearch/ElasticsearchRecordsReader.java
@@ -19,6 +19,7 @@ import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.entities.HitEntity;
 import io.camunda.operate.exceptions.NoSuchIndexException;
+import io.camunda.operate.exceptions.OperateFatalException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.BackoffIdleStrategy;
@@ -239,6 +240,15 @@ public class ElasticsearchRecordsReader implements RecordsReader {
   @Override
   public ImportBatch readNextBatchBySequence(final Long sequence, final Long lastSequence)
       throws NoSuchIndexException {
+    if (sequence != null && lastSequence != null && sequence > lastSequence) {
+      final String negativeBatchError =
+          String.format(
+              "Batch read sequence %d is greater than last sequence %d. Import value type %s, partition %d.",
+              sequence, lastSequence, importValueType.name(), partitionId);
+      LOGGER.error(negativeBatchError);
+      throw new OperateFatalException(negativeBatchError);
+    }
+
     final String aliasName =
         importValueType.getAliasName(operateProperties.getZeebeElasticsearch().getPrefix());
     final int batchSize = batchSizeThrottle.get();
@@ -578,6 +588,10 @@ public class ElasticsearchRecordsReader implements RecordsReader {
           execute(active);
         }
         return imported;
+      } catch (final OperateFatalException ex) {
+        LOGGER.error(
+            "Fatal error occurred when importing data, not retrying: {}", ex.getMessage(), ex);
+        return false;
       } catch (final Exception ex) {
         LOGGER.error("Exception occurred when importing data: " + ex.getMessage(), ex);
         // retry the same job

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -429,6 +429,29 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     }
   }
 
+  @Test
+  public void shouldThrowFatalExceptionForNegativeSizedImportBatch() {
+    // given
+    final var reader =
+        beanFactory.getBean(
+            ElasticsearchRecordsReader.class,
+            1,
+            ImportValueType.PROCESS_INSTANCE,
+            operateProperties.getImporter().getQueueSize());
+
+    // when: sequence (100) > lastSequence (50) which would create a negative-sized batch
+    final var exception =
+        org.junit.Assert.assertThrows(
+            io.camunda.operate.exceptions.OperateFatalException.class,
+            () -> reader.readNextBatchBySequence(100L, 50L));
+
+    // then
+    assertThat(exception.getMessage())
+        .contains("Batch read sequence 100 is greater than last sequence 50")
+        .contains("Import value type PROCESS_INSTANCE")
+        .contains("partition 1");
+  }
+
   private void assertImportPositionMatchesRecord(
       final Record<RecordValue> record, final ImportValueType type, final int partitionId) {
     await()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -347,6 +347,29 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     }
   }
 
+  @Test
+  public void shouldThrowFatalExceptionForNegativeSizedImportBatch() {
+    // given
+    final var reader =
+        beanFactory.getBean(
+            OpensearchRecordsReader.class,
+            1,
+            ImportValueType.PROCESS_INSTANCE,
+            operateProperties.getImporter().getQueueSize());
+
+    // when: sequence (100) > lastSequence (50) which would create a negative-sized batch
+    final var exception =
+        org.junit.Assert.assertThrows(
+            io.camunda.operate.exceptions.OperateFatalException.class,
+            () -> reader.readNextBatchBySequence(100L, 50L));
+
+    // then
+    assertThat(exception.getMessage())
+        .contains("Batch read sequence 100 is greater than last sequence 50")
+        .contains("Import value type PROCESS_INSTANCE")
+        .contains("partition 1");
+  }
+
   private void assertImportPositionMatchesRecord(
       final Record<RecordValue> record, final ImportValueType type, final int partitionId) {
     Awaitility.await()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a sanity check if the last sequence is lower than the current sequence in the record importer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #28694
