### PR TITLE
variable store elasticsearch java client upgrade

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -9,11 +9,6 @@ package io.camunda.tasklist.store.elasticsearch;
 
 import static io.camunda.tasklist.util.CollectionUtil.isNotEmpty;
 import static io.camunda.tasklist.util.ElasticsearchUtil.UPDATE_RETRY_COUNT;
-import static io.camunda.tasklist.util.ElasticsearchUtil.createSearchRequest;
-import static io.camunda.tasklist.util.ElasticsearchUtil.fromSearchHit;
-import static io.camunda.tasklist.util.ElasticsearchUtil.joinWithAnd;
-import static io.camunda.tasklist.util.ElasticsearchUtil.scroll;
-import static io.camunda.tasklist.util.ElasticsearchUtil.scrollInChunks;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.ID;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NAME;
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.PROCESS_INSTANCE_KEY;
@@ -22,19 +17,20 @@ import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.VA
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.NotFoundException;
-import io.camunda.tasklist.exceptions.PersistenceException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.VariableStore;
-import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
+import io.camunda.tasklist.util.ElasticsearchTenantHelper;
 import io.camunda.tasklist.util.ElasticsearchUtil;
+import io.camunda.tasklist.util.ElasticsearchUtil.QueryType;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
@@ -48,24 +44,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.TermsQueryBuilder;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,10 +63,10 @@ public class VariableStoreElasticSearch implements VariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreElasticSearch.class);
 
   @Autowired
-  @Qualifier("tasklistEsClient")
-  private RestHighLevelClient esClient;
+  @Qualifier("tasklistEs8Client")
+  private ElasticsearchClient es8Client;
 
-  @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
+  @Autowired private ElasticsearchTenantHelper tenantHelper;
 
   @Autowired private VariableTemplate variableIndex;
 
@@ -93,24 +76,19 @@ public class VariableStoreElasticSearch implements VariableStore {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired
-  @Qualifier("tasklistObjectMapper")
-  private ObjectMapper objectMapper;
-
   @Override
   public List<VariableEntity> getVariablesByFlowNodeInstanceIds(
       final List<String> flowNodeInstanceIds,
       final List<String> varNames,
       final Set<String> fieldNames) {
     try {
-      return scrollInChunks(
+      return ElasticsearchUtil.scrollInChunks(
+          es8Client,
           flowNodeInstanceIds,
           tasklistProperties.getElasticsearch().getMaxTermsCount(),
-          chunk -> buildSearchVariablesByScopeFNIsAndVarNamesRequest(chunk, varNames, fieldNames),
-          VariableEntity.class,
-          objectMapper,
-          esClient);
-    } catch (final IOException e) {
+          chunk -> buildSearchVariablesByFlowNodeInstanceIdsRequest(chunk, varNames, fieldNames),
+          VariableEntity.class);
+    } catch (final Exception e) {
       final String message =
           String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -125,10 +103,10 @@ public class VariableStoreElasticSearch implements VariableStore {
       return new HashMap<>();
     }
 
-    final TermsQueryBuilder taskIdsQ =
-        termsQuery(
-            SnapshotTaskVariableTemplate.TASK_ID,
-            requests.stream().map(GetVariablesRequest::getTaskId).collect(toList()));
+    final var taskIds = requests.stream().map(GetVariablesRequest::getTaskId).collect(toList());
+    final var taskIdsQuery =
+        ElasticsearchUtil.termsQuery(SnapshotTaskVariableTemplate.TASK_ID, taskIds);
+
     final List<String> varNames =
         requests.stream()
             .map(GetVariablesRequest::getVarNames)
@@ -136,29 +114,32 @@ public class VariableStoreElasticSearch implements VariableStore {
             .flatMap(List::stream)
             .distinct()
             .collect(toList());
-    TermsQueryBuilder varNamesQ = null;
-    if (isNotEmpty(varNames)) {
-      varNamesQ = termsQuery(VariableTemplate.NAME, varNames);
-    }
 
-    final SearchSourceBuilder searchSourceBuilder =
-        new SearchSourceBuilder().query(constantScoreQuery(joinWithAnd(taskIdsQ, varNamesQ)));
-    applyFetchSourceForTaskVariableTemplate(
-        searchSourceBuilder,
-        requests
-            .get(0)
-            .getFieldNames()); // we assume here that all requests has the same list of fields
+    final var query =
+        isNotEmpty(varNames)
+            ? ElasticsearchUtil.joinWithAnd(
+                taskIdsQuery, ElasticsearchUtil.termsQuery(VariableTemplate.NAME, varNames))
+            : taskIdsQuery;
+    final var constantScoreQuery = ElasticsearchUtil.constantScoreQuery(query);
 
-    final SearchRequest searchRequest =
-        new SearchRequest(taskVariableTemplate.getAlias()).source(searchSourceBuilder);
+    final var searchRequestBuilder =
+        new SearchRequest.Builder()
+            .index(taskVariableTemplate.getAlias())
+            .query(constantScoreQuery);
+
+    // Apply fetch source using field names from the first request
+    applyFetchSourceForTaskVariableTemplate(searchRequestBuilder, requests.get(0).getFieldNames());
+
     try {
       final List<SnapshotTaskVariableEntity> entities =
-          scroll(searchRequest, SnapshotTaskVariableEntity.class, objectMapper, esClient);
+          ElasticsearchUtil.scrollAllToList(
+              es8Client, searchRequestBuilder, SnapshotTaskVariableEntity.class);
+
       return entities.stream()
           .collect(
               groupingBy(
                   SnapshotTaskVariableEntity::getTaskId, mapping(Function.identity(), toList())));
-    } catch (final IOException e) {
+    } catch (final Exception e) {
       final String message =
           String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -167,44 +148,41 @@ public class VariableStoreElasticSearch implements VariableStore {
 
   @Override
   public Map<String, String> getTaskVariablesIdsWithIndexByTaskIds(final List<String> taskIds) {
-    final SearchRequest searchRequest =
-        ElasticsearchUtil.createSearchRequest(taskVariableTemplate)
-            .source(
-                SearchSourceBuilder.searchSource()
-                    .query(termsQuery(SnapshotTaskVariableTemplate.TASK_ID, taskIds))
-                    .fetchField(SnapshotTaskVariableTemplate.ID));
+    final var query = ElasticsearchUtil.termsQuery(SnapshotTaskVariableTemplate.TASK_ID, taskIds);
+
+    final var searchRequestBuilder =
+        new SearchRequest.Builder()
+            .index(ElasticsearchUtil.whereToSearch(taskVariableTemplate, QueryType.ALL))
+            .query(query)
+            .source(s -> s.filter(f -> f.includes(SnapshotTaskVariableTemplate.ID)));
+
     try {
-      return ElasticsearchUtil.scrollIdsWithIndexToMap(searchRequest, esClient);
-    } catch (final IOException e) {
+      return ElasticsearchUtil.scrollIdsWithIndexToMap(es8Client, searchRequestBuilder);
+    } catch (final Exception e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
 
   @Override
   public void persistTaskVariables(final Collection<SnapshotTaskVariableEntity> finalVariables) {
-    final BulkRequest bulkRequest = new BulkRequest();
-    for (final SnapshotTaskVariableEntity variableEntity : finalVariables) {
-      bulkRequest.add(createUpsertRequest(variableEntity));
-    }
     try {
-      ElasticsearchUtil.processBulkRequest(
-          esClient, bulkRequest, WriteRequest.RefreshPolicy.WAIT_UNTIL);
-    } catch (final PersistenceException ex) {
-      throw new TasklistRuntimeException(ex);
+      final var bulkOperations = finalVariables.stream().map(this::createUpsertRequest).toList();
+      ElasticsearchUtil.executeBulkRequest(es8Client, bulkOperations, Refresh.WaitFor);
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException("Error persisting task variables", e);
     }
   }
 
   @Override
   public List<FlowNodeInstanceEntity> getFlowNodeInstances(final List<Long> processInstanceKeys) {
     try {
-      return scrollInChunks(
+      return ElasticsearchUtil.scrollInChunks(
+          es8Client,
           processInstanceKeys,
           tasklistProperties.getElasticsearch().getMaxTermsCount(),
-          this::buildSearchFNIByProcessInstanceKeysRequest,
-          FlowNodeInstanceEntity.class,
-          objectMapper,
-          esClient);
-    } catch (final IOException e) {
+          this::buildSearchFlowNodeInstancesRequest,
+          FlowNodeInstanceEntity.class);
+    } catch (final Exception e) {
       final String message =
           String.format("Exception occurred, while obtaining all flow nodes: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
@@ -213,19 +191,21 @@ public class VariableStoreElasticSearch implements VariableStore {
 
   @Override
   public VariableEntity getRuntimeVariable(final String variableId, final Set<String> fieldNames) {
-    final SearchSourceBuilder searchSourceBuilder =
-        new SearchSourceBuilder().query(idsQuery().addIds(variableId));
-    applyFetchSourceForVariableIndex(searchSourceBuilder, fieldNames);
-    final SearchRequest request =
-        new SearchRequest(variableIndex.getFullQualifiedName()).source(searchSourceBuilder);
+    final var query = ElasticsearchUtil.idsQuery(variableId);
+    final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
+
+    final var requestBuilder =
+        new SearchRequest.Builder()
+            .index(variableIndex.getFullQualifiedName())
+            .query(tenantAwareQuery);
+
+    applyFetchSourceForVariableIndex(requestBuilder, fieldNames);
+
     try {
-      final SearchResponse response = tenantAwareClient.search(request);
-      if (response.getHits().getTotalHits().value == 1) {
-        return fromSearchHit(
-            response.getHits().getHits()[0].getSourceAsString(),
-            objectMapper,
-            VariableEntity.class);
-      } else if (response.getHits().getTotalHits().value > 1) {
+      final var response = es8Client.search(requestBuilder.build(), VariableEntity.class);
+      if (response.hits().total().value() == 1) {
+        return response.hits().hits().get(0).source();
+      } else if (response.hits().total().value() > 1) {
         throw new NotFoundException(
             String.format("Unique variable with id %s was not found", variableId));
       } else {
@@ -241,19 +221,20 @@ public class VariableStoreElasticSearch implements VariableStore {
   @Override
   public SnapshotTaskVariableEntity getTaskVariable(
       final String variableId, final Set<String> fieldNames) {
-    final SearchSourceBuilder searchSourceBuilder =
-        new SearchSourceBuilder().query(idsQuery().addIds(variableId));
-    applyFetchSourceForTaskVariableTemplate(searchSourceBuilder, fieldNames);
-    final SearchRequest request =
-        createSearchRequest(taskVariableTemplate).source(searchSourceBuilder);
+    final var query = ElasticsearchUtil.idsQuery(variableId);
+    final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
+
+    final var requestBuilder =
+        new SearchRequest.Builder().index(taskVariableTemplate.getAlias()).query(tenantAwareQuery);
+
+    applyFetchSourceForTaskVariableTemplate(requestBuilder, fieldNames);
+
     try {
-      final SearchResponse response = tenantAwareClient.search(request);
-      if (response.getHits().getTotalHits().value == 1) {
-        return fromSearchHit(
-            response.getHits().getHits()[0].getSourceAsString(),
-            objectMapper,
-            SnapshotTaskVariableEntity.class);
-      } else if (response.getHits().getTotalHits().value > 1) {
+      final var response =
+          es8Client.search(requestBuilder.build(), SnapshotTaskVariableEntity.class);
+      if (response.hits().total().value() == 1) {
+        return response.hits().hits().get(0).source();
+      } else if (response.hits().total().value() > 1) {
         throw new NotFoundException(
             String.format("Unique task variable with id %s was not found", variableId));
       } else {
@@ -274,25 +255,23 @@ public class VariableStoreElasticSearch implements VariableStore {
     Set<Long> processInstanceKeys = null;
 
     for (int i = 0; i < varNames.size(); i++) {
-      final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-      boolQuery.must(QueryBuilders.termQuery(NAME, varNames.get(i)));
-      boolQuery.must(QueryBuilders.termQuery(VALUE, varValues.get(i)));
+      final var nameQuery = ElasticsearchUtil.termsQuery(NAME, varNames.get(i));
+      final var valueQuery = ElasticsearchUtil.termsQuery(VALUE, varValues.get(i));
+      final var query = ElasticsearchUtil.joinWithAnd(nameQuery, valueQuery);
 
-      final SearchSourceBuilder searchSourceBuilder =
-          new SearchSourceBuilder()
-              .query(boolQuery)
-              .fetchSource(PROCESS_INSTANCE_KEY, null)
+      final var searchRequestBuilder =
+          new SearchRequest.Builder()
+              .index(variableIndex.getFullQualifiedName())
+              .query(query)
+              .source(s -> s.filter(f -> f.includes(PROCESS_INSTANCE_KEY)))
               .size(tasklistProperties.getElasticsearch().getBatchSize());
-
-      final SearchRequest searchRequest =
-          new SearchRequest(variableIndex.getFullQualifiedName()).source(searchSourceBuilder);
 
       final Set<Long> currentKeys;
       try {
         currentKeys =
-            new HashSet<>(
-                ElasticsearchUtil.scrollFieldToList(searchRequest, PROCESS_INSTANCE_KEY, esClient));
-      } catch (final IOException e) {
+            ElasticsearchUtil.scrollFieldToLongSet(
+                es8Client, searchRequestBuilder, PROCESS_INSTANCE_KEY);
+      } catch (final Exception e) {
         final String message =
             String.format(
                 "Exception occurred while obtaining flowNodeInstanceIds for variable %s: %s",
@@ -318,111 +297,91 @@ public class VariableStoreElasticSearch implements VariableStore {
         : new ArrayList<>(processInstanceKeys);
   }
 
-  private SearchRequest buildSearchFNIByProcessInstanceKeysRequest(
-      final List<Long> processInstanceKeys) {
-    final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
-
-    final TermsQueryBuilder processInstanceKeyQuery =
-        termsQuery(FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys);
-    final var flowNodeInstanceStateQuery =
-        termsQuery(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.toString());
-
-    queryBuilder.must(flowNodeInstanceStateQuery);
-    queryBuilder.must(processInstanceKeyQuery);
-
-    final TermsQueryBuilder typeQuery =
-        QueryBuilders.termsQuery(
-            FlowNodeInstanceTemplate.TYPE,
-            FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
-            FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE.toString(),
-            FlowNodeType.USER_TASK.toString(),
-            FlowNodeType.SUB_PROCESS.toString(),
-            FlowNodeType.EVENT_SUB_PROCESS.toString(),
-            FlowNodeType.MULTI_INSTANCE_BODY.toString(),
-            FlowNodeType.PROCESS.toString());
-    queryBuilder.must(typeQuery);
-
-    final var query =
-        ElasticsearchUtil.joinWithAnd(
-            typeQuery, processInstanceKeyQuery, flowNodeInstanceStateQuery);
-    return new SearchRequest(flowNodeInstanceIndex.getFullQualifiedName())
-        .source(
-            new SearchSourceBuilder()
-                .query(constantScoreQuery(query))
-                .sort(FlowNodeInstanceTemplate.POSITION, SortOrder.ASC)
-                .size(tasklistProperties.getElasticsearch().getBatchSize()));
-  }
-
-  private SearchRequest buildSearchVariablesByScopeFNIsAndVarNamesRequest(
-      final List<String> scopeFlowNodeIds,
+  private SearchRequest.Builder buildSearchVariablesByFlowNodeInstanceIdsRequest(
+      final List<String> flowNodeInstanceIds,
       final List<String> varNames,
       final Set<String> fieldNames) {
-    final TermsQueryBuilder flowNodeInstanceKeyQ = termsQuery(SCOPE_KEY, scopeFlowNodeIds);
-    TermsQueryBuilder varNamesQ = null;
-    if (isNotEmpty(varNames)) {
-      varNamesQ = termsQuery(VariableTemplate.NAME, varNames);
-    }
-    final SearchSourceBuilder searchSourceBuilder =
-        new SearchSourceBuilder()
-            .query(constantScoreQuery(joinWithAnd(flowNodeInstanceKeyQ, varNamesQ)))
-            .size(tasklistProperties.getElasticsearch().getBatchSize());
-    applyFetchSourceForVariableIndex(searchSourceBuilder, fieldNames);
+    final var scopeKeyQuery = ElasticsearchUtil.termsQuery(SCOPE_KEY, flowNodeInstanceIds);
+    final var query =
+        isNotEmpty(varNames)
+            ? ElasticsearchUtil.joinWithAnd(
+                scopeKeyQuery, ElasticsearchUtil.termsQuery(VariableTemplate.NAME, varNames))
+            : scopeKeyQuery;
+    final var constantScoreQuery = ElasticsearchUtil.constantScoreQuery(query);
 
-    return new SearchRequest(variableIndex.getFullQualifiedName()).source(searchSourceBuilder);
+    final var searchRequestBuilder =
+        new SearchRequest.Builder()
+            .index(variableIndex.getFullQualifiedName())
+            .query(constantScoreQuery)
+            .size(tasklistProperties.getElasticsearch().getBatchSize());
+
+    applyFetchSourceForVariableIndex(searchRequestBuilder, fieldNames);
+    return searchRequestBuilder;
   }
 
-  private UpdateRequest createUpsertRequest(final SnapshotTaskVariableEntity variableEntity) {
-    try {
-      final Map<String, Object> updateFields = new HashMap<>();
-      updateFields.put(SnapshotTaskVariableTemplate.TASK_ID, variableEntity.getTaskId());
-      updateFields.put(SnapshotTaskVariableTemplate.NAME, variableEntity.getName());
-      updateFields.put(SnapshotTaskVariableTemplate.VALUE, variableEntity.getValue());
+  private SearchRequest.Builder buildSearchFlowNodeInstancesRequest(
+      final List<Long> processInstanceKeys) {
+    final var processInstanceKeyQuery =
+        ElasticsearchUtil.termsQuery(
+            FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys);
+    final var stateQuery =
+        ElasticsearchUtil.termsQuery(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.name());
+    final var typeQuery =
+        ElasticsearchUtil.termsQuery(
+            FlowNodeInstanceTemplate.TYPE,
+            List.of(
+                FlowNodeType.AD_HOC_SUB_PROCESS.name(),
+                FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE.name(),
+                FlowNodeType.USER_TASK.name(),
+                FlowNodeType.SUB_PROCESS.name(),
+                FlowNodeType.EVENT_SUB_PROCESS.name(),
+                FlowNodeType.MULTI_INSTANCE_BODY.name(),
+                FlowNodeType.PROCESS.name()));
 
-      // format date fields properly
-      final Map<String, Object> jsonMap =
-          objectMapper.readValue(objectMapper.writeValueAsString(updateFields), HashMap.class);
+    final var query = ElasticsearchUtil.joinWithAnd(processInstanceKeyQuery, stateQuery, typeQuery);
+    final var constantScoreQuery = ElasticsearchUtil.constantScoreQuery(query);
 
-      return new UpdateRequest()
-          .index(taskVariableTemplate.getFullQualifiedName())
-          .id(variableEntity.getId())
-          .upsert(objectMapper.writeValueAsString(variableEntity), XContentType.JSON)
-          .doc(jsonMap)
-          .retryOnConflict(UPDATE_RETRY_COUNT);
-
-    } catch (final IOException e) {
-      throw new TasklistRuntimeException(
-          String.format(
-              "Error preparing the query to upsert task variable instance [%s]",
-              variableEntity.getId()),
-          e);
-    }
+    return new SearchRequest.Builder()
+        .index(flowNodeInstanceIndex.getFullQualifiedName())
+        .query(constantScoreQuery)
+        .sort(ElasticsearchUtil.sortOrder(FlowNodeInstanceTemplate.POSITION, SortOrder.Asc))
+        .size(tasklistProperties.getElasticsearch().getBatchSize());
   }
 
   private void applyFetchSourceForVariableIndex(
-      final SearchSourceBuilder searchSourceBuilder, final Set<String> fieldNames) {
-    final String[] includesFields;
+      final SearchRequest.Builder requestBuilder, final Set<String> fieldNames) {
     if (isNotEmpty(fieldNames)) {
       final Set<String> elsFieldNames =
           VariableStore.getVariableTemplateElsFieldsByGraphqlFields(fieldNames);
       elsFieldNames.add(ID);
       elsFieldNames.add(NAME);
       elsFieldNames.add(SCOPE_KEY);
-      includesFields = elsFieldNames.toArray(new String[elsFieldNames.size()]);
-      searchSourceBuilder.fetchSource(includesFields, null);
+      final var includesFields = elsFieldNames.toArray(new String[0]);
+      requestBuilder.source(s -> s.filter(f -> f.includes(List.of(includesFields))));
     }
   }
 
   private void applyFetchSourceForTaskVariableTemplate(
-      final SearchSourceBuilder searchSourceBuilder, final Set<String> fieldNames) {
-    final String[] includesFields;
+      final SearchRequest.Builder requestBuilder, final Set<String> fieldNames) {
     if (isNotEmpty(fieldNames)) {
       final Set<String> elsFieldNames =
           VariableStore.getTaskVariableElsFieldsByGraphqlFields(fieldNames);
       elsFieldNames.add(SnapshotTaskVariableTemplate.ID);
       elsFieldNames.add(SnapshotTaskVariableTemplate.NAME);
       elsFieldNames.add(SnapshotTaskVariableTemplate.TASK_ID);
-      includesFields = elsFieldNames.toArray(new String[elsFieldNames.size()]);
-      searchSourceBuilder.fetchSource(includesFields, null);
+      final var includesFields = elsFieldNames.toArray(new String[0]);
+      requestBuilder.source(s -> s.filter(f -> f.includes(List.of(includesFields))));
     }
+  }
+
+  private BulkOperation createUpsertRequest(final SnapshotTaskVariableEntity variableEntity) {
+    return BulkOperation.of(
+        op ->
+            op.update(
+                u ->
+                    u.index(taskVariableTemplate.getFullQualifiedName())
+                        .id(variableEntity.getId())
+                        .retryOnConflict(UPDATE_RETRY_COUNT)
+                        .action(a -> a.doc(variableEntity).docAsUpsert(true))));
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
@@ -533,25 +533,6 @@ public class VariableService {
     return result;
   }
 
-  public VariableDTO getVariable(final String variableId, final Set<String> fieldNames) {
-    try {
-      // 1st search in runtime variables
-      final VariableEntity runtimeVariable =
-          variableStore.getRuntimeVariable(variableId, fieldNames);
-      return VariableDTO.createFrom(runtimeVariable);
-    } catch (final NotFoundException ex) {
-      // then in task variables (for completed tasks)
-      try {
-        // 2nd search in runtime variables
-        final SnapshotTaskVariableEntity taskVariable =
-            variableStore.getTaskVariable(variableId, fieldNames);
-        return VariableDTO.createFrom(taskVariable);
-      } catch (final NotFoundException ex2) {
-        throw new NotFoundApiException(String.format("Variable with id %s not found.", variableId));
-      }
-    }
-  }
-
   public VariableResponse getVariableResponse(final String variableId) {
     try {
       // 1st search in runtime variables


### PR DESCRIPTION
## Description

convert ES variable store to java client.

- there is a shared initial commit [feat: dependencies and helper functions](https://github.com/camunda/camunda/commit/dd597f97c7da203250c40bbb57ffc9339882fe06) between all the tasklist store java client upgrade branches fyi so delta is a lot smaller.
- The reason indent output is removed is it actually breaks bulk update requests due to how it serialises the bulk request.

