### PR TITLE
test: fix nightly fails for api tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
@@ -197,7 +197,7 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
@@ -199,7 +199,6 @@ test.describe
         authRes,
         "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
       );
-      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
@@ -197,7 +197,8 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
@@ -226,7 +226,7 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
@@ -228,7 +228,6 @@ test.describe
         authRes,
         "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
       );
-      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
@@ -226,7 +226,8 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -241,7 +241,6 @@ test.describe
         authRes,
         "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
       );
-      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -239,7 +239,8 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -239,7 +239,7 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -231,7 +231,8 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -233,7 +233,6 @@ test.describe
         authRes,
         "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
       );
-      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -231,7 +231,7 @@ test.describe
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -216,7 +216,7 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -218,7 +218,6 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
         authRes,
         "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
       );
-      );
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -216,7 +216,8 @@ test.describe.parallel('Create Authorization API - Unhappy paths', () => {
       );
       await assertBadRequest(
         authRes,
-        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: ",
+        "Unexpected value 'WRONG_VALUE_FOR_TEST' for enum field 'resourceType'. Use any of the following values: [AUDIT_LOG, AUTHORIZATION, BATCH, CLUSTER_VARIABLE, COMPONENT, DECISION_DEFINITION, DECISION_REQUIREMENTS_DEFINITION, DOCUMENT, EXPRESSION, GLOBAL_LISTENER, GROUP, MAPPING_RULE, MESSAGE, PROCESS_DEFINITION, RESOURCE, ROLE, SYSTEM, TENANT, USER, USER_TASK]",
+      );
       );
     }).toPass(defaultAssertionOptions);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -52,7 +52,7 @@ const LIMITED_ROLE_AUTHORIZATION = {
   permissionTypes: ['READ_DECISION_DEFINITION'],
 };
 
-test.describe('Get usage metrics API Tests', () => {
+test.describe.serial('Get usage metrics API Tests', () => {
   test('Get Usage Metrics Success', async ({request}) => {
     const startOfTodayLocal = new Date();
     startOfTodayLocal.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Description

This PR fixes API tests that failed during [nighty run](https://github.com/camunda/camunda/actions/runs/21084637838) on Saturday 17.01. It's done by updating details of API resopnse that have changed in all 5 authorization files.
Additionally it updates get-usage-metrics test so it runs serially.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## On demand workflow
[was successful](https://github.com/camunda/camunda/actions/runs/21110071733)

