### PR TITLE
[Backport stable/8.6] fix: use clock to compute job activation deadline

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
+import java.time.InstantSource;
 import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -52,14 +53,18 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final Writers writers,
       final ProcessingState state,
       final KeyGenerator keyGenerator,
-      final JobProcessingMetrics jobMetrics) {
+      final JobProcessingMetrics jobMetrics,
+      final InstantSource clock) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     jobBatchCollector =
         new JobBatchCollector(
-            state.getJobState(), state.getVariableState(), stateWriter::canWriteEventOfLength);
+            state.getJobState(),
+            state.getVariableState(),
+            stateWriter::canWriteEventOfLength,
+            clock);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -101,7 +101,7 @@ public final class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, processingState, processingState.getKeyGenerator(), jobMetrics))
+                writers, processingState, processingState.getKeyGenerator(), jobMetrics, clock))
         .withListener(
             new JobTimeoutCheckerScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -26,12 +26,16 @@ import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValueAssert;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.ControllableStreamClockImpl;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +53,8 @@ final class JobBatchCollectorTest {
   private static final String JOB_TYPE = "job";
 
   private final RecordLengthEvaluator lengthEvaluator = new RecordLengthEvaluator();
+  private final ControllableStreamClock clock =
+      new ControllableStreamClockImpl(InstantSource.system());
 
   @SuppressWarnings("unused") // injected by the extension
   private MutableProcessingState state;
@@ -58,7 +64,8 @@ final class JobBatchCollectorTest {
   @BeforeEach
   void beforeEach() {
     collector =
-        new JobBatchCollector(state.getJobState(), state.getVariableState(), lengthEvaluator);
+        new JobBatchCollector(
+            state.getJobState(), state.getVariableState(), lengthEvaluator, clock);
   }
 
   @Test
@@ -173,7 +180,9 @@ final class JobBatchCollectorTest {
     // given
     final TypedRecord<JobBatchRecord> record = createRecord();
     final long scopeKey = state.getKeyGenerator().nextKey();
-    final long expectedDeadline = record.getTimestamp() + record.getValue().getTimeout();
+    clock.pinAt(Instant.now().plusSeconds(30)); // pin clock for a deterministic timeout
+
+    final long expectedDeadline = clock.millis() + record.getValue().getTimeout();
     createJob(scopeKey);
     createJob(scopeKey);
 


### PR DESCRIPTION
# Description
Backport of #44018 to `stable/8.6`.

relates to #42244