### PR TITLE
feat(qa): enable parallel test execution for acceptance tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -36,10 +36,13 @@ import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class AuditLogAuthorizationsIT {
   protected static final boolean USE_REST_API = true;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -39,6 +39,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Acceptance tests for audit log entries related to process operations. This test class verifies
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  */
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class AuditLogProcessOperationsIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -57,6 +57,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -79,6 +81,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @Testcontainers
 @ZeebeIntegration
+@Execution(ExecutionMode.SAME_THREAD)
 public class BackupRestoreIT {
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreIT.class);
   private static final String REPOSITORY_NAME = "test-repository";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchIT.java
@@ -19,9 +19,12 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class CreateDocumentBatchIT {
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CreateDocumentIT.java
@@ -22,9 +22,12 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class CreateDocumentIT {
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchIT.java
@@ -35,11 +35,14 @@ import java.util.random.RandomGenerator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ElementInstanceSearchIT {
 
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByDefinitionIT.java
@@ -38,9 +38,12 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+@Execution(ExecutionMode.SAME_THREAD)
 public class IncidentProcessInstanceStatisticsByDefinitionIT {
 
   private static final String PASSWORD = "password";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentProcessInstanceStatisticsByErrorIT.java
@@ -39,8 +39,11 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class IncidentProcessInstanceStatisticsByErrorIT {
 
   private static final String PASSWORD = "password";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionInstanceStatisticsIT.java
@@ -36,9 +36,12 @@ import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest(enableMultiTenancy = true, enableAuthorization = true)
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessDefinitionInstanceStatisticsIT {
 
   private static final String TENANT_ID_1 = "tenant1";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
@@ -32,12 +32,15 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessDefinitionSearchIT {
   private static final String PROCESS_ID_WITH_START_FORM = "Process_11hxie4";
   private static final String FORM_ID = "test";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
@@ -43,9 +43,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessDefinitionStatisticsIT {
 
   public static final String INCIDENT_ERROR_MESSAGE_V1 =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -43,9 +43,12 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceSearchIT {
 
   public static final String INCIDENT_ERROR_MESSAGE_V1 =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchWithTagsIT.java
@@ -23,9 +23,12 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceSearchWithTagsIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSequenceFlowsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSequenceFlowsIT.java
@@ -25,9 +25,12 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceSequenceFlowsIT {
 
   public static final List<String> RESOURCES =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
@@ -24,9 +24,12 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @CompatibilityTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceStatisticsIT {
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
@@ -38,8 +38,11 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ClusterPurgeMultiDbIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -54,6 +54,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -69,6 +71,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 
 @Testcontainers
 @ZeebeIntegration
+@Execution(ExecutionMode.SAME_THREAD)
 public class DynamicNodeIdIT {
   @Container
   private static final LocalStackContainer S3 =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/HealthCheckIT.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
@@ -42,6 +44,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 @Testcontainers
 @ZeebeIntegration
+@Execution(ExecutionMode.SAME_THREAD)
 public class HealthCheckIT {
 
   @Container

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/usagemetrics/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/usagemetrics/UsageMetricsIT.java
@@ -35,6 +35,8 @@ import java.util.stream.Stream;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
@@ -43,6 +45,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /** Usage metrics integration test for both Elasticsearch and OpenSearch. */
 @Testcontainers
 @ZeebeIntegration
+@Execution(ExecutionMode.SAME_THREAD)
 public class UsageMetricsIT {
 
   private static final String REPOSITORY_NAME = "um-test-repository";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -24,8 +24,11 @@ import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @HistoryMultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class HistoryCleanupIT {
 
   static final String RESOURCE_NAME = "process/process_with_assigned_user_task.bpmn";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryAuthorizationIT.java
@@ -38,9 +38,12 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class DeleteProcessInstanceHistoryAuthorizationIT {
 
   public static final String PROCESS_ID = "testProcess";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -20,7 +20,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.SAME_THREAD)
 public class McpServerConfigurationIT {
 
   @Nested

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AdHocSubprocessMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AdHocSubprocessMigrationIT.java
@@ -29,12 +29,15 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Acceptance tests for process instance migration with Ad Hoc Subprocess functionality. These tests
  * verify end-to-end migration scenarios involving ad hoc subprocesses.
  */
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class AdHocSubprocessMigrationIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
@@ -29,8 +29,11 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class IncidentIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ProcessMigrationIT.java
@@ -34,8 +34,11 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessMigrationIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
@@ -19,8 +19,11 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class VariableIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
@@ -48,6 +50,7 @@ import org.springframework.test.context.TestPropertySource;
 @AutoConfigurationPackage
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
+@Execution(ExecutionMode.SAME_THREAD)
 public class HistoryCleanupIT {
 
   private static final List<String> PROCESS_RELATED_TABLE_NAMES =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -26,9 +26,12 @@ import io.camunda.search.sort.AuditLogSort;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class AuditLogIT {
 
   public static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/correlatedmessagesubscription/CorrelatedMessageSubscriptionIT.java
@@ -28,9 +28,12 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class CorrelatedMessageSubscriptionIT {
 
   public static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -29,9 +29,12 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class DecisionInstanceSortIT {
 
   public static final Long PARTITION_ID = 0L;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -30,6 +30,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,7 @@ import org.springframework.test.context.TestPropertySource;
 @AutoConfigurationPackage
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
+@Execution(ExecutionMode.SAME_THREAD)
 public class DecisionInstanceSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSortIT.java
@@ -28,9 +28,12 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class ElementInstanceSortIT {
 
   public static final Long PARTITION_ID = 0L;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/elementinstance/ElementInstanceSpecificFilterIT.java
@@ -27,6 +27,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,7 @@ import org.springframework.test.context.TestPropertySource;
 @AutoConfigurationPackage
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
+@Execution(ExecutionMode.SAME_THREAD)
 public class ElementInstanceSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -43,9 +43,12 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class IncidentIT {
 
   public static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -32,9 +32,12 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class JobIT {
 
   public static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,7 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.data.secondary-storage.type=rdbms",
       "logging.level.io.camunda.db.rdbms=DEBUG"
     })
+@Execution(ExecutionMode.SAME_THREAD)
 public class MessageSubscriptionSpecificFilterIT {
   private static final Long MESSAGE_SUBSCRIPTION_KEY = CommonFixtures.nextKey();
   private static final String MESSAGE_NAME = "messageName";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -34,9 +34,12 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceIT {
 
   public static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -48,6 +50,7 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.data.secondary-storage.type=rdbms",
       "logging.level.io.camunda.db.rdbms.sql=DEBUG"
     })
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -42,6 +42,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -61,6 +63,7 @@ import org.springframework.test.context.TestPropertySource;
       "camunda.data.secondary-storage.type=rdbms",
       "logging.level.io.camunda.db.rdbms=TRACE"
     })
+@Execution(ExecutionMode.SAME_THREAD)
 public class RoleSpecificFilterIT {
   public static final String ROLE_ID = "roleId";
   public static final String ROLE_DESCRIPTION = "roleDescription";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,7 @@ import org.springframework.test.context.TestPropertySource;
 @AutoConfigurationPackage
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
+@Execution(ExecutionMode.SAME_THREAD)
 public class TenantSpecificFilterIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskTagIT.java
@@ -21,9 +21,12 @@ import java.util.Set;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class UserTaskTagIT {
 
   private static final int PARTITION_ID = 0;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
@@ -27,9 +27,12 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 public class VariableSortIT {
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -29,8 +29,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
+@Execution(ExecutionMode.SAME_THREAD)
 public class UserTaskIT {
 
   private static CamundaClient client;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUserTaskAuthorizationIT.java
@@ -30,10 +30,13 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class CompatibilityTasklistUserTaskAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
@@ -34,10 +34,13 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/form/TasklistV1ApiFormPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/form/TasklistV1ApiFormPermissionsIT.java
@@ -36,11 +36,14 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.http.HttpStatus;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class TasklistV1ApiFormPermissionsIT {
   @MultiDbTestApplication
   static final TestCamundaApplication STANDALONE_CAMUNDA =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -26,9 +26,12 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessDefinitionTenancyIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -26,9 +26,12 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class ProcessInstanceTenancyIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
@@ -25,9 +25,12 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Execution(ExecutionMode.SAME_THREAD)
 public class SequenceFlowTenancyIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/resources/junit-platform.properties
+++ b/qa/acceptance-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+# Enable parallel test execution for faster CI runs
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4


### PR DESCRIPTION
Enable JUnit 5 parallel test execution to speed up CI runs.

- Add junit-platform.properties with parallel execution config
- Add @Execution(SAME_THREAD) to 50 test classes with shared mutable state
- Remaining ~194 tests can run in parallel

Expected improvement: ~30-40% reduction in test execution time

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
