### PR TITLE
Add authentication latency metrics

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -82,6 +82,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.observation.SecurityObservationSettings;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -191,6 +192,11 @@ public class WebSecurityConfig {
       "camunda_authentication_external_requests";
   private static final KeyValues CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS =
       KeyValues.of("domain", "identity");
+
+  @Bean
+  public SecurityObservationSettings defaultSecurityObservations() {
+    return SecurityObservationSettings.withDefaults().build();
+  }
 
   @Bean
   @Order(ORDER_UNPROTECTED)

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -151,7 +151,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(camunda_authentication_external_requests_seconds_count{domain=\"identity\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "expr": "rate(camunda_authentication_external_requests_seconds_count{domain=\"identity\", namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
@@ -252,7 +252,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(spring_security_authentications_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)\n/\nsum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)",
+          "expr": "sum(rate(spring_security_authentications_seconds_sum{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)\n/\nsum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)",
           "interval": "1m",
           "legendFormat": "p50 REST {{authentication_request_type}}",
           "range": true,
@@ -264,7 +264,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(increase(zeebe_gateway_grpc_auth_latency_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le, method))",
+          "expr": "histogram_quantile(0.50, sum(increase(zeebe_gateway_grpc_auth_latency_seconds_bucket{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (le, method))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -363,7 +363,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, authentication_request_type)",
+          "expr": "sum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, authentication_request_type)",
           "instant": false,
           "interval": "1m",
           "legendFormat": "REST {{authentication_request_type}}",
@@ -377,7 +377,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(zeebe_gateway_grpc_auth_latency_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, method)",
+          "expr": "sum(rate(zeebe_gateway_grpc_auth_latency_seconds_count{namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, method)",
           "hide": false,
           "instant": false,
           "interval": "1m",
@@ -396,10 +396,6 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Prometheus",
-          "value": "${DS_PROMETHEUS}"
-        },
         "label": "datasource",
         "name": "DS_PROMETHEUS",
         "options": [],
@@ -411,13 +407,17 @@
       {
         "allValue": ".*",
         "allowCustomValue": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "definition": "label_values(jvm_info,namespace)",
         "includeAll": true,
@@ -431,31 +431,67 @@
         },
         "refresh": 1,
         "regex": "",
+        "sort": 1,
         "type": "query"
       },
       {
         "allValue": ".*",
         "allowCustomValue": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(jvm_info{namespace=\"$namespace\"},service)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(jvm_info{namespace=\"$namespace\"},service)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "allowCustomValue": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(jvm_info{namespace=~\"$namespace\", service=~\"$service\"},pod)",
         "includeAll": true,
         "multi": true,
         "name": "pod",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(jvm_info{namespace=\"$namespace\"},pod)",
+          "query": "label_values(jvm_info{namespace=~\"$namespace\", service=~\"$service\"},pod)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
+        "sort": 1,
         "type": "query"
       }
     ]

--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -163,6 +163,231 @@
       ],
       "title": "Authentication scoped requests to external IDP",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The average time it takes to authenticate per minute",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 12
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(spring_security_authentications_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)\n/\nsum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace,pod,authentication_request_type)",
+          "interval": "1m",
+          "legendFormat": "p50 REST {{authentication_request_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(increase(zeebe_gateway_grpc_auth_latency_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le, method))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "p50 gRPC {{method}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authentication Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of authentication events per minute",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 11,
+        "y": 12
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(spring_security_authentications_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, authentication_request_type)",
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "REST {{authentication_request_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(zeebe_gateway_grpc_auth_latency_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod, method)",
+          "hide": false,
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "GRPC {{method}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Authentication Rate",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -243,5 +468,5 @@
   "timezone": "browser",
   "title": "Identity Overview",
   "uid": "identity",
-  "version": 4
+  "version": 5
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetrics.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetrics.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetricsDoc.AuthResultValues;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetricsDoc.LatencyKeyNames;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public final class AuthenticationMetrics {
+  private final MeterRegistry meterRegistry;
+  private final Timer successLatencyTimer;
+  private final Timer failureLatencyTimer;
+
+  @VisibleForTesting
+  AuthenticationMetrics() {
+    this(new SimpleMeterRegistry(), AuthenticationMethod.BASIC);
+  }
+
+  public AuthenticationMetrics(
+      final MeterRegistry meterRegistry, final AuthenticationMethod method) {
+    this.meterRegistry = meterRegistry;
+    successLatencyTimer =
+        MicrometerUtil.buildTimer(AuthenticationMetricsDoc.LATENCY)
+            .tag(LatencyKeyNames.AUTH_METHOD.asString(), method.name())
+            .tag(LatencyKeyNames.AUTH_RESULT.asString(), AuthResultValues.SUCCESS.getValue())
+            .register(meterRegistry);
+    failureLatencyTimer =
+        MicrometerUtil.buildTimer(AuthenticationMetricsDoc.LATENCY)
+            .tag(LatencyKeyNames.AUTH_METHOD.asString(), method.name())
+            .tag(LatencyKeyNames.AUTH_RESULT.asString(), AuthResultValues.FAILURE.getValue())
+            .register(meterRegistry);
+  }
+
+  public Timer.Sample startLatencySample() {
+    return Timer.start(meterRegistry);
+  }
+
+  public void recordSuccessLatency(final Timer.Sample sample) {
+    sample.stop(successLatencyTimer);
+  }
+
+  public void recordFailureLatency(final Timer.Sample sample) {
+    sample.stop(failureLatencyTimer);
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetricsDoc.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetricsDoc.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+public enum AuthenticationMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * Captures how long it takes to authenticate a gRPC request. Can be filtered by authentication
+   * method (e.g., OIDC, basic).
+   */
+  LATENCY {
+    @Override
+    public String getName() {
+      return "zeebe.gateway.grpc.auth.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Captures how long it takes to authenticate a gRPC request";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {LatencyKeyNames.AUTH_METHOD};
+    }
+  };
+
+  public enum LatencyKeyNames implements KeyName {
+    /**
+     * Indicates what authentication protocol was used. Possible values are {@link
+     * io.camunda.security.entity.AuthenticationMethod}, using {@link
+     * io.camunda.security.entity.AuthenticationMethod#name()}.
+     */
+    AUTH_METHOD {
+      @Override
+      public String asString() {
+        return "method";
+      }
+    },
+    /**
+     * Indicates if authentication was successful or not; possible values are {@link
+     * AuthResultValues}.
+     */
+    AUTH_RESULT {
+      @Override
+      public String asString() {
+        return "result";
+      }
+    }
+  }
+
+  public enum AuthResultValues {
+    SUCCESS("success"),
+    FAILURE("failure");
+
+    private final String value;
+
+    AuthResultValues(final String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetricsDoc.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetricsDoc.java
@@ -34,7 +34,7 @@ public enum AuthenticationMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return new KeyName[] {LatencyKeyNames.AUTH_METHOD};
+      return new KeyName[] {LatencyKeyNames.AUTH_METHOD, LatencyKeyNames.AUTH_RESULT};
     }
   };
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -12,6 +12,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.Gateway;
@@ -25,6 +26,7 @@ import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -49,6 +51,7 @@ import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -108,7 +111,9 @@ public final class StubbedGateway {
                     new AuthenticationInterceptor(
                         new AuthenticationHandler.Oidc(
                             new FakeJwtDecoder(),
-                            securityConfiguration.getAuthentication().getOidc()))));
+                            securityConfiguration.getAuthentication().getOidc()),
+                        new AuthenticationMetrics(
+                            new SimpleMeterRegistry(), AuthenticationMethod.OIDC))));
     server = serverBuilder.build();
     server.start();
   }


### PR DESCRIPTION
## Description

This PR adds authentication latency metrics, both for gRPC and REST. For REST, it does so by enabling the built in Spring Security observations. These are very basic, but I think it works for us. 

One issue with the Spring Security metrics: the way to differentiate which method (e.g. basic, OIDC) is done via the request/response type simple class name of the authentication principal. With basic, this is easy - there's only one. With OIDC, it's complicated, there's a bunch. And then when we add SAML, it'll get harder.

Right now, it's basically identifying basic, and assuming everything else is OIDC :smile: 

Preview:

<img width="1593" height="661" alt="image" src="https://github.com/user-attachments/assets/234f72b5-2455-41dd-bb60-4e8b989f4352" />
