### PR TITLE
task metrics store elasticsearch java client upgrade

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -244,12 +244,6 @@
     <!-- TEST -->
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -282,12 +276,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -176,12 +176,6 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
@@ -189,12 +183,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -43,10 +43,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-authentication</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
     </dependency>
 
@@ -189,14 +185,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -291,11 +279,6 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
@@ -307,11 +290,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -216,12 +216,6 @@
 
     <!-- TEST -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/CommonUtils.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/CommonUtils.java
@@ -52,7 +52,7 @@ public final class CommonUtils {
             DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE,
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
             DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS, SerializationFeature.INDENT_OUTPUT)
+        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS)
         .build();
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
@@ -55,7 +55,7 @@ public class JacksonConfig {
                 DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE,
                 DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                 DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-            .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS, SerializationFeature.INDENT_OUTPUT)
+            .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS)
             .build();
   }
 

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -74,11 +74,6 @@
 
     <!-- ELASTICSEARCH -->
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-x-content</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
     </dependency>
@@ -167,12 +162,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-x-content</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
     </dependency>
@@ -189,7 +194,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
-          <ignoredUnusedDeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies combine.children="append">
             <dep>org.junit.platform:junit-platform-suite</dep>
             <dep>org.junit.platform:junit-platform-suite-engine</dep>
           </ignoredUnusedDeclaredDependencies>

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -55,7 +55,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
 
   @Autowired
   @Qualifier("tasklistEs8Client")
-  private ElasticsearchClient es8Client;
+  private ElasticsearchClient esClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -103,7 +103,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
                     .size(0));
 
     try {
-      final var response = es8Client.search(searchRequest, Void.class);
+      final var response = esClient.search(searchRequest, Void.class);
       final var aggregations = response.aggregations();
 
       if (aggregations == null || !aggregations.containsKey(ASSIGNEE)) {
@@ -128,7 +128,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
           IndexRequest.of(
               b -> b.index(template.getFullQualifiedName()).id(entity.getId()).document(entity));
 
-      final var response = es8Client.index(request);
+      final var response = esClient.index(request);
       final var result = response.result();
 
       return Result.Created.equals(result) || Result.Updated.equals(result);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -416,6 +416,21 @@ public abstract class ElasticsearchUtil {
     return result;
   }
 
+  public static <T, ID> List<T> scrollInChunks(
+      final List<ID> list,
+      final int chunkSize,
+      final Function<List<ID>, SearchRequest> chunkToSearchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient)
+      throws IOException {
+    final var result = new ArrayList<T>();
+    for (final var chunk : ListUtils.partition(list, chunkSize)) {
+      result.addAll(scroll(chunkToSearchRequest.apply(chunk), clazz, objectMapper, esClient));
+    }
+    return result;
+  }
+
   public static <T> List<T> scroll(
       final SearchRequest searchRequest,
       final Class<T> clazz,

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/TasklistAPICaller.java
@@ -173,7 +173,7 @@ public class TasklistAPICaller {
             DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE,
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
             DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS, SerializationFeature.INDENT_OUTPUT)
+        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS)
         .build();
   }
 

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -116,16 +116,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
@@ -350,12 +340,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -373,11 +357,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -239,6 +239,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/CommonUtils.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/CommonUtils.java
@@ -43,7 +43,7 @@ public final class CommonUtils {
             DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE,
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
             DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS, SerializationFeature.INDENT_OUTPUT)
+        .featuresToEnable(JsonParser.Feature.ALLOW_COMMENTS)
         .build();
   }
 }


### PR DESCRIPTION
## Description

convert ES task metrics store to java client.

- there is a shared initial commit [feat: dependencies and helper functions](https://github.com/camunda/camunda/commit/dd597f97c7da203250c40bbb57ffc9339882fe06) between all the tasklist store java client upgrade branches fyi so delta is a lot smaller.

- The reason indent output is removed is it actually breaks bulk update requests due to how it serialises the bulk request.

