### PR TITLE
feat: migrate core dashboard statistics to v2 process-definition instances statistics

### DIFF
--- a/operate/client/src/App/Dashboard/v2/MetricPanel/index.tsx
+++ b/operate/client/src/App/Dashboard/v2/MetricPanel/index.tsx
@@ -60,8 +60,8 @@ const MetricPanel = observer(() => {
       </Title>
       {count && (
         <InstancesBar
-          incidentsCount={count?.withIncidents}
-          activeInstancesCount={count?.withoutIncidents}
+          incidentsCount={count.withIncidents}
+          activeInstancesCount={count.withoutIncidents}
           size="large"
         />
       )}

--- a/operate/client/src/App/Dashboard/v2/index.test.tsx
+++ b/operate/client/src/App/Dashboard/v2/index.test.tsx
@@ -22,6 +22,7 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser, searchResult} from 'modules/testUtils';
+import {createProcessDefinitionInstancesStatistics} from 'modules/mocks/mockProcessDefinitionStatistics';
 
 type Props = {
   children?: React.ReactNode;
@@ -45,6 +46,14 @@ describe('Dashboard', () => {
     mockFetchProcessCoreStatistics().withSuccess(statistics);
     mockFetchIncidentsByError().withSuccess(mockIncidentsByError);
     mockFetchProcessDefinitionStatistics().withSuccess(mockWithSingleVersion);
+    mockFetchProcessDefinitionStatistics().withSuccess(
+      searchResult([
+        createProcessDefinitionInstancesStatistics({
+          activeInstancesWithIncidentCount: 877,
+          activeInstancesWithoutIncidentCount: 210,
+        }),
+      ]),
+    );
 
     render(<Dashboard />, {wrapper: Wrapper});
 
@@ -64,6 +73,7 @@ describe('Dashboard', () => {
     mockFetchProcessCoreStatistics().withSuccess(statistics);
     mockFetchIncidentsByError().withSuccess(mockIncidentsByError);
     mockFetchProcessDefinitionStatistics().withSuccess(searchResult([]));
+    mockFetchProcessDefinitionStatistics().withSuccess(searchResult([]));
 
     render(<Dashboard />, {wrapper: Wrapper});
 
@@ -78,6 +88,7 @@ describe('Dashboard', () => {
   it('should render empty state (no incidents)', async () => {
     mockFetchProcessCoreStatistics().withSuccess(statistics);
     mockFetchIncidentsByError().withSuccess([]);
+    mockFetchProcessDefinitionStatistics().withSuccess(mockWithSingleVersion);
     mockFetchProcessDefinitionStatistics().withSuccess(mockWithSingleVersion);
 
     render(<Dashboard />, {wrapper: Wrapper});

--- a/operate/client/src/modules/mocks/mockProcessDefinitionStatistics.ts
+++ b/operate/client/src/modules/mocks/mockProcessDefinitionStatistics.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ProcessDefinitionInstanceStatistics} from '@camunda/camunda-api-zod-schemas/8.8';
+
+function createProcessDefinitionInstancesStatistics(
+  options?: Partial<ProcessDefinitionInstanceStatistics>,
+): ProcessDefinitionInstanceStatistics {
+  return {
+    processDefinitionId: 'orderProcess',
+    latestProcessDefinitionName: 'Order process',
+    hasMultipleVersions: true,
+    activeInstancesWithIncidentCount: 0,
+    activeInstancesWithoutIncidentCount: 0,
+    tenantId: '<default>',
+    ...options,
+  };
+}
+
+export {createProcessDefinitionInstancesStatistics};

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useRunningInstancesCountStatistics.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useRunningInstancesCountStatistics.ts
@@ -36,8 +36,11 @@ function aggregateRunningInstancesCount(
 function useRunningInstancesCountStatistics() {
   return useQuery({
     queryKey: queryKeys.processDefinitionStatistics.runningInstancesCount(),
+    refetchInterval: 5000,
     queryFn: async () => {
-      const {response, error} = await fetchProcessDefinitionStatistics();
+      const {response, error} = await fetchProcessDefinitionStatistics({
+        sort: [{field: 'activeInstancesWithoutIncidentCount', order: 'desc'}],
+      });
       if (error) {
         throw error;
       }
@@ -48,6 +51,7 @@ function useRunningInstancesCountStatistics() {
 
       const {response: remaining, error: remainingError} =
         await fetchProcessDefinitionStatistics({
+          sort: [{field: 'activeInstancesWithoutIncidentCount', order: 'desc'}],
           page: {from: response.items.length, limit: response.page.totalItems},
         });
       if (remainingError) {
@@ -57,7 +61,6 @@ function useRunningInstancesCountStatistics() {
       const allItems = response.items.concat(remaining.items);
       return aggregateRunningInstancesCount(allItems);
     },
-    refetchInterval: 5000,
   });
 }
 

--- a/operate/client/src/modules/queries/processDefinitionStatistics/useRunningInstancesCountStatistics.ts
+++ b/operate/client/src/modules/queries/processDefinitionStatistics/useRunningInstancesCountStatistics.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {fetchProcessDefinitionStatistics} from 'modules/api/v2/processDefinitions/fetchProcessDefinitionStatistics';
+import {queryKeys} from '../queryKeys.ts';
+import type {ProcessDefinitionInstanceStatistics} from '@camunda/camunda-api-zod-schemas/8.8';
+
+interface RunningProcessInstancesCount {
+  total: number;
+  withoutIncidents: number;
+  withIncidents: number;
+}
+
+function aggregateRunningInstancesCount(
+  definitionStatistics: ProcessDefinitionInstanceStatistics[],
+): RunningProcessInstancesCount {
+  let count: RunningProcessInstancesCount = {
+    total: 0,
+    withoutIncidents: 0,
+    withIncidents: 0,
+  };
+  for (const statistic of definitionStatistics) {
+    count.withoutIncidents += statistic.activeInstancesWithoutIncidentCount;
+    count.withIncidents += statistic.activeInstancesWithIncidentCount;
+  }
+  count.total = count.withoutIncidents + count.withIncidents;
+  return count;
+}
+
+function useRunningInstancesCountStatistics() {
+  return useQuery({
+    queryKey: queryKeys.processDefinitionStatistics.runningInstancesCount(),
+    queryFn: async () => {
+      const {response, error} = await fetchProcessDefinitionStatistics();
+      if (error) {
+        throw error;
+      }
+
+      if (response.page.totalItems <= response.items.length) {
+        return aggregateRunningInstancesCount(response.items);
+      }
+
+      const {response: remaining, error: remainingError} =
+        await fetchProcessDefinitionStatistics({
+          page: {from: response.items.length, limit: response.page.totalItems},
+        });
+      if (remainingError) {
+        throw remainingError;
+      }
+
+      const allItems = response.items.concat(remaining.items);
+      return aggregateRunningInstancesCount(allItems);
+    },
+    refetchInterval: 5000,
+  });
+}
+
+export {useRunningInstancesCountStatistics};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -91,6 +91,10 @@ const queryKeys = {
       processDefinitionId: string,
       payload?: GetProcessDefinitionInstanceVersionStatisticsRequestBody,
     ) => ['processDefinitionVersionStatistics', processDefinitionId, payload],
+    runningInstancesCount: () => [
+      'processDefinitionStatistics',
+      'runningInstancesCount',
+    ],
   },
   incidents: {
     get: (incidentKey: string) => ['incident', incidentKey],


### PR DESCRIPTION
## Description

Migrates the core dashboard statistics to aggregate running instances counts from the [process-definitions instances statistics endpoint](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/get-process-definition-instance-statistics/).

The changes have only been applied to the Dashboard v2 subarea. They could easily be copied to the v1 area as well, since the files are basically identical. This would allow us to cleanup the statistics store already.
@juliasaienko You originally created the copied v2 dashboard area. Should I hold off with applying the changes to the v1 area as well, or would it already help with the cleanup later? What are your thoughts around this?

## Checklist

- [X] ~There is currently a bug in the backend, which includes _completed_ and _cancelled_ PIs in the statistics. We might want to hold of with the merge until it is fixed.~
  - This PR implements a workaround so it is not affected by the bug. The bug will be tackled in #44368.

## Related issues

relates #27401
