### PR TITLE
test: audit: updated RDBMS exporter tests to reflect deterministic audit log PK key

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -414,7 +414,7 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportDecisionRequirements() {
     // given
-    final var record = getDecisionRequirementsCreatedRecord(1L);
+    final var record = getDecisionRequirementsCreatedRecord(32L);
 
     // when
     exporter.export(record);
@@ -451,7 +451,7 @@ class RdbmsExporterIT {
             .withDecisionType(DecisionDefinitionType.DECISION_TABLE.toString())
             .build();
     final var decisionEvaluationRecord =
-        getDecisionEvaluationEvaluatedRecord(1L, List.of(evaluatedDecisionValue));
+        getDecisionEvaluationEvaluatedRecord(64L, List.of(evaluatedDecisionValue));
 
     // when
     exporter.export(decisionEvaluationRecord);
@@ -858,7 +858,7 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportCreatedAndDeletedMapping() {
     // given
-    final var mappingRuleCreatedRecord = getMappingRuleRecord(1L, MappingRuleIntent.CREATED);
+    final var mappingRuleCreatedRecord = getMappingRuleRecord(16L, MappingRuleIntent.CREATED);
 
     // when
     exporter.export(mappingRuleCreatedRecord);


### PR DESCRIPTION
## Description

test: audit: updated RDBMS exporter tests to reflect deterministic audit log PK key

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related to https://camunda.slack.com/archives/C09HWN20VJL/p1768482938865319
