### PR TITLE
ci: Increase timeout for build-operate-backend job

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -63,7 +63,7 @@ jobs:
     if: inputs.runBeTests
     name: "Build Back End"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Description

While we investigate why the runtime nearly doubled in a week. [Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1768821195512769)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
