### PR TITLE
draft variables store elasticsearch java client upgrade

### DIFF
--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -103,11 +103,6 @@
       <artifactId>elasticsearch-java</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-    </dependency>
-
     <!-- OPENSEARCH -->
 
     <dependency>
@@ -144,6 +139,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
     </dependency>
 
     <dependency>
@@ -197,6 +197,11 @@
           <ignoredUnusedDeclaredDependencies combine.children="append">
             <dep>org.junit.platform:junit-platform-suite</dep>
             <dep>org.junit.platform:junit-platform-suite-engine</dep>
+            <dep>io.camunda:zeebe-build-tools</dep>
+            <dep>org.apache.logging.log4j:log4j-core</dep>
+            <dep>org.apache.logging.log4j:log4j-slf4j2-impl</dep>
+            <dep>org.apache.lucene:lucene-core</dep>
+            <dep>org.elasticsearch:elasticsearch-x-content</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description

convert ES draft variable store to java client.

- there is a shared initial commit [feat: dependencies and helper functions](https://github.com/camunda/camunda/commit/dd597f97c7da203250c40bbb57ffc9339882fe06) between all the tasklist store java client upgrade branches fyi so delta is a lot smaller.

- The reason indent output is removed is it actually breaks bulk update requests due to how it serialises the bulk request.
