### PR TITLE
Make logout CORS configurable

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -25,6 +25,7 @@ public class IdentityClientConfigController {
   private static final Logger LOG = LoggerFactory.getLogger(IdentityClientConfigController.class);
 
   private static final String IS_OIDC = "isOidc";
+  private static final String IS_LOGOUT_CORS_ENABLED = "isLogoutCorsEnabled";
   private static final String IS_CAMUNDA_GROUPS_ENABLED = "isCamundaGroupsEnabled";
   private static final String IS_TENANTS_API_ENABLED = "isTenantsApiEnabled";
   private static final String ORGANIZATION_ID = "organizationId";
@@ -57,6 +58,9 @@ public class IdentityClientConfigController {
     final var saasConfiguration = securityConfiguration.getSaas();
 
     config.put(IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)));
+    config.put(
+        IS_LOGOUT_CORS_ENABLED,
+        String.valueOf(securityConfiguration.getAuthentication().getLogoutCorsEnabled()));
     config.put(
         IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)));
     config.put(

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -20,6 +20,10 @@ const loginApiUrl = "/login";
 const logoutApiUrl = "/logout";
 
 export const isOIDC = getClientConfigBoolean("isOidc", false);
+export const isLogoutCorsEnabled = getClientConfigBoolean(
+  "isLogoutCorsEnabled",
+  true,
+);
 export const isCamundaGroupsEnabled = getClientConfigBoolean(
   "isCamundaGroupsEnabled",
   true,

--- a/identity/client/src/types/global.d.ts
+++ b/identity/client/src/types/global.d.ts
@@ -14,6 +14,7 @@ export declare global {
     organizationId?: string;
     clusterId?: string;
     idPattern?: string;
+    isLogoutCorsEnabled?: string;
   }
 
   interface Window {

--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -6,7 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getBaseUrl, getLoginApiUrl, getLogoutApiUrl } from "src/configuration";
+import {
+  getBaseUrl,
+  getLoginApiUrl,
+  getLogoutApiUrl,
+  isLogoutCorsEnabled,
+} from "src/configuration";
 
 let loggedIn = false;
 
@@ -57,9 +62,11 @@ export function login(
 
 export function logout(): Promise<void> {
   const data = new FormData();
+  const logoutCorsMode = isLogoutCorsEnabled ? "cors" : "no-cors";
   return fetch(getLogoutApiUrl(), {
     method: "post",
     body: data,
+    mode: logoutCorsMode,
   })
     .then((response: Response) => {
       if (response.status < 400) {

--- a/operate/client/src/modules/request/index.ts
+++ b/operate/client/src/modules/request/index.ts
@@ -90,6 +90,7 @@ async function requestWithThrow<T>({
 async function request(
   {url, method, body, headers, signal}: RequestParams,
   {skipSessionCheck = false}: {skipSessionCheck?: boolean} = {},
+  corsMode: RequestMode = 'cors',
 ) {
   const csrfToken = sessionStorage.getItem('X-CSRF-TOKEN');
   const hasCsrfToken =
@@ -108,7 +109,7 @@ async function request(
         ...(hasCsrfToken ? {'X-CSRF-TOKEN': csrfToken} : {}),
         ...headers,
       },
-      mode: 'cors',
+      mode: corsMode,
       signal,
     },
   );

--- a/operate/client/src/modules/stores/authentication.ts
+++ b/operate/client/src/modules/stores/authentication.ts
@@ -84,6 +84,9 @@ class Authentication {
   };
 
   handleLogout = async () => {
+    const logoutCorsMode = window.clientConfig?.isLogoutCorsEnabled
+      ? 'cors'
+      : 'no-cors';
     try {
       const response = await request(
         {
@@ -93,6 +96,7 @@ class Authentication {
         {
           skipSessionCheck: true,
         },
+        logoutCorsMode,
       );
 
       if (!response.ok) {

--- a/operate/client/src/modules/types/global.d.ts
+++ b/operate/client/src/modules/types/global.d.ts
@@ -33,6 +33,7 @@ export declare global {
       clusterId?: null | string;
       canLogout?: null | boolean;
       isLoginDelegated?: null | boolean;
+      isLogoutCorsEnabled?: boolean;
       mixpanelToken?: null | string;
       mixpanelAPIHost?: null | string;
       tasklistUrl?: null | string;

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -14,6 +14,7 @@ const ClientConfigSchema = z.object({
   baseName: z.string().optional().default('/'),
   canLogout: z.boolean().optional().default(true),
   isLoginDelegated: z.boolean().optional().default(false),
+  isLogoutCorsEnabled: z.boolean().optional().default(true),
   organizationId: z.string().min(1).nullable().optional().default(null),
   clusterId: z.string().min(1).nullable().optional().default(null),
   mixpanelToken: z.string().nullable().optional().default(null),

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -52,6 +52,7 @@ public class ClientConfig {
     canLogout = securityConfiguration.getAuthentication().getOidc().getOrganizationId() == null;
     isLoginDelegated = profileService.isLoginDelegated();
     isLogoutCorsEnabled = securityConfiguration.getAuthentication().getLogoutCorsEnabled();
+    tasklistUrl = operateProperties.getTasklistUrl();
     resourcePermissionsEnabled = securityConfiguration.getAuthorizations().isEnabled();
     multiTenancyEnabled = securityConfiguration.getMultiTenancy().isChecksEnabled();
     databaseType = environmentService.getDatabaseType();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -29,6 +29,7 @@ public class ClientConfig {
   public String mixpanelAPIHost;
   public String mixpanelToken;
   public boolean isLoginDelegated;
+  public boolean isLogoutCorsEnabled;
   public String tasklistUrl;
   public boolean resourcePermissionsEnabled;
   public boolean multiTenancyEnabled;
@@ -50,7 +51,7 @@ public class ClientConfig {
     // when operating in SaaS we don't have the logout option.
     canLogout = securityConfiguration.getAuthentication().getOidc().getOrganizationId() == null;
     isLoginDelegated = profileService.isLoginDelegated();
-    tasklistUrl = operateProperties.getTasklistUrl();
+    isLogoutCorsEnabled = securityConfiguration.getAuthentication().getLogoutCorsEnabled();
     resourcePermissionsEnabled = securityConfiguration.getAuthorizations().isEnabled();
     multiTenancyEnabled = securityConfiguration.getMultiTenancy().isChecksEnabled();
     databaseType = environmentService.getDatabaseType();

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -12,12 +12,14 @@ import io.camunda.security.entity.AuthenticationMethod;
 public class AuthenticationConfiguration {
   public static final AuthenticationMethod DEFAULT_METHOD = AuthenticationMethod.BASIC;
   public static final boolean DEFAULT_UNPROTECTED_API = false;
+  public static final boolean DEFAULT_LOGOUT_CORS_ENABLED = true;
 
   private AuthenticationMethod method = DEFAULT_METHOD;
   private String authenticationRefreshInterval = "PT30S";
   private OidcAuthenticationConfiguration oidcAuthenticationConfiguration =
       new OidcAuthenticationConfiguration();
   private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
+  private boolean logoutCorsEnabled = DEFAULT_LOGOUT_CORS_ENABLED;
 
   private ProvidersConfiguration providers;
 
@@ -27,6 +29,14 @@ public class AuthenticationConfiguration {
 
   public void setUnprotectedApi(final boolean value) {
     unprotectedApi = value;
+  }
+
+  public boolean getLogoutCorsEnabled() {
+    return logoutCorsEnabled;
+  }
+
+  public void setLogoutCorsEnabled(final boolean value) {
+    logoutCorsEnabled = value;
   }
 
   public AuthenticationMethod getMethod() {

--- a/tasklist/client/src/common/api/index.ts
+++ b/tasklist/client/src/common/api/index.ts
@@ -27,6 +27,10 @@ function getFullURL(url: string) {
   );
 }
 
+const logoutCorsMode = getClientConfig().isLogoutCorsEnabled
+  ? 'cors'
+  : 'no-cors';
+
 const commonApi = {
   login: (body: {username: string; password: string}) => {
     return new Request(getFullURL('/login'), {
@@ -45,6 +49,7 @@ const commonApi = {
       headers: {
         'Content-Type': 'application/json',
       },
+      mode: logoutCorsMode,
     }),
   getCurrentUser: () =>
     new Request(getFullURL(endpoints.getCurrentUser.getUrl()), {

--- a/tasklist/client/src/common/config/getClientConfig.ts
+++ b/tasklist/client/src/common/config/getClientConfig.ts
@@ -14,6 +14,7 @@ const ClientConfigSchema = z.object({
   baseName: z.string().optional().default('/'),
   canLogout: z.boolean().optional().default(true),
   isLoginDelegated: z.boolean().optional().default(false),
+  isLogoutCorsEnabled: z.boolean().optional().default(true),
   organizationId: z.string().min(1).nullable().optional().default(null),
   clusterId: z.string().min(1).nullable().optional().default(null),
   mixpanelToken: z.string().nullable().optional().default(null),

--- a/tasklist/client/src/common/global.d.ts
+++ b/tasklist/client/src/common/global.d.ts
@@ -29,6 +29,7 @@ export declare global {
       baseName?: string;
       canLogout?: boolean;
       isLoginDelegated?: boolean;
+      isLogoutCorsEnabled?: boolean;
       organizationId?: null | string;
       clusterId?: null | string;
       mixpanelToken?: null | string;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/rest/ClientConfig.java
@@ -22,6 +22,7 @@ import org.springframework.util.unit.DataSize;
 public class ClientConfig {
 
   public boolean isEnterprise;
+  public boolean isLogoutCorsEnabled;
   public boolean isMultiTenancyEnabled;
   public boolean canLogout;
   public boolean isLoginDelegated;
@@ -69,6 +70,7 @@ public class ClientConfig {
   @PostConstruct
   public void init() {
     isEnterprise = tasklistProperties.isEnterprise();
+    isLogoutCorsEnabled = securityConfiguration.getAuthentication().getLogoutCorsEnabled();
     isMultiTenancyEnabled = securityConfiguration.getMultiTenancy().isChecksEnabled();
     contextPath = context.getContextPath();
     baseName = context.getContextPath() + "/tasklist";


### PR DESCRIPTION
## Description
Making logout CORS mode configurable for Identity, Operate and Tasklist.
Sours of truth for logout CORS mode is `AuthenticationConfiguration` `logoutCorsEnabled` property.
Tested by setting `CAMUNDA_SECURITY_AUTHENTICATION_LOGOUTCORSENABLED` to `false`

After testing: 
Identity
<img width="500" height="225" alt="Screenshot 2026-01-16 at 14 37 47" src="https://github.com/user-attachments/assets/a9b3a410-592b-4f3c-a1d2-65407ae16b82" />

Tasklist
<img width="744" height="342" alt="Screenshot 2026-01-16 at 15 38 23" src="https://github.com/user-attachments/assets/5a2c929f-d282-4554-9b5b-4a7f4695cee9" />

Operate
<img width="581" height="306" alt="Screenshot 2026-01-16 at 15 57 49" src="https://github.com/user-attachments/assets/1f6e537d-3bf9-406d-b287-e743344eaba3" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
