### PR TITLE
refactor: migrate flownode-selection store usage in variables panel

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.test.tsx
@@ -9,20 +9,12 @@
 import {InputOutputMappings} from './index';
 import {render, screen} from 'modules/testing-library';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {act, useEffect} from 'react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
-  useEffect(() => {
-    return () => {
-      flowNodeSelectionStore.reset();
-    };
-  }, []);
-
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       <ProcessDefinitionKeyContext.Provider value="123">
@@ -40,25 +32,16 @@ describe('Input Mappings', () => {
   );
 
   it('should display input mappings', async () => {
-    act(() => {
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'Event_0bonl61',
-      });
-    });
-
-    const {rerender} = render(<InputOutputMappings type="Input" />, {
-      wrapper: Wrapper,
-    });
+    const {rerender} = render(
+      <InputOutputMappings type="Input" elementId="Event_0bonl61" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
 
-    act(() => {
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'Activity_0qtp1k6',
-      });
-    });
-
-    rerender(<InputOutputMappings type="Input" />);
+    rerender(<InputOutputMappings type="Input" elementId="Activity_0qtp1k6" />);
 
     expect(await screen.findByText(/local variable name/i)).toBeInTheDocument();
     expect(screen.getByText(/variable assignment value/i)).toBeInTheDocument();
@@ -69,25 +52,18 @@ describe('Input Mappings', () => {
   });
 
   it('should display output mappings', async () => {
-    act(() => {
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'Event_0bonl61',
-      });
-    });
-
-    const {rerender} = render(<InputOutputMappings type="Input" />, {
-      wrapper: Wrapper,
-    });
+    const {rerender} = render(
+      <InputOutputMappings type="Input" elementId="Event_0bonl61" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
 
-    act(() => {
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'Activity_0qtp1k6',
-      });
-    });
-
-    rerender(<InputOutputMappings type="Output" />);
+    rerender(
+      <InputOutputMappings type="Output" elementId="Activity_0qtp1k6" />,
+    );
     expect(
       await screen.findByText(/process variable name/i),
     ).toBeInTheDocument();
@@ -107,15 +83,11 @@ describe('Input Mappings', () => {
       message:
         'Output mappings are defined while modelling the diagram. They are used to control the variable propagation from the flow node scope. Process variables in the parent scopes are created/updated with the specified assignment.',
     },
-  ])(
+  ] as const)(
     'should display/hide information banner for input/output mappings',
     async ({type, message}) => {
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'Activity_0qtp1k6',
-      });
-
       const {user, rerender} = render(
-        <InputOutputMappings type={type as 'Input' | 'Output'} />,
+        <InputOutputMappings type={type} elementId="Activity_0qtp1k6" />,
         {
           wrapper: Wrapper,
         },
@@ -129,7 +101,9 @@ describe('Input Mappings', () => {
       mockFetchProcessDefinitionXml().withSuccess(
         mockProcessWithInputOutputMappingsXML,
       );
-      rerender(<InputOutputMappings type={type as 'Input' | 'Output'} />);
+      rerender(
+        <InputOutputMappings type={type} elementId="Activity_0qtp1k6" />,
+      );
       expect(screen.queryByText(message)).not.toBeInTheDocument();
     },
   );

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.tsx
@@ -6,8 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {observer} from 'mobx-react';
 import {getMappings} from 'modules/bpmn-js/utils/getInputOutputMappings';
 import {Content, EmptyMessage} from './styled';
 import {IOMappingInfoBanner} from './IOMappingInfoBanner';
@@ -26,21 +24,17 @@ const INFORMATION_TEXT = {
 
 type Props = {
   type: 'Input' | 'Output';
+  elementId: string;
 };
 
-const InputOutputMappings: React.FC<Props> = observer(({type}) => {
-  const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
+const InputOutputMappings: React.FC<Props> = ({type, elementId}) => {
   const [isInfoBannerVisible, setIsInfoBannerVisible] = useState(
     !getStateLocally()?.[`hide${type}MappingsHelperBanner`],
   );
 
-  if (flowNodeId === undefined) {
-    return null;
-  }
-
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {data} = useProcessInstanceXml({processDefinitionKey});
-  const businessObject = data?.businessObjects[flowNodeId];
+  const businessObject = data?.businessObjects[elementId];
 
   const mappings =
     businessObject === undefined ? [] : getMappings(businessObject, type);
@@ -91,6 +85,6 @@ const InputOutputMappings: React.FC<Props> = observer(({type}) => {
       )}
     </Content>
   );
-});
+};
 
 export {InputOutputMappings};

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
@@ -59,7 +59,6 @@ const VariablePanel: React.FC<Props> = observer(function VariablePanel({
     useState<ListenerTypeFilter>();
   const [selectedTab, setSelectedTab] = useState<TabId>('variables');
 
-  const shouldFetchListeners = selectedElementInstanceKey || selectedElementId;
   const {
     data: jobs,
     fetchNextPage,
@@ -75,7 +74,7 @@ const VariablePanel: React.FC<Props> = observer(function VariablePanel({
         kind: listenerTypeFilter,
       },
     },
-    disabled: !shouldFetchListeners,
+    disabled: !hasSelection,
     select: (data) => data.pages?.flatMap((page) => page.items),
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Operation.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Operation.tsx
@@ -14,10 +14,11 @@ import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {Button} from '@carbon/react';
 import {TrashCan} from '@carbon/react/icons';
 import {Operations} from '../Operations';
-import {useNewScopeIdForFlowNode} from 'modules/hooks/modifications';
+import {useNewScopeKeyForElement} from 'modules/hooks/modifications';
 import {getScopeId} from 'modules/utils/variables';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 import {useVariableScopeKey} from 'modules/hooks/variables';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 type Props = {
   variableName: string;
@@ -28,13 +29,16 @@ const Operation: React.FC<Props> = ({variableName, onRemove}) => {
   const {
     input: {value: currentId},
   } = useField(createNewVariableFieldName(variableName, 'id'));
-  const newScopeIdForFlowNode = useNewScopeIdForFlowNode(
-    flowNodeSelectionStore.state.selection?.flowNodeId,
+  const {selectedElementId} = useProcessInstanceElementSelection();
+  const newScopeKeyForElement = useNewScopeKeyForElement(
+    IS_ELEMENT_SELECTION_V2
+      ? selectedElementId
+      : (flowNodeSelectionStore.state.selection?.flowNodeId ?? null),
   );
   const scopeKey = IS_ELEMENT_SELECTION_V2
     ? // eslint-disable-next-line react-hooks/rules-of-hooks
-      useVariableScopeKey(newScopeIdForFlowNode)
-    : (getScopeId() ?? newScopeIdForFlowNode);
+      useVariableScopeKey(newScopeKeyForElement)
+    : (getScopeId() ?? newScopeKeyForElement);
 
   return (
     <Operations>

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/index.tsx
@@ -19,7 +19,7 @@ import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {VariablesTable} from './VariablesTable';
 import {Footer} from './Footer';
 import {Skeleton} from './Skeleton';
-import {useNewScopeIdForFlowNode} from 'modules/hooks/modifications';
+import {useNewScopeKeyForElement} from 'modules/hooks/modifications';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
 import {useIsRootNodeSelected} from 'modules/hooks/flowNodeSelection';
@@ -38,8 +38,12 @@ type FooterVariant = React.ComponentProps<typeof Footer>['variant'];
 const Variables: React.FC<Props> = observer(
   ({isVariableModificationAllowed = false}) => {
     const {displayStatus} = useVariables();
-    const newScopeIdForFlowNode = useNewScopeIdForFlowNode(
-      flowNodeSelectionStore.state.selection?.flowNodeId,
+    const {selectedElementId, resolvedElementInstance} =
+      useProcessInstanceElementSelection();
+    const newScopeKeyForElement = useNewScopeKeyForElement(
+      IS_ELEMENT_SELECTION_V2
+        ? selectedElementId
+        : (flowNodeSelectionStore.state.selection?.flowNodeId ?? null),
     );
     const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
     const isRootNodeSelected = useIsRootNodeSelected();
@@ -47,8 +51,8 @@ const Variables: React.FC<Props> = observer(
       useState<FooterVariant>('initial');
 
     const scopeKey = IS_ELEMENT_SELECTION_V2
-      ? useVariableScopeKey(newScopeIdForFlowNode)
-      : (getScopeId() ?? newScopeIdForFlowNode);
+      ? useVariableScopeKey(newScopeKeyForElement)
+      : (getScopeId() ?? newScopeKeyForElement);
 
     const {isModificationModeEnabled} = modificationsStore;
 
@@ -76,8 +80,6 @@ const Variables: React.FC<Props> = observer(
         modificationsStore.getAddVariableModifications(scopeKey).length === 0
       : initialValues === undefined ||
         Object.values(initialValues).length === 0;
-
-    const {resolvedElementInstance} = useProcessInstanceElementSelection();
 
     useEffect(() => {
       const isSelectedElementInstanceRunning = IS_ELEMENT_SELECTION_V2

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -13,7 +13,7 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {
   useModificationsByFlowNode,
   useWillAllFlowNodesBeCanceled,
-  useNewScopeIdForFlowNode,
+  useNewScopeKeyForElement,
 } from './modifications';
 import {modificationsStore} from 'modules/stores/modifications';
 import {type GetProcessInstanceStatisticsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
@@ -300,17 +300,17 @@ describe('modifications hooks', () => {
     });
   });
 
-  describe('useNewScopeIdForFlowNode', () => {
+  describe('useNewScopeKeyForElement', () => {
     beforeEach(() => {
       mockFetchProcessInstance().withSuccess(mockProcessInstance);
     });
 
-    it('should return null if elementId is undefined', () => {
+    it('should return null if elementId is null', () => {
       mockFetchProcessDefinitionXml().withSuccess(
         mockProcessWithInputOutputMappingsXML,
       );
 
-      const {result} = renderHook(() => useNewScopeIdForFlowNode(), {
+      const {result} = renderHook(() => useNewScopeKeyForElement(null), {
         wrapper: getWrapper(),
       });
 
@@ -332,7 +332,7 @@ describe('modifications hooks', () => {
         mockProcessWithInputOutputMappingsXML,
       );
 
-      const {result} = renderHook(() => useNewScopeIdForFlowNode('node1'), {
+      const {result} = renderHook(() => useNewScopeKeyForElement('node1'), {
         wrapper: getWrapper(),
       });
 
@@ -356,7 +356,7 @@ describe('modifications hooks', () => {
         mockProcessWithInputOutputMappingsXML,
       );
 
-      const {result} = renderHook(() => useNewScopeIdForFlowNode('node1'), {
+      const {result} = renderHook(() => useNewScopeKeyForElement('node1'), {
         wrapper: getWrapper(),
       });
 
@@ -381,7 +381,7 @@ describe('modifications hooks', () => {
         mockProcessWithInputOutputMappingsXML,
       );
 
-      const {result} = renderHook(() => useNewScopeIdForFlowNode('node2'), {
+      const {result} = renderHook(() => useNewScopeKeyForElement('node2'), {
         wrapper: getWrapper(),
       });
 
@@ -406,7 +406,7 @@ describe('modifications hooks', () => {
         mockProcessWithInputOutputMappingsXML,
       );
 
-      const {result} = renderHook(() => useNewScopeIdForFlowNode('node2'), {
+      const {result} = renderHook(() => useNewScopeKeyForElement('node2'), {
         wrapper: getWrapper(),
       });
 

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -193,11 +193,11 @@ const useModificationsByFlowNode = () => {
   }, {});
 };
 
-const useNewScopeIdForFlowNode = (elementId?: string) => {
+const useNewScopeKeyForElement = (elementId: string | null) => {
   const modificationsByFlowNode = useModificationsByFlowNode();
 
   if (
-    elementId === undefined ||
+    elementId === null ||
     (modificationsByFlowNode[elementId]?.newTokens ?? 0) !== 1
   ) {
     return null;
@@ -327,6 +327,6 @@ export {
   useAvailableModifications,
   useCanBeModified,
   useModificationsByFlowNode,
-  useNewScopeIdForFlowNode,
+  useNewScopeKeyForElement,
   useWillAllFlowNodesBeCanceled,
 };

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -77,10 +77,16 @@ const useDisplayStatus = ({
   const hasNoContent = useHasNoContent();
   const hasMultipleInstances = useHasMultipleInstances();
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
-  const isFetchingElementError = IS_ELEMENT_SELECTION_V2
-    ? // eslint-disable-next-line react-hooks/rules-of-hooks
-      useProcessInstanceElementSelection().isFetchingElementError
+  let {isFetchingElementError, isSelectedInstancePlaceholder} =
+    useProcessInstanceElementSelection();
+
+  // TODO: Remove these assignments once the feature flag is fully rolled out
+  isFetchingElementError = IS_ELEMENT_SELECTION_V2
+    ? isFetchingElementError
     : flowNodeMetaDataStore.state.status === 'error';
+  isSelectedInstancePlaceholder = IS_ELEMENT_SELECTION_V2
+    ? isSelectedInstancePlaceholder
+    : (flowNodeSelectionStore.state.selection?.isPlaceholder ?? false);
 
   if (isError || isFetchingElementError) {
     return 'error';
@@ -94,10 +100,7 @@ const useDisplayStatus = ({
     return 'multi-instances';
   }
 
-  if (
-    flowNodeSelectionStore.state.selection?.isPlaceholder ||
-    newTokenCountForSelectedNode === 1
-  ) {
+  if (isSelectedInstancePlaceholder || newTokenCountForSelectedNode === 1) {
     return 'no-variables';
   }
 

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -20,6 +20,7 @@ import {useProcessInstanceElementSelection} from './useProcessInstanceElementSel
 import {TOKEN_OPERATIONS} from 'modules/constants';
 import {useElementSelectionInstanceKey} from './useElementSelectionInstanceKey';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 
 const useHasNoContent = () => {
   const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
@@ -76,13 +77,18 @@ const useDisplayStatus = ({
 }) => {
   const hasNoContent = useHasNoContent();
   const hasMultipleInstances = useHasMultipleInstances();
-  const isPlaceholderSelected = useIsPlaceholderSelected();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+  let isPlaceholderSelected = useIsPlaceholderSelected();
   let {isFetchingElementError} = useProcessInstanceElementSelection();
 
   // TODO: Remove these assignments once the feature flag is fully rolled out
   isFetchingElementError = IS_ELEMENT_SELECTION_V2
     ? isFetchingElementError
     : flowNodeMetaDataStore.state.status === 'error';
+  isPlaceholderSelected = IS_ELEMENT_SELECTION_V2
+    ? isPlaceholderSelected
+    : flowNodeSelectionStore.state.selection?.isPlaceholder ||
+      newTokenCountForSelectedNode === 1;
 
   if (isError || isFetchingElementError) {
     return 'error';

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -7,10 +7,10 @@
  */
 
 import {logger} from 'modules/logger';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {modificationsStore} from 'modules/stores/modifications';
 import {
   useHasRunningOrFinishedTokens,
+  useIsPlaceholderSelected,
   useIsRootNodeSelected,
   useNewTokenCountForSelectedNode,
 } from './flowNodeSelection';
@@ -76,17 +76,13 @@ const useDisplayStatus = ({
 }) => {
   const hasNoContent = useHasNoContent();
   const hasMultipleInstances = useHasMultipleInstances();
-  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
-  let {isFetchingElementError, isSelectedInstancePlaceholder} =
-    useProcessInstanceElementSelection();
+  const isPlaceholderSelected = useIsPlaceholderSelected();
+  let {isFetchingElementError} = useProcessInstanceElementSelection();
 
   // TODO: Remove these assignments once the feature flag is fully rolled out
   isFetchingElementError = IS_ELEMENT_SELECTION_V2
     ? isFetchingElementError
     : flowNodeMetaDataStore.state.status === 'error';
-  isSelectedInstancePlaceholder = IS_ELEMENT_SELECTION_V2
-    ? isSelectedInstancePlaceholder
-    : (flowNodeSelectionStore.state.selection?.isPlaceholder ?? false);
 
   if (isError || isFetchingElementError) {
     return 'error';
@@ -100,7 +96,7 @@ const useDisplayStatus = ({
     return 'multi-instances';
   }
 
-  if (isSelectedInstancePlaceholder || newTokenCountForSelectedNode === 1) {
+  if (isPlaceholderSelected) {
     return 'no-variables';
   }
 


### PR DESCRIPTION
## Description

- Migrates the Input/Output panel as a required prop since it never renders without some (simplifies its tests as well).
- Migrates the argument for the useNewScopeIdForFlowNode (hook renamed to match v2 naming)
- Migrates the `useDisplayStatus` hook for variables to no longer depend on the selection store

## Related issues

relates #41829
