### PR TITLE
[Backport stable/8.6] fix: add missing SLOs for timers

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -78,6 +78,7 @@ public class BackupManagerMetrics {
     return Timer.builder(BACKUP_OPERATIONS_LATENCY.getName())
         .description(BACKUP_OPERATIONS_LATENCY.getDescription())
         .tag(MetricKeyName.OPERATION.asString(), operationType.name())
+        .serviceLevelObjectives(BACKUP_OPERATIONS_LATENCY.getTimerSLOs())
         .register(registry);
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -181,6 +181,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_LATENCY;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .register(registry);
   }
 
@@ -188,6 +189,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(ProcessingDurationKeys.VALUE_TYPE.asString(), valueType.name())
         .tag(ProcessingDurationKeys.INTENT.asString(), intent.name())
         .register(registry);


### PR DESCRIPTION
This fix was missing from 8.6. Without this, metrics such as the stream processing latency would not show up as histograms.

(cherry picked from commit 197ab7c116ba43cfe7ecd8abf2dfba74c7d88669)

Closes #44102