### PR TITLE
fix: be more defensive when converting BatchOperationItemEntity

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -176,10 +176,15 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SearchQueryResponseMapper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SearchQueryResponseMapper.class);
 
   private SearchQueryResponseMapper() {}
 
@@ -781,11 +786,21 @@ public final class SearchQueryResponseMapper {
             entity.operationType() != null
                 ? BatchOperationTypeEnum.fromValue(entity.operationType().name())
                 : null)
-        .itemKey(entity.itemKey().toString())
-        .processInstanceKey(entity.processInstanceKey().toString())
+        .itemKey(
+            warnIfNull(entity, BatchOperationItemEntity::itemKey, "itemKey")
+                .map(Object::toString)
+                .orElse(null))
+        .processInstanceKey(
+            warnIfNull(entity, BatchOperationItemEntity::processInstanceKey, "processInstanceKey")
+                .map(Object::toString)
+                .orElse(null))
         .processedDate(formatDate(entity.processedDate()))
         .errorMessage(entity.errorMessage())
-        .state(BatchOperationItemResponse.StateEnum.fromValue(entity.state().name()));
+        .state(
+            warnIfNull(entity, BatchOperationItemEntity::state, "state")
+                .map(Enum::name)
+                .map(BatchOperationItemResponse.StateEnum::fromValue)
+                .orElse(null));
   }
 
   private static BatchOperationError toBatchOperationError(
@@ -1477,6 +1492,18 @@ public final class SearchQueryResponseMapper {
                     SearchQueryResponseMapper
                         ::toProcessDefinitionMessageSubscriptionStatisticsQueryResponse)
                 .orElseGet(Collections::emptyList));
+  }
+
+  // sometimes we've seen null for properties that should not be null; log a warning if that happens
+  // so we can at least return data - rather than erroring out the whole response
+  private static <T, R> Optional<R> warnIfNull(
+      final T entity, final Function<T, R> mapper, final String propertyName) {
+    final R value = mapper.apply(entity);
+    if (value == null) {
+      LOGGER.warn("{} value is null for entity: {}", propertyName, entity);
+      return Optional.empty();
+    }
+    return Optional.of(value);
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
+import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
+import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationType;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class SearchQueryResponseMapperTest {
+
+  @Test
+  void shouldConvertBatchOperationItemEntity() {
+    // given
+    final BatchOperationItemEntity item =
+        new BatchOperationItemEntity(
+            "batchOperationKey",
+            BatchOperationType.MIGRATE_PROCESS_INSTANCE,
+            1234L,
+            4321L,
+            BatchOperationItemState.COMPLETED,
+            OffsetDateTime.parse("2025-01-15T11:53:00Z"),
+            "errorMessage");
+
+    // when
+    final BatchOperationItemResponse response =
+        SearchQueryResponseMapper.toBatchOperationItem(item);
+
+    // then
+    assertThat(response.getBatchOperationKey()).isEqualTo("batchOperationKey");
+    assertThat(response.getOperationType())
+        .isEqualTo(BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE);
+    assertThat(response.getItemKey()).isEqualTo("1234");
+    assertThat(response.getProcessInstanceKey()).isEqualTo("4321");
+    assertThat(response.getState()).isEqualTo(StateEnum.COMPLETED);
+    assertThat(response.getProcessedDate()).isEqualTo("2025-01-15T11:53:00.000Z");
+    assertThat(response.getErrorMessage()).isEqualTo("errorMessage");
+  }
+
+  @Test
+  void shouldHandleNullFieldsInBatchOperationItemEntity() {
+    // given
+    final BatchOperationItemEntity item =
+        new BatchOperationItemEntity(null, null, null, null, null, null, null);
+
+    // when
+    final BatchOperationItemResponse response =
+        SearchQueryResponseMapper.toBatchOperationItem(item);
+
+    // then
+    assertThat(response.getBatchOperationKey()).isNull();
+    assertThat(response.getOperationType()).isNull();
+    assertThat(response.getItemKey()).isNull();
+    assertThat(response.getProcessInstanceKey()).isNull();
+    assertThat(response.getState()).isNull();
+    assertThat(response.getProcessedDate()).isNull();
+    assertThat(response.getErrorMessage()).isNull();
+  }
+}


### PR DESCRIPTION
so a single corrupted item won't cause search requests to fail.  As we do not expect these fields to be null we will log a WARN with details of the field + entity to aid debugging.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

Closes: #43569
