### PR TITLE
[Backport stable/8.8] Make max rockDB memory fraction configurable.

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1299,8 +1299,9 @@
         # Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
         # allocated to RocksDB will be the number of partitions times the configured memory limit. If the
         # value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-        # memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
-        # to RocksDB that can be configured via the memoryFraction configuration [0,1].
+        # memory limit. If set to 'FRACTION', Zeebe will allocate a fraction of
+        # total memory to RocksDB that can be configured via the memoryFraction
+        # configuration [0,1].
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYALLOCATIONSTRATEGY
         # memoryAllocationStrategy: PARTITION
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1212,8 +1212,9 @@
         # Configures the memory allocation strategy by RocksDB. If set to 'PARTITION', the total memory
         # allocated to RocksDB will be the number of partitions times the configured memory limit. If the
         # value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
-        # memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
-        # to RocksDB that can be configured via the memoryFraction configuration [0,1].
+        # memory limit. If set to 'FRACTION', Zeebe will allocate a fraction of
+        # total memory to RocksDB that can be configured via the memoryFraction
+        # configuration [0,1].
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYALLOCATIONSTRATEGY
         # memoryAllocationStrategy: PARTITION
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -31,6 +31,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
   private double memoryFraction = 0.1;
+  private double maxMemoryFraction = -1;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -90,6 +91,14 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
+  }
+
+  public double getMaxMemoryFraction() {
+    return maxMemoryFraction;
+  }
+
+  public void setMaxMemoryFraction(final double maxMemoryFraction) {
+    this.maxMemoryFraction = maxMemoryFraction;
   }
 
   public int getMaxOpenFiles() {
@@ -177,6 +186,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
         + memoryAllocationStrategy
         + ", memoryFraction="
         + memoryFraction
+        + ", maxMemoryFraction="
+        + maxMemoryFraction
         + ", maxOpenFiles="
         + maxOpenFiles
         + ", maxWriteBufferNumber="


### PR DESCRIPTION
# Description
Backport of #43023 to `stable/8.8`.

relates to camunda/camunda#42278