### PR TITLE
refactor: remove Authentication dependency on zeebe-auth

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -113,11 +113,6 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-auth</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
@@ -8,7 +8,6 @@
 package io.camunda.authentication.converter;
 
 import static io.camunda.security.auth.OidcGroupsLoader.DERIVED_GROUPS_ARE_NOT_STRING_ARRAY;
-import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -301,7 +300,6 @@ public class TokenClaimsConverterTest {
       assertThat(authentication.authenticatedRoleIds())
           .containsExactlyInAnyOrder(roleR1.roleId(), groupRole.roleId());
       assertThat(authentication.authenticatedGroupIds()).containsExactly("group-g1");
-      assertThat(authentication.claims().get(USER_GROUPS_CLAIMS)).isNull();
       assertThat(authentication.authenticatedTenantIds())
           .containsExactlyInAnyOrder(tenantT1.tenantId(), groupTenant.tenantId());
     }


### PR DESCRIPTION
## Description

Remove `zeebe-auth` Maven dependencies from the Authentication module.
The module needs to be independent from the Orchestration Cluster.

The test check for `CamundaAuthentication`
```java
assertThat(authentication.claims().get(USER_GROUPS_CLAIMS)).isNull()
``` 
is removed.
* The constant is never set in the claims map
* The access to this constant will be removed from the point of view of the class in one of the next PRs

## Related issues

closes #43963

