### PR TITLE
refactor: remove Authentication dependency on camunda-search-*

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -106,14 +106,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-search-domain</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-search-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-auth</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Description

Remove `camunda-search-*` Maven dependencies from the Authentication module.
The module needs to be independent from the Orchestration Cluster.

## Related issues

closes #43962 
