### PR TITLE
feat: add sorting to task details history

### DIFF
--- a/tasklist/client/src/common/tasks/available-tasks/AvailableTaskItem/index.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/AvailableTaskItem/index.tsx
@@ -33,6 +33,7 @@ import cn from 'classnames';
 import {useIsCurrentTaskOpen} from './useIsCurrentTaskOpen';
 import {getNavLinkLabel} from './getNavLinkLabel';
 import {getSecondaryDate} from './getSecondaryDate';
+import {removeSortParam} from 'common/tasks/removeSortParam';
 
 type Props = {
   taskId: string;
@@ -84,7 +85,7 @@ const AvailableTaskItem = React.forwardRef<HTMLDivElement, Props>(
     });
 
     const searchWithRefTag = useMemo(() => {
-      const params = new URLSearchParams(location.search);
+      const params = new URLSearchParams(removeSortParam(location.search));
       params.set(
         'ref',
         encodeTaskOpenedRef({

--- a/tasklist/client/src/common/tasks/removeSortParam.ts
+++ b/tasklist/client/src/common/tasks/removeSortParam.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function removeSortParam(search: string): string {
+  const params = new URLSearchParams(search);
+  params.delete('sort');
+  return params.toString();
+}
+export {removeSortParam};

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/ColumnHeader.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/ColumnHeader.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {MemoryRouter} from 'react-router-dom';
+import {render, screen} from 'common/testing/testing-library';
+import {ColumnHeader} from './ColumnHeader';
+import {Table, TableHead, TableRow} from '@carbon/react';
+import {LocationLog} from 'common/testing/LocationLog';
+
+function getWrapper(initialEntry: string = '/') {
+  const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Table>
+        <TableHead>
+          <TableRow>{children}</TableRow>
+        </TableHead>
+      </Table>
+      <LocationLog />
+    </MemoryRouter>
+  );
+
+  return Wrapper;
+}
+
+describe('<ColumnHeader />', () => {
+  it('should render non-sortable header when no sortKey is provided', () => {
+    render(
+      <ColumnHeader
+        label="Status"
+        isDisabled={false}
+        sortKey={undefined}
+        isDefault={false}
+      >
+        Status
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    const header = screen.getByText('Status');
+    expect(header).toBeInTheDocument();
+    expect(header.closest('th')).not.toHaveAttribute('aria-sort');
+  });
+
+  it('should render non-sortable header when isDisabled is true', () => {
+    render(
+      <ColumnHeader
+        label="Details"
+        isDisabled={true}
+        sortKey="details"
+        isDefault={false}
+      >
+        Details
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    const header = screen.getByText('Details');
+    expect(header).toBeInTheDocument();
+    expect(header.closest('th')).not.toHaveAttribute('aria-sort');
+  });
+
+  it('should show default sort indicator when isDefault and no URL param', () => {
+    render(
+      <ColumnHeader
+        label="Time"
+        isDisabled={false}
+        sortKey="timestamp"
+        isDefault={true}
+      >
+        Time
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+  });
+
+  it('should navigate on click and update URL', async () => {
+    const {user} = render(
+      <ColumnHeader
+        label="Operation"
+        isDisabled={false}
+        sortKey="operationType"
+        isDefault={false}
+      >
+        Operation
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    await user.click(screen.getByRole('button', {name: /sort by operation/i}));
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.getByTestId('search')).toHaveTextContent(
+      'sort=operationType%2Bdesc',
+    );
+  });
+
+  it('should toggle sort order when clicking same column', async () => {
+    const {user} = render(
+      <ColumnHeader
+        label="Time"
+        isDisabled={false}
+        sortKey="timestamp"
+        isDefault={false}
+      >
+        Operation
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper('/?sort=timestamp%2Bdesc'),
+      },
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'descending',
+    );
+
+    await user.click(screen.getByRole('button', {name: /sort by time/i}));
+
+    expect(screen.getByTestId('search')).toHaveTextContent(
+      'sort=timestamp%2Basc',
+    );
+  });
+
+  it('should show correct sort direction based on URL params', () => {
+    render(
+      <ColumnHeader
+        label="Actor"
+        isDisabled={false}
+        sortKey="actorId"
+        isDefault={false}
+      >
+        Actor
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper('/?sort=actorId%2Basc'),
+      },
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+  });
+
+  it('should show no sort indicator for inactive column', () => {
+    render(
+      <ColumnHeader
+        label="Operation"
+        isDisabled={false}
+        sortKey="operationType"
+        isDefault={false}
+      >
+        Operation
+      </ColumnHeader>,
+      {
+        wrapper: getWrapper('/?sort=timestamp%2Basc'),
+      },
+    );
+
+    expect(screen.getByRole('columnheader')).toHaveAttribute(
+      'aria-sort',
+      'none',
+    );
+  });
+});

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/ColumnHeader.tsx
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/ColumnHeader.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useLocation, useNavigate} from 'react-router-dom';
+import {TableHeader} from '@carbon/react';
+import {getSortParams, toggleSorting, INITIAL_SORT_ORDER} from './sortUtils';
+import {z} from 'zod';
+
+const sortDirectionSchema = z
+  .enum(['asc', 'desc'])
+  .transform((value) => value.toUpperCase())
+  .pipe(z.enum(['ASC', 'DESC', 'NONE']))
+  .default('NONE');
+
+function getCurrentSortOrder(params: {
+  sortParams: ReturnType<typeof getSortParams>;
+  isDefault: boolean;
+  sortKey: string;
+}): 'asc' | 'desc' | undefined {
+  const {sortParams, isDefault, sortKey} = params;
+
+  if (sortParams?.sortOrder === undefined && isDefault) {
+    return INITIAL_SORT_ORDER;
+  }
+
+  if (sortParams?.sortBy === sortKey) {
+    return sortParams?.sortOrder;
+  }
+
+  return undefined;
+}
+
+type Props = {
+  label: string;
+  sortKey: string | undefined;
+  isDefault: boolean;
+  isDisabled: boolean;
+  children: React.ReactNode;
+};
+
+const ColumnHeader: React.FC<Props> = ({
+  sortKey,
+  label,
+  isDefault,
+  isDisabled,
+  children,
+}) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const sortParams = getSortParams(location.search);
+
+  if (!sortKey || isDisabled) {
+    return <TableHeader>{children}</TableHeader>;
+  }
+
+  const isActive =
+    sortParams !== null ? sortParams.sortBy === sortKey : isDefault;
+
+  const currentSortOrder = getCurrentSortOrder({
+    sortParams,
+    isDefault,
+    sortKey,
+  });
+
+  return (
+    <TableHeader
+      onClick={() => {
+        navigate({
+          search: toggleSorting(location.search, sortKey, currentSortOrder),
+        });
+      }}
+      isSortHeader
+      title={`Sort by ${label}`}
+      aria-label={`Sort by ${label}`}
+      sortDirection={
+        isActive ? sortDirectionSchema.safeParse(currentSortOrder).data : 'NONE'
+      }
+      isSortable
+    >
+      {children}
+    </TableHeader>
+  );
+};
+
+export {ColumnHeader};

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/index.ts
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/index.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+
+const INITIAL_SORT_ORDER = 'desc';
+
+const sortOrderSchema = z.enum(['asc', 'desc']);
+
+const sortParamsSchema = z.object({
+  sortBy: z.enum(['timestamp', 'operationType', 'actorId']),
+  sortOrder: sortOrderSchema,
+});
+
+type SortParams = z.infer<typeof sortParamsSchema>;
+
+function getSortParams(search: string): SortParams | null {
+  const params = new URLSearchParams(search);
+  const sort = params.get('sort');
+
+  if (sort === null) {
+    return null;
+  }
+
+  const parts = sort.split('+');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [sortBy, sortOrder] = parts;
+
+  const result = sortParamsSchema.safeParse({sortBy, sortOrder});
+  return result.success ? result.data : null;
+}
+
+function toggleSorting(
+  search: string,
+  sortKey: string,
+  currentSortOrder?: 'asc' | 'desc',
+): string {
+  const params = new URLSearchParams(search);
+
+  if (currentSortOrder === undefined) {
+    params.set('sort', `${sortKey}+${INITIAL_SORT_ORDER}`);
+    return params.toString();
+  }
+
+  params.set(
+    'sort',
+    `${sortKey}+${currentSortOrder === 'asc' ? 'desc' : 'asc'}`,
+  );
+  return params.toString();
+}
+
+export {getSortParams, toggleSorting, INITIAL_SORT_ORDER, sortParamsSchema};

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/tests/getSortParams.test.ts
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/tests/getSortParams.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getSortParams} from '../index';
+
+describe('getSortParams', () => {
+  it('should return null for empty search', () => {
+    expect(getSortParams('')).toBeNull();
+  });
+
+  it('should return null when no sort param exists', () => {
+    expect(getSortParams('?foo=bar')).toBeNull();
+  });
+
+  it('should parse valid sort param with desc order', () => {
+    expect(getSortParams('?sort=timestamp%2Bdesc')).toEqual({
+      sortBy: 'timestamp',
+      sortOrder: 'desc',
+    });
+  });
+
+  it('should parse valid sort param with asc order', () => {
+    expect(getSortParams('?sort=actorId%2Basc')).toEqual({
+      sortBy: 'actorId',
+      sortOrder: 'asc',
+    });
+  });
+
+  it('should return null for invalid format without order', () => {
+    expect(getSortParams('?sort=timestamp')).toBeNull();
+  });
+
+  it('should return null for invalid format with wrong order', () => {
+    expect(getSortParams('?sort=timestamp+invalid')).toBeNull();
+  });
+
+  it('should return null for empty sort value', () => {
+    expect(getSortParams('?sort=')).toBeNull();
+  });
+
+  it('should handle search string with other params', () => {
+    expect(getSortParams('?foo=bar&sort=operationType%2Basc&baz=qux')).toEqual({
+      sortBy: 'operationType',
+      sortOrder: 'asc',
+    });
+  });
+});

--- a/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/tests/toggleSorting.test.ts
+++ b/tasklist/client/src/v2/TaskDetailsHistoryView/sortUtils/tests/toggleSorting.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {toggleSorting} from '../index';
+
+describe('toggleSorting', () => {
+  it('should add sort param with desc order when none exists', () => {
+    expect(toggleSorting('', 'timestamp', undefined)).toBe(
+      'sort=timestamp%2Bdesc',
+    );
+  });
+
+  it('should add sort param when other params exist', () => {
+    expect(toggleSorting('?foo=bar', 'timestamp', undefined)).toBe(
+      'foo=bar&sort=timestamp%2Bdesc',
+    );
+  });
+
+  it('should toggle asc to desc', () => {
+    expect(toggleSorting('?sort=timestamp+asc', 'timestamp', 'asc')).toBe(
+      'sort=timestamp%2Bdesc',
+    );
+  });
+
+  it('should toggle desc to asc', () => {
+    expect(toggleSorting('?sort=timestamp+desc', 'timestamp', 'desc')).toBe(
+      'sort=timestamp%2Basc',
+    );
+  });
+
+  it('should change sort column and reset to desc', () => {
+    expect(toggleSorting('?sort=timestamp+asc', 'actorId', undefined)).toBe(
+      'sort=actorId%2Bdesc',
+    );
+  });
+
+  it('should preserve other params when toggling', () => {
+    expect(
+      toggleSorting('?foo=bar&sort=timestamp+asc', 'timestamp', 'asc'),
+    ).toBe('foo=bar&sort=timestamp%2Bdesc');
+  });
+});

--- a/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
@@ -26,6 +26,7 @@ import {TaskDetailsHeader} from 'common/tasks/details/TaskDetailsHeader';
 import {tracking} from 'common/tracking';
 import {decodeTaskOpenedRef} from 'common/tracking/reftags';
 import {AssignButton} from './AssignButton';
+import {removeSortParam} from 'common/tasks/removeSortParam';
 
 type OutletContext = {
   task: UserTask;
@@ -107,6 +108,7 @@ const TaskDetailsLayout: React.FC = () => {
       selected: useMatch(pages.taskDetails()) !== null,
       to: {
         pathname: pages.taskDetails(id),
+        search: removeSortParam(searchParams.toString()),
       },
     },
     {
@@ -116,6 +118,7 @@ const TaskDetailsLayout: React.FC = () => {
       selected: useMatch(pages.taskDetailsProcess()) !== null,
       to: {
         pathname: pages.taskDetailsProcess(id),
+        search: removeSortParam(searchParams.toString()),
       },
       visible: !isTaskCompleted && processXml !== undefined,
     },

--- a/tasklist/client/src/v2/api/useUserTaskAuditLogs.query.ts
+++ b/tasklist/client/src/v2/api/useUserTaskAuditLogs.query.ts
@@ -9,17 +9,37 @@
 import {infiniteQueryOptions} from '@tanstack/react-query';
 import {api} from 'v2/api';
 import {request} from 'common/api/request';
-import type {QueryUserTaskAuditLogsResponseBody} from '@camunda/camunda-api-zod-schemas/8.9';
+import {
+  type QueryUserTaskAuditLogsResponseBody,
+  auditLogSortFieldEnum,
+} from '@camunda/camunda-api-zod-schemas/8.9';
 
 const MAX_AUDIT_LOGS_PER_REQUEST = 50;
 
-function getUserTaskAuditLogsQueryOptions(userTaskKey: string) {
+const AUDIT_LOG_SORT_FIELDS = auditLogSortFieldEnum.options;
+type AuditLogSortField = (typeof AUDIT_LOG_SORT_FIELDS)[number];
+
+type AuditLogSort = {
+  field: AuditLogSortField;
+  order: 'asc' | 'desc';
+};
+
+const DEFAULT_SORT: AuditLogSort = {
+  field: 'timestamp',
+  order: 'desc',
+};
+
+function getUserTaskAuditLogsQueryOptions(
+  userTaskKey: string,
+  sort: AuditLogSort = DEFAULT_SORT,
+) {
   return infiniteQueryOptions({
-    queryKey: ['userTaskAuditLogs', userTaskKey],
+    queryKey: ['userTaskAuditLogs', userTaskKey, sort],
     queryFn: async ({pageParam}) => {
       const {response, error} = await request(
         api.queryUserTaskAuditLogs({
           userTaskKey,
+          sort: [sort],
           page: {
             from: pageParam,
             limit: MAX_AUDIT_LOGS_PER_REQUEST,
@@ -56,4 +76,10 @@ function getUserTaskAuditLogsQueryOptions(userTaskKey: string) {
   });
 }
 
-export {getUserTaskAuditLogsQueryOptions};
+export {
+  getUserTaskAuditLogsQueryOptions,
+  DEFAULT_SORT,
+  AUDIT_LOG_SORT_FIELDS,
+  type AuditLogSort,
+  type AuditLogSortField,
+};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds sorting to the task details history

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/40532
