### PR TITLE
fix: do not print entire stacktrace when NativeFS cannot be used

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
@@ -34,7 +34,9 @@ public final class PosixFs {
           MethodHandles.privateLookupIn(FileDescriptor.class, MethodHandles.lookup())
               .findVarHandle(FileDescriptor.class, "fd", int.class);
     } catch (final NoSuchFieldException | IllegalAccessException e) {
-      LOGGER.warn("Cannot look up file descriptor via reflection; NativeFS will be disabled", e);
+      LOGGER.warn(
+          "Cannot look up file descriptor via reflection; NativeFS will be disabled: {}",
+          e.getMessage());
       fileDescriptorFd = null;
     }
 


### PR DESCRIPTION
## Description
The stacktrace is not really useful and adds a lot of noise. The reason should be clear from the exception message.

Example stacktrace from a [CI run ](https://github.com/camunda/camunda/actions/runs/21128672216/job/60754808044?pr=43794), see `Start Operate`

Java module will be opened in PR #44257


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
