### PR TITLE
fix: Identity metrics alterations including the dashboard

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -61,6 +61,10 @@
       <artifactId>micrometer-observation</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.micrometer.common.KeyValues;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.client.observation.ClientRequestObservationContext;
+import org.springframework.http.client.observation.DefaultClientRequestObservationConvention;
+
+/**
+ * Custom implementation of DefaultClientRequestObservationConvention that allows adding common tags
+ * to all observations.
+ */
+public class CustomDefaultClientRequestObservationConvention
+    extends DefaultClientRequestObservationConvention {
+  private final KeyValues commonTags;
+
+  public CustomDefaultClientRequestObservationConvention(
+      final String name, final KeyValues commonTags) {
+    super(name);
+    this.commonTags = commonTags;
+  }
+
+  @Override
+  public @NonNull KeyValues getLowCardinalityKeyValues(
+      final @NonNull ClientRequestObservationContext context) {
+    return KeyValues.of(
+            clientName(context),
+            exception(context),
+            method(context),
+            outcome(context),
+            status(context),
+            uri(context))
+        .and(commonTags);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -43,6 +43,7 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -186,6 +187,10 @@ public class WebSecurityConfig {
   private static final int ORDER_WEBAPP_API = 1;
   // Intended for a "catch-all-unhandled"-chain protecting all resources by default
   private static final int ORDER_UNHANDLED = 2;
+  private static final String CAMUNDA_AUTHENTICATION_OBSERVATION_NAME =
+      "camunda_authentication_external_requests";
+  private static final KeyValues CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS =
+      KeyValues.of("domain", "identity");
 
   @Bean
   @Order(ORDER_UNPROTECTED)
@@ -974,6 +979,10 @@ public class WebSecurityConfig {
       // The message converters are taken from the expected rest client in
       // AbstractRestClientOAuth2AccessTokenResponseClient
       return RestClient.builder()
+          .observationConvention(
+              new CustomDefaultClientRequestObservationConvention(
+                  CAMUNDA_AUTHENTICATION_OBSERVATION_NAME,
+                  CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS))
           .messageConverters(
               (messageConverters) -> {
                 messageConverters.clear();

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -40,6 +40,7 @@
       }
     ]
   },
+  "description": "A collection of visualisations relating to the Identity domain tracking metrics across authentication and authorization.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -64,6 +65,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "This visualisation tracks the rate of requests made using the RestClient set in the authentication classes used by Spring.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -147,19 +149,19 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(http_client_requests_seconds_count{client_name=~\".+\"}[$__interval])",
+          "expr": "rate(camunda_authentication_external_requests_seconds_count{domain=\"identity\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
-          "legendFormat": "[{{client_name}}, method: {{method}}, status:{{status}}, uri:{{uri}}]",
+          "legendFormat": "[{{status}}] {{uri}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "Increase in requests to IDP",
+      "title": "Authentication scoped requests to external IDP",
       "type": "timeseries"
     }
   ],
@@ -170,7 +172,6 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "Prometheus",
           "value": "${DS_PROMETHEUS}"
         },
@@ -181,16 +182,66 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "allowCustomValue": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(jvm_info,namespace)",
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(jvm_info,namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "allowCustomValue": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
+        "includeAll": true,
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Identity",
+  "title": "Identity Overview",
   "uid": "identity",
-  "version": 11
+  "version": 4
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR is designed to achieve three core things:
1. Use a distinct name for the metrics emitted by Spring in our new instrumented RestClient (that is passed into the Spring authentication flow classes)
2. Apply a `domain` label to the metrics created from this Rest Client so its future proof for other domains to be added.
3. Refine the Identity dashboard by: including `namespace` and `pod` variables, adding descriptions to explain whats being observed.
