### PR TITLE
fix: success status instead of failure on print info

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -126,7 +126,7 @@ func usage(exitcode int) {
 
 func getBaseCommand() (string, error) {
 	if len(os.Args) == 1 {
-		usage(1)
+		usage(0)
 	}
 
 	switch os.Args[1] {


### PR DESCRIPTION
Typical CLIs consider “no arguments” a valid way to see command overview, so I switched it to usage(0). The only behavior
  difference is the exit status: it now signals success (0) instead of failure (1), aligning with standard CLI expectations and keeping the printed
  output identical.
closes #34456
