### PR TITLE
42387 fix process level incident updates

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -52,7 +52,11 @@ public class ListViewFlowNodeFromIncidentHandler
 
   @Override
   public boolean handlesRecord(final Record<IncidentRecordValue> record) {
-    return SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent());
+    if (!SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent())) {
+      return false;
+    }
+    final var recordValue = record.getValue();
+    return isNotProcessLevelIncident(recordValue);
   }
 
   @Override
@@ -115,5 +119,11 @@ public class ListViewFlowNodeFromIncidentHandler
 
   public String trimWhitespace(final String str) {
     return (str == null) ? null : str.strip();
+  }
+
+  private boolean isNotProcessLevelIncident(final IncidentRecordValue recordValue) {
+    // most incidents are related to a specific flow node/element, but it is possible
+    // to have errors on the process instance level too, but we don't want to handle those here
+    return recordValue.getProcessInstanceKey() != recordValue.getElementInstanceKey();
   }
 }


### PR DESCRIPTION
This should fix how we handle incidents that happen at a process instance level.

These can happen when a worker fails a task associated with an execution listener for the start event:
```
<bpmn:process id="Process_ID" isExecutable="true" name="name">
    <bpmn:extensionElements>
      <zeebe:versionTag value="2.0.4-dev"/>
      <zeebe:executionListeners>
        <zeebe:executionListener eventType="start" retries="1" type="startListener"/>
        <zeebe:executionListener eventType="end" type="endListener"/>
      </zeebe:executionListeners>
    </bpmn:extensionElements>
```

There were two issues to fix:
* stop trying to upsert a flow node from the `IncidentRecordValue` (as it's not an incident related to a flow node)
* ensure the `IncidentUpdateTask` also knows to avoid updating flow nodes

- [x] Needs: https://github.com/camunda/camunda/pull/44262

Refs: #42387
