### PR TITLE
RocksDb: AUTO strategy accounts for direct memory.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
-  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.50;
+  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.15;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -63,8 +63,8 @@ public class RocksDbSharedCache {
       maxNonHeapBytes = Math.round(0.25 * totalMemorySize);
       LOGGER.info(
           "Warning: Non-Heap limit is not set. Using an assumption of 25% of "
-              + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
-              + "Consider setting -XX:MaxMetaspaceSize explicitly.",
+              + "total RAM :{} Bytes for safety, for RocksDB memory calculation. "
+              + "Consider setting -XX:MaxMetaspaceSize, -XX:CompressedClassSpaceSize, and -XX:ReservedCodeCacheSize explicitly.",
           maxNonHeapBytes);
     }
     // -XX:MaxRAMPercentage is almost always set, but in case it is removed.

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.partitioning;
 import static io.camunda.zeebe.broker.partitioning.RocksDbSharedCache.MINIMUM_PARTITION_MEMORY_LIMIT;
 import static org.assertj.core.api.Assertions.*;
 
+import com.sun.management.HotSpotDiagnosticMXBean;
+import com.sun.management.VMOption;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import java.lang.management.ManagementFactory;
@@ -40,23 +42,43 @@ class RocksDbSharedCacheTest {
    * MockedStatic for use in try-with-resources.
    */
   private static MockedStatic<ManagementFactory> mockMemoryEnvironment(
-      final long totalMemorySize, final long heapMax, final long nonHeapMax) {
+      final long totalMemorySize,
+      final long heapMax,
+      final long nonHeapMax,
+      final long directMemoryMax) {
     final MockedStatic<ManagementFactory> managementFactoryMock =
         Mockito.mockStatic(ManagementFactory.class);
     final var osBean = Mockito.mock(com.sun.management.OperatingSystemMXBean.class);
     final var memoryBean = Mockito.mock(java.lang.management.MemoryMXBean.class);
     final var heapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
     final var nonHeapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
+    // Mock HotSpotDiagnosticMXBean for Direct Memory
+    final var diagnosticBean = Mockito.mock(HotSpotDiagnosticMXBean.class);
+    final var vmOption =
+        new VMOption(
+            "MaxDirectMemorySize",
+            String.valueOf(directMemoryMax),
+            false,
+            VMOption.Origin.VM_CREATION);
 
     managementFactoryMock.when(ManagementFactory::getOperatingSystemMXBean).thenReturn(osBean);
     managementFactoryMock.when(ManagementFactory::getMemoryMXBean).thenReturn(memoryBean);
+    managementFactoryMock
+        .when(() -> ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class))
+        .thenReturn(diagnosticBean);
     Mockito.when(osBean.getTotalMemorySize()).thenReturn(totalMemorySize);
     Mockito.when(memoryBean.getHeapMemoryUsage()).thenReturn(heapUsage);
     Mockito.when(memoryBean.getNonHeapMemoryUsage()).thenReturn(nonHeapUsage);
     Mockito.when(heapUsage.getMax()).thenReturn(heapMax);
     Mockito.when(nonHeapUsage.getMax()).thenReturn(nonHeapMax);
+    Mockito.when(diagnosticBean.getVMOption("MaxDirectMemorySize")).thenReturn(vmOption);
 
     return managementFactoryMock;
+  }
+
+  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(
+      final long totalMemorySize, final long heapMax, final long nonHeapMax) {
+    return mockMemoryEnvironment(totalMemorySize, heapMax, nonHeapMax, 0);
   }
 
   /** Overload for cases where only totalMemorySize is relevant. */
@@ -139,8 +161,9 @@ class RocksDbSharedCacheTest {
     // we have broker with 512mb of ram, where:
     // - max heap is 128mb
     // - max non-heap is 128mb
-    // so available memory is 512 - 128 - 128 = 256mb with a
-    // ROCKSDB_OVERHEAD_FACTOR of 0.5 we can allocate 128mb to rocksdb
+    // so available memory is 512 - 128 - 128 - 128 (inherited direct memory implied equals heap) =
+    // 128mb
+    // with a ROCKSDB_OVERHEAD_FACTOR of 0.15 we can allocate 108.8mb to rocksdb
     try (final var managementFactoryMock =
         mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
       assertThatCode(
@@ -151,8 +174,8 @@ class RocksDbSharedCacheTest {
           .doesNotThrowAnyException();
     }
 
-    final int morePartitionsCount = 7;
-    // should not be valid with 7 partitions since 128 / 7 = 19mb < 32mb
+    final int morePartitionsCount = 4;
+    // 108.8 / 4 = 27.2 < 32MB -> Should throw
     try (final var managementFactoryMock =
         mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
       final var throwable =
@@ -166,7 +189,7 @@ class RocksDbSharedCacheTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
               "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
-              MINIMUM_PARTITION_MEMORY_LIMIT, 19_173_961); // 128mb / 7 partitions
+              MINIMUM_PARTITION_MEMORY_LIMIT, 28_521_267); // 108.8mb / 4
     }
   }
 
@@ -177,10 +200,36 @@ class RocksDbSharedCacheTest {
         mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, -1)) {
       final long available = RocksDbSharedCache.getAvailableMemoryCapacity();
       // 25% of 512MB = 128MB fallback for non-heap
+      // Direct Memory fallback = Heap = 128MB
+      // Total Internal = 128 (Heap) + 128 (NonHeap) + 128 (Direct) = 384MB
+      // Available = 512 - 384 = 128MB
+      // Result = 128 * 0.85 = 108.8MB
       final long expectedNonHeap = 128L * 1024 * 1024;
+      final long expectedDirect = 128L * 1024 * 1024;
       final long expectedAvailable =
-          (long) (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap) * (1.0 - 0.5));
+          (long)
+              (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap - expectedDirect)
+                  * (1.0 - 0.15));
       // Assert
+      assertThat(available).isEqualTo(expectedAvailable);
+    }
+  }
+
+  @Test
+  void shouldReturnExpectedAvailableMemoryCapacityWhenDirectMemorySet() {
+    // 512MB total, 128MB heap, 128MB non-heap, 64MB direct memory
+    try (final var managementFactoryMock =
+        mockMemoryEnvironment(
+            512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024, 64L * 1024 * 1024)) {
+      final long available = RocksDbSharedCache.getAvailableMemoryCapacity();
+
+      // Calculation:
+      // Total = 512
+      // Internal = 128 (heap) + 128 (non-heap) + 64 (direct) = 320
+      // Available Budget = 512 - 320 = 192
+      // Result = 192 * (1 - 0.15) = 192 * 0.85 = 163.2
+
+      final long expectedAvailable = (long) (192L * 1024 * 1024 * (1.0 - 0.15));
       assertThat(available).isEqualTo(expectedAvailable);
     }
   }


### PR DESCRIPTION
## Description

This pull request makes the `AUTO` allocation strategy also to account for direct memory. When is not set (which we dont set by default in our application), it sets the value to be the same as Maximum Heap Size (which by default is 25%).

Therefore this changes significantly our calculations for the base case. Where before for default configurations with `AUTO` allocation strage we were reserving 25% for Maximum Heap Size, plus 25% non-heap, now we also reserve another additional 25% for DirectMemory, from the remaining we will allocate fraction of this (1 -`ROCKSDB_OVERHEAD_FACTOR`) to RocksDB shared Cache.

Therefore this PR also sets back the `ROCKSDB_OVERHEAD_FACTOR` to 15%. For a base configuration scnario we will be allocating 21.25% to the RocksDB shared cache.

As stated in the main issue [here](https://github.com/camunda/camunda/issues/36455#issuecomment-3744563538), there are still several memory pools that are not being accounted here, but hopefully the fact that we are dealing with maximum size estimations, plus the overhead factor this can be a good trade off between a reasonable estimation and simplicity.

This PR also corrects the log message of how to configure the non-heap memory pools max sizes.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/44096
