### PR TITLE
[Backport stable/8.8] [CPT] test: Update deprecated configuration prefix

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
@@ -35,8 +35,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
     properties = {
-      "io.camunda.process.test.connectors-enabled=true",
-      "io.camunda.process.test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
+      "camunda.process-test.connectors-enabled=true",
+      "camunda.process-test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
     })
 @CamundaSpringProcessTest
 public class ConnectorProcessTest {


### PR DESCRIPTION
# Description
Backport of #44252 to `stable/8.8`.

relates to 