### PR TITLE
[Backport stable/8.7] ci: Increase timeout for build-operate-backend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,7 @@ jobs:
     if: needs.detect-changes.outputs.operate-backend-changes == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
# Description
Backport of #44287 to `stable/8.7`.

relates to 