### PR TITLE
[Backport stable/8.8] ci: Increase timeout for build-operate-backend job

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -64,7 +64,7 @@ jobs:
     if: inputs.runBeTests
     name: "Build Back End"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
# Description
Backport of #44287 to `stable/8.8`.

relates to 