### PR TITLE
fix: open java.base in all modules for tests & spring-boot 

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1030,6 +1030,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <jvmArguments>--add-opens=java.base/java.io=ALL-UNNAMED</jvmArguments>
+        </configuration>
         <executions>
           <execution>
             <id>build-info</id>
@@ -1045,6 +1048,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2467,6 +2467,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.surefire}</version>
           <configuration>
+            <!-- Required to access the raw file descriptor from FileDescriptor for NativeFS -->
+            <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
             <!-- by default, exclude performance and strace tests -->
             <excludedGroups>performance, strace</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
@@ -2505,6 +2507,8 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${plugin.version.failsafe}</version>
           <configuration>
+            <!-- Required to access the raw file descriptor from FileDescriptor for NativeFS -->
+            <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -169,25 +169,6 @@
           </usedDependencies>
         </configuration>
       </plugin>
-
-      <!--      NEED to open java.base for FFI -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- required to access the raw file descriptor from FileDescriptor -->
-          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <!-- required to access the raw file descriptor from FileDescriptor -->
-          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION

## Description
To allow all modules to use the Posix filesystem api they all need to expose java.base module, otherwise those modules will run the tests with the fallback.

The spring-boot plugin needs to open that module as well as it's used by CI

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
