### PR TITLE
feat: only observe availability for 100 PIs at a time

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -127,6 +127,12 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   public boolean recordProcessInstanceStart(
       final long processInstanceKey, final long startTimeNanos) {
     if (startedInstances.size() >= MAX_OBSERVED_INSTANCES) {
+      LOG.debug(
+          "Maximum number of observed process instances ({}) reached; "
+              + "rejecting tracking for process instance {}. Currently tracking {} instances.",
+          MAX_OBSERVED_INSTANCES,
+          processInstanceKey,
+          startedInstances.size());
       return false;
     }
     startedInstances.put(


### PR DESCRIPTION
## Description

During load tests which run in backpressure and a larger exporting latency, it can happen, that the latency meter of the Starter load test pod observes too many processInstances at a time. Because it always queries them with the full list as IN clause, the DB queries get so big that they influence the load test.

This limits the number of observed instances to 100.