### PR TITLE
Add process instance retention mode config to unified configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
@@ -17,6 +18,8 @@ public class DocumentBasedHistory {
   public static final Duration DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS = Duration.ofMillis(60000);
   private static final Duration DEFAULT_HISTORY_DELAY_BETWEEN_RUNS = Duration.ofMillis(2000);
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
+  private static final ProcessInstanceRetentionMode
+      DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI_HIERARCHY;
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
@@ -26,6 +29,8 @@ public class DocumentBasedHistory {
       Map.of(
           "process-instance-enabled",
           "zeebe.broker.exporters.camundaexporter.args.history.process-instance-enabled",
+          "process-instance-retention-mode",
+          "zeebe.broker.exporters.camundaexporter.args.history.processInstanceRetentionMode",
           "els-rollover-date-format",
           "zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat",
           "rollover-interval",
@@ -41,6 +46,9 @@ public class DocumentBasedHistory {
   private final String prefix;
 
   private boolean processInstanceEnabled = DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED;
+
+  private ProcessInstanceRetentionMode processInstanceRetentionMode =
+      DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE;
 
   /** Date format for historical indices in Java DateTimeFormatter syntax */
   private String elsRolloverDateFormat = DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT;
@@ -81,6 +89,20 @@ public class DocumentBasedHistory {
 
   public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
     this.processInstanceEnabled = processInstanceEnabled;
+  }
+
+  public ProcessInstanceRetentionMode getProcessInstanceRetentionMode() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        prefix + ".process-instance-retention-mode",
+        processInstanceRetentionMode,
+        ProcessInstanceRetentionMode.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_BROKER_PROPERTIES.get("process-instance-retention-mode")));
+  }
+
+  public void setProcessInstanceRetentionMode(
+      final ProcessInstanceRetentionMode processInstanceRetentionMode) {
+    this.processInstanceRetentionMode = processInstanceRetentionMode;
   }
 
   public String getPrefix() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -870,6 +870,11 @@ public class BrokerBasedPropertiesOverride {
     setArg(
         args, "history.processInstanceEnabled", database.getHistory().isProcessInstanceEnabled());
 
+    setArg(
+        args,
+        "history.processInstanceRetentionMode",
+        database.getHistory().getProcessInstanceRetentionMode());
+
     setArg(args, "history.retention.policyName", database.getHistory().getPolicyName());
     setArg(args, "history.elsRolloverDateFormat", database.getHistory().getElsRolloverDateFormat());
     setArg(args, "history.rolloverInterval", database.getHistory().getRolloverInterval());

--- a/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryElasticsearchTest.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOve
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class HistoryElasticsearchTest {
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
   private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
+  private static final String EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = "PI";
 
   private ExporterConfiguration getExporterConfiguration(
       final BrokerBasedProperties brokerBasedProperties) {
@@ -55,7 +57,9 @@ public class HistoryElasticsearchTest {
         "camunda.data.secondary-storage.elasticsearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
         "camunda.data.secondary-storage.elasticsearch.history.policy-name="
-            + EXPECTED_HISTORY_POLICY_NAME
+            + EXPECTED_HISTORY_POLICY_NAME,
+        "camunda.data.secondary-storage.elasticsearch.history.process-instance-retention-mode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
   class WithOnlyUnifiedConfigSet {
     final SearchEngineRetentionProperties searchEngineRetentionProperties;
@@ -83,6 +87,8 @@ public class HistoryElasticsearchTest {
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
       assertThat(exporterConfiguration.getHistory().getRetention())
           .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
+      assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
+          .isEqualTo(ProcessInstanceRetentionMode.PI);
     }
   }
 
@@ -93,7 +99,12 @@ public class HistoryElasticsearchTest {
         // policy name
         "camunda.data.secondary-storage.elasticsearch.history.policy-name="
             + EXPECTED_HISTORY_POLICY_NAME,
-        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME
+        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME,
+        // process instance retention mode
+        "camunda.data.secondary-storage.elasticsearch.history.process-instance-retention-mode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE,
+        "zeebe.broker.exporters.camundaexporter.args.history.processInstanceRetentionMode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
   class WithNewAndLegacySet {
     final SearchEngineRetentionProperties searchEngineRetentionProperties;
@@ -119,6 +130,8 @@ public class HistoryElasticsearchTest {
 
       assertThat(exporterConfiguration.getHistory().getRetention().getPolicyName())
           .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
+      assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
+          .isEqualTo(ProcessInstanceRetentionMode.PI);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryOpensearchTest.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOve
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class HistoryOpensearchTest {
 
   private static final boolean EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED = false;
   private static final String EXPECTED_HISTORY_POLICY_NAME = "policy-name-foo";
+  private static final String EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = "PI";
 
   private ExporterConfiguration getExporterConfiguration(
       final BrokerBasedProperties brokerBasedProperties) {
@@ -55,7 +57,9 @@ public class HistoryOpensearchTest {
         "camunda.data.secondary-storage.opensearch.history.process-instance-enabled="
             + EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED,
         "camunda.data.secondary-storage.opensearch.history.policy-name="
-            + EXPECTED_HISTORY_POLICY_NAME
+            + EXPECTED_HISTORY_POLICY_NAME,
+        "camunda.data.secondary-storage.opensearch.history.process-instance-retention-mode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
   class WithOnlyUnifiedConfigSet {
     final SearchEngineRetentionProperties searchEngineRetentionProperties;
@@ -83,6 +87,8 @@ public class HistoryOpensearchTest {
           .isEqualTo(EXPECTED_HISTORY_PROCESS_INSTANCE_ENABLED);
       assertThat(exporterConfiguration.getHistory().getRetention().getPolicyName())
           .isEqualTo(EXPECTED_HISTORY_POLICY_NAME);
+      assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
+          .isEqualTo(ProcessInstanceRetentionMode.PI);
     }
   }
 
@@ -93,7 +99,12 @@ public class HistoryOpensearchTest {
         // policy name
         "camunda.data.secondary-storage.opensearch.history.policy-name="
             + EXPECTED_HISTORY_POLICY_NAME,
-        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME
+        "camunda.database.retention.policyName=" + EXPECTED_HISTORY_POLICY_NAME,
+        // process instance retention mode
+        "camunda.data.secondary-storage.opensearch.history.process-instance-retention-mode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE,
+        "zeebe.broker.exporters.camundaexporter.args.history.processInstanceRetentionMode="
+            + EXPECTED_HISTORY_PROCESS_INSTANCE_RETENTION_MODE
       })
   class WithNewAndLegacySet {
     final SearchEngineRetentionProperties searchEngineRetentionProperties;
@@ -119,6 +130,8 @@ public class HistoryOpensearchTest {
 
       assertThat(exporterConfiguration.getHistory().getRetention())
           .returns(EXPECTED_HISTORY_POLICY_NAME, RetentionConfiguration::getPolicyName);
+      assertThat(exporterConfiguration.getHistory().getProcessInstanceRetentionMode())
+          .isEqualTo(ProcessInstanceRetentionMode.PI);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -221,6 +221,8 @@ public class ExporterConfiguration {
 
   public static class HistoryConfiguration {
     private boolean processInstanceEnabled = true;
+    private ProcessInstanceRetentionMode processInstanceRetentionMode =
+        ProcessInstanceRetentionMode.PI_HIERARCHY;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
@@ -230,7 +232,6 @@ public class ExporterConfiguration {
     private int maxDelayBetweenRuns = 60000;
     private RetentionConfiguration retention = new RetentionConfiguration();
     private boolean trackArchivalMetricsForProcessInstance = true;
-    private RetentionMode retentionMode = RetentionMode.PI_HIERARCHY;
 
     public boolean isProcessInstanceEnabled() {
       return processInstanceEnabled;
@@ -331,7 +332,7 @@ public class ExporterConfiguration {
           + ", trackArchivalMetricsForProcessInstance="
           + trackArchivalMetricsForProcessInstance
           + ", retentionMode="
-          + retentionMode
+          + processInstanceRetentionMode
           + '}';
     }
 
@@ -344,15 +345,16 @@ public class ExporterConfiguration {
       this.trackArchivalMetricsForProcessInstance = trackArchivalMetricsForProcessInstance;
     }
 
-    public RetentionMode getRetentionMode() {
-      return retentionMode;
+    public ProcessInstanceRetentionMode getProcessInstanceRetentionMode() {
+      return processInstanceRetentionMode;
     }
 
-    public void setRetentionMode(final RetentionMode retentionMode) {
-      this.retentionMode = retentionMode;
+    public void setProcessInstanceRetentionMode(
+        final ProcessInstanceRetentionMode processInstanceRetentionMode) {
+      this.processInstanceRetentionMode = processInstanceRetentionMode;
     }
 
-    public enum RetentionMode {
+    public enum ProcessInstanceRetentionMode {
       PI_HIERARCHY,
       PI_HIERARCHY_IGNORE_LEGACY,
       PI

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -35,7 +35,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
@@ -345,11 +345,11 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var partitionQ =
         QueryBuilders.term(q -> q.field(ListViewTemplate.PARTITION_ID).value(partitionId));
 
-    final var retentionMode = config.getRetentionMode();
+    final var retentionMode = config.getProcessInstanceRetentionMode();
     final Query hierarchyQ;
 
-    if (retentionMode == RetentionMode.PI_HIERARCHY
-        || retentionMode == RetentionMode.PI_HIERARCHY_IGNORE_LEGACY) {
+    if (retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY
+        || retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY) {
       final var rootExists =
           QueryBuilders.exists(e -> e.field(ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY));
       final var parentExists =
@@ -358,7 +358,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       // (parentPI IS NULL AND rootPI IS NOT NULL) (New hierarchy filter)
       final var newHierarchy = QueryBuilders.bool(b -> b.mustNot(parentExists).must(rootExists));
 
-      if (retentionMode == RetentionMode.PI_HIERARCHY) {
+      if (retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY) {
         // (rootPI IS NULL) (Legacy)
         final var legacyPiFilter = QueryBuilders.bool(b -> b.mustNot(rootExists));
         hierarchyQ =
@@ -452,7 +452,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
               final List<Long> processInstanceKeys = new ArrayList<>();
               final List<Long> rootProcessInstanceKeys = new ArrayList<>();
 
-              if (config.getRetentionMode() == RetentionMode.PI) {
+              if (config.getProcessInstanceRetentionMode() == ProcessInstanceRetentionMode.PI) {
                 batchHits.forEach(h -> processInstanceKeys.add(Long.valueOf(h.id())));
               } else {
                 for (final var hit : batchHits) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -15,7 +15,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
@@ -386,11 +386,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             .value(FieldValue.of(partitionId))
             .build();
 
-    final var retentionMode = config.getRetentionMode();
+    final var retentionMode = config.getProcessInstanceRetentionMode();
     final Query hierarchyQ;
 
-    if (retentionMode == RetentionMode.PI_HIERARCHY
-        || retentionMode == RetentionMode.PI_HIERARCHY_IGNORE_LEGACY) {
+    if (retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY
+        || retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY) {
       final var rootExists =
           QueryBuilders.exists()
               .field(ListViewTemplate.ROOT_PROCESS_INSTANCE_KEY)
@@ -406,7 +406,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final var newHierarchy =
           QueryBuilders.bool().mustNot(parentExists).must(rootExists).build().toQuery();
 
-      if (retentionMode == RetentionMode.PI_HIERARCHY) {
+      if (retentionMode == ProcessInstanceRetentionMode.PI_HIERARCHY) {
         // (rootPI IS NULL) (Legacy)
         final var legacy = QueryBuilders.bool().mustNot(rootExists).build().toQuery();
         hierarchyQ =
@@ -567,7 +567,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
               final List<Long> processInstanceKeys = new ArrayList<>();
               final List<Long> rootProcessInstanceKeys = new ArrayList<>();
 
-              if (config.getRetentionMode() == RetentionMode.PI) {
+              if (config.getProcessInstanceRetentionMode() == ProcessInstanceRetentionMode.PI) {
                 batchHits.forEach(h -> processInstanceKeys.add(Long.valueOf(h.id())));
               } else {
                 for (final var hit : batchHits) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -22,7 +22,7 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -422,7 +422,7 @@ final class ElasticsearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();
@@ -451,7 +451,7 @@ final class ElasticsearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIHierarchyMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();
@@ -481,7 +481,7 @@ final class ElasticsearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIHierarchyIgnoreLegacyMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -25,7 +25,7 @@ import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.SimpleJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -84,7 +84,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   public void shouldConstructCorrectQueryForPIMode() {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     final var client = mock(ElasticsearchAsyncClient.class);
     final var repository = createRepository(client, config);
     when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
@@ -110,7 +110,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   public void shouldMapBatchForPIMode() {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     final var client = mock(ElasticsearchAsyncClient.class);
     final var repository = createRepository(client, config);
     final var hit1 = createHit("1", "2024-01-01", null);
@@ -132,7 +132,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   public void shouldMapBatchForPIHierarchyMode() {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY);
     final var client = mock(ElasticsearchAsyncClient.class);
     final var repository = createRepository(client, config);
     final var hit1 = createHit("1", "2024-01-01", null); // Legacy
@@ -155,7 +155,7 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   public void shouldMapBatchForPIHierarchyIgnoreLegacyMode() {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
     final var client = mock(ElasticsearchAsyncClient.class);
     final var repository = createRepository(client, config);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -405,7 +405,7 @@ final class OpenSearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();
@@ -434,7 +434,7 @@ final class OpenSearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIHierarchyMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();
@@ -464,7 +464,7 @@ final class OpenSearchArchiverRepositoryIT {
   @Test
   void shouldHandlePIHierarchyIgnoreLegacyMode() throws Exception {
     // given
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
     config.setRolloverBatchSize(100);
     config.setWaitPeriodBeforeArchiving("0s");
     final var repository = createRepository();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.RetentionMode;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -88,7 +88,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   public void shouldConstructCorrectQueryForPIMode() throws IOException {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
     when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
@@ -108,7 +108,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   public void shouldMapBatchForPIMode() throws IOException {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
     final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
     final var hit1 = createHit("1", "2024-01-01", null);
@@ -130,7 +130,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   public void shouldMapBatchForPIHierarchyMode() throws IOException {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY);
     final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
     final var hit1 = createHit("1", "2024-01-01", null); // Legacy
@@ -152,7 +152,7 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   public void shouldMapBatchForPIHierarchyIgnoreLegacyMode() throws IOException {
     // given
     final var config = new HistoryConfiguration();
-    config.setRetentionMode(RetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
+    config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
     final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

**Configuration and API changes:**


* Updates the configuration key from `retentionMode` to `processInstanceRetentionMode` throughout the codebase,
* includes `processInstanceRetentionMode`  in the `DocumentBasedHistory` class part of the unified configuration

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/41664
