### PR TITLE
Fix audit log variable entity key

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ListViewReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ListViewReaderIT.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import io.camunda.operate.util.TestUtil;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.webapp.reader.ListViewReader;
 import io.camunda.operate.webapp.rest.dto.SortingDto;
@@ -75,8 +76,7 @@ public class ListViewReaderIT extends OperateSearchAbstractIT {
             .setVarName("p1v1")
             .setVarValue("Y")
             .setTenantId("tenant1")
-            .setId(
-                VariableForListViewEntity.getIdBy(activeProcess.getProcessInstanceKey(), "p1v1"));
+            .setId(TestUtil.getVariableId(activeProcess.getProcessInstanceKey(), "p1v1"));
 
     variableEntity.getJoinRelation().setParent(activeProcess.getProcessInstanceKey());
     testSearchRepository.createOrUpdateDocumentFromObject(

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
@@ -404,6 +404,21 @@ public abstract class TestUtil {
     return result;
   }
 
+  /**
+   * Generates a unique ID for a variable based on its scope key and name.
+   *
+   * <p>The format is: {@code <scopeKey>-<name>}
+   *
+   * @param scopeKey the scope key of the variable
+   * @param name the name of the variable
+   * @return the unique ID in the format "{scopeKey}-{name}"
+   * @see io.camunda.zeebe.protocol.record.value.VariableRecordValue#getFullyQualifiedName() for a
+   *     convenience method on record values
+   */
+  public static String getVariableId(final long scopeKey, final String name) {
+    return scopeKey + "-" + name;
+  }
+
   public static VariableForListViewEntity createVariableForListView(final Long processInstanceKey) {
     final String name = UUID.randomUUID().toString();
     final String value = UUID.randomUUID().toString();
@@ -413,7 +428,7 @@ public abstract class TestUtil {
   public static VariableForListViewEntity createVariableForListView(
       final Long processInstanceKey, final Long scopeKey, final String name, final String value) {
     final VariableForListViewEntity variable = new VariableForListViewEntity();
-    variable.setId(VariableForListViewEntity.getIdBy(scopeKey, name));
+    variable.setId(getVariableId(scopeKey, name));
     variable.setProcessInstanceKey(processInstanceKey);
     variable.setScopeKey(scopeKey);
     variable.setVarName(name);
@@ -435,7 +450,7 @@ public abstract class TestUtil {
       final String name,
       final String value) {
     final VariableEntity variable = new VariableEntity();
-    variable.setId(scopeKey + "-" + name);
+    variable.setId(getVariableId(scopeKey, name));
     variable.setProcessInstanceKey(processInstanceKey);
     variable.setProcessDefinitionKey(processDefinitionKey);
     variable.setBpmnProcessId(bpmnProcessId);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/VariableForListViewEntity.java
@@ -38,10 +38,6 @@ public class VariableForListViewEntity
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long rootProcessInstanceKey;
 
-  public static String getIdBy(final long scopeKey, final String name) {
-    return String.format("%d-%s", scopeKey, name);
-  }
-
   @Override
   public String getId() {
     return id;

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -22,7 +22,8 @@ public class VariableAddUpdateAuditLogTransformer
   @Override
   public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setProcessInstanceKey(value.getProcessInstanceKey())
+    log.setEntityKey(value.getFullyQualifiedName())
+        .setProcessInstanceKey(value.getProcessInstanceKey())
         .setProcessDefinitionId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setElementInstanceKey(value.getScopeKey());

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
@@ -31,6 +31,7 @@ class VariableAddUpdateAuditLogTransformerTest {
     final VariableRecordValue recordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
+            .withName("myVariable")
             .withProcessDefinitionKey(456L)
             .withBpmnProcessId("bpmn-process-id")
             .withTenantId("tenant-1")
@@ -47,6 +48,7 @@ class VariableAddUpdateAuditLogTransformerTest {
     transformer.transform(record, entity);
 
     // then
+    assertThat(entity.getEntityKey()).isEqualTo("789-myVariable");
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(456L);
     assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmn-process-id");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -56,9 +56,7 @@ public class ListViewVariableFromVariableHandler
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
-    final var recordValue = record.getValue();
-    return List.of(
-        VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()));
+    return List.of(record.getValue().getFullyQualifiedName());
   }
 
   @Override
@@ -71,7 +69,7 @@ public class ListViewVariableFromVariableHandler
       final Record<VariableRecordValue> record, final VariableForListViewEntity entity) {
     final var recordValue = record.getValue();
     entity
-        .setId(VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()))
+        .setId(recordValue.getFullyQualifiedName())
         .setKey(record.getKey())
         .setPartitionId(record.getPartitionId())
         .setPosition(record.getPosition())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
-import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -44,9 +43,7 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
-    final var recordValue = record.getValue();
-    return List.of(
-        VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()));
+    return List.of(record.getValue().getFullyQualifiedName());
   }
 
   @Override
@@ -59,7 +56,7 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
     final var recordValue = record.getValue();
 
     entity
-        .setId(VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()))
+        .setId(recordValue.getFullyQualifiedName())
         .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setPosition(record.getPosition())
         .setBpmnProcessId(recordValue.getBpmnProcessId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -30,7 +30,6 @@ public class UserTaskVariableHandler
 
   private static final Logger LOG = LoggerFactory.getLogger(UserTaskVariableHandler.class);
 
-  private static final String ID_PATTERN = "%s-%s";
   protected final int variableSizeThreshold;
   private final String indexName;
 
@@ -56,8 +55,7 @@ public class UserTaskVariableHandler
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
-    return List.of(
-        ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName()));
+    return List.of(record.getValue().getFullyQualifiedName());
   }
 
   @Override
@@ -70,8 +68,7 @@ public class UserTaskVariableHandler
       final Record<VariableRecordValue> record, final UserTaskVariableBatch batchEntity) {
 
     final var processVariable = createVariableFromRecord(record);
-    processVariable.setId(
-        ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName()));
+    processVariable.setId(record.getValue().getFullyQualifiedName());
 
     final TaskJoinRelationship joinRelationship = new TaskJoinRelationship();
     joinRelationship.setParent(processVariable.getProcessInstanceId());
@@ -82,8 +79,7 @@ public class UserTaskVariableHandler
     if (record.getValue().getProcessInstanceKey() != record.getValue().getScopeKey()) {
       final TaskVariableEntity taskVariable = createVariableFromRecord(record);
       taskVariable.setId(
-          ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName())
-              + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
+          record.getValue().getFullyQualifiedName() + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
 
       final TaskJoinRelationship localTaskJoinRelationship = new TaskJoinRelationship();
       localTaskJoinRelationship.setParent(taskVariable.getScopeKey());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -11,7 +11,6 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.VariableEntity;
-import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -45,9 +44,7 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
-    final var recordValue = record.getValue();
-    return List.of(
-        VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()));
+    return List.of(record.getValue().getFullyQualifiedName());
   }
 
   @Override
@@ -60,7 +57,7 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
     final var recordValue = record.getValue();
 
     entity
-        .setId(VariableForListViewEntity.getIdBy(recordValue.getScopeKey(), recordValue.getName()))
+        .setId(recordValue.getFullyQualifiedName())
         .setKey(record.getKey())
         .setPartitionId(record.getPartitionId())
         .setScopeKey(recordValue.getScopeKey())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -80,9 +80,7 @@ public class ListViewVariableFromVariableHandlerTest {
     // given
     final Record<VariableRecordValue> variableRecord =
         factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED));
-    final String expectedId =
-        VariableForListViewEntity.getIdBy(
-            variableRecord.getValue().getScopeKey(), variableRecord.getValue().getName());
+    final String expectedId = variableRecord.getValue().getFullyQualifiedName();
 
     // when
     final var idList = underTest.generateIds(variableRecord);
@@ -140,10 +138,7 @@ public class ListViewVariableFromVariableHandlerTest {
     underTest.updateEntity(variableRecord, entity);
 
     // then
-    assertThat(entity.getId())
-        .isEqualTo(
-            VariableForListViewEntity.getIdBy(
-                variableRecord.getValue().getScopeKey(), variableRecord.getValue().getName()));
+    assertThat(entity.getId()).isEqualTo(variableRecord.getValue().getFullyQualifiedName());
     assertThat(entity.getKey()).isEqualTo(variableRecord.getKey());
     assertThat(entity.getPartitionId()).isEqualTo(variableRecord.getPartitionId());
     assertThat(entity.getScopeKey()).isEqualTo(variableRecord.getValue().getScopeKey());

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -69,4 +69,19 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
    * @return the key of the root process instance, or {@code -1} if not set
    */
   long getRootProcessInstanceKey();
+
+  /**
+   * Returns the fully qualified name of the variable, which is a combination of the scope key and
+   * the variable name. This unique identifier can be used to distinguish variables with the same
+   * name that exist in different scopes.
+   *
+   * <p>The format is: {@code <scopeKey>-<name>}
+   *
+   * <p>Example: For a variable named "amount" in scope 12345, this returns "12345-amount".
+   *
+   * @return the fully qualified name in the format "{scopeKey}-{name}"
+   */
+  default String getFullyQualifiedName() {
+    return getScopeKey() + "-" + getName();
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -81,6 +82,7 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
    *
    * @return the fully qualified name in the format "{scopeKey}-{name}"
    */
+  @JsonIgnore
   default String getFullyQualifiedName() {
     return getScopeKey() + "-" + getName();
   }


### PR DESCRIPTION
## Description

1. feat: Use fully qualified name for variables audit log entity key (scopeKey + variableName)
2. refactor: adjust other code to use new getFullyQualifiedName method (consistent, unified concept)