### PR TITLE
`description` field can be set to an empty string when updating the group

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/group/UpdateGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UpdateGroupTest.java
@@ -53,6 +53,20 @@ public class UpdateGroupTest extends ClientRestTest {
   }
 
   @Test
+  void shouldUpdateGroupWithEmptyDescription() {
+    // given
+    gatewayService.onUpdateGroupRequest(GROUP_ID, Instancio.create(GroupUpdateResult.class));
+
+    // when
+    client.newUpdateGroupCommand(GROUP_ID).name(UPDATED_NAME).description("").send().join();
+
+    // then
+    final GroupUpdateRequest request = gatewayService.getLastRequest(GroupUpdateRequest.class);
+    assertThat(request.getName()).isEqualTo(UPDATED_NAME);
+    assertThat(request.getDescription()).isEqualTo("");
+  }
+
+  @Test
   void shouldRaiseExceptionOnNotFoundGroup() {
     // given
     gatewayService.errorOnRequest(

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -155,6 +155,28 @@ public class GroupServiceTest {
   }
 
   @Test
+  public void shouldUpdateGroupWithEmptyDescription() {
+    // given
+    final var groupKey = Protocol.encodePartitionId(1, 100L);
+    final var groupId = String.valueOf(groupKey);
+    final var name = "UpdatedName";
+    final var description = "";
+
+    // when
+    services.updateGroup(groupId, name, description);
+
+    // then
+    final BrokerGroupUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
+    assertThat(request.getPartitionId()).isEqualTo(Protocol.DEPLOYMENT_PARTITION);
+    assertThat(request.getValueType()).isEqualTo(ValueType.GROUP);
+    assertThat(request.getIntent()).isNotEvent().isEqualTo(GroupIntent.UPDATE);
+    final GroupRecord record = request.getRequestWriter();
+    assertThat(record).hasName(name);
+    assertThat(record).hasGroupId(groupId);
+    assertThat(record).hasDescription(description);
+  }
+
+  @Test
   public void shouldDeleteGroup() {
     // given
     final var groupKey = Protocol.encodePartitionId(1, 123L);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -105,9 +105,8 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
       persistedGroup.setName(updatedName);
     }
     final var updatedDescription = updateRecord.getDescription();
-    if (!updatedDescription.isEmpty()) {
-      persistedGroup.setDescription(updatedDescription);
-    }
+
+    persistedGroup.setDescription(updatedDescription);
   }
 
   private void updateState(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -78,6 +78,23 @@ public class GroupTest {
   }
 
   @Test
+  public void shouldUpdateGroupWithEmptyDescription() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var groupId = UUID.randomUUID().toString();
+    final var description = "some description";
+    engine.group().newGroup(groupId).withName(name).withDescription(description).create();
+
+    // when
+    final var updatedDescription = "";
+    final var updatedGroupRecord =
+        engine.group().updateGroup(groupId).withDescription(updatedDescription).update();
+
+    final var updatedGroup = updatedGroupRecord.getValue();
+    assertThat(updatedGroup).hasDescription(updatedDescription);
+  }
+
+  @Test
   public void shouldRejectUpdatedIfNoGroupExists() {
     // when
     final var groupId = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -128,7 +128,7 @@ public class GroupClient {
     }
 
     public GroupUpdateClient withDescription(final String description) {
-      groupRecord.setName(description);
+      groupRecord.setDescription(description);
       return this;
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -74,6 +74,11 @@ public class GroupClient {
       return this;
     }
 
+    public GroupCreateClient withDescription(final String description) {
+      groupRecord.setDescription(description);
+      return this;
+    }
+
     public Record<GroupRecordValue> create() {
       final long position = writer.writeCommand(GroupIntent.CREATE, groupRecord);
       return expectation.apply(position);
@@ -119,6 +124,11 @@ public class GroupClient {
 
     public GroupUpdateClient withName(final String name) {
       groupRecord.setName(name);
+      return this;
+    }
+
+    public GroupUpdateClient withDescription(final String description) {
+      groupRecord.setName(description);
       return this;
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -452,6 +452,48 @@ public class GroupControllerTest {
     }
 
     @Test
+    void shouldUpdateGroupWithEmptyDescriptionAndReturnResponse() {
+      // given
+      final var groupKey = 111L;
+      final var groupId = "111";
+      final var groupName = "updatedName";
+      final var description = "";
+      when(groupServices.updateGroup(groupId, groupName, description))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new GroupRecord()
+                      .setGroupKey(groupKey)
+                      .setGroupId(groupId)
+                      .setName(groupName)
+                      .setDescription(description)));
+
+      // when
+      webClient
+          .put()
+          .uri("%s/%s".formatted(GROUP_BASE_URL, groupId))
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(new GroupUpdateRequest().name(groupName).description(description))
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody()
+          .json(
+              """
+            {
+              "groupId": "%s",
+              "name": "%s",
+              "description": "%s"
+            }
+            """
+                  .formatted(groupId, groupName, description),
+              JsonCompareMode.STRICT);
+
+      // then
+      verify(groupServices, times(1)).updateGroup(groupId, groupName, description);
+    }
+
+    @Test
     void shouldFailOnUpdateGroupWithEmptyName() {
       // given
       final var groupId = "groupId";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateGroupTest.java
@@ -71,6 +71,18 @@ class UpdateGroupTest {
   }
 
   @Test
+  void shouldUpdateGroupWithEmptyDescription() {
+    // when
+    client.newUpdateGroupCommand(groupId).name(UPDATED_GROUP_NAME).description("").send().join();
+
+    // then
+    ZeebeAssertHelper.assertGroupUpdated(
+        UPDATED_GROUP_NAME,
+        group ->
+            assertThat(group).hasGroupId(groupId).hasName(UPDATED_GROUP_NAME).hasDescription(""));
+  }
+
+  @Test
   void shouldRejectUpdateIfNameIsNull() {
     // when / then
     assertThatThrownBy(


### PR DESCRIPTION
Currently, user cannot delete group description content.

In this PR:
I've removed unnecessary check for `description` as `description` field can be set to an empty string when updating the group.

Most of this PR are tests. Please note, tests in each class are written in line with the other tests from the same class.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #32593
