### PR TITLE
feat: adjust event-based gateway validation to allow conditionals

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
@@ -79,6 +79,11 @@ public class EventBasedGatewayValidator implements ModelElementValidator<EventBa
     ModelUtil.verifyNoDuplicatedEventDefinition(
         signalEventDefinitions, error -> validationResultCollector.addError(0, error));
 
+    final List<ConditionalEventDefinition> conditionalEventDefinitions =
+        getConditionalEventDefinitions(outgoingSequenceFlows).collect(Collectors.toList());
+    ModelUtil.verifyNoDuplicatedConditionalExpressions(
+        conditionalEventDefinitions, error -> validationResultCollector.addError(0, error));
+
     if (!succeedingNodesOnlyHaveEventBasedGatewayAsIncomingFlows(element)) {
       validationResultCollector.addError(
           0,
@@ -113,10 +118,10 @@ public class EventBasedGatewayValidator implements ModelElementValidator<EventBa
       final Collection<SequenceFlow> outgoingSequenceFlows) {
     return outgoingSequenceFlows.stream()
         .map(SequenceFlow::getTarget)
-        .filter(t -> t instanceof IntermediateCatchEvent)
+        .filter(IntermediateCatchEvent.class::isInstance)
         .map(IntermediateCatchEvent.class::cast)
         .flatMap(e -> e.getEventDefinitions().stream())
-        .filter(e -> e instanceof MessageEventDefinition)
+        .filter(MessageEventDefinition.class::isInstance)
         .map(MessageEventDefinition.class::cast);
   }
 
@@ -124,11 +129,22 @@ public class EventBasedGatewayValidator implements ModelElementValidator<EventBa
       final Collection<SequenceFlow> outgoingSequenceFlows) {
     return outgoingSequenceFlows.stream()
         .map(SequenceFlow::getTarget)
-        .filter(t -> t instanceof IntermediateCatchEvent)
+        .filter(IntermediateCatchEvent.class::isInstance)
         .map(IntermediateCatchEvent.class::cast)
         .flatMap(e -> e.getEventDefinitions().stream())
-        .filter(e -> e instanceof SignalEventDefinition)
+        .filter(SignalEventDefinition.class::isInstance)
         .map(SignalEventDefinition.class::cast);
+  }
+
+  private Stream<ConditionalEventDefinition> getConditionalEventDefinitions(
+      final Collection<SequenceFlow> outgoingSequenceFlows) {
+    return outgoingSequenceFlows.stream()
+        .map(SequenceFlow::getTarget)
+        .filter(IntermediateCatchEvent.class::isInstance)
+        .map(IntermediateCatchEvent.class::cast)
+        .flatMap(e -> e.getEventDefinitions().stream())
+        .filter(ConditionalEventDefinition.class::isInstance)
+        .map(ConditionalEventDefinition.class::cast);
   }
 
   private boolean succeedingNodesOnlyHaveEventBasedGatewayAsIncomingFlows(

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventBasedGateway;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
@@ -36,10 +37,13 @@ public class EventBasedGatewayValidator implements ModelElementValidator<EventBa
 
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENTS =
       Arrays.asList(
-          TimerEventDefinition.class, MessageEventDefinition.class, SignalEventDefinition.class);
+          TimerEventDefinition.class,
+          MessageEventDefinition.class,
+          SignalEventDefinition.class,
+          ConditionalEventDefinition.class);
 
   private static final String ERROR_UNSUPPORTED_TARGET_NODE =
-      "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events.";
+      "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal/conditional intermediate catch events.";
 
   @Override
   public Class<EventBasedGateway> getElementType() {

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidationTest {
@@ -102,7 +103,7 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
         singletonList(
             expect(
                 EventBasedGateway.class,
-                "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events."))
+                "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal/conditional intermediate catch events."))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -121,6 +122,19 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
             expect(
                 EventBasedGateway.class,
                 "Target elements of an event gateway must not have any additional incoming sequence flows other than that from the event gateway."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .eventBasedGateway()
+            .intermediateCatchEvent()
+            .condition("x > 1")
+            .moveToLastGateway()
+            .intermediateCatchEvent("catch2")
+            .timerWithDuration("PT2M")
+            .endEvent()
+            .done(),
+        Collections.emptyList()
       }
     };
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
@@ -135,6 +135,35 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
             .endEvent()
             .done(),
         Collections.emptyList()
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .eventBasedGateway()
+            .intermediateCatchEvent()
+            .condition("x > 1")
+            .moveToLastGateway()
+            .intermediateCatchEvent("catch2")
+            .condition("x > 1") // Same condition - should fail
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                EventBasedGateway.class,
+                "Multiple conditional event definitions with the same condition expression '=x > 1' are not allowed."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .eventBasedGateway()
+            .intermediateCatchEvent()
+            .condition("x > 1")
+            .moveToLastGateway()
+            .intermediateCatchEvent("catch2")
+            .condition("x > 2") // Same condition - should fail
+            .endEvent()
+            .done(),
+        Collections.emptyList()
       }
     };
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
@@ -122,7 +122,7 @@ public class ZeebeLinkEventValidationTest {
             "Event-based gateway must have at least 2 outgoing sequence flows."),
         expect(
             EventBasedGateway.class,
-            "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events."));
+            "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal/conditional intermediate catch events."));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
@@ -117,7 +117,7 @@ public class LinkEventDefinitionTest {
         .contains("Element: Gateway_")
         .contains("ERROR: Event-based gateway must have at least 2 outgoing sequence flows.")
         .contains(
-            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events.");
+            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal/conditional intermediate catch events.");
   }
 
   @Test


### PR DESCRIPTION
## Description

It seems we forgot to adjust the event-based gateway validation to allow attaching conditional catch events.

https://github.com/camunda/camunda/blob/1da535ee21c51213ef7b74db31f8984058d644d7/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java#L37C2-L39C51

This means that we reject the deployment of processes with a conditional catch event attached to an event-based gateway currently.

> ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer/signal intermediate catch events.


```
Bpmn.createExecutableProcess("process")
    .startEvent()
    .eventBasedGateway()
    .intermediateCatchEvent()
    .condition("x > 1")
    .endEvent()
    .moveToLastGateway()
    .intermediateCatchEvent("catch2")
    .timerWithDuration("PT2M")
    .endEvent()
    .done();
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/41773
