### PR TITLE
fix: use proper logger in `CCSMAuthenticationCookieFilter`

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMAuthenticationCookieFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMAuthenticationCookieFilter.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
@@ -38,6 +40,9 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
 @Conditional(CCSMCondition.class)
 @AllArgsConstructor
 public class CCSMAuthenticationCookieFilter extends AbstractPreAuthenticatedProcessingFilter {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CCSMAuthenticationCookieFilter.class);
 
   private final CCSMTokenService ccsmTokenService;
   private final ConfigurationService configurationService;
@@ -77,7 +82,7 @@ public class CCSMAuthenticationCookieFilter extends AbstractPreAuthenticatedProc
       } catch (final NotAuthorizedException notAuthorizedException) {
         // During token verification, it could be that the user is no longer authorized to access
         // Optimize, in which case we delete any existing cookies
-        logger.debug(notAuthorizedException.getMessage());
+        LOGGER.debug(notAuthorizedException.getMessage());
         deleteCookies(response);
       }
     }


### PR DESCRIPTION
## Description

`CCSMAuthenticationCookieFilter#doFilter` did not seem to have good behavior.

### Reasons
- `com.auth0.jwt.exceptions.TokenExpiredException` could never be caught and then call `tryCookieRenewal`
- `io.camunda.identity.sdk.exception.IdentityException` could never be caught and then call `revokeToken`, `deleteCookies`
- if access token was present but not valid -- then could not call `tryCookieRenewal` -- used to return 401 instead

### Fixes
- replace `com.auth0.jwt.exceptions.TokenExpiredException` with `io.camunda.identity.sdk.authentication.exception.TokenVerificationException` in order to `tryCookieRenewal` on invalid access token
- remove `io.camunda.identity.sdk.exception.IdentityException` since code was unreachable
- introduce `verifyAccessToken` method that helps catch `io.camunda.identity.sdk.authentication.exception.TokenVerificationException` and `tryCookieRenewal` -- instead of throw `NotAuthorizedException` and return 401
- introduced test cases that showcase expected behavior

### Links
Channel: [#inc-support-30092-c8-optimize-unoauthorized-after-3-4-minutes](https://camunda.slack.com/archives/C09UAH1T56D)
Issue: relates #44006