### PR TITLE
[Backport 8.8] RocksDB: make AUTO strategy based on fixed percentage. 

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -70,8 +70,7 @@ public class RocksDb {
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy =
-      MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
 
   /**
    * Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -67,10 +67,18 @@ public class RocksDb {
    * Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
    * allocated to RocksDB will be the number of partitions times the configured memory limit. If the
    * value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-   * memory limit. If set to 'AUTO', Zeebe will allocate the remaining memory available to RocksDB
-   * after accounting for other components, such as the JVM heap and other native memory consumers.
+   * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
+   * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy =
+      MemoryAllocationStrategy.PARTITION;
+
+  /**
+   * Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'
+   * memory allocation strategy. The value must be between 0 and 1 (exclusive). For example, a value
+   * of 0.1 means 10% of total system memory will be allocated to RocksDB.
+   */
+  private double memoryFraction = 0.1;
 
   /**
    * Configures how many files are kept open by RocksDB, per default it is unlimited (-1). This is a
@@ -117,7 +125,7 @@ public class RocksDb {
 
   /**
    * Configures if the RocksDB SST files should be partitioned based on some virtual column
-   * families. By default RocksDB will not partition the SST files, which might have influence on
+   * families. By default, RocksDB will not partition the SST files, which might have influence on
    * the compacting of certain key ranges. Enabling this option gives RocksDB some good hints how to
    * improve compaction and reduce the write amplification. Benchmarks have show impressive results
    * allowing to sustain performance on larger states. This setting will increase the general file
@@ -178,6 +186,14 @@ public class RocksDb {
 
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
+  }
+
+  public double getMemoryFraction() {
+    return memoryFraction;
+  }
+
+  public void setMemoryFraction(final double memoryFraction) {
+    this.memoryFraction = memoryFraction;
   }
 
   public int getMaxOpenFiles() {

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1299,10 +1299,16 @@
         # Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
         # allocated to RocksDB will be the number of partitions times the configured memory limit. If the
         # value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-        # memory limit. If set to 'AUTO', Zeebe will allocate the remaining memory available to RocksDB
-        # after accounting for other components, such as the JVM heap and other native memory consumers.
+        # memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
+        # to RocksDB that can be configured via the memoryFraction configuration [0,1].
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYALLOCATIONSTRATEGY
         # memoryAllocationStrategy: PARTITION
+
+        # Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'
+        # memory allocation strategy. The value must be between 0 and 1 (exclusive). For example, a value
+        # of 0.1 means 10% of total system memory will be allocated to RocksDB.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYFRACTION
+        # memoryFraction: 0.1
 
         # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
         # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1212,10 +1212,16 @@
         # Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
         # allocated to RocksDB will be the number of partitions times the configured memory limit. If the
         # value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-        # memory limit. If set to 'AUTO', Zeebe will allocate the remaining memory available to RocksDB
-        # after accounting for other components, such as the JVM heap and other native memory consumers.
+        # memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
+        # to RocksDB that can be configured via the memoryFraction configuration [0,1].
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYALLOCATIONSTRATEGY
         # memoryAllocationStrategy: PARTITION
+
+        # Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'
+        # memory allocation strategy. The value must be between 0 and 1 (exclusive). For example, a value
+        # of 0.1 means 10% of total system memory will be allocated to RocksDB.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYFRACTION
+        # memoryFraction: 0.1
 
         # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
         # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -10,15 +10,14 @@ package io.camunda.zeebe.broker.partitioning;
 import com.sun.management.OperatingSystemMXBean;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
 import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RocksDbSharedCache {
   public static final long MINIMUM_PARTITION_MEMORY_LIMIT = 32 * 1024 * 1024L;
-  private static final double ROCKSDB_OVERHEAD_FACTOR = 0.15;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
@@ -40,50 +39,16 @@ public class RocksDbSharedCache {
 
     return switch (rocksdbCfg.getMemoryAllocationStrategy()) {
       case BROKER -> rocksdbCfg.getMemoryLimit().toBytes();
-      case AUTO -> getAvailableMemoryCapacity();
+      case AUTO -> getFixedMemoryPercentage(rocksdbCfg.getMemoryFraction());
       // in case of PARTITION or null, we allocate per partition
       default -> rocksdbCfg.getMemoryLimit().toBytes() * partitionsCount;
     };
   }
 
-  static long getAvailableMemoryCapacity() {
+  static long getFixedMemoryPercentage(final double memoryFraction) {
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
-    final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
-
-    // This is the largest size the JVM Heap is allowed to grow to. -XX:MaxRAMPercentage.
-    long maxHeapBytes = memoryBean.getHeapMemoryUsage().getMax();
-    // Get Maximum Non-Heap Size, -XX:MaxMetaspaceSize
-    long maxNonHeapBytes = memoryBean.getNonHeapMemoryUsage().getMax();
-    // both return -1 if not defined.
-
-    // if not set, assume default to 25% of total memory
-    if (maxNonHeapBytes < 0) {
-      maxNonHeapBytes = Math.round(0.25 * totalMemorySize);
-      LOGGER.info(
-          "Warning: Non-Heap limit is not set. Using an assumption of 25% of "
-              + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
-              + "Consider setting -XX:MaxMetaspaceSize explicitly.",
-          maxNonHeapBytes);
-    }
-    // -XX:MaxRAMPercentage is almost always set, but in case it is removed.
-    if (maxHeapBytes < 0) {
-      maxHeapBytes = Math.round(0.25 * totalMemorySize);
-      LOGGER.info(
-          "Warning: Heap limit is not set. Using an assumption of 25% of "
-              + "total RAM :{} Bytes for safety, for RocksDB memory calculation."
-              + "Consider setting -XX:MaxRAMPercentage explicitly.",
-          maxHeapBytes);
-    }
-
-    // Estimate Total JVM Memory Usage (Heap + Non-Heap)
-    final long maxJvmInternalBytes = maxHeapBytes + maxNonHeapBytes;
-
-    final long availableOffHeapBudget = totalMemorySize - maxJvmInternalBytes;
-
-    // We set the cache capacity to a percentage of the remaining budget and
-    // reserve space for native overheads.
-    return (long) (availableOffHeapBudget * (1.0 - ROCKSDB_OVERHEAD_FACTOR));
+    return (long) (totalMemorySize * memoryFraction);
   }
 
   public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
@@ -94,6 +59,15 @@ public class RocksDbSharedCache {
           String.format(
               "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
               MINIMUM_PARTITION_MEMORY_LIMIT, blockCacheBytes / partitionsCount));
+    }
+
+    // makes sure that memoryFraction is between [0 and 1] when using AUTO strategy
+    if (rocksdbCfg.getMemoryAllocationStrategy() == MemoryAllocationStrategy.AUTO
+        && (rocksdbCfg.getMemoryFraction() <= 0.0 || rocksdbCfg.getMemoryFraction() >= 1.0)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the memoryFraction for RocksDB AUTO memory allocation strategy to be between 0 and 1, but was %s.",
+              rocksdbCfg.getMemoryFraction()));
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -30,6 +30,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private double memoryFraction = 0.1;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -73,6 +74,14 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setMemoryLimit(final DataSize memoryLimit) {
     this.memoryLimit = memoryLimit;
+  }
+
+  public double getMemoryFraction() {
+    return memoryFraction;
+  }
+
+  public void setMemoryFraction(final double memoryFraction) {
+    this.memoryFraction = memoryFraction;
   }
 
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
@@ -166,6 +175,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
         + memoryLimit
         + ", memoryAllocationStrategy="
         + memoryAllocationStrategy
+        + ", memoryFraction="
+        + memoryFraction
         + ", maxOpenFiles="
         + maxOpenFiles
         + ", maxWriteBufferNumber="

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -117,7 +117,7 @@ class RocksDbSharedCacheTest {
     brokerCfg
         .getExperimental()
         .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.AUTO);
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.FRACTION);
     brokerCfg.getExperimental().getRocksdb().setMemoryFraction(0.15);
     final int partitionsCount = 1;
 
@@ -157,7 +157,7 @@ class RocksDbSharedCacheTest {
       final double fraction = 0.15;
       final long available = RocksDbSharedCache.getFixedMemoryPercentage(fraction);
       // 15% of 512MB
-      final long expectedAvailable = (long) (512L * 1024 * 1024 * fraction);
+      final long expectedAvailable = Math.round(512L * 1024 * 1024 * fraction);
       // Assert
       assertThat(available).isEqualTo(expectedAvailable);
     }
@@ -169,7 +169,7 @@ class RocksDbSharedCacheTest {
     brokerCfg
         .getExperimental()
         .getRocksdb()
-        .setMemoryAllocationStrategy(MemoryAllocationStrategy.AUTO);
+        .setMemoryAllocationStrategy(MemoryAllocationStrategy.FRACTION);
 
     // when fraction > 1
     brokerCfg.getExperimental().getRocksdb().setMemoryFraction(1.1);
@@ -185,7 +185,7 @@ class RocksDbSharedCacheTest {
     assertThat(throwable)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Expected the memoryFraction for RocksDB AUTO memory allocation strategy to be between 0 and 1, but was %s.",
+            "Expected the memoryFraction for RocksDB FRACTION memory allocation strategy to be between 0 and 1, but was %s.",
             1.1);
 
     // when fraction <= 0
@@ -202,7 +202,7 @@ class RocksDbSharedCacheTest {
     assertThat(throwable)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Expected the memoryFraction for RocksDB AUTO memory allocation strategy to be between 0 and 1, but was %s.",
+            "Expected the memoryFraction for RocksDB FRACTION memory allocation strategy to be between 0 and 1, but was %s.",
             0.0);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -35,33 +35,17 @@ class RocksDbSharedCacheTest {
   }
 
   /**
-   * Mocks both ManagementFactory.getOperatingSystemMXBean() and getMemoryMXBean() to control total
-   * memory, heap max, and non-heap max for testing memory allocation strategies. Returns a
+   * Mocks both ManagementFactory.getOperatingSystemMXBean() to control total memory. Returns a
    * MockedStatic for use in try-with-resources.
    */
-  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(
-      final long totalMemorySize, final long heapMax, final long nonHeapMax) {
+  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(final long totalMemorySize) {
     final MockedStatic<ManagementFactory> managementFactoryMock =
         Mockito.mockStatic(ManagementFactory.class);
     final var osBean = Mockito.mock(com.sun.management.OperatingSystemMXBean.class);
-    final var memoryBean = Mockito.mock(java.lang.management.MemoryMXBean.class);
-    final var heapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
-    final var nonHeapUsage = Mockito.mock(java.lang.management.MemoryUsage.class);
-
     managementFactoryMock.when(ManagementFactory::getOperatingSystemMXBean).thenReturn(osBean);
-    managementFactoryMock.when(ManagementFactory::getMemoryMXBean).thenReturn(memoryBean);
     Mockito.when(osBean.getTotalMemorySize()).thenReturn(totalMemorySize);
-    Mockito.when(memoryBean.getHeapMemoryUsage()).thenReturn(heapUsage);
-    Mockito.when(memoryBean.getNonHeapMemoryUsage()).thenReturn(nonHeapUsage);
-    Mockito.when(heapUsage.getMax()).thenReturn(heapMax);
-    Mockito.when(nonHeapUsage.getMax()).thenReturn(nonHeapMax);
 
     return managementFactoryMock;
-  }
-
-  /** Overload for cases where only totalMemorySize is relevant. */
-  private static MockedStatic<ManagementFactory> mockMemoryEnvironment(final long totalMemorySize) {
-    return mockMemoryEnvironment(totalMemorySize, 0, 0);
   }
 
   @Test
@@ -134,15 +118,12 @@ class RocksDbSharedCacheTest {
         .getExperimental()
         .getRocksdb()
         .setMemoryAllocationStrategy(MemoryAllocationStrategy.AUTO);
+    brokerCfg.getExperimental().getRocksdb().setMemoryFraction(0.15);
     final int partitionsCount = 1;
 
     // we have broker with 512mb of ram, where:
-    // - max heap is 128mb
-    // - max non-heap is 128mb
-    // so available memory is 512 - 128 - 128 = 256mb with a
-    // ROCKSDB_OVERHEAD_FACTOR of 0.15 we can allocate 217.6mb to rocksdb
-    try (final var managementFactoryMock =
-        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
+    // we allocate 15% of total memory to rocksdb = 76.8mb
+    try (final var managementFactoryMock = mockMemoryEnvironment(512L * 1024 * 1024)) {
       assertThatCode(
               () -> {
                 RocksDbSharedCache.validateRocksDbMemory(
@@ -151,10 +132,9 @@ class RocksDbSharedCacheTest {
           .doesNotThrowAnyException();
     }
 
-    final int morePartitionsCount = 7;
-    // should not be valid with 7 partitions since 217.6 / 7 = 31.08mb < 32mb
-    try (final var managementFactoryMock =
-        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, 128L * 1024 * 1024)) {
+    final int morePartitionsCount = 3;
+    // should not be valid with 3 partitions since 76.8 / 3 = 25.6mb < 32mb
+    try (final var managementFactoryMock = mockMemoryEnvironment(512L * 1024 * 1024)) {
       final var throwable =
           catchThrowable(
               () -> {
@@ -166,20 +146,18 @@ class RocksDbSharedCacheTest {
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
               "Expected the allocated memory for RocksDB per partition to be at least %s bytes, but was %s bytes.",
-              MINIMUM_PARTITION_MEMORY_LIMIT, 32_595_733); // 217.6mb / 7 partitions
+              MINIMUM_PARTITION_MEMORY_LIMIT, 26_843_545); // 76.8mb / 3 partitions
     }
   }
 
   @Test
-  void shouldReturnExpectedAvailableMemoryCapacityWhenNonHeapNotSet() {
-    // 512MB total, 128MB heap, -1 non-heap triggers fallback
-    try (final var managementFactoryMock =
-        mockMemoryEnvironment(512L * 1024 * 1024, 128L * 1024 * 1024, -1)) {
-      final long available = RocksDbSharedCache.getAvailableMemoryCapacity();
-      // 25% of 512MB = 128MB fallback for non-heap
-      final long expectedNonHeap = 128L * 1024 * 1024;
-      final long expectedAvailable =
-          (long) (((512L * 1024 * 1024) - (128L * 1024 * 1024) - expectedNonHeap) * (1.0 - 0.15));
+  void shouldReturnFixedMemoryPercentage() {
+    // 512MB total
+    try (final var managementFactoryMock = mockMemoryEnvironment(512L * 1024 * 1024)) {
+      final double fraction = 0.15;
+      final long available = RocksDbSharedCache.getFixedMemoryPercentage(fraction);
+      // 15% of 512MB
+      final long expectedAvailable = (long) (512L * 1024 * 1024 * fraction);
       // Assert
       assertThat(available).isEqualTo(expectedAvailable);
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -172,6 +172,6 @@ public final class RocksDbConfiguration {
   public enum MemoryAllocationStrategy {
     PARTITION,
     BROKER,
-    AUTO
+    FRACTION
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -138,10 +138,10 @@ final class ZeebeRocksDbFactoryTest {
   }
 
   @Test
-  void shouldHaveDefaultsIfPerAutoMemoryAllocationStrategy() {
+  void shouldHaveDefaultsIfPerFractionMemoryAllocationStrategy() {
     // when configuring with per-broker memory allocation strategy
     final RocksDbConfiguration rocksDbConfiguration = new RocksDbConfiguration();
-    rocksDbConfiguration.setMemoryAllocationStrategy(MemoryAllocationStrategy.AUTO);
+    rocksDbConfiguration.setMemoryAllocationStrategy(MemoryAllocationStrategy.FRACTION);
 
     // then - options should match our defaults
     // we expect the same options regardless of the memory allocation strategy


### PR DESCRIPTION
## Description

Backport of PR https://github.com/camunda/camunda/pull/44143 to 8.8.

This only differs from the main pr in having the description of the new configs in the broker templates as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
