### PR TITLE
refactor: migrate flownode selection init

### DIFF
--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -37,12 +37,14 @@ import {useCallHierarchy} from 'modules/queries/callHierarchy/useCallHierarchy';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {init as initFlowNodeSelection} from 'modules/utils/flowNodeSelection';
 import {
+  useClearSelectionOnModificationUndo,
   useIsRootNodeSelected,
   useRootNode,
 } from 'modules/hooks/flowNodeSelection';
 import {notificationsStore} from 'modules/stores/notifications';
 import {useNavigate} from 'react-router-dom';
 import {Locations} from 'modules/Routes';
+import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 const ProcessInstance: React.FC = observer(() => {
   const {data: processInstance, error} = useProcessInstance();
@@ -62,6 +64,10 @@ const ProcessInstance: React.FC = observer(() => {
       shouldInterrupt: modificationsStore.isModificationModeEnabled,
       ignoreSearchParams: true,
     });
+
+if (IS_ELEMENT_SELECTION_V2) {
+    useClearSelectionOnModificationUndo();
+  }
 
   useEffect(() => {
     if (error?.response?.status === 404 && processInstanceId) {
@@ -102,7 +108,9 @@ const ProcessInstance: React.FC = observer(() => {
       processInstance?.processInstanceKey &&
       rootNode
     ) {
-      initFlowNodeSelection(rootNode, processInstanceId, isRootNodeSelected);
+      if (!IS_ELEMENT_SELECTION_V2) {
+        initFlowNodeSelection(rootNode, processInstanceId, isRootNodeSelected);
+      }
       isInitialized.current = true;
     }
   }, [processInstance, rootNode, processInstanceId, isRootNodeSelected]);

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -44,6 +44,7 @@ import {
 import {notificationsStore} from 'modules/stores/notifications';
 import {useNavigate} from 'react-router-dom';
 import {Locations} from 'modules/Routes';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 const ProcessInstance: React.FC = observer(() => {
@@ -58,6 +59,7 @@ const ProcessInstance: React.FC = observer(() => {
   const isRootNodeSelected = useIsRootNodeSelected();
   const rootNode = useRootNode();
   const navigate = useNavigate();
+  const {clearSelection} = useProcessInstanceElementSelection();
 
   const {isNavigationInterrupted, confirmNavigation, cancelNavigation} =
     useCallbackPrompt({
@@ -65,7 +67,7 @@ const ProcessInstance: React.FC = observer(() => {
       ignoreSearchParams: true,
     });
 
-if (IS_ELEMENT_SELECTION_V2) {
+  if (IS_ELEMENT_SELECTION_V2) {
     useClearSelectionOnModificationUndo();
   }
 
@@ -90,6 +92,9 @@ if (IS_ELEMENT_SELECTION_V2) {
     const disposer = reaction(
       () => modificationsStore.isModificationModeEnabled,
       (isModificationModeEnabled) => {
+        if (IS_ELEMENT_SELECTION_V2) {
+          clearSelection();
+        }
         if (!isModificationModeEnabled) {
           instanceHistoryModificationStore.reset();
         }
@@ -99,7 +104,7 @@ if (IS_ELEMENT_SELECTION_V2) {
     return () => {
       disposer();
     };
-  }, [processInstance]);
+  }, [processInstance, clearSelection]);
 
   const isInitialized = useRef(false);
   useEffect(() => {

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -23,6 +23,8 @@ import {getFlowNodeName} from 'modules/utils/flowNodes';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {useProcessInstanceElementSelection} from './useProcessInstanceElementSelection';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
+import {useEffect} from 'react';
+import {reaction} from 'mobx';
 
 /**
  * @deprecated
@@ -83,6 +85,79 @@ const useHasPendingCancelOrMoveModificationV2 = () => {
       modificationsByFlowNode,
     })
   );
+};
+
+/**
+ * This hook adds a reaction to the flow node modifications when mounted
+ * and removes the reaction when unmounted.
+ *
+ * When the user adds or moves a token to an element and
+ * when the user selects the newly created placeholder element from the instance history and
+ * when the user undoes the last modification
+ * then the element selection is cleared.
+ */
+const useClearSelectionOnModificationUndo = () => {
+  const {
+    selectedElementId,
+    selectedElementInstanceKey,
+    resolvedElementInstance,
+    clearSelection,
+  } = useProcessInstanceElementSelection();
+
+  useEffect(() => {
+    const lastModificationRemovedDisposer = reaction(
+      () => modificationsStore.flowNodeModifications,
+      (modificationsNext, modificationsPrev) => {
+        if (
+          selectedElementId === null ||
+          modificationsNext.length >= modificationsPrev.length
+        ) {
+          return;
+        }
+
+        const elementInstanceKey =
+          resolvedElementInstance?.elementInstanceKey ??
+          selectedElementInstanceKey;
+
+        if (elementInstanceKey === null) {
+          return;
+        }
+
+        const newScopeIds = modificationsStore.flowNodeModifications.reduce<
+          string[]
+        >((scopeIds, modification) => {
+          if (modification.operation === 'ADD_TOKEN') {
+            return [
+              ...scopeIds,
+              ...Object.values(modification.parentScopeIds),
+              ...[modification.scopeId],
+            ];
+          }
+
+          if (modification.operation === 'MOVE_TOKEN') {
+            return [
+              ...scopeIds,
+              ...Object.values(modification.parentScopeIds),
+              ...modification.scopeIds,
+            ];
+          }
+
+          return scopeIds;
+        }, []);
+
+        if (!newScopeIds.includes(elementInstanceKey)) {
+          clearSelection();
+        }
+      },
+    );
+
+    return () => lastModificationRemovedDisposer();
+  }, [
+    clearSelection,
+    selectedElementId,
+    selectedElementInstanceKey,
+    resolvedElementInstance,
+  ]);
 };
 
 /**
@@ -281,4 +356,5 @@ export {
   useNewTokenCountForSelectedNode,
   useRootNode,
   useSelectedFlowNodeName,
+  useClearSelectionOnModificationUndo,
 };

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -130,7 +130,7 @@ const useClearSelectionOnModificationUndo = () => {
             return [
               ...scopeIds,
               ...Object.values(modification.parentScopeIds),
-              ...[modification.scopeId],
+              modification.scopeId,
             ];
           }
 


### PR DESCRIPTION
## Description

This PR migrates init function from flowNodeSelection:

- `rootNodeSelectionDisposer` - obsolete. This was setting the root node when entering process instance details page. The root node is now handled in a different way, setting it explicitly is not needed anymore.

- `modificationModeChangeDisposer` - moved to `App/ProcessInstance/index`. This is clearing the element selection when entering or exiting the modification mode.

- lastModificationRemovedDisposer - moved to `hooks/flowNodeSelection`. Please see hook description what this is doing. 

This allows us to move the init function call behind the feature flag in `App/ProcessInstance/index`

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #41829 
