### PR TITLE
[CPT] test: Update deprecated configuration prefix

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
@@ -35,8 +35,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
     properties = {
-      "io.camunda.process.test.connectors-enabled=true",
-      "io.camunda.process.test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
+      "camunda.process-test.connectors-enabled=true",
+      "camunda.process-test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
     })
 @CamundaSpringProcessTest
 public class ConnectorProcessTest {


### PR DESCRIPTION
## Description

Replace the deprecated configuration prefix `io.camunda.process.test` with the new one `camunda.process-test` in the CPT example test class `ConnectorProcessTest`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues


