### PR TITLE
feat: extend batch operation item schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.32
+
+### 🚀 Enhancements
+
+- add `operationType` field to `batchOperationItem` schema ([#42145](https://github.com/camunda/camunda/pull/42145))
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
 ## v0.0.31
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.8/batch-operation.ts
@@ -64,6 +64,7 @@ const batchOperationItemSchema = z.object({
 	state: batchOperationItemStateSchema,
 	processedDate: z.string().optional(),
 	errorMessage: z.string().optional(),
+	operationType: batchOperationTypeSchema,
 });
 type BatchOperationItem = z.infer<typeof batchOperationItemSchema>;
 

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.0",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.31",
+        "@camunda/camunda-api-zod-schemas": "0.0.32",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.71.0",
         "@carbon/react": "1.57.0",
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.31.tgz",
-      "integrity": "sha512-SZemH13UaTi4fnKOGp3hQr/u46Oaf0VjSxvORbbP0O9g4fo5ThPzBvsoOZVJxOe3MHA7QzDXvLl4vtMWXnqfMA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.32.tgz",
+      "integrity": "sha512-BykfbuzE95zIOZe/+GhbuSN6B1RwKU5XaG5tNrcfmEqjIZvqyBZ0dqJt2VmW7UPtn3Xp2AWkVyBeV4VnUmgcWg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.0",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.31",
+    "@camunda/camunda-api-zod-schemas": "0.0.32",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.71.0",
     "@carbon/react": "1.57.0",

--- a/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
@@ -32,6 +32,7 @@ const createMockBatchOperationItems = (
     itemKey: `item-${i + 1}`,
     processInstanceKey: `2251799813685${250 + i}`,
     state: options?.state ?? 'COMPLETED',
+    operationType: 'MIGRATE_PROCESS_INSTANCE',
     processedDate: '2023-11-22T09:03:29.564+0100',
     errorMessage: options?.withErrors
       ? `Error processing item ${i + 1}`

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
@@ -224,6 +224,7 @@ describe('ElementInstanceLog', () => {
           batchOperationKey: 'op-1',
           processInstanceKey: '1',
           state: 'COMPLETED',
+          operationType: 'RESOLVE_INCIDENT',
           processedDate: '2018-12-12T00:00:00.000+0000',
         },
       ],

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/ProcessInstanceOperations.test.tsx
@@ -221,6 +221,7 @@ describe('ProcessInstanceOperations', () => {
           batchOperationKey: 'batch-123',
           processInstanceKey: '123456789',
           state: 'ACTIVE',
+          operationType: 'CANCEL_PROCESS_INSTANCE',
           itemKey: '123456789',
         },
       ],

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
@@ -182,6 +182,7 @@ describe('InstanceHeader', () => {
           itemKey: '1',
           processInstanceKey: mockInstance.processInstanceKey,
           state: 'ACTIVE',
+          operationType: 'CANCEL_PROCESS_INSTANCE',
         },
       ],
       page: {totalItems: 1},

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.31",
+        "@camunda/camunda-api-zod-schemas": "0.0.32",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.31.tgz",
-      "integrity": "sha512-SZemH13UaTi4fnKOGp3hQr/u46Oaf0VjSxvORbbP0O9g4fo5ThPzBvsoOZVJxOe3MHA7QzDXvLl4vtMWXnqfMA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.32.tgz",
+      "integrity": "sha512-BykfbuzE95zIOZe/+GhbuSN6B1RwKU5XaG5tNrcfmEqjIZvqyBZ0dqJt2VmW7UPtn3Xp2AWkVyBeV4VnUmgcWg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.31",
+    "@camunda/camunda-api-zod-schemas": "0.0.32",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

Add `operationType` field to batch operation item schema

[API docs ](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/search-batch-operation-items/)

## Related issues

related to #43698 
