### PR TITLE
process store elasticsearch java client upgrade

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -7,6 +7,13 @@
  */
 package io.camunda.tasklist.store.elasticsearch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.util.NamedValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
@@ -14,37 +21,14 @@ import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.IdentityProperties;
 import io.camunda.tasklist.store.ProcessStore;
-import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
+import io.camunda.tasklist.util.ElasticsearchTenantHelper;
 import io.camunda.tasklist.util.ElasticsearchUtil;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
-import org.elasticsearch.search.aggregations.bucket.filter.Filter;
-import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.collapse.CollapseBuilder;
-import org.elasticsearch.search.sort.SortBuilders;
-import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
@@ -57,7 +41,6 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   private static final Boolean CASE_INSENSITIVE = true;
   private static final String BPMN_PROCESS_ID_TENANT_ID_AGG_NAME = "bpmnProcessId_tenantId_buckets";
   private static final String TOP_HITS_AGG_NAME = "top_hit_doc";
-  private static final String DEFINITION_ID_TERMS_SOURCE_NAME = "group_by_definition_id";
   private static final String TENANT_ID_TERMS_SOURCE_NAME = "group_by_tenant_id";
   private static final String MAX_VERSION_DOCUMENTS_AGG_NAME = "max_version_docs";
   private static final String STARTED_BY_FORM_FILTERED_DOCS = "started_by_form_docs";
@@ -65,7 +48,11 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   @Autowired private ProcessIndex processIndex;
   @Autowired private SecurityConfiguration securityConfiguration;
 
-  @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
+  @Qualifier("tasklistEs8Client")
+  @Autowired
+  private ElasticsearchClient es8Client;
+
+  @Autowired private ElasticsearchTenantHelper tenantHelper;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -73,22 +60,22 @@ public class ProcessStoreElasticSearch implements ProcessStore {
 
   @Override
   public ProcessEntity getProcessByProcessDefinitionKey(final String processDefinitionKey) {
-    final QueryBuilder qb = QueryBuilders.termQuery(ProcessIndex.KEY, processDefinitionKey);
+    final var query = ElasticsearchUtil.termsQuery(ProcessIndex.KEY, processDefinitionKey);
+    final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
 
-    final SearchRequest searchRequest =
-        new SearchRequest(processIndex.getAlias())
-            .source(
-                new SearchSourceBuilder()
-                    .query(qb)
-                    .collapse(new CollapseBuilder(ProcessIndex.KEY))
-                    .sort(SortBuilders.fieldSort(ProcessIndex.VERSION).order(SortOrder.DESC))
-                    .size(1));
+    final var request =
+        new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+            .index(processIndex.getAlias())
+            .query(tenantAwareQuery)
+            .collapse(c -> c.field(ProcessIndex.KEY))
+            .sort(ElasticsearchUtil.sortOrder(ProcessIndex.VERSION, SortOrder.Desc))
+            .size(1)
+            .build();
+
     try {
-      final SearchResponse response = tenantAwareClient.search(searchRequest);
-      if (response.getHits().getTotalHits().value > 0) {
-        final ProcessEntity processEntity =
-            fromSearchHit(response.getHits().getHits()[0].getSourceAsString());
-        return processEntity;
+      final var response = es8Client.search(request, ProcessEntity.class);
+      if (response.hits().total().value() > 0) {
+        return response.hits().hits().get(0).source();
       } else {
         throw new NotFoundException(
             String.format("Process with key %s not found", processDefinitionKey));
@@ -107,31 +94,32 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   @Override
   public ProcessEntity getProcessByBpmnProcessId(
       final String bpmnProcessId, final String tenantId) {
-    final QueryBuilder qb;
+    final Query query;
     if (securityConfiguration.getMultiTenancy().isChecksEnabled()
         && StringUtils.isNotBlank(tenantId)) {
-      qb =
-          ElasticsearchUtil.joinWithAnd(
-              QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, bpmnProcessId),
-              QueryBuilders.termQuery(ProcessIndex.TENANT_ID, tenantId));
+      final var bpmnProcessIdQuery =
+          ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, bpmnProcessId);
+      final var tenantIdQuery = ElasticsearchUtil.termsQuery(ProcessIndex.TENANT_ID, tenantId);
+      query = ElasticsearchUtil.joinWithAnd(bpmnProcessIdQuery, tenantIdQuery);
     } else {
-      qb = QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, bpmnProcessId);
+      query = ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, bpmnProcessId);
     }
 
-    final SearchRequest searchRequest =
-        new SearchRequest(processIndex.getAlias())
-            .source(
-                new SearchSourceBuilder()
-                    .query(qb)
-                    .collapse(new CollapseBuilder(ProcessIndex.BPMN_PROCESS_ID))
-                    .sort(SortBuilders.fieldSort(ProcessIndex.VERSION).order(SortOrder.DESC))
-                    .size(1));
+    final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
+
+    final var request =
+        new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+            .index(processIndex.getAlias())
+            .query(tenantAwareQuery)
+            .collapse(c -> c.field(ProcessIndex.BPMN_PROCESS_ID))
+            .sort(ElasticsearchUtil.sortOrder(ProcessIndex.VERSION, SortOrder.Desc))
+            .size(1)
+            .build();
+
     try {
-      final SearchResponse response = tenantAwareClient.search(searchRequest);
-      if (response.getHits().getTotalHits().value > 0) {
-        final ProcessEntity processEntity =
-            fromSearchHit(response.getHits().getHits()[0].getSourceAsString());
-        return processEntity;
+      final var response = es8Client.search(request, ProcessEntity.class);
+      if (response.hits().total().value() > 0) {
+        return response.hits().hits().get(0).source();
       } else {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", bpmnProcessId));
@@ -145,17 +133,20 @@ public class ProcessStoreElasticSearch implements ProcessStore {
 
   @Override
   public ProcessEntity getProcess(final String processId) {
-    final SearchRequest searchRequest =
-        new SearchRequest(processIndex.getAlias())
-            .source(
-                new SearchSourceBuilder()
-                    .query(QueryBuilders.termQuery(ProcessIndex.KEY, processId)));
+    final var query = ElasticsearchUtil.termsQuery(ProcessIndex.KEY, processId);
+    final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
+
+    final var request =
+        new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+            .index(processIndex.getAlias())
+            .query(tenantAwareQuery)
+            .build();
 
     try {
-      final SearchResponse response = tenantAwareClient.search(searchRequest);
-      if (response.getHits().getTotalHits().value == 1) {
-        return fromSearchHit(response.getHits().getHits()[0].getSourceAsString());
-      } else if (response.getHits().getTotalHits().value > 1) {
+      final var response = es8Client.search(request, ProcessEntity.class);
+      if (response.hits().total().value() == 1) {
+        return response.hits().hits().get(0).source();
+      } else if (response.hits().total().value() > 1) {
         throw new TasklistRuntimeException(
             String.format("Could not find unique process with id '%s'.", processId));
       } else {
@@ -172,36 +163,30 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   @Override
   public List<ProcessEntity> getProcesses(
       final List<String> processDefinitions, final String tenantId, final Boolean isStartedByForm) {
-    final QueryBuilder qb;
-
-    if (securityConfiguration.getAuthorizations().isEnabled()) {
-      if (processDefinitions.isEmpty()) {
-        return new ArrayList<>();
-      }
-
-      if (processDefinitions.contains(IdentityProperties.ALL_RESOURCES)) {
-        qb =
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.existsQuery(ProcessIndex.BPMN_PROCESS_ID))
-                .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
-      } else {
-
-        qb =
-            QueryBuilders.boolQuery()
-                .must(QueryBuilders.termsQuery(ProcessIndex.BPMN_PROCESS_ID, processDefinitions))
-                .must(QueryBuilders.existsQuery(ProcessIndex.BPMN_PROCESS_ID))
-                .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
-      }
-
-    } else {
-      qb =
-          QueryBuilders.boolQuery()
-              .must(QueryBuilders.existsQuery(ProcessIndex.BPMN_PROCESS_ID))
-              .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
+    // Early return if authorization is enabled but no processes are allowed
+    if (securityConfiguration.getAuthorizations().isEnabled() && processDefinitions.isEmpty()) {
+      return new ArrayList<>();
     }
 
-    final QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery, isStartedByForm);
+    // Build base query: field exists AND field is not empty
+    final Query existsQuery = ElasticsearchUtil.existsQuery(ProcessIndex.BPMN_PROCESS_ID);
+    final Query notEmptyQuery =
+        ElasticsearchUtil.mustNotQuery(
+            ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
+
+    // Add process definition filter if needed
+    final Query query;
+    if (securityConfiguration.getAuthorizations().isEnabled()
+        && !processDefinitions.contains(IdentityProperties.ALL_RESOURCES)) {
+      final Query termsQuery =
+          ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, processDefinitions);
+      query = ElasticsearchUtil.joinWithAnd(termsQuery, existsQuery, notEmptyQuery);
+    } else {
+      query = ElasticsearchUtil.joinWithAnd(existsQuery, notEmptyQuery);
+    }
+
+    final Query finalQuery = enhanceQueryByTenantIdCheck(query, tenantId);
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantIdEs8(finalQuery, isStartedByForm);
   }
 
   @Override
@@ -216,170 +201,251 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     }
 
     final String regexSearch = String.format(".*%s.*", search);
-    BoolQueryBuilder qb =
-        QueryBuilders.boolQuery()
-            .should(QueryBuilders.termQuery(ProcessIndex.ID, search))
-            .should(
-                QueryBuilders.regexpQuery(ProcessIndex.NAME, regexSearch)
-                    .caseInsensitive(CASE_INSENSITIVE))
-            .should(
-                QueryBuilders.regexpQuery(ProcessIndex.BPMN_PROCESS_ID, regexSearch)
-                    .caseInsensitive(CASE_INSENSITIVE))
-            .must(QueryBuilders.existsQuery(ProcessIndex.BPMN_PROCESS_ID))
-            .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""))
-            .minimumShouldMatch(1);
+    final Query idQuery = ElasticsearchUtil.termsQuery(ProcessIndex.ID, search);
+    final Query nameRegexpQuery =
+        Query.of(
+            q ->
+                q.regexp(
+                    r ->
+                        r.field(ProcessIndex.NAME)
+                            .value(regexSearch)
+                            .caseInsensitive(CASE_INSENSITIVE)));
+    final Query bpmnProcessIdRegexpQuery =
+        Query.of(
+            q ->
+                q.regexp(
+                    r ->
+                        r.field(ProcessIndex.BPMN_PROCESS_ID)
+                            .value(regexSearch)
+                            .caseInsensitive(CASE_INSENSITIVE)));
+    final Query existsQuery = ElasticsearchUtil.existsQuery(ProcessIndex.BPMN_PROCESS_ID);
+    final Query notEmptyQuery = ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, "");
+
+    Query query =
+        Query.of(
+            q ->
+                q.bool(
+                    b ->
+                        b.should(idQuery)
+                            .should(nameRegexpQuery)
+                            .should(bpmnProcessIdRegexpQuery)
+                            .must(existsQuery)
+                            .mustNot(notEmptyQuery)
+                            .minimumShouldMatch("1")));
 
     if (securityConfiguration.getAuthorizations().isEnabled()) {
       if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }
       if (!processDefinitions.contains(IdentityProperties.ALL_RESOURCES)) {
-        qb = qb.must(QueryBuilders.termsQuery(ProcessIndex.BPMN_PROCESS_ID, processDefinitions));
+        final Query termsQuery =
+            ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, processDefinitions);
+        query = ElasticsearchUtil.joinWithAnd(query, termsQuery);
       }
     }
-    final QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery, isStartedByForm);
+    final Query finalQuery = enhanceQueryByTenantIdCheck(query, tenantId);
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantIdEs8(finalQuery, isStartedByForm);
   }
 
   @Override
   public List<ProcessEntity> getProcessesStartedByForm() {
-    final QueryBuilder qb;
-
-    qb =
-        QueryBuilders.boolQuery()
-            .must(QueryBuilders.existsQuery(ProcessIndex.BPMN_PROCESS_ID))
-            .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
-
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(qb, true);
+    final Query existsQuery = ElasticsearchUtil.existsQuery(ProcessIndex.BPMN_PROCESS_ID);
+    final Query notEmptyQuery =
+        ElasticsearchUtil.mustNotQuery(
+            ElasticsearchUtil.termsQuery(ProcessIndex.BPMN_PROCESS_ID, ""));
+    final Query query = ElasticsearchUtil.joinWithAnd(existsQuery, notEmptyQuery);
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantIdEs8(query, true);
   }
 
-  private ProcessEntity fromSearchHit(final String processString) {
-    return ElasticsearchUtil.fromSearchHit(processString, objectMapper, ProcessEntity.class);
-  }
-
-  private QueryBuilder enhanceQueryByTenantIdCheck(final QueryBuilder qb, final String tenantId) {
+  private Query enhanceQueryByTenantIdCheck(final Query query, final String tenantId) {
     if (securityConfiguration.getMultiTenancy().isChecksEnabled()
         && StringUtils.isNotBlank(tenantId)) {
-      return ElasticsearchUtil.joinWithAnd(
-          QueryBuilders.termQuery(ProcessIndex.TENANT_ID, tenantId), qb);
+      final Query tenantIdQuery = ElasticsearchUtil.termsQuery(ProcessIndex.TENANT_ID, tenantId);
+      return ElasticsearchUtil.joinWithAnd(tenantIdQuery, query);
     }
 
-    return qb;
+    return query;
   }
 
-  public List<ProcessEntity> getProcessEntityUniqueByProcessDefinitionIdAndTenantId(
-      final QueryBuilder qb, final Boolean isStartedByForm) {
+  // ES8 helper methods
 
-    final CompositeAggregationBuilder processDefinitionAndTenantBucket =
-        AggregationBuilders.composite(
-                BPMN_PROCESS_ID_TENANT_ID_AGG_NAME,
-                List.of(
-                    new TermsValuesSourceBuilder(DEFINITION_ID_TERMS_SOURCE_NAME)
-                        .field(ProcessIndex.BPMN_PROCESS_ID),
-                    new TermsValuesSourceBuilder(TENANT_ID_TERMS_SOURCE_NAME)
-                        .field(ProcessIndex.TENANT_ID)))
-            .size(ElasticsearchUtil.QUERY_MAX_SIZE);
-
-    final AggregationBuilder maxVersionDocsAggregate =
-        AggregationBuilders.terms(MAX_VERSION_DOCUMENTS_AGG_NAME)
-            .field(ProcessIndex.VERSION)
-            .order(BucketOrder.key(false))
-            .size(1);
-
-    final AggregationBuilder topHitsAggregate =
-        AggregationBuilders.topHits(TOP_HITS_AGG_NAME)
-            .sort(SortBuilders.fieldSort(ProcessIndex.VERSION).order(SortOrder.DESC))
-            .size(1);
-
-    final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(qb).size(0);
-    if (isStartedByForm == null) {
-      sourceBuilder.aggregation(
-          processDefinitionAndTenantBucket.subAggregation(
-              maxVersionDocsAggregate.subAggregation(topHitsAggregate)));
+  private Aggregation buildStartedByFormFilterAggEs8(
+      final boolean isStartedByForm, final Aggregation topHitsAgg) {
+    if (isStartedByForm) {
+      return Aggregation.of(
+          a ->
+              a.filter(
+                      f ->
+                          f.bool(
+                              b ->
+                                  b.should(ElasticsearchUtil.existsQuery(ProcessIndex.FORM_KEY))
+                                      .should(ElasticsearchUtil.existsQuery(ProcessIndex.FORM_ID))
+                                      .minimumShouldMatch("1")))
+                  .aggregations(TOP_HITS_AGG_NAME, topHitsAgg));
     } else {
-      sourceBuilder.aggregation(
-          processDefinitionAndTenantBucket.subAggregation(
-              maxVersionDocsAggregate.subAggregation(
-                  startedByFormAggregateFilter(isStartedByForm).subAggregation(topHitsAggregate))));
+      return Aggregation.of(
+          a ->
+              a.filter(
+                      f ->
+                          f.bool(
+                              b ->
+                                  b.mustNot(ElasticsearchUtil.existsQuery(ProcessIndex.FORM_KEY))
+                                      .mustNot(ElasticsearchUtil.existsQuery(ProcessIndex.FORM_ID))
+                                      .minimumShouldMatch("1")))
+                  .aggregations(TOP_HITS_AGG_NAME, topHitsAgg));
+    }
+  }
+
+  private List<ProcessEntity> getAggregateSearchHitsEs8(final Aggregate aggregate) {
+    return aggregate.sterms().buckets().array().stream()
+        .flatMap(
+            bpmnProcessIdBucket -> {
+              final Aggregate tenantIdBuckets =
+                  bpmnProcessIdBucket.aggregations().get(TENANT_ID_TERMS_SOURCE_NAME);
+              return tenantIdBuckets.sterms().buckets().array().stream()
+                  .flatMap(
+                      tenantIdBucket -> {
+                        final Aggregate versionBuckets =
+                            tenantIdBucket.aggregations().get(MAX_VERSION_DOCUMENTS_AGG_NAME);
+                        return versionBuckets.lterms().buckets().array().stream()
+                            .flatMap(
+                                versionBucket -> {
+                                  final Aggregate topHitsAgg =
+                                      versionBucket.aggregations().get(TOP_HITS_AGG_NAME);
+                                  return topHitsAgg.topHits().hits().hits().stream()
+                                      .map(hit -> hit.source().to(ProcessEntity.class));
+                                });
+                      });
+            })
+        .toList();
+  }
+
+  private List<ProcessEntity> getFilteredAggregateSearchHitsEs8(final Aggregate aggregate) {
+    return aggregate.sterms().buckets().array().stream()
+        .flatMap(
+            bpmnProcessIdBucket -> {
+              final Aggregate tenantIdBuckets =
+                  bpmnProcessIdBucket.aggregations().get(TENANT_ID_TERMS_SOURCE_NAME);
+              return tenantIdBuckets.sterms().buckets().array().stream()
+                  .flatMap(
+                      tenantIdBucket -> {
+                        final Aggregate versionBuckets =
+                            tenantIdBucket.aggregations().get(MAX_VERSION_DOCUMENTS_AGG_NAME);
+                        return versionBuckets.lterms().buckets().array().stream()
+                            .flatMap(
+                                versionBucket -> {
+                                  final Aggregate filterAgg =
+                                      versionBucket
+                                          .aggregations()
+                                          .get(STARTED_BY_FORM_FILTERED_DOCS);
+                                  final Aggregate topHitsAgg =
+                                      filterAgg.filter().aggregations().get(TOP_HITS_AGG_NAME);
+                                  return topHitsAgg.topHits().hits().hits().stream()
+                                      .map(hit -> hit.source().to(ProcessEntity.class));
+                                });
+                      });
+            })
+        .toList();
+  }
+
+  public List<ProcessEntity> getProcessEntityUniqueByProcessDefinitionIdAndTenantIdEs8(
+      final Query query, final Boolean isStartedByForm) {
+
+    // Build aggregations from innermost to outermost
+    // Level 4: TopHits - get the actual document sorted by version DESC
+    final Aggregation topHitsAgg =
+        Aggregation.of(
+            a ->
+                a.topHits(
+                    th ->
+                        th.sort(ElasticsearchUtil.sortOrder(ProcessIndex.VERSION, SortOrder.Desc))
+                            .size(1)));
+
+    // Level 3: Terms on VERSION field - get max version (size=1, order by key DESC)
+    final Aggregation maxVersionDocsAgg =
+        Aggregation.of(
+            a ->
+                a.terms(
+                    t ->
+                        t.field(ProcessIndex.VERSION)
+                            .size(1)
+                            .order(NamedValue.of("_key", SortOrder.Desc))));
+
+    // Level 2: Terms on TENANT_ID with optional filter for form-started processes
+    final Aggregation tenantIdAgg;
+    if (isStartedByForm != null) {
+      // Add filter aggregation between version terms and topHits
+      final Aggregation filterAgg = buildStartedByFormFilterAggEs8(isStartedByForm, topHitsAgg);
+      final Aggregation maxVersionWithFilter =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(ProcessIndex.VERSION)
+                                  .size(1)
+                                  .order(NamedValue.of("_key", SortOrder.Desc)))
+                      .aggregations(STARTED_BY_FORM_FILTERED_DOCS, filterAgg));
+      tenantIdAgg =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(ProcessIndex.TENANT_ID)
+                                  .size(ElasticsearchUtil.QUERY_MAX_SIZE))
+                      .aggregations(MAX_VERSION_DOCUMENTS_AGG_NAME, maxVersionWithFilter));
+    } else {
+      final Aggregation maxVersionWithTopHits =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(ProcessIndex.VERSION)
+                                  .size(1)
+                                  .order(NamedValue.of("_key", SortOrder.Desc)))
+                      .aggregations(TOP_HITS_AGG_NAME, topHitsAgg));
+      tenantIdAgg =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(ProcessIndex.TENANT_ID)
+                                  .size(ElasticsearchUtil.QUERY_MAX_SIZE))
+                      .aggregations(MAX_VERSION_DOCUMENTS_AGG_NAME, maxVersionWithTopHits));
     }
 
-    final SearchRequest searchRequest =
-        new SearchRequest(processIndex.getAlias()).source(sourceBuilder);
+    // Level 1: Terms on BPMN_PROCESS_ID
+    final Aggregation bpmnProcessIdAgg =
+        Aggregation.of(
+            a ->
+                a.terms(
+                        t ->
+                            t.field(ProcessIndex.BPMN_PROCESS_ID)
+                                .size(ElasticsearchUtil.QUERY_MAX_SIZE))
+                    .aggregations(TENANT_ID_TERMS_SOURCE_NAME, tenantIdAgg));
 
-    final SearchResponse response;
+    final SearchRequest request =
+        new SearchRequest.Builder()
+            .index(processIndex.getAlias())
+            .query(query)
+            .aggregations(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME, bpmnProcessIdAgg)
+            .size(0)
+            .build();
+
     try {
-      response = tenantAwareClient.search(searchRequest);
-      final CompositeAggregation compositeAgg =
-          response.getAggregations().get(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME);
-      final Set<SearchHit> hits =
-          isStartedByForm != null
-              ? getFilteredAggregateSearchHits(compositeAgg)
-              : getAggregateSearchHits(compositeAgg);
-      return hits.stream()
-          .map(
-              hit ->
-                  ElasticsearchUtil.fromSearchHit(
-                      hit.getSourceAsString(), objectMapper, ProcessEntity.class))
-          .toList();
+      final var response = es8Client.search(request, ProcessEntity.class);
+      final Aggregate bpmnProcessIdBuckets =
+          response.aggregations().get(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME);
+
+      if (isStartedByForm != null) {
+        return getFilteredAggregateSearchHitsEs8(bpmnProcessIdBuckets);
+      } else {
+        return getAggregateSearchHitsEs8(bpmnProcessIdBuckets);
+      }
 
     } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
     }
-  }
-
-  private FilterAggregationBuilder startedByFormAggregateFilter(final boolean isStartedByForm) {
-    return isStartedByForm
-        ? AggregationBuilders.filter(
-            STARTED_BY_FORM_FILTERED_DOCS,
-            QueryBuilders.boolQuery()
-                .should(QueryBuilders.existsQuery(ProcessIndex.FORM_KEY))
-                .should(QueryBuilders.existsQuery(ProcessIndex.FORM_ID))
-                .minimumShouldMatch(1))
-        : AggregationBuilders.filter(
-            STARTED_BY_FORM_FILTERED_DOCS,
-            QueryBuilders.boolQuery()
-                .mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_KEY))
-                .mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_ID))
-                .minimumShouldMatch(1));
-  }
-
-  private Set<SearchHit> getFilteredAggregateSearchHits(final CompositeAggregation composite) {
-    return composite.getBuckets().stream()
-        .flatMap(
-            bucket ->
-                ((ParsedTerms) bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
-                    .getBuckets().stream()
-                        .flatMap(
-                            versionBucket -> {
-                              final var startedByFormDocs =
-                                  ((Filter)
-                                          versionBucket
-                                              .getAggregations()
-                                              .get(STARTED_BY_FORM_FILTERED_DOCS))
-                                      .getAggregations();
-                              return Arrays.stream(
-                                  ((TopHits) startedByFormDocs.get(TOP_HITS_AGG_NAME))
-                                      .getHits()
-                                      .getHits());
-                            }))
-        .collect(Collectors.toSet());
-  }
-
-  private Set<SearchHit> getAggregateSearchHits(final CompositeAggregation composite) {
-    return composite.getBuckets().stream()
-        .flatMap(
-            bucket ->
-                ((ParsedTerms) bucket.getAggregations().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
-                    .getBuckets().stream()
-                        .flatMap(
-                            versionBucket ->
-                                Arrays.stream(
-                                    ((TopHits)
-                                            versionBucket.getAggregations().get(TOP_HITS_AGG_NAME))
-                                        .getHits()
-                                        .getHits())))
-        .collect(Collectors.toSet());
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -108,7 +108,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
 
     final var request =
-        new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
+        new SearchRequest.Builder()
             .index(processIndex.getAlias())
             .query(tenantAwareQuery)
             .collapse(c -> c.field(ProcessIndex.BPMN_PROCESS_ID))
@@ -137,10 +137,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     final var tenantAwareQuery = tenantHelper.makeQueryTenantAware(query);
 
     final var request =
-        new co.elastic.clients.elasticsearch.core.SearchRequest.Builder()
-            .index(processIndex.getAlias())
-            .query(tenantAwareQuery)
-            .build();
+        new SearchRequest.Builder().index(processIndex.getAlias()).query(tenantAwareQuery).build();
 
     try {
       final var response = es8Client.search(request, ProcessEntity.class);
@@ -426,7 +423,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     final SearchRequest request =
         new SearchRequest.Builder()
             .index(processIndex.getAlias())
-            .query(query)
+            .query(tenantHelper.makeQueryTenantAware(query))
             .aggregations(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME, bpmnProcessIdAgg)
             .size(0)
             .build();

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -398,7 +398,7 @@
      classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
           </usedDependencies>
-          <ignoredUnusedDeclaredDependencies combine.children="append">
+          <ignoredUnusedDeclaredDependencies>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
             <dep>jakarta.annotation:jakarta.annotation-api</dep>
             <dep>org.springframework:spring-aspects</dep>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -239,12 +239,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
@@ -404,7 +398,7 @@
      classes on the classpath to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>
           </usedDependencies>
-          <ignoredUnusedDeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies combine.children="append">
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
             <dep>jakarta.annotation:jakarta.annotation-api</dep>
             <dep>org.springframework:spring-aspects</dep>

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -196,7 +196,6 @@ class ProcessStoreElasticSearchTest {
     when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
         .thenReturn(searchResponse);
 
-    // Level 1: bpmnProcessId_tenantId_buckets -> sterms() with empty buckets
     final var bpmnProcessIdTermsAggregate =
         mock(co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate.class);
     final var aggregate = mock(Aggregate.class);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -16,6 +16,19 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Buckets;
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.TopHitsAggregate;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.TotalHits;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -28,8 +41,7 @@ import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.store.elasticsearch.ProcessStoreElasticSearch;
-import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
-import io.camunda.tasklist.util.ElasticsearchUtil;
+import io.camunda.tasklist.util.ElasticsearchTenantHelper;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.webapp.permission.TasklistPermissionServices;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
@@ -37,15 +49,7 @@ import io.camunda.webapps.schema.entities.ProcessEntity;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import org.apache.lucene.search.TotalHits;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,7 +66,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ProcessStoreElasticSearchTest {
   @Mock private ProcessIndex processIndex;
-  @Mock private TenantAwareElasticsearchClient tenantAwareClient;
+  @Mock private ElasticsearchClient es8Client;
+  @Mock private ElasticsearchTenantHelper tenantHelper;
   @InjectMocks private ProcessStoreElasticSearch processStore;
   @Mock private ObjectMapper objectMapper;
   @InjectMocks private SpringContextHolder springContextHolder;
@@ -80,6 +85,7 @@ class ProcessStoreElasticSearchTest {
         permissionServices, "authenticationProvider", authenticationProvider);
     ReflectionTestUtils.setField(
         permissionServices, "resourceAccessProvider", resourceAccessProvider);
+    when(tenantHelper.makeQueryTenantAware(any(Query.class))).thenAnswer(i -> i.getArgument(0));
   }
 
   // ** Test Get Process by BPMN Process Id ** //
@@ -110,7 +116,8 @@ class ProcessStoreElasticSearchTest {
   public void shouldReturnIOExceptionForGetProcessByBpmnId() throws IOException {
     // given
     final IOException mockedException = new IOException("IO Exception during search");
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenThrow(mockedException);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
+        .thenThrow(mockedException);
     when(processIndex.getAlias()).thenReturn("alias");
 
     // when
@@ -159,7 +166,7 @@ class ProcessStoreElasticSearchTest {
     final String errorMessage = "IOException error message";
     final IOException exception = new IOException(errorMessage);
 
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenThrow(exception);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class))).thenThrow(exception);
     when(processIndex.getAlias()).thenReturn("index_alias");
 
     // given and then
@@ -172,6 +179,7 @@ class ProcessStoreElasticSearchTest {
 
   // ** Test get processes && And get processes with search condition ** //
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldNotReturnProcessesWhenResourceAuthIsEnabledButNoAuthorization()
       throws IOException {
     // when
@@ -183,13 +191,23 @@ class ProcessStoreElasticSearchTest {
     when(identityProperties.baseUrl()).thenReturn("baseUrl");
     mockAuthenticationOverIdentity(false);
     when(processIndex.getAlias()).thenReturn("index_alias");
-    final SearchResponse searchResponse = mock(SearchResponse.class);
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenReturn(searchResponse);
-    final var aggregations = mock(Aggregations.class);
-    when(searchResponse.getAggregations()).thenReturn(aggregations);
-    final var compositeAggregation = mock(CompositeAggregation.class);
-    when(aggregations.get("bpmnProcessId_tenantId_buckets")).thenReturn(compositeAggregation);
-    when(compositeAggregation.getBuckets()).thenReturn(Collections.emptyList());
+
+    final SearchResponse<ProcessEntity> searchResponse = mock(SearchResponse.class);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
+        .thenReturn(searchResponse);
+
+    // Level 1: bpmnProcessId_tenantId_buckets -> sterms() with empty buckets
+    final var bpmnProcessIdTermsAggregate =
+        mock(co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate.class);
+    final var aggregate = mock(Aggregate.class);
+    when(aggregate.sterms()).thenReturn(bpmnProcessIdTermsAggregate);
+    when(searchResponse.aggregations())
+        .thenReturn(Map.of("bpmnProcessId_tenantId_buckets", aggregate));
+
+    final Buckets<StringTermsBucket> buckets = mock(Buckets.class);
+    when(bpmnProcessIdTermsAggregate.buckets()).thenReturn(buckets);
+    when(buckets.array()).thenReturn(Collections.emptyList());
+
     final List<String> authorizations =
         permissionServices.getProcessDefinitionsWithCreateProcessInstancePermission();
 
@@ -205,6 +223,7 @@ class ProcessStoreElasticSearchTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnProcessesWhenResourceAuthIsEnabledWithAuthorization() throws Exception {
     // when
     when(securityConfiguration.getAuthorizations())
@@ -226,6 +245,7 @@ class ProcessStoreElasticSearchTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnProcessesWhenResourceAuthorizationIsFalse() throws Exception {
     // when
     when(securityConfiguration.getAuthorizations())
@@ -268,64 +288,105 @@ class ProcessStoreElasticSearchTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private void mockElasticSearchSuccess() throws IOException {
-    final SearchResponse searchResponse = mock(SearchResponse.class);
-    final SearchHits searchHits = mock(SearchHits.class);
+    final SearchResponse<ProcessEntity> searchResponse = mock(SearchResponse.class);
+    final HitsMetadata<ProcessEntity> hitsMetadata = mock(HitsMetadata.class);
     final ProcessEntity processEntityMock = mock(ProcessEntity.class);
-    final TotalHits totalHits = new TotalHits(1L, TotalHits.Relation.EQUAL_TO);
-    final String jsonString = "any-json-string";
+    final TotalHits totalHits = mock(TotalHits.class);
 
-    when(searchHits.getTotalHits()).thenReturn(totalHits);
-    when(searchHits.getHits()).thenReturn(new SearchHit[] {mock(SearchHit.class)});
-    when(searchHits.getHits()[0].getSourceAsString()).thenReturn(jsonString);
-    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(totalHits.value()).thenReturn(1L);
+    when(totalHits.relation()).thenReturn(TotalHitsRelation.Eq);
+    when(hitsMetadata.total()).thenReturn(totalHits);
+
+    final Hit<ProcessEntity> hit = mock(Hit.class);
+    when(hit.source()).thenReturn(processEntityMock);
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(searchResponse.hits()).thenReturn(hitsMetadata);
     when(processEntityMock.getId()).thenReturn("1");
-    when(ElasticsearchUtil.fromSearchHit(jsonString, objectMapper, ProcessEntity.class))
-        .thenReturn(processEntityMock);
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenReturn(searchResponse);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
+        .thenReturn(searchResponse);
     when(processIndex.getAlias()).thenReturn("index_alias");
   }
 
+  @SuppressWarnings("unchecked")
   private void mockElasticSearchSuccessWithAggregatedResponse() throws IOException {
-    final var mockedSearchResponse = mock(SearchResponse.class);
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenReturn(mockedSearchResponse);
+    final SearchResponse<ProcessEntity> mockedSearchResponse = mock(SearchResponse.class);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
+        .thenReturn(mockedSearchResponse);
     when(processIndex.getAlias()).thenReturn("index_alias");
 
-    final var aggregations = mock(Aggregations.class);
-    when(mockedSearchResponse.getAggregations()).thenReturn(aggregations);
-    final var compositeAggregation = mock(CompositeAggregation.class);
-    when(aggregations.get("bpmnProcessId_tenantId_buckets")).thenReturn(compositeAggregation);
-    final var bucket = mock(CompositeAggregation.Bucket.class);
-    when((List<CompositeAggregation.Bucket>) compositeAggregation.getBuckets())
-        .thenReturn(List.of(bucket));
-    when(bucket.getAggregations()).thenReturn(aggregations);
-    final var termsBucket = mock(ParsedTerms.ParsedBucket.class);
-    final var maxVersionTerms = mock(ParsedTerms.class);
-    when((List<ParsedTerms.ParsedBucket>) maxVersionTerms.getBuckets())
-        .thenReturn(List.of(termsBucket));
-    when(aggregations.get("max_version_docs")).thenReturn(maxVersionTerms);
-    final var versionBucket = mock(ParsedTerms.ParsedBucket.class);
-    when((List<ParsedTerms.ParsedBucket>) maxVersionTerms.getBuckets())
-        .thenReturn(List.of(versionBucket));
-    when(versionBucket.getAggregations()).thenReturn(aggregations);
-    final var topHits = mock(TopHits.class);
-    when(aggregations.get("top_hit_doc")).thenReturn(topHits);
-    final var searchHits = mock(SearchHits.class);
-    when(topHits.getHits()).thenReturn(searchHits);
-    final var searchHit = mock(SearchHit.class);
-    when(searchHits.getHits()).thenReturn(new SearchHit[] {searchHit});
-    when(searchHit.getSourceAsString()).thenReturn("");
+    // Level 1: bpmnProcessId_tenantId_buckets -> sterms()
+    final var bpmnProcessIdTermsAggregate =
+        mock(co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate.class);
+    final var bpmnProcessIdAggregate = mock(Aggregate.class);
+    when(bpmnProcessIdAggregate.sterms()).thenReturn(bpmnProcessIdTermsAggregate);
+    when(mockedSearchResponse.aggregations())
+        .thenReturn(Map.of("bpmnProcessId_tenantId_buckets", bpmnProcessIdAggregate));
+
+    final Buckets<StringTermsBucket> bpmnProcessIdBuckets = mock(Buckets.class);
+    when(bpmnProcessIdTermsAggregate.buckets()).thenReturn(bpmnProcessIdBuckets);
+
+    final StringTermsBucket bpmnProcessIdBucket = mock(StringTermsBucket.class);
+    when(bpmnProcessIdBuckets.array()).thenReturn(List.of(bpmnProcessIdBucket));
+
+    // Level 2: group_by_tenant_id -> sterms()
+    final var tenantIdTermsAggregate =
+        mock(co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate.class);
+    final var tenantIdAggregate = mock(Aggregate.class);
+    when(tenantIdAggregate.sterms()).thenReturn(tenantIdTermsAggregate);
+    when(bpmnProcessIdBucket.aggregations())
+        .thenReturn(Map.of("group_by_tenant_id", tenantIdAggregate));
+
+    final Buckets<StringTermsBucket> tenantIdBuckets = mock(Buckets.class);
+    when(tenantIdTermsAggregate.buckets()).thenReturn(tenantIdBuckets);
+
+    final StringTermsBucket tenantIdBucket = mock(StringTermsBucket.class);
+    when(tenantIdBuckets.array()).thenReturn(List.of(tenantIdBucket));
+
+    // Level 3: max_version_docs -> lterms()
+    final var maxVersionTermsAggregate =
+        mock(co.elastic.clients.elasticsearch._types.aggregations.LongTermsAggregate.class);
+    final var maxVersionAggregate = mock(Aggregate.class);
+    when(maxVersionAggregate.lterms()).thenReturn(maxVersionTermsAggregate);
+    when(tenantIdBucket.aggregations()).thenReturn(Map.of("max_version_docs", maxVersionAggregate));
+
+    final Buckets<LongTermsBucket> maxVersionBuckets = mock(Buckets.class);
+    when(maxVersionTermsAggregate.buckets()).thenReturn(maxVersionBuckets);
+
+    final LongTermsBucket versionBucket = mock(LongTermsBucket.class);
+    when(maxVersionBuckets.array()).thenReturn(List.of(versionBucket));
+
+    // Level 4: top_hit_doc -> topHits()
+    final TopHitsAggregate topHitsAggregate = mock(TopHitsAggregate.class);
+    final var topHitsAgg = mock(Aggregate.class);
+    when(topHitsAgg.topHits()).thenReturn(topHitsAggregate);
+    when(versionBucket.aggregations()).thenReturn(Map.of("top_hit_doc", topHitsAgg));
+
+    final HitsMetadata<co.elastic.clients.json.JsonData> topHitsMetadata = mock(HitsMetadata.class);
+    when(topHitsAggregate.hits()).thenReturn(topHitsMetadata);
+
+    final Hit<co.elastic.clients.json.JsonData> topHit = mock(Hit.class);
+    when(topHitsMetadata.hits()).thenReturn(List.of(topHit));
+
+    final co.elastic.clients.json.JsonData jsonData = mock(co.elastic.clients.json.JsonData.class);
+    when(topHit.source()).thenReturn(jsonData);
+    when(jsonData.to(ProcessEntity.class)).thenReturn(new ProcessEntity());
   }
 
+  @SuppressWarnings("unchecked")
   private void mockElasticSearchNotFound() throws IOException {
-    final SearchResponse searchResponse = mock(SearchResponse.class);
-    final SearchHits searchHits = mock(SearchHits.class);
-    final TotalHits totalHits = new TotalHits(0L, TotalHits.Relation.EQUAL_TO);
+    final SearchResponse<ProcessEntity> searchResponse = mock(SearchResponse.class);
+    final HitsMetadata<ProcessEntity> hitsMetadata = mock(HitsMetadata.class);
+    final TotalHits totalHits = mock(TotalHits.class);
 
-    when(searchResponse.getHits()).thenReturn(searchHits);
-    when(searchHits.getTotalHits()).thenReturn(totalHits);
-    when(searchHits.getHits()).thenReturn(new SearchHit[] {mock(SearchHit.class)});
-    when(tenantAwareClient.search(any(SearchRequest.class))).thenReturn(searchResponse);
+    when(totalHits.value()).thenReturn(0L);
+    when(totalHits.relation()).thenReturn(TotalHitsRelation.Eq);
+    when(hitsMetadata.total()).thenReturn(totalHits);
+    when(hitsMetadata.hits()).thenReturn(Collections.emptyList());
+    when(searchResponse.hits()).thenReturn(hitsMetadata);
+    when(es8Client.search(any(SearchRequest.class), eq(ProcessEntity.class)))
+        .thenReturn(searchResponse);
     when(processIndex.getAlias()).thenReturn("index_alias");
   }
 }


### PR DESCRIPTION
## Description

convert ES task store to java client.

- there is a shared initial commit [feat: dependencies and helper functions](https://github.com/camunda/camunda/commit/dd597f97c7da203250c40bbb57ffc9339882fe06) between all the tasklist store java client upgrade branches fyi so delta is a lot smaller.

- The reason indent output is removed is it actually breaks bulk update requests due to how it serialises the bulk request.

