### PR TITLE
42387 ensure correct handler flush order in exporter for inconsistence entity id usage

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.config.ConnectionTypes;
@@ -155,7 +156,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -220,9 +221,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new CaffeineCacheStatsCounter(NAMESPACE, "form", meterRegistry));
 
-    exportHandlers = new HashSet<>();
+    exportHandlers = new LinkedHashSet<>();
     exportHandlers.addAll(
-        Set.of(
+        ImmutableSet.of(
             new RoleCreateUpdateHandler(
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -123,6 +123,7 @@ class ExporterBatchWriterTest {
 
     batchWriter.addRecord(record);
     assertThat(batchWriter.getBatchSize()).isEqualTo(1);
+    assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(1);
 
     // When
     final BatchRequest batchRequest = mock(BatchRequest.class);
@@ -133,5 +134,6 @@ class ExporterBatchWriterTest {
     verify(handler).flush(entity, batchRequest);
     verify(batchRequest).execute(any());
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
+    assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
Normally export handler flush order is consistent, but if we have two entities with the same id, but a different entity type then the order is not well-defined and can change over time.

This is only really a problem when those entities both end up in the same index (which probably means we have a bug of some sort).  this change means that at least we no longer have undefined behaviour in this case and hopefully reproducing bugs should be easier.

For a more concrete example if we have a `FlowNodeInstanceForListViewEntity` and `ProcessInstanceForListViewEntity` with the same ID then the order those are flushed in matters a lot (as we could end up with the wrong `joinRelation` set).

Refs: #42387