### PR TITLE
refactor: add error rates for Identity specific errors

### DIFF
--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -407,7 +407,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Count of REST authentication errors per method. High values may indicate server-side issues or crashes.",
+      "description": "Count of REST authentication and authorization errors per URI endpoint and status code. High values may indicate server-side issues or crashes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -490,7 +490,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
+          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    service=~\"$service\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
@@ -503,7 +503,7 @@
           "useBackend": false
         }
       ],
-      "title": "Error Rate REST (top 10)",
+      "title": "Error Rate REST",
       "type": "timeseries"
     },
     {
@@ -511,7 +511,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Count of REST authentication errors per method. High values may indicate server-side issues or crashes.",
+      "description": "Count of REST authentication errors per URI endpoint and status code. High values may indicate server-side issues or crashes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -570,7 +570,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
+          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    service=~\"$service\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
           "format": "table",
           "fullMetaSearch": false,
           "hide": false,
@@ -583,7 +583,7 @@
           "useBackend": false
         }
       ],
-      "title": "Error Rate REST (top 10)",
+      "title": "Error Rate REST",
       "transformations": [
         {
           "id": "organize",
@@ -701,7 +701,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
+          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      service=~\"$service\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
@@ -714,7 +714,7 @@
           "useBackend": false
         }
       ],
-      "title": "Error Rate gRPC (top 10)",
+      "title": "Error Rate gRPC",
       "type": "timeseries"
     },
     {
@@ -788,7 +788,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
+          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      service=~\"$service\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
           "format": "table",
           "fullMetaSearch": false,
           "hide": false,

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -714,7 +714,7 @@
           "useBackend": false
         }
       ],
-      "title": "Error Rate REST (top 10)",
+      "title": "Error Rate gRPC (top 10)",
       "type": "timeseries"
     },
     {

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -122,8 +122,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 23,
+        "h": 8,
+        "w": 24,
         "x": 0,
         "y": 1
       },
@@ -227,9 +227,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 11,
+        "w": 12,
         "x": 0,
-        "y": 12
+        "y": 9
       },
       "id": 3,
       "options": {
@@ -338,8 +338,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 11,
-        "y": 12
+        "x": 12,
+        "y": 9
       },
       "id": 4,
       "options": {
@@ -388,6 +388,447 @@
       ],
       "title": "Authentication Rate",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "panels": [],
+      "title": "API Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count of REST authentication errors per method. High values may indicate server-side issues or crashes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "{{uri}} {{status}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error Rate REST (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count of REST authentication errors per method. High values may indicate server-side issues or crashes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false,
+            "minWidth": 80
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (uri,status)(\n  rate(http_server_requests_seconds_count{\n    outcome=\"CLIENT_ERROR\",\n    status=~\"401|403\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\"\n  }[$__rate_interval])\n)",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "1m",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error Rate REST (top 10)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Error Rate"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Error Rate"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count of gRPC authentication errors per method. High values may indicate server-side issues or crashes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "{{method}} {{statusCode}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error Rate REST (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count of gRPC authentication errors per method. High values may indicate server-side issues or crashes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "method"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "\n  sum by(method, statusCode) (\n    rate(grpc_server_processing_duration_seconds_count{\n      statusCode=~\"UNAUTHENTICATED|PERMISSION_DENIED\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval]) != 0\n  )\n",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error Rate gRPC (top 10)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Error Rate"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Error Rate"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,
@@ -504,5 +945,5 @@
   "timezone": "browser",
   "title": "Identity Overview",
   "uid": "identity",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
## Description

This PR adds new visualizations to the Identity dashboard to also see IAM error rates at a glance.

Quick preview:

<img width="1580" height="663" alt="image" src="https://github.com/user-attachments/assets/57160315-12a3-4d4c-bc49-24f8854f897d" />
