### PR TITLE
task store elasticsearch java client upgrade

### DIFF
--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
@@ -13,25 +13,27 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.queries.TaskQuery;
-import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
+import io.camunda.tasklist.util.ElasticsearchTenantHelper;
 import io.camunda.tasklist.views.TaskSearchView;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,7 +50,9 @@ class TaskStoreElasticSearchTest {
 
   @Captor private ArgumentCaptor<SearchRequest> searchRequestCaptor;
 
-  @Mock private TenantAwareElasticsearchClient tenantAwareClient;
+  @Mock private ElasticsearchClient es8Client;
+
+  @Mock private ElasticsearchTenantHelper tenantHelper;
 
   @Spy private TaskTemplate taskTemplate = new TaskTemplate("test", true);
 
@@ -68,22 +72,18 @@ class TaskStoreElasticSearchTest {
     // Given
     final TaskQuery taskQuery = new TaskQuery().setPageSize(50).setState(taskState);
 
-    final SearchResponse mockedResponse = mock();
-    when(tenantAwareClient.search(searchRequestCaptor.capture())).thenReturn(mockedResponse);
+    // Mock tenant helper to return query as-is
+    when(tenantHelper.makeQueryTenantAware(any(Query.class))).thenAnswer(i -> i.getArgument(0));
 
-    final SearchHits mockedHints = mock();
-    when(mockedResponse.getHits()).thenReturn(mockedHints);
-
-    final SearchHit mockedHit = mock();
-    when(mockedHints.getHits()).thenReturn(new SearchHit[] {mockedHit});
-
-    when(mockedHit.getSourceAsString()).thenReturn(getTaskExampleAsString(taskState));
+    final SearchResponse<TaskEntity> mockedResponse = mockSearchResponse(taskState);
+    when(es8Client.search(searchRequestCaptor.capture(), eq(TaskEntity.class)))
+        .thenReturn(mockedResponse);
 
     // When
     final List<TaskSearchView> result = instance.getTasks(taskQuery);
 
     // Then
-    assertThat(searchRequestCaptor.getValue().indices())
+    assertThat(searchRequestCaptor.getValue().index())
         .singleElement(as(STRING))
         .satisfies(
             index -> {
@@ -92,7 +92,7 @@ class TaskStoreElasticSearchTest {
             });
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getImplementation()).isEqualTo(TaskImplementation.JOB_WORKER);
-    verify(tenantAwareClient).search(any());
+    verify(es8Client).search(any(SearchRequest.class), eq(TaskEntity.class));
   }
 
   @Test
@@ -103,45 +103,49 @@ class TaskStoreElasticSearchTest {
             .setPageSize(50)
             .setState(TaskState.CREATED);
 
-    final SearchResponse mockedResponse = mock();
-    when(tenantAwareClient.searchByTenantIds(any(), eq(Set.of("tenant_a", "tenant_b"))))
+    // Mock tenant helper with specific tenant ids
+    when(tenantHelper.makeQueryTenantAware(any(Query.class), eq(Set.of("tenant_a", "tenant_b"))))
+        .thenAnswer(i -> i.getArgument(0));
+
+    final SearchResponse<TaskEntity> mockedResponse = mockSearchResponse(TaskState.CREATED);
+    when(es8Client.search(any(SearchRequest.class), eq(TaskEntity.class)))
         .thenReturn(mockedResponse);
-
-    final SearchHits mockedHints = mock();
-    when(mockedResponse.getHits()).thenReturn(mockedHints);
-
-    final SearchHit mockedHit = mock();
-    when(mockedHints.getHits()).thenReturn(new SearchHit[] {mockedHit});
-
-    when(mockedHit.getSourceAsString()).thenReturn(getTaskExampleAsString(TaskState.CREATED));
 
     // When
     final List<TaskSearchView> result = instance.getTasks(taskQuery);
 
     // Then
-    verify(tenantAwareClient, never()).search(any());
+    verify(tenantHelper).makeQueryTenantAware(any(Query.class), eq(Set.of("tenant_a", "tenant_b")));
     assertThat(result).hasSize(1);
   }
 
-  private static String getTaskExampleAsString(final TaskState taskState) {
-    return "{\n"
-        + "  \"id\": \"123456789\",\n"
-        + "  \"key\": 123456789,\n"
-        + "  \"partitionId\": 2,\n"
-        + "  \"bpmnProcessId\": \"bigFormProcess\",\n"
-        + "  \"processDefinitionId\": \"00000000000\",\n"
-        + "  \"flowNodeBpmnId\": \"Activity_0aaaaa\",\n"
-        + "  \"flowNodeInstanceId\": \"11111111111\",\n"
-        + "  \"processInstanceId\": \"2222222222\",\n"
-        + "  \"creationTime\": \"2023-01-01T00:00:02.523+0200\",\n"
-        + "  \"completionTime\": null,\n"
-        + "  \"state\": \""
-        + taskState.toString()
-        + "\",\n"
-        + "  \"assignee\": null,\n"
-        + "  \"candidateGroups\": null,\n"
-        + "  \"formKey\": \"camunda-forms:bpmn:userTaskForm_1111111\",\n"
-        + "  \"implementation\": \"JOB_WORKER\"\n"
-        + "}";
+  @SuppressWarnings("unchecked")
+  private SearchResponse<TaskEntity> mockSearchResponse(final TaskState taskState) {
+    final SearchResponse<TaskEntity> mockedResponse = mock(SearchResponse.class);
+    final HitsMetadata<TaskEntity> mockedHits = mock(HitsMetadata.class);
+    final Hit<TaskEntity> mockedHit = mock(Hit.class);
+
+    when(mockedResponse.hits()).thenReturn(mockedHits);
+    when(mockedHits.hits()).thenReturn(List.of(mockedHit));
+    when(mockedHit.source()).thenReturn(createTaskEntity(taskState));
+    when(mockedHit.sort()).thenReturn(List.of());
+
+    return mockedResponse;
+  }
+
+  private TaskEntity createTaskEntity(final TaskState taskState) {
+    final TaskEntity entity = new TaskEntity();
+    entity.setId("123456789");
+    entity.setKey(123456789L);
+    entity.setPartitionId(2);
+    entity.setBpmnProcessId("bigFormProcess");
+    entity.setProcessDefinitionId("00000000000");
+    entity.setFlowNodeBpmnId("Activity_0aaaaa");
+    entity.setFlowNodeInstanceId("11111111111");
+    entity.setProcessInstanceId("2222222222");
+    entity.setState(taskState);
+    entity.setFormKey("camunda-forms:bpmn:userTaskForm_1111111");
+    entity.setImplementation(TaskImplementation.JOB_WORKER);
+    return entity;
   }
 }


### PR DESCRIPTION
## Description

convert ES task store to java client.

- there is a shared initial commit [feat: dependencies and helper functions](https://github.com/camunda/camunda/commit/dd597f97c7da203250c40bbb57ffc9339882fe06) between all the tasklist store java client upgrade branches fyi so delta is a lot smaller.

- The reason indent output is removed is it actually breaks bulk update requests due to how it serialises the bulk request.
