### PR TITLE
feat: Enforce user task ID-based permissions (search layer)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -121,7 +121,7 @@ class UserTaskAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_USER_TASK' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform any of the operations: 'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'");
   }
 
   @Test
@@ -152,7 +152,7 @@ class UserTaskAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_USER_TASK' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform any of the operations: 'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'");
   }
 
   @Test
@@ -184,7 +184,7 @@ class UserTaskAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_USER_TASK' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform any of the operations: 'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'");
   }
 
   private long getUserTaskKey(final CamundaClient camundaClient, final String processId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -8,14 +8,19 @@
 package io.camunda.it.auth;
 
 import static io.camunda.client.api.search.enums.PermissionType.*;
+import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static io.camunda.client.api.search.enums.ResourceType.USER_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -47,6 +52,8 @@ class UserTaskAuthorizationIT {
   private static final String USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2 =
       "userWithProcessDefReadUserTaskProcess2";
   private static final String USER_WITH_USER_TASK_READ_WILDCARD = "userWithUserTaskReadWildcard";
+  private static final String USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK =
+      "userWithUserTaskReadProcessId1FirstTask";
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -54,6 +61,8 @@ class UserTaskAuthorizationIT {
           ADMIN,
           "password",
           List.of(
+              new Permissions(AUTHORIZATION, CREATE, List.of("*")),
+              new Permissions(AUTHORIZATION, READ, List.of("*")),
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
@@ -81,6 +90,13 @@ class UserTaskAuthorizationIT {
           "password",
           List.of(new Permissions(USER_TASK, READ, List.of("*"))));
 
+  @UserDefinition
+  private static final TestUser USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK_USER =
+      new TestUser(
+          USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK,
+          "password",
+          List.of()); // Empty permissions - will be added dynamically in @BeforeAll
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
     deployResource(adminClient, "process/bpm_variable_test.bpmn");
@@ -91,6 +107,15 @@ class UserTaskAuthorizationIT {
     startProcessInstance(adminClient, PROCESS_ID_2);
 
     waitForProcessAndTasksBeingExported(adminClient);
+
+    // Add USER_TASK[READ] permission for specific task key at runtime
+    final var processId1FirstUserTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
+    createAuthorizationAndWait(
+        adminClient,
+        USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK,
+        USER_TASK,
+        READ,
+        String.valueOf(processId1FirstUserTaskKey));
   }
 
   @Test
@@ -234,7 +259,62 @@ class UserTaskAuthorizationIT {
     assertThat(result.getBpmnProcessId()).isEqualTo(PROCESS_ID_2);
   }
 
-  private long getUserTaskKey(final CamundaClient camundaClient, final String processId) {
+  @Test
+  void searchShouldReturnOnlyAuthorizedUserTaskForSpecificKeyPermission(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK)
+          final CamundaClient camundaClient) {
+    // given - user has permission only for the first user task from PROCESS_ID_1
+
+    // when
+    final var result = camundaClient.newUserTaskSearchRequest().send().join();
+
+    // then - return only the authorized user task: 1 from PROCESS_ID_1
+    assertThat(result.items())
+        .hasSize(1)
+        .extracting(UserTask::getBpmnProcessId, UserTask::getUserTaskKey)
+        .containsExactly(tuple(PROCESS_ID_1, getUserTaskKey(adminClient, PROCESS_ID_1)));
+  }
+
+  @Test
+  void getByKeyShouldReturnUserTaskForSpecificKeyPermission(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK)
+          final CamundaClient camundaClient) {
+    // given - the authorized task key from @BeforeAll
+    final var authorizedTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
+
+    // when
+    final var result = camundaClient.newUserTaskGetRequest(authorizedTaskKey).send().join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getBpmnProcessId()).isEqualTo(PROCESS_ID_1);
+    assertThat(result.getUserTaskKey()).isEqualTo(authorizedTaskKey);
+  }
+
+  @Test
+  void getByKeyShouldReturnForbiddenForUnauthorizedUserTaskWithSpecificKeyPermission(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK)
+          final CamundaClient camundaClient) {
+    // given - an unauthorized task key from PROCESS_ID_2
+    final var unauthorizedTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
+
+    // when
+    final ThrowingCallable executeGet =
+        () -> camundaClient.newUserTaskGetRequest(unauthorizedTaskKey).send().join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform any of the operations: 'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'");
+  }
+
+  private static long getUserTaskKey(final CamundaClient camundaClient, final String processId) {
     return camundaClient
         .newUserTaskSearchRequest()
         .filter(f -> f.bpmnProcessId(processId))
@@ -288,6 +368,44 @@ class UserTaskAuthorizationIT {
                           .items())
                   .hasSize(2);
               assertThat(camundaClient.newUserTaskSearchRequest().send().join().items()).hasSize(3);
+            });
+  }
+
+  /**
+   * Creates an authorization for a user and waits until it's visible in the system.
+   *
+   * @param adminClient the admin client to use for creating the authorization
+   * @param username the username (owner ID) to grant the permission to
+   * @param resourceType the resource type (e.g., USER_TASK, PROCESS_DEFINITION)
+   * @param permissionType the permission type (e.g., READ, UPDATE)
+   * @param resourceId the resource ID to grant permission for
+   */
+  private static void createAuthorizationAndWait(
+      final CamundaClient adminClient,
+      final String username,
+      final ResourceType resourceType,
+      final PermissionType permissionType,
+      final String resourceId) {
+    final long authorizationKey =
+        adminClient
+            .newCreateAuthorizationCommand()
+            .ownerId(username)
+            .ownerType(OwnerType.USER)
+            .resourceId(resourceId)
+            .resourceType(resourceType)
+            .permissionTypes(permissionType)
+            .send()
+            .join()
+            .getAuthorizationKey();
+
+    Awaitility.await("authorization with key '" + authorizationKey + "' to be created")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var authorization =
+                  adminClient.newAuthorizationGetRequest(authorizationKey).send().join();
+              assertThat(authorization).isNotNull();
             });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -40,8 +40,10 @@ class UserTaskAuthorizationIT {
   private static final String PROCESS_ID_1 = "bpmProcessVariable";
   private static final String PROCESS_ID_2 = "processWithForm";
   private static final String ADMIN = "admin";
-  private static final String USER1 = "user1";
-  private static final String USER2 = "user2";
+  private static final String USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1 =
+      "userWithProcessDefReadUserTaskProcess1";
+  private static final String USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2 =
+      "userWithProcessDefReadUserTaskProcess2";
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -56,16 +58,16 @@ class UserTaskAuthorizationIT {
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
 
   @UserDefinition
-  private static final TestUser USER1_USER =
+  private static final TestUser USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1_USER =
       new TestUser(
-          USER1,
+          USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1,
           "password",
           List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_1))));
 
   @UserDefinition
-  private static final TestUser USER2_USER =
+  private static final TestUser USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2_USER =
       new TestUser(
-          USER2,
+          USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2,
           "password",
           List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_2))));
 
@@ -83,7 +85,8 @@ class UserTaskAuthorizationIT {
 
   @Test
   public void searchShouldReturnAuthorizedUserTasks(
-      @Authenticated(USER1) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1)
+          final CamundaClient camundaClient) {
     // when
     final var result = camundaClient.newUserTaskSearchRequest().send().join();
 
@@ -96,7 +99,8 @@ class UserTaskAuthorizationIT {
   @Test
   void getByKeyShouldReturnAuthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER1) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
     // when
@@ -109,7 +113,8 @@ class UserTaskAuthorizationIT {
   @Test
   void getByKeyShouldReturnForbiddenForUnauthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER1) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
     // when
@@ -127,7 +132,8 @@ class UserTaskAuthorizationIT {
   @Test
   void getUserTaskFormShouldReturnFormForAuthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER2) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
     // when
@@ -140,7 +146,8 @@ class UserTaskAuthorizationIT {
   @Test
   void getUserTaskFormShouldReturnForbiddenForUnauthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER1) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_2);
     // when
@@ -158,7 +165,8 @@ class UserTaskAuthorizationIT {
   @Test
   void searchUserTaskVariablesShouldReturnVariablesForAuthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER1) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
     // when
@@ -170,7 +178,8 @@ class UserTaskAuthorizationIT {
   @Test
   void searchUserTaskVariablesShouldReturnForbiddenForUnauthorizedUserTask(
       @Authenticated(ADMIN) final CamundaClient adminClient,
-      @Authenticated(USER2) final CamundaClient camundaClient) {
+      @Authenticated(USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2)
+          final CamundaClient camundaClient) {
     // given
     final var userTaskKey = getUserTaskKey(adminClient, PROCESS_ID_1);
     // when

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentResourceAccessControllerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentResourceAccessControllerTest.java
@@ -430,7 +430,7 @@ class DocumentResourceAccessControllerTest {
     // when - then
     assertThatExceptionOfType(ResourceAccessDeniedException.class)
         .isThrownBy(() -> controller.doGet(securityContext, doGetAccessCheckApplier(document)))
-        .withMessageContaining(
+        .withMessage(
             "Unauthorized to perform operation 'READ_PROCESS_DEFINITION' on resource 'PROCESS_DEFINITION'")
         .satisfies(
             err -> {
@@ -469,8 +469,8 @@ class DocumentResourceAccessControllerTest {
     // when - then
     assertThatExceptionOfType(ResourceAccessDeniedException.class)
         .isThrownBy(() -> controller.doGet(securityContext, doGetAccessCheckApplier(document)))
-        .withMessageContaining(
-            "Unauthorized to perform any of the operations ('READ_USER_TASK' on 'PROCESS_DEFINITION'), ('READ' on 'USER_TASK')")
+        .withMessage(
+            "Unauthorized to perform any of the operations: 'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'")
         .satisfies(
             err -> {
               assertThat(err.getReason()).isEqualTo(Reason.FORBIDDEN);

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ResourceAccessDeniedException.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ResourceAccessDeniedException.java
@@ -67,10 +67,11 @@ public class ResourceAccessDeniedException extends CamundaSearchException {
 
     final var parts =
         missingAuthorization.stream()
-            .map(ma -> "('%s' on '%s')".formatted(ma.permissionType(), ma.resourceType()))
-            .collect(Collectors.joining(", "));
+            .map(ma -> "'%s' on '%s'".formatted(ma.permissionType(), ma.resourceType()))
+            .distinct()
+            .collect(Collectors.joining(" or "));
 
-    return "Unauthorized to perform any of the operations %s".formatted(parts);
+    return "Unauthorized to perform any of the operations: %s".formatted(parts);
   }
 
   public record MissingAuthorization(

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -11,7 +11,7 @@ import static io.camunda.search.query.SearchQueryBuilders.auditLogSearchQuery;
 import static io.camunda.search.query.SearchQueryBuilders.userTaskSearchQuery;
 import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
 import static io.camunda.security.auth.Authorization.withAuthorization;
-import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION;
 
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
@@ -107,7 +107,7 @@ public final class UserTaskServices
     return search(
         query,
         securityContextProvider.provideSecurityContext(
-            authentication, USER_TASK_READ_AUTHORIZATION));
+            authentication, PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
   }
 
   private SearchQueryResult<UserTaskEntity> search(
@@ -200,7 +200,8 @@ public final class UserTaskServices
                         securityContextProvider.provideSecurityContext(
                             authentication,
                             withAuthorization(
-                                USER_TASK_READ_AUTHORIZATION, UserTaskEntity::processDefinitionId)))
+                                PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION,
+                                UserTaskEntity::processDefinitionId)))
                     .getUserTask(userTaskKey));
 
     final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -95,6 +95,9 @@ public abstract class Authorizations {
       PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION =
           Authorization.of(a -> a.processDefinition().readUserTask());
 
+  public static final Authorization<UserTaskEntity> USER_TASK_READ_AUTHORIZATION =
+      Authorization.of(a -> a.userTask().read());
+
   public static final Authorization<VariableEntity> VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
 

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -91,8 +91,9 @@ public abstract class Authorizations {
   public static final Authorization<UserEntity> USER_READ_AUTHORIZATION =
       Authorization.of(a -> a.user().read());
 
-  public static final Authorization<UserTaskEntity> USER_TASK_READ_AUTHORIZATION =
-      Authorization.of(a -> a.processDefinition().readUserTask());
+  public static final Authorization<UserTaskEntity>
+      PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION =
+          Authorization.of(a -> a.processDefinition().readUserTask());
 
   public static final Authorization<VariableEntity> VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -89,7 +89,8 @@ public class UserTaskServiceTest {
       // given
       when(client.getUserTask(any(Long.class)))
           .thenThrow(
-              new ResourceAccessDeniedException(Authorizations.USER_TASK_READ_AUTHORIZATION));
+              new ResourceAccessDeniedException(
+                  Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
 
       // when
       final ThrowingCallable executable =
@@ -140,7 +141,8 @@ public class UserTaskServiceTest {
       // given
       when(client.getUserTask(any(Long.class)))
           .thenThrow(
-              new ResourceAccessDeniedException(Authorizations.USER_TASK_READ_AUTHORIZATION));
+              new ResourceAccessDeniedException(
+                  Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
 
       // when
       final ThrowingCallable executable =
@@ -279,7 +281,8 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class)))
           .thenThrow(
-              new ResourceAccessDeniedException(Authorizations.USER_TASK_READ_AUTHORIZATION));
+              new ResourceAccessDeniedException(
+                  Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
 
       final ThrowingCallable executable = () -> services.getByKey(entity.userTaskKey());
 


### PR DESCRIPTION
## Description

This PR implements the first step of #41682 by enforcing `USER_TASK[READ]` ID-based permissions in addition to the existing `PROCESS_DEFINITION[READ_USER_TASK]` permission for user task APIs in the Search layer.

### Changes

Users can now read user tasks if they have either: 
- `PROCESS_DEFINITION[READ_USER_TASK]` permission for the corresponding process definition (or wildcard `*` for all process definitions), **OR**
- `USER_TASK[READ]` permission for the specific user task key (or wildcard `*` for all user tasks)

This applies to the following endpoints:
- Search user tasks (`UserTaskServices.search`)
- Get user task by key (`UserTaskServices.getByKey`)

### Implementation details

- Updated `UserTaskServices` to use composite authorization conditions via `AuthorizationConditions.anyOf()` combining both `PROCESS_DEFINITION[READ_USER_TASK]` and `USER_TASK[READ]` checks
- Introduced a new `PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION` constant to distinguish it from `USER_TASK_READ_AUTHORIZATION`
- Improved error messaging for unauthorized access attempts to clearly indicate both permission options
- Extended `UserTaskAuthorizationIT` with comprehensive test coverage for: 
  - Wildcard `USER_TASK[READ]` permission (`*`)
  - Specific task key-based `USER_TASK[READ]` permission

> [!NOTE]
> The 2nd implementation part for #41682 — enforcing `USER_TASK[READ]` PROPERTY-based permissions (assignee, candidateUsers, candidateGroups) — will be introduced in a separate PR after [PR #43860](https://github.com/camunda/camunda/pull/43860) is merged.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

implements 1st step of: #41682
