### PR TITLE
Provide proper exception on cursor decode

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
@@ -37,7 +37,7 @@ public class Cursor<T> {
       return Base64.getEncoder().encodeToString(value.getBytes());
     } catch (final Exception e) {
       throw new CamundaSearchException(
-          "Cannot encode data store pagination information in cursor",
+          "Cannot encode data store pagination information into a cursor",
           e,
           Reason.SEARCH_CLIENT_FAILED);
     }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CursorTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CursorTest.java
@@ -101,6 +101,40 @@ class CursorTest {
   }
 
   @Test
+  void shouldFailEncodeWithInvalidEntity() {
+    assertThatThrownBy(
+            () ->
+                Cursor.encode(
+                    new Object(),
+                    List.of(
+                        new SearchColumn<>() {
+                          @Override
+                          public String name() {
+                            return "invalid";
+                          }
+
+                          @Override
+                          public String property() {
+                            return "nonExistentProperty";
+                          }
+
+                          @Override
+                          public Class<Object> getEntityClass() {
+                            return Object.class;
+                          }
+
+                          @Override
+                          public Object getPropertyValue(final Object entity) {
+                            return new Object();
+                          }
+                        })))
+        .isInstanceOf(CamundaSearchException.class)
+        .hasMessageContaining("Cannot encode data store pagination information into a cursor")
+        .extracting("reason")
+        .isEqualTo(Reason.SEARCH_CLIENT_FAILED);
+  }
+
+  @Test
   void shouldFailDecodeWithInvalidCursor() {
     assertThatThrownBy(
             () ->

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/GatewayErrorMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/GatewayErrorMapperTest.java
@@ -7,10 +7,18 @@
  */
 package io.camunda.gateway.mapping.http;
 
+import static io.camunda.service.exception.ServiceException.Status.ALREADY_EXISTS;
+import static io.camunda.service.exception.ServiceException.Status.INTERNAL;
+import static io.camunda.service.exception.ServiceException.Status.INVALID_ARGUMENT;
+import static io.camunda.service.exception.ServiceException.Status.UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
+import java.io.IOException;
+import java.net.ConnectException;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -69,6 +77,152 @@ public class GatewayErrorMapperTest {
         .isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(GatewayErrorMapper.mapStatus(Status.DEADLINE_EXCEEDED))
         .isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenNoReason() {
+    // given
+    final CamundaSearchException cse = new CamundaSearchException("No reason");
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    assertThat(problemDetail.getDetail()).isEqualTo("No reason");
+    assertThat(problemDetail.getTitle()).isEqualTo("INTERNAL");
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenNotFound() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException("Item not found", CamundaSearchException.Reason.NOT_FOUND);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getDetail()).isEqualTo("Item not found");
+    assertThat(problemDetail.getTitle()).isEqualTo(CamundaSearchException.Reason.NOT_FOUND.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenNotUnique() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException("Item not unique", CamundaSearchException.Reason.NOT_UNIQUE);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+    assertThat(problemDetail.getDetail()).isEqualTo("Item not unique");
+    assertThat(problemDetail.getTitle()).isEqualTo(ALREADY_EXISTS.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenESClientCannotConnect() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Request failed",
+            new ConnectException("No connection"),
+            CamundaSearchException.Reason.CONNECTION_FAILED);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE.value());
+    assertThat(problemDetail.getDetail())
+        .isEqualTo("The search client could not connect to the search server");
+    assertThat(problemDetail.getTitle()).isEqualTo(UNAVAILABLE.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenESClientIOException() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Request failed",
+            new IOException("Generic IO Error"),
+            CamundaSearchException.Reason.SEARCH_CLIENT_FAILED);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    assertThat(problemDetail.getDetail())
+        .isEqualTo("The search client was unable to process the request");
+    assertThat(problemDetail.getTitle()).isEqualTo(INTERNAL.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenOSClientCannotConnect() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Request failed",
+            new ConnectException("No connection"),
+            CamundaSearchException.Reason.CONNECTION_FAILED);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE.value());
+    assertThat(problemDetail.getDetail())
+        .isEqualTo("The search client could not connect to the search server");
+    assertThat(problemDetail.getTitle()).isEqualTo(UNAVAILABLE.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenOSClientIOException() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Request failed",
+            new IOException("Generic IO Error"),
+            CamundaSearchException.Reason.SEARCH_CLIENT_FAILED);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    assertThat(problemDetail.getDetail())
+        .isEqualTo("The search client was unable to process the request");
+    assertThat(problemDetail.getTitle()).isEqualTo(INTERNAL.name());
+  }
+
+  @Test
+  void shouldMapCamundaSearchExceptionWhenInvalidArgument() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Invalid argument provided",
+            new IllegalArgumentException("Illegal argument"),
+            CamundaSearchException.Reason.INVALID_ARGUMENT);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // then
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    assertThat(problemDetail.getDetail()).isEqualTo("Invalid argument provided");
+    assertThat(problemDetail.getTitle()).isEqualTo(INVALID_ARGUMENT.name());
   }
 
   // Sample custom ServiceException for testing

--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -58,10 +58,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/Cursor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/Cursor.java
@@ -29,7 +29,7 @@ public class Cursor {
       return Base64.getEncoder().encodeToString(value.getBytes());
     } catch (final Exception e) {
       throw new CamundaSearchException(
-          "Cannot encode data store pagination information in cursor",
+          "Cannot encode data store pagination information into a cursor",
           e,
           Reason.SEARCH_CLIENT_FAILED);
     }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/Cursor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/Cursor.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.search.clients.transformers.query;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import java.io.IOException;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import java.util.Base64;
 
 public class Cursor {
@@ -27,8 +27,11 @@ public class Cursor {
       final var value = MAPPER.writeValueAsString(values);
 
       return Base64.getEncoder().encodeToString(value.getBytes());
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException(e);
+    } catch (final Exception e) {
+      throw new CamundaSearchException(
+          "Cannot encode data store pagination information in cursor",
+          e,
+          Reason.SEARCH_CLIENT_FAILED);
     }
   }
 
@@ -41,8 +44,9 @@ public class Cursor {
       final var decodedCursor = Base64.getDecoder().decode(cursor);
 
       return MAPPER.readValue(decodedCursor, Object[].class);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+    } catch (final Exception e) {
+      throw new CamundaSearchException(
+          "Cannot decode pagination cursor '%s'".formatted(cursor), e, Reason.INVALID_ARGUMENT);
     }
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
@@ -59,6 +59,15 @@ class CursorTest {
   }
 
   @Test
+  void shouldFailEncodeWithInvalidEntity() {
+    assertThatThrownBy(() -> Cursor.encode(new Object[] {new Object()}))
+        .isInstanceOf(CamundaSearchException.class)
+        .hasMessageContaining("Cannot encode data store pagination information into a cursor")
+        .extracting("reason")
+        .isEqualTo(Reason.SEARCH_CLIENT_FAILED);
+  }
+
+  @Test
   void shouldFailDecodeWithInvalidCursor() {
     assertThatThrownBy(() -> Cursor.decode("invalid_cursor"))
         .isInstanceOf(CamundaSearchException.class)

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/CursorTest.java
@@ -8,7 +8,10 @@
 package io.camunda.search.clients.transformers.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,7 +31,7 @@ class CursorTest {
 
   @ParameterizedTest(name = "{0}:{1}")
   @MethodSource("provideExamples")
-  void testEncodeDecode(final String description, final Object[] values) {
+  void shouldEncodeDecodeValues(final String ignored, final Object[] values) {
     final String encoded = Cursor.encode(values);
     final Object[] decoded = Cursor.decode(encoded);
 
@@ -36,30 +39,31 @@ class CursorTest {
   }
 
   @Test
-  void testEncodeWithNull() {
-    final String encoded = Cursor.encode(null);
-
-    assertThat(encoded).isNull();
+  void shouldEncodeToNullWithNullValues() {
+    assertThat(Cursor.encode(null)).isNull();
   }
 
   @Test
-  void testEncodeWithEmptyArray() {
-    final String encoded = Cursor.encode(new Object[] {});
-
-    assertThat(encoded).isNull();
+  void shouldEncodeToNullWithEmptyValues() {
+    assertThat(Cursor.encode(new Object[] {})).isNull();
   }
 
   @Test
-  void testDecodeWithNull() {
-    final Object[] decoded = Cursor.decode(null);
-
-    assertThat(decoded).isNull();
+  void shouldDecodeToNullWithNullCursor() {
+    assertThat(Cursor.decode(null)).isNull();
   }
 
   @Test
-  void testDecodeWithEmptyString() {
-    final Object[] decoded = Cursor.decode("");
+  void shouldDecodeToNullWithEmptyCursor() {
+    assertThat(Cursor.decode("")).isNull();
+  }
 
-    assertThat(decoded).isNull();
+  @Test
+  void shouldFailDecodeWithInvalidCursor() {
+    assertThatThrownBy(() -> Cursor.decode("invalid_cursor"))
+        .isInstanceOf(CamundaSearchException.class)
+        .hasMessageContaining("Cannot decode pagination cursor 'invalid_cursor'")
+        .extracting("reason")
+        .isEqualTo(Reason.INVALID_ARGUMENT);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/exception/CamundaSearchException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/CamundaSearchException.java
@@ -47,6 +47,7 @@ public class CamundaSearchException extends RuntimeException {
   }
 
   public enum Reason {
+    INVALID_ARGUMENT,
     NOT_FOUND,
     NOT_UNIQUE,
     CONNECTION_FAILED,

--- a/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
+++ b/service/src/main/java/io/camunda/service/exception/ErrorMapper.java
@@ -65,6 +65,7 @@ public class ErrorMapper {
   public static ServiceException mapSearchError(final CamundaSearchException cse) {
     final String errorMessage = cse.getMessage();
     return switch (cse.getReason()) {
+      case INVALID_ARGUMENT -> new ServiceException(errorMessage, INVALID_ARGUMENT);
       case NOT_FOUND -> new ServiceException(errorMessage, NOT_FOUND);
       case NOT_UNIQUE -> new ServiceException(errorMessage, ALREADY_EXISTS);
       case FORBIDDEN -> new ServiceException(errorMessage, FORBIDDEN);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -820,4 +820,23 @@ public class ErrorMapperTest extends RestControllerTest {
         .isEqualTo("The search client was unable to process the request");
     assertThat(problemDetail.getTitle()).isEqualTo(INTERNAL.name());
   }
+
+  @Test
+  public void shouldMapCamundaSearchExceptionWhenInvalidArgument() {
+    // given
+    final CamundaSearchException cse =
+        new CamundaSearchException(
+            "Invalid argument provided",
+            new IllegalArgumentException("Illegal argument"),
+            CamundaSearchException.Reason.INVALID_ARGUMENT);
+
+    // when
+    final ProblemDetail problemDetail =
+        GatewayErrorMapper.mapErrorToProblem(ErrorMapper.mapSearchError(cse));
+
+    // when
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    assertThat(problemDetail.getDetail()).isEqualTo("Invalid argument provided");
+    assertThat(problemDetail.getTitle()).isEqualTo(INVALID_ARGUMENT.name());
+  }
 }


### PR DESCRIPTION
## Description

Returns an exception pointing to invalid input when decoding an invalid cursor. In general, cursor implementations return proper exceptions on decode and encode instead of returning a generic runtime exception.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44198 
