### PR TITLE
fix: delete c8run data dir on shutdown if h2 used

### DIFF
--- a/c8run/internal/shutdown/shutdownhandler.go
+++ b/c8run/internal/shutdown/shutdownhandler.go
@@ -4,11 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/camunda/camunda/c8run/internal/processmanagement"
 	"github.com/camunda/camunda/c8run/internal/types"
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 )
 
 type ShutdownHandler struct {
@@ -78,6 +81,10 @@ func (s *ShutdownHandler) stopCommand(settings types.C8RunSettings, processes ty
 	} else {
 		log.Info().Msg("Camunda is stopped.")
 	}
+
+	if shouldDeleteDataDir(settings, processes) {
+		deleteDataDir(processes)
+	}
 }
 
 func (s *ShutdownHandler) stopProcess(pidPath string) error {
@@ -120,4 +127,107 @@ func (s *ShutdownHandler) stopProcess(pidPath string) error {
 	log.Info().Str("pidFile", pidPath).Msg("Successfully stopped process")
 
 	return nil
+}
+
+func shouldDeleteDataDir(settings types.C8RunSettings, processes types.Processes) bool {
+	// Only consider deletion when using H2 (default) secondary storage.
+	if settings.SecondaryStorageType == "" || strings.EqualFold(settings.SecondaryStorageType, "elasticsearch") {
+		return false
+	}
+
+	// Highest precedence: explicit env override.
+	if url, ok := os.LookupEnv("CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL"); ok {
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(url)), "jdbc:h2:")
+	}
+
+	baseDir := filepath.Dir(processes.Camunda.PidPath)
+	for _, cfg := range resolveConfigPaths(baseDir, settings.Config) {
+		if url, err := detectRdbmsURL(cfg); err == nil && strings.HasPrefix(strings.ToLower(url), "jdbc:h2:") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func deleteDataDir(processes types.Processes) {
+	baseDir := filepath.Dir(processes.Camunda.PidPath)
+	dataDir := filepath.Join(baseDir, "camunda-zeebe-"+processes.Camunda.Version, "data")
+	if dataDir == "" {
+		return
+	}
+
+	if err := os.RemoveAll(dataDir); err != nil {
+		log.Warn().Err(err).Str("dataDir", dataDir).Msg("Failed to delete data directory for H2 cleanup")
+		return
+	}
+
+	log.Info().Str("dataDir", dataDir).Msg("Deleted data directory to keep H2 in-memory state consistent across restarts")
+}
+
+func resolveConfigPaths(baseDir string, userConfig string) []string {
+	var paths []string
+	if userConfig != "" {
+		candidate := filepath.Join(baseDir, userConfig)
+		if info, err := os.Stat(candidate); err == nil {
+			if info.IsDir() {
+				candidate = filepath.Join(candidate, "application.yaml")
+			}
+			paths = append(paths, candidate)
+		}
+	}
+	defaultConfig := filepath.Join(baseDir, "configuration", "application.yaml")
+	paths = append(paths, defaultConfig)
+	return paths
+}
+
+func detectRdbmsURL(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	if info.IsDir() {
+		return detectRdbmsURL(filepath.Join(path, "application.yaml"))
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	if len(strings.TrimSpace(string(content))) == 0 {
+		return "", nil
+	}
+
+	var root map[string]any
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return "", err
+	}
+
+	camundaNode, ok := root["camunda"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	dataNode, ok := camundaNode["data"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	secondaryNode, ok := dataNode["secondary-storage"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	rdbmsNode, ok := secondaryNode["rdbms"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	if url, ok := rdbmsNode["url"].(string); ok {
+		return strings.TrimSpace(url), nil
+	}
+	return "", nil
 }

--- a/c8run/internal/shutdown/shutdownhandler_test.go
+++ b/c8run/internal/shutdown/shutdownhandler_test.go
@@ -1,0 +1,211 @@
+package shutdown
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/camunda/camunda/c8run/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldDeleteDataDirUsesEnvOverride(t *testing.T) {
+	t.Setenv("CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL", " jdbc:h2:mem:testdb ")
+	baseDir := t.TempDir()
+
+	settings := types.C8RunSettings{SecondaryStorageType: "rdbms"}
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	require.True(t, shouldDeleteDataDir(settings, processes))
+}
+
+func TestShouldDeleteDataDirIgnoresNonH2EnvOverride(t *testing.T) {
+	t.Setenv("CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL", "jdbc:postgres://localhost")
+	baseDir := t.TempDir()
+
+	settings := types.C8RunSettings{SecondaryStorageType: "rdbms"}
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	require.False(t, shouldDeleteDataDir(settings, processes))
+}
+
+func TestShouldDeleteDataDirUsesCustomConfigDirectory(t *testing.T) {
+	unsetEnv(t, "CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL")
+	baseDir := t.TempDir()
+	userConfigDir := filepath.Join(baseDir, "my-config")
+	configPath := filepath.Join(userConfigDir, "application.yaml")
+	writeConfig(t, configPath, `
+camunda:
+  data:
+    secondary-storage:
+      rdbms:
+        url: jdbc:h2:file:./foo
+`)
+
+	settings := types.C8RunSettings{
+		SecondaryStorageType: "rdbms",
+		Config:               "my-config",
+	}
+
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	url, err := detectRdbmsURL(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "jdbc:h2:file:./foo", url)
+	require.True(t, shouldDeleteDataDir(settings, processes))
+}
+
+func TestShouldDeleteDataDirUsesDefaultConfig(t *testing.T) {
+	unsetEnv(t, "CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL")
+	baseDir := t.TempDir()
+	defaultConfig := filepath.Join(baseDir, "configuration", "application.yaml")
+	writeConfig(t, defaultConfig, `
+camunda:
+  data:
+    secondary-storage:
+      rdbms:
+        url: jdbc:h2:./foo
+`)
+
+	settings := types.C8RunSettings{SecondaryStorageType: "rdbms"}
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	url, err := detectRdbmsURL(defaultConfig)
+	require.NoError(t, err)
+	require.Equal(t, "jdbc:h2:./foo", url)
+	require.True(t, shouldDeleteDataDir(settings, processes))
+}
+
+func TestShouldDeleteDataDirHandlesMissingOrMalformedConfig(t *testing.T) {
+	unsetEnv(t, "CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL")
+	baseDir := t.TempDir()
+	settings := types.C8RunSettings{SecondaryStorageType: "rdbms"}
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	require.False(t, shouldDeleteDataDir(settings, processes), "missing config should not trigger deletion")
+
+	malformedConfig := filepath.Join(baseDir, "configuration", "application.yaml")
+	writeConfig(t, malformedConfig, ":\n  bad yaml")
+
+	require.False(t, shouldDeleteDataDir(settings, processes), "malformed config should not trigger deletion")
+}
+
+func TestShouldDeleteDataDirSkipsWhenSecondaryStorageNotExplicitlySet(t *testing.T) {
+	t.Setenv("CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL", "jdbc:h2:mem:foo")
+	baseDir := t.TempDir()
+	settings := types.C8RunSettings{SecondaryStorageType: ""}
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "8.9.0",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	require.False(t, shouldDeleteDataDir(settings, processes))
+
+	settings = types.C8RunSettings{SecondaryStorageType: "elasticsearch"}
+	require.False(t, shouldDeleteDataDir(settings, processes))
+}
+
+func TestDeleteDataDirRemovesH2Data(t *testing.T) {
+	baseDir := t.TempDir()
+	version := "8.9.0"
+	dataDir := filepath.Join(baseDir, "camunda-zeebe-"+version, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "dummy.txt"), []byte("value"), 0o644))
+
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: version,
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	deleteDataDir(processes)
+
+	_, err := os.Stat(dataDir)
+	require.True(t, os.IsNotExist(err), "data directory should be removed for H2 cleanup")
+}
+
+func TestDeleteDataDirSkipsWhenVersionEmpty(t *testing.T) {
+	baseDir := t.TempDir()
+	targetDir := filepath.Join(baseDir, "camunda-zeebe-", "data")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: "",
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	deleteDataDir(processes)
+
+	_, err := os.Stat(targetDir)
+	require.NoError(t, err, "data directory should remain because version is empty")
+}
+
+func TestDeleteDataDirSkipsWhenVersionContainsPathTraversal(t *testing.T) {
+	baseDir := t.TempDir()
+	version := "../evil"
+	targetDir := filepath.Join(baseDir, "camunda-zeebe-"+version, "data")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+
+	processes := types.Processes{
+		Camunda: types.Process{
+			Version: version,
+			PidPath: filepath.Join(baseDir, "camunda.process"),
+		},
+	}
+
+	deleteDataDir(processes)
+
+	_, err := os.Stat(targetDir)
+	require.NoError(t, err, "data directory should remain because version contained path traversal characters")
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	oldValue, had := os.LookupEnv(key)
+	if had {
+		t.Cleanup(func() {
+			_ = os.Setenv(key, oldValue)
+		})
+	} else {
+		t.Cleanup(func() {
+			_ = os.Unsetenv(key)
+		})
+	}
+	require.NoError(t, os.Unsetenv(key))
+}
+
+func writeConfig(t *testing.T, path string, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/c8run/internal/shutdown/shutdownhandler_test.go
+++ b/c8run/internal/shutdown/shutdownhandler_test.go
@@ -173,8 +173,10 @@ func TestDeleteDataDirSkipsWhenVersionEmpty(t *testing.T) {
 func TestDeleteDataDirSkipsWhenVersionContainsPathTraversal(t *testing.T) {
 	baseDir := t.TempDir()
 	version := "../evil"
-	targetDir := filepath.Join(baseDir, "camunda-zeebe-"+version, "data")
-	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	safeDir := filepath.Join(baseDir, "camunda-zeebe-safe", "data")
+	require.NoError(t, os.MkdirAll(safeDir, 0o755))
+	sentinel := filepath.Join(safeDir, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep"), 0o644))
 
 	processes := types.Processes{
 		Camunda: types.Process{
@@ -185,8 +187,8 @@ func TestDeleteDataDirSkipsWhenVersionContainsPathTraversal(t *testing.T) {
 
 	deleteDataDir(processes)
 
-	_, err := os.Stat(targetDir)
-	require.NoError(t, err, "data directory should remain because version contained path traversal characters")
+	_, err := os.Stat(sentinel)
+	require.NoError(t, err, "sentinel file should remain because version contained path traversal characters")
 }
 
 func unsetEnv(t *testing.T, key string) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

related to https://github.com/camunda/camunda/issues/44192

Validated the PR for the linked bugfix. 

@dmytrivv2 please double check and merge if agree. We should re-release a new alpha3 version with the quick fix imo.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
