### PR TITLE
refactor: migrate flow-node selection store usage in diagram component

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -407,16 +407,20 @@ const TopPanel: React.FC = observer(() => {
                     ? selectedElementIds
                     : selectedFlowNode
                 }
-                selectedFlowNodeId={
-                  IS_ELEMENT_SELECTION_V2
+                onRootChange={(rootElementId, getSelectionRootId) => {
+                  const elementId = IS_ELEMENT_SELECTION_V2
                     ? (selectedElementId ?? undefined)
-                    : flowNodeSelection?.flowNodeId
-                }
-                onRootChange={() => {
-                  if (IS_ELEMENT_SELECTION_V2) {
-                    clearSelection();
-                  } else {
-                    clearSelectionV1(rootNode);
+                    : flowNodeSelection?.flowNodeId;
+                  if (!elementId) {
+                    return;
+                  }
+
+                  if (rootElementId !== getSelectionRootId(elementId)) {
+                    if (IS_ELEMENT_SELECTION_V2) {
+                      clearSelection();
+                    } else {
+                      clearSelectionV1(rootNode);
+                    }
                   }
                 }}
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -407,6 +407,18 @@ const TopPanel: React.FC = observer(() => {
                     ? selectedElementIds
                     : selectedFlowNode
                 }
+                selectedFlowNodeId={
+                  IS_ELEMENT_SELECTION_V2
+                    ? (selectedElementId ?? undefined)
+                    : flowNodeSelection?.flowNodeId
+                }
+                onRootChange={() => {
+                  if (IS_ELEMENT_SELECTION_V2) {
+                    clearSelection();
+                  } else {
+                    clearSelectionV1(rootNode);
+                  }
+                }}
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
                   if (modificationsStore.state.status === 'moving-token') {
                     const ancestorSelectionRequired = hasMultipleScopes(

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -34,6 +34,8 @@ type OnFlowNodeSelection = (
   isMultiInstance?: boolean,
 ) => void;
 
+type OnRootChange = (rootElementId: string) => void;
+
 type RenderOptions = {
   container: HTMLElement;
   xml: string;
@@ -57,7 +59,7 @@ class BpmnJS {
   selectedFlowNode?: SVGGraphicsElement;
   onFlowNodeSelection?: OnFlowNodeSelection;
   onViewboxChange?: (isChanging: boolean) => void;
-  onRootChange?: (rootElementId: string) => void;
+  onRootChange?: OnRootChange;
   #overlaysData: OverlayData[] = [];
   #hasOuterBorderOnSelection = false;
   #rootElement?: BpmnElement;
@@ -456,4 +458,4 @@ class BpmnJS {
 }
 
 export {BpmnJS};
-export type {OnFlowNodeSelection, OverlayData};
+export type {OnFlowNodeSelection, OnRootChange, OverlayData};

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -34,8 +34,6 @@ type OnFlowNodeSelection = (
   isMultiInstance?: boolean,
 ) => void;
 
-type OnRootChange = (rootElementId: string) => void;
-
 type RenderOptions = {
   container: HTMLElement;
   xml: string;
@@ -59,7 +57,7 @@ class BpmnJS {
   selectedFlowNode?: SVGGraphicsElement;
   onFlowNodeSelection?: OnFlowNodeSelection;
   onViewboxChange?: (isChanging: boolean) => void;
-  onRootChange?: OnRootChange;
+  onRootChange?: (rootElementId: string) => void;
   #overlaysData: OverlayData[] = [];
   #hasOuterBorderOnSelection = false;
   #rootElement?: BpmnElement;
@@ -458,4 +456,4 @@ class BpmnJS {
 }
 
 export {BpmnJS};
-export type {OnFlowNodeSelection, OnRootChange, OverlayData};
+export type {OnFlowNodeSelection, OverlayData};

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -10,12 +10,16 @@ import React, {useRef, useEffect, useLayoutEffect, useState} from 'react';
 import {
   BpmnJS,
   type OnFlowNodeSelection,
-  type OnRootChange,
   type OverlayData,
 } from 'modules/bpmn-js/BpmnJS';
 import DiagramControls from './DiagramControls';
 import {Diagram as StyledDiagram, DiagramCanvas} from './styled';
 import {observer} from 'mobx-react';
+
+type OnRootChange = (
+  rootElementId: string,
+  getSelectionRootId: (elementId: string) => string | undefined,
+) => void;
 
 type SelectedFlowNodeOverlayProps = {
   selectedFlowNodeRef: SVGElement;
@@ -25,7 +29,6 @@ type SelectedFlowNodeOverlayProps = {
 type Props = {
   xml: string;
   processDefinitionKey?: string;
-  selectedFlowNodeId?: string;
   selectableFlowNodes?: string[];
   selectedFlowNodeIds?: string[];
   onFlowNodeSelection?: OnFlowNodeSelection;
@@ -45,7 +48,6 @@ const Diagram: React.FC<Props> = observer(
   ({
     xml,
     processDefinitionKey,
-    selectedFlowNodeId,
     selectableFlowNodes,
     selectedFlowNodeIds,
     onFlowNodeSelection,
@@ -108,17 +110,12 @@ const Diagram: React.FC<Props> = observer(
         viewer.onViewboxChange = setIsViewboxChanging;
 
         viewer.onRootChange = (rootElementId) => {
-          if (!selectedFlowNodeId) {
-            return;
-          }
-
-          const currentSelectionRootId = viewer.findRootId(selectedFlowNodeId);
-          if (rootElementId !== currentSelectionRootId) {
-            onRootChange?.(rootElementId);
-          }
+          const getSelectionRootId = (elementId: string) =>
+            viewer.findRootId(elementId);
+          onRootChange?.(rootElementId, getSelectionRootId);
         };
       }
-    }, [viewer, onFlowNodeSelection, onRootChange, selectedFlowNodeId]);
+    }, [viewer, onFlowNodeSelection, onRootChange]);
 
     useEffect(() => {
       return () => {


### PR DESCRIPTION
## Description

This PR migrates the `Diagram` component to use the new element selection API when the feature flag is enabled.

## Related issues

relates #41829
