### PR TITLE
[Backport 8.7]: Add data availability measurement in starter application

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -463,7 +463,7 @@ jobs:
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
-          ${{ inputs.operate-included && '--set app.monitorDataAvailability=true' || '' }}
+          ${{ inputs.operate-included && '--set global.extraEnvVars[0].name="CONFIG_FORCE_app_monitorDataAvailability" --set global.extraEnvVars[0].value="true"' || '' }}
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -45,6 +45,11 @@ on:
         type: boolean
         required: false
         default: false
+      operate-included:
+        description: 'Enable Operate: Should run a load test, including operate (allows the measurement for data-availability)'
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -87,6 +92,11 @@ on:
         default: false
       realistic:
         description: 'Should run a realistic load test, with real-world process and load'
+        type: boolean
+        required: false
+        default: false
+      operate-included:
+        description: 'Enable Operate: Should run a load test, including operate (allows the measurement for data-availability)'
         type: boolean
         required: false
         default: false
@@ -182,7 +192,7 @@ jobs:
   build-operate-image:
     name: Build + Push Operate Docker image
     needs: calculate-image-tag
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.operate-included && inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -374,14 +384,12 @@ jobs:
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set operate.enabled=true
-          --set operate.image.repository=gcr.io/zeebe-io/operate
-          --set operate.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set elasticsearch.master.persistence.size=128Gi
           --set zeebe.retention.minimumAge=1d
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
+          ${{ inputs.operate-included && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/camunda-platform-operate-values.yaml', github.ref) || '' }}
+          ${{ inputs.operate-included && format('--set operate.image.tag={0}', needs.calculate-image-tag.outputs.image-tag) || '' }}
           ${{ inputs.platform-helm-values }}
 
       - name: Summarize deployment
@@ -455,6 +463,7 @@ jobs:
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
+          ${{ inputs.operate-included && '--set app.monitorDataAvailability=true' || '' }}
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -124,7 +124,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  build-camunda-image:
+  build-zeebe-image:
     name: Build Camunda
     needs: calculate-image-tag
     if: ${{ inputs.reuse-tag == '' }}
@@ -194,6 +194,84 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  build-operate-image:
+    name: Build + Push Operate Docker image
+    needs: calculate-image-tag
+    if: ${{ inputs.reuse-tag == '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      # See https://github.com/marketplace/actions/authenticate-to-google-cloud#setup
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "adopt"
+          java-version: "21"
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
+        with:
+          maven-version: 3.8.8
+          set-mvnw: true
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: operate
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v3.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+      - name: Build backend
+        run: ./mvnw clean install -DskipChecks -P -docker -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push to Zeebe gcr.io registry
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: .
+          push: true
+          tags: gcr.io/zeebe-io/operate:${{ needs.calculate-image-tag.outputs.image-tag }}
+          file: operate.Dockerfile
+
   build-load-test-images:
     name: Build Starter and Worker
     if: ${{ inputs.reuse-tag == '' }}
@@ -245,7 +323,8 @@ jobs:
     name: Deploy cluster under test
     needs:
       - calculate-image-tag
-      - build-camunda-image
+      - build-zeebe-image
+      - build-operate-image
       - build-load-test-images
     # To have the possibility to re-deploy the tests without rebuilding the images,
     # the deploy will be run, when build is skipped or successful.
@@ -309,6 +388,11 @@ jobs:
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set operate.enabled=true
+          --set operate.image.repository=gcr.io/zeebe-io/operate
+          --set operate.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set elasticsearch.master.persistence.size=128Gi
+          --set zeebe.retention.minimumAge=1d
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
@@ -339,7 +423,8 @@ jobs:
       # We need to depend on calculate-image-tag, so that we can use the output in the job
       - calculate-image-tag
       - deploy-cluster-under-test
-      - build-camunda-image
+      - build-zeebe-image
+      - build-operate-image
       - build-load-test-images
       # To have the possibility to re-deploy the tests without rebuilding the images,
       # the deploy will be run, when build is skipped or successful.

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -125,7 +125,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   build-zeebe-image:
-    name: Build Camunda
+    name: Build Zeebe Docker image
     needs: calculate-image-tag
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
@@ -143,23 +143,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/build-frontend
-        name: Build Operate Frontend
-        id: build-operate-fe
-        with:
-          directory: ./operate/client
-      - uses: ./.github/actions/build-frontend
-        name: Build Tasklist Frontend
-        id: build-tasklist-fe
-        with:
-          directory: ./tasklist/client
-      - uses: ./.github/actions/build-frontend
-        name: Build Identity Frontend
-        id: build-identity-fe
-        with:
-          directory: ./identity/client
       - uses: ./.github/actions/build-zeebe
-        name: Build Camunda Platform
+        name: Build Zeebe
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize -Dmaven.test.skip=true
@@ -176,7 +161,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
-        name: Build Camunda Docker Image
+        name: Build Zeebe Docker Image
         with:
           repository: 'gcr.io/zeebe-io/zeebe'
           revision: ${{ inputs.ref }}
@@ -330,7 +315,8 @@ jobs:
     # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-operate-image.result == 'success' || needs.build-operate-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -430,7 +416,8 @@ jobs:
       # the deploy will be run, when build is skipped or successful.
     if: |
       always() &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+      (needs.build-zeebe-image.result == 'success' || needs.build-zeebe-image.result == 'skipped') &&
+      (needs.build-operate-image.result == 'success' || needs.build-operate-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/zeebe/benchmarks/camunda-platform-operate-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-operate-values.yaml
@@ -5,6 +5,36 @@ operate:
   image:
     repository: gcr.io/zeebe-io/operate
     tag: 8.7.0
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 600m
+      memory: 400Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  # Retention can be used to define the data in Elasticsearch (ILM).
+  retention:
+    ## @param operate.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+    enabled: true
+    ## @param operate.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+    minimumAge: 30m # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick
+
+  env:
+    - name: OPERATE_LOG_APPENDER
+      value: Stackdriver
+    - name: OPERATE_LOG_STACKDRIVER_SERVICENAME
+      value: operate
+    - name: OPERATE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+  logging:
+    level:
+      io.camunda.operate: INFO
+
 zeebe:
   retention:
     minimumAge: 1d

--- a/zeebe/benchmarks/camunda-platform-operate-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-operate-values.yaml
@@ -1,0 +1,21 @@
+# Values for Operate in the Camunda Platform Chart.
+
+operate:
+  enabled: true
+  image:
+    repository: gcr.io/zeebe-io/operate
+    tag: 8.7.0
+zeebe:
+  retention:
+    minimumAge: 1d
+elasticsearch:
+  master:
+    persistence:
+      size: 128Gi
+    resources:
+      requests:
+        cpu: 3
+        memory: 3Gi
+      limits:
+        cpu: 3
+        memory: 6Gi

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -51,37 +51,6 @@ postgresql:
 
 operate:
   enabled: false
-  image:
-    tag: SNAPSHOT
-  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
-  resources:
-    requests:
-      cpu: 600m
-      memory: 400Mi
-    limits:
-      cpu: 2000m
-      memory: 2Gi
-
-  # Retention can be used to define the data in Elasticsearch (ILM).
-  retention:
-    ## @param operate.retention.enabled if true, the ILM Policy is created and applied to the index templates.
-    enabled: true
-    ## @param operate.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
-    minimumAge: 30m # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick
-
-  env:
-    - name: OPERATE_LOG_APPENDER
-      value: Stackdriver
-    - name: OPERATE_LOG_STACKDRIVER_SERVICENAME
-      value: operate
-    - name: OPERATE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-
-  logging:
-    level:
-      io.camunda.operate: INFO
 
 tasklist:
   enabled: false

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -222,6 +222,8 @@ zeebeGateway:
     # See https://github.com/camunda/camunda-platform-helm/issues/2197
     - name: SPRING_CONFIG_ADDITIONALLOCATION
       value: "/usr/local/zeebe/config/application.yml"
+    - name: CAMUNDA_REST_QUERY_ENABLED
+      value: "true"
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -51,6 +51,37 @@ postgresql:
 
 operate:
   enabled: false
+  image:
+    tag: SNAPSHOT
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 600m
+      memory: 400Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  # Retention can be used to define the data in Elasticsearch (ILM).
+  retention:
+    ## @param operate.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+    enabled: true
+    ## @param operate.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+    minimumAge: 30m # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick
+
+  env:
+    - name: OPERATE_LOG_APPENDER
+      value: Stackdriver
+    - name: OPERATE_LOG_STACKDRIVER_SERVICENAME
+      value: operate
+    - name: OPERATE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
+  logging:
+    level:
+      io.camunda.operate: INFO
 
 tasklist:
   enabled: false

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>config</artifactId>
       <version>${version.config}</version>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
 
     <!-- Shared dependencies with the rest of the project -->
     <dependency>
@@ -97,6 +101,11 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
@@ -125,6 +134,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -87,7 +87,8 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
 
     LOG.debug("Current instances awaiting {}", startedInstances.size());
     availabilityChecker
-        .findAvailableInstances(List.copyOf(startedInstances.keySet()))
+        .findAvailableInstances(
+            startedInstances.values().stream().map(PiCreationResult::businessKey).toList())
         .whenCompleteAsync(
             (availableInstances, error) -> {
               if (error != null) {
@@ -123,12 +124,13 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     startedInstances.remove(awaitingPI.processInstanceKey);
   }
 
-  public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {
+  public void recordProcessInstanceStart(
+      final long processInstanceKey, final long businessKey, final long startTimeNanos) {
     startedInstances.put(
-        processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+        processInstanceKey, new PiCreationResult(processInstanceKey, businessKey, startTimeNanos));
   }
 
-  record PiCreationResult(long processInstanceKey, long startTimeNanos) {}
+  record PiCreationResult(long processInstanceKey, long businessKey, long startTimeNanos) {}
 
   /**
    * Interface to check the availability of process instances.
@@ -139,10 +141,11 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     /**
      * Finds the process instances that are available from the given list of process instance keys.
      *
-     * @param processInstanceKeys the list of process instance keys to check
+     * @param businessInstanceKeys the list of business instance keys to check identify the process
+     *     instances
      * @return a CompletionStage that, when completed, provides the list of available process
      *     instance keys
      */
-    CompletionStage<List<Long>> findAvailableInstances(List<Long> processInstanceKeys);
+    CompletionStage<List<Long>> findAvailableInstances(List<Long> businessInstanceKeys);
   }
 }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe;
+
+import io.camunda.zeebe.StarterLatencyMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessInstanceStartMeter implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
+  private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
+  private final Map<Long, PiCreationResult> startedInstances;
+  private final ScheduledExecutorService piCheckExecutorService;
+  private final AvailabilityChecker availabilityChecker;
+  private final MeterRegistry registry;
+  private final Duration availabilityCheckInterval;
+
+  public ProcessInstanceStartMeter(
+      final MeterRegistry meterRegistry,
+      final ScheduledExecutorService scheduledExecutorService,
+      final Duration availabilityCheckInterval,
+      final AvailabilityChecker availabilityChecker) {
+    registry = meterRegistry;
+    partitionToTimerMap = new ConcurrentHashMap<>();
+    startedInstances = new ConcurrentHashMap<>();
+    piCheckExecutorService = scheduledExecutorService;
+    this.availabilityCheckInterval = availabilityCheckInterval;
+    this.availabilityChecker = availabilityChecker;
+  }
+
+  /** Starts the periodic checking for process instance availability. */
+  public void start() {
+    piCheckExecutorService.scheduleAtFixedRate(
+        () -> {
+          try {
+            checkForProcessInstances();
+          } catch (final Exception e) {
+            LOG.error("Failed to check process instances. Will retry...", e);
+          }
+        },
+        availabilityCheckInterval.toMillis(),
+        availabilityCheckInterval.toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  /** Stops the periodic checking for process instance availability. */
+  public void stop() {
+    close();
+  }
+
+  @Override
+  public void close() {
+    piCheckExecutorService.shutdownNow();
+  }
+
+  private void checkForProcessInstances() {
+    if (startedInstances.isEmpty()) {
+      LOG.debug("No instances awaiting, skip check for process instances.");
+      return;
+    }
+
+    LOG.debug("Current instances awaiting {}", startedInstances.size());
+    availabilityChecker
+        .findAvailableInstances(List.copyOf(startedInstances.keySet()))
+        .whenCompleteAsync(
+            (availableInstances, error) -> {
+              if (error != null) {
+                LOG.error("Error while checking for available process instances", error);
+                return;
+              }
+
+              LOG.debug("Available process instances items: {} ", availableInstances.size());
+              availableInstances.stream()
+                  .map(startedInstances::get)
+                  .filter(Objects::nonNull)
+                  .forEach(this::recordInstanceAvailable);
+            },
+            piCheckExecutorService);
+  }
+
+  private void recordInstanceAvailable(final PiCreationResult awaitingPI) {
+    final long durationNanos = System.nanoTime() - awaitingPI.startTimeNanos;
+    LOG.debug(
+        "Process instance {} retrieved in {} ms",
+        awaitingPI.processInstanceKey,
+        TimeUnit.NANOSECONDS.toMillis(durationNanos));
+
+    final int partitionId = Protocol.decodePartitionId(awaitingPI.processInstanceKey);
+    partitionToTimerMap
+        .computeIfAbsent(
+            partitionId,
+            key ->
+                MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY)
+                    .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
+                    .register(registry))
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+    startedInstances.remove(awaitingPI.processInstanceKey);
+  }
+
+  public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {
+    startedInstances.put(
+        processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+  }
+
+  record PiCreationResult(long processInstanceKey, long startTimeNanos) {}
+
+  /**
+   * Interface to check the availability of process instances.
+   *
+   * <p>Used to decouple the availability checking logic from the ProcessInstanceStartMeter.
+   */
+  public interface AvailabilityChecker {
+    /**
+     * Finds the process instances that are available from the given list of process instance keys.
+     *
+     * @param processInstanceKeys the list of process instance keys to check
+     * @return a CompletionStage that, when completed, provides the list of available process
+     *     instance keys
+     */
+    CompletionStage<List<Long>> findAvailableInstances(List<Long> processInstanceKeys);
+  }
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -297,6 +297,7 @@ public class Starter extends App {
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
             .grpcAddress(URI.create(appCfg.getBrokerUrl()))
+            .restAddress(URI.create(appCfg.getBrokerRestUrl()))
             .numJobWorkerExecutionThreads(0)
             .withProperties(System.getProperties())
             .withInterceptors(monitoringInterceptor);

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -141,7 +141,7 @@ public class Starter extends App {
                       .sort(ProcessInstanceSort::startDate)
                       .page(
                           p ->
-                              p.limit(100)
+                              p.limit(1000)
                                   .searchAfter(
                                       responsePage == null
                                           ? List.of()

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -24,16 +24,20 @@ import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1.DeployReso
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.micrometer.core.instrument.Timer;
 import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -56,6 +60,9 @@ public class Starter extends App {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final AppCfg appCfg;
   private final StarterCfg starterCfg;
+  private Timer responseLatencyTimer;
+  private ScheduledExecutorService executorService;
+  private ProcessInstanceStartMeter processInstanceStartMeter;
 
   Starter(final AppCfg appCfg) {
     this.appCfg = appCfg;
@@ -64,9 +71,13 @@ public class Starter extends App {
 
   @Override
   public void run() {
-    final int rate = starterCfg.getRate();
-    final String processId = starterCfg.getProcessId();
+    responseLatencyTimer =
+        MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.RESPONSE_LATENCY).register(registry);
+
     final ZeebeClient client = createZeebeClient();
+    if (appCfg.isMonitorDataAvailability()) {
+      setupDataAvailabilityMeter(client);
+    }
 
     // init - check for topology and deploy process
     printTopology(client);
@@ -74,8 +85,7 @@ public class Starter extends App {
 
     // setup to start instances on given rate
     final CountDownLatch countDownLatch = new CountDownLatch(1);
-    final ScheduledExecutorService executorService =
-        Executors.newScheduledThreadPool(starterCfg.getThreads());
+    executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch, client);
 
@@ -85,6 +95,9 @@ public class Starter extends App {
                 () -> {
                   if (!executorService.isShutdown()) {
                     executorService.shutdown();
+                    if (appCfg.isMonitorDataAvailability()) {
+                      processInstanceStartMeter.close();
+                    }
                     try {
                       executorService.awaitTermination(60, TimeUnit.SECONDS);
                     } catch (final InterruptedException e) {
@@ -104,6 +117,36 @@ public class Starter extends App {
 
     scheduledTask.cancel(true);
     executorService.shutdown();
+
+    if (appCfg.isMonitorDataAvailability()) {
+      processInstanceStartMeter.close();
+    }
+  }
+
+  private void setupDataAvailabilityMeter(final ZeebeClient client) {
+    LOG.info("Monitor data availability of started process instances");
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            registry,
+            Executors.newScheduledThreadPool(1),
+            appCfg.getMonitorDataAvailabilityInterval(),
+            (listOfStartedInstances) -> {
+              return CompletableFuture.completedFuture(List.of());
+              //              final CamundaFuture<SearchResponse<ProcessInstance>> send =
+              //                  client
+              //                      .newProcessInstanceSearchRequest()
+              //                      .filter((f) -> f.processInstanceKey(key ->
+              // key.in(listOfStartedInstances)))
+              //                      .sort(ProcessInstanceSort::startDate)
+              //                      .send();
+              //
+              //              return send.thenApply(
+              //                  processInstanceSearchResponse ->
+              //                      processInstanceSearchResponse.items().stream()
+              //                          .map(ProcessInstance::getProcessInstanceKey)
+              //                          .toList());
+            });
+    processInstanceStartMeter.start();
   }
 
   private ScheduledFuture<?> scheduleProcessInstanceCreation(
@@ -133,6 +176,7 @@ public class Starter extends App {
             final var vars = new HashMap<>(baseVariables);
             vars.put(starterCfg.getBusinessKey(), businessKey.incrementAndGet());
 
+            final var startTime = System.nanoTime();
             final CompletionStage<?> requestFuture;
             if (starterCfg.isStartViaMessage()) {
               requestFuture = startInstanceByMessagePublishing(client, vars);
@@ -140,10 +184,12 @@ public class Starter extends App {
               requestFuture =
                   startInstanceWithAwaitingResult(client, starterCfg.getProcessId(), vars);
             } else {
-              requestFuture = startInstance(client, starterCfg.getProcessId(), vars);
+              requestFuture = startInstance(client, startTime, starterCfg.getProcessId(), vars);
             }
-            requestFuture.exceptionally(
-                (error) -> {
+            requestFuture.whenComplete(
+                (noop, error) -> {
+                  final long durationNanos = System.nanoTime() - startTime;
+                  responseLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
                   if (error instanceof final StatusRuntimeException statusRuntimeException) {
                     if (statusRuntimeException.getStatus().getCode() != Code.RESOURCE_EXHAUSTED) {
                       // we don't want to flood the log
@@ -153,7 +199,6 @@ public class Starter extends App {
                           error);
                     }
                   }
-                  return null;
                 });
           } catch (final Exception e) {
             THROTTLED_LOGGER.error("Error on creating new process instance", e);
@@ -164,14 +209,28 @@ public class Starter extends App {
         TimeUnit.NANOSECONDS);
   }
 
-  private static CompletionStage<?> startInstance(
-      final ZeebeClient client, final String processId, final HashMap<String, Object> variables) {
-    return client
-        .newCreateInstanceCommand()
-        .bpmnProcessId(processId)
-        .latestVersion()
-        .variables(variables)
-        .send();
+  private CompletionStage<?> startInstance(
+      final ZeebeClient client,
+      final long startTime,
+      final String processId,
+      final HashMap<String, Object> variables) {
+    final var sendFuture =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(variables)
+            .send();
+
+    if (appCfg.isMonitorDataAvailability()) {
+      return sendFuture.thenApply(
+          (response) -> {
+            final long processInstanceKey = response.getProcessInstanceKey();
+            processInstanceStartMeter.recordProcessInstanceStart(processInstanceKey, startTime);
+            return response;
+          });
+    }
+    return sendFuture;
   }
 
   private CompletionStage<?> startInstanceWithAwaitingResult(

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -29,9 +29,6 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
     private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
 
     private static final Duration[] BUCKETS = {
-      Duration.ofMillis(500),
-      Duration.ofSeconds(1),
-      Duration.ofMillis(2500),
       Duration.ofSeconds(5),
       Duration.ofSeconds(10),
       Duration.ofSeconds(15),
@@ -39,6 +36,9 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
       Duration.ofSeconds(45),
       Duration.ofSeconds(60),
       Duration.ofSeconds(90),
+      Duration.ofSeconds(120),
+      Duration.ofMinutes(3),
+      Duration.ofMinutes(4)
     };
 
     @Override

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/StarterLatencyMetricsDoc.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * The data availability latency when starting process instances. It measures the time from
+   * instance creation to the time the instance can be queried.
+   */
+  DATA_AVAILABILITY_LATENCY {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.PARTITION};
+
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofSeconds(60),
+      Duration.ofSeconds(90),
+    };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The data availability latency when starting process instances. It measures the time from instance creation to the time the instance can be queried.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.data.availability.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /**
+   * The response latency when starting process instances. It measures the time from sending the
+   * request to receiving the response.
+   */
+  RESPONSE_LATENCY {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(10),
+      Duration.ofMillis(25),
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The response latency when starting process instances. It measures the time from sending the request to receiving the response.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.response.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  };
+
+  public enum StarterMetricKeyNames implements KeyName {
+
+    /** The ID of the partition associated to the metric */
+    PARTITION {
+      @Override
+      public String asString() {
+        return "partition";
+      }
+    },
+  }
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 public class AppCfg {
 
   private String brokerUrl;
+  private String brokerRestUrl;
   private boolean tls;
   private int monitoringPort;
   private StarterCfg starter;
@@ -33,6 +34,14 @@ public class AppCfg {
 
   public void setBrokerUrl(final String brokerUrl) {
     this.brokerUrl = brokerUrl;
+  }
+
+  public String getBrokerRestUrl() {
+    return brokerRestUrl;
+  }
+
+  public void setBrokerRestUrl(final String brokerRestUrl) {
+    this.brokerRestUrl = brokerRestUrl;
   }
 
   public boolean isTls() {

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.config;
 
+import java.time.Duration;
+
 public class AppCfg {
 
   private String brokerUrl;
@@ -22,12 +24,14 @@ public class AppCfg {
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
+  private boolean monitorDataAvailability = true;
+  private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
 
   public String getBrokerUrl() {
     return brokerUrl;
   }
 
-  public void setBrokerUrl(String brokerUrl) {
+  public void setBrokerUrl(final String brokerUrl) {
     this.brokerUrl = brokerUrl;
   }
 
@@ -43,7 +47,7 @@ public class AppCfg {
     return starter;
   }
 
-  public void setStarter(StarterCfg starter) {
+  public void setStarter(final StarterCfg starter) {
     this.starter = starter;
   }
 
@@ -51,7 +55,7 @@ public class AppCfg {
     return worker;
   }
 
-  public void setWorker(WorkerCfg worker) {
+  public void setWorker(final WorkerCfg worker) {
     this.worker = worker;
   }
 
@@ -59,7 +63,23 @@ public class AppCfg {
     return monitoringPort;
   }
 
-  public void setMonitoringPort(int monitoringPort) {
+  public void setMonitoringPort(final int monitoringPort) {
     this.monitoringPort = monitoringPort;
+  }
+
+  public boolean isMonitorDataAvailability() {
+    return monitorDataAvailability;
+  }
+
+  public void setMonitorDataAvailability(final boolean monitorDataAvailability) {
+    this.monitorDataAvailability = monitorDataAvailability;
+  }
+
+  public Duration getMonitorDataAvailabilityInterval() {
+    return monitorDataAvailabilityInterval;
+  }
+
+  public void setMonitorDataAvailabilityInterval(final Duration monitorDataAvailabilityInterval) {
+    this.monitorDataAvailabilityInterval = monitorDataAvailabilityInterval;
   }
 }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -25,7 +25,7 @@ public class AppCfg {
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
-  private boolean monitorDataAvailability = true;
+  private boolean monitorDataAvailability = false;
   private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
 
   public String getBrokerUrl() {

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -3,6 +3,8 @@ app {
   brokerUrl = ${?ZEEBE_ADDRESS}
   tls = false
   monitoringPort = 9600
+  monitorDataAvailability = true
+  monitorDataAvailabilityInterval = 250ms
 
   starter {
     processId = "benchmark"

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -1,6 +1,8 @@
 app {
   brokerUrl = "localhost:26500"
   brokerUrl = ${?ZEEBE_ADDRESS}
+  brokerRestUrl = "http://localhost:8080"
+  brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
   monitoringPort = 9600
   monitorDataAvailability = true

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -5,7 +5,7 @@ app {
   brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
   monitoringPort = 9600
-  monitorDataAvailability = true
+  monitorDataAvailability = false
   monitorDataAvailabilityInterval = 250ms
 
   starter {

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.ProcessInstanceStartMeter.AvailabilityChecker;
+import io.camunda.zeebe.protocol.Protocol;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProcessInstanceStartMeterTest {
+
+  private ProcessInstanceStartMeter processInstanceStartMeter;
+  private SimpleMeterRegistry meterRegistry;
+  private AvailabilityChecker availabilityChecker;
+
+  @BeforeEach
+  public void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    availabilityChecker = CompletableFuture::completedFuture;
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            meterRegistry,
+            Executors.newScheduledThreadPool(1),
+            Duration.ofMillis(1),
+            (list) -> availabilityChecker.findAvailableInstances(list));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    processInstanceStartMeter.stop();
+    meterRegistry.close();
+  }
+
+  @Test
+  public void shouldRecordInstanceAvailability() {
+    // given
+
+    // when
+    processInstanceStartMeter.start();
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    await()
+        .ignoreExceptions()
+        .until(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer()
+                    .count(),
+            (count) -> count == 1);
+
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS))
+        .isGreaterThan(1);
+  }
+
+  @Test
+  public void shouldNotRecordInstanceAvailability() throws InterruptedException {
+    // given
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    availabilityChecker =
+        (list) -> {
+          countDownLatch.countDown();
+          return CompletableFuture.completedFuture(list);
+        };
+
+    // when
+    processInstanceStartMeter.start();
+
+    // then
+    countDownLatch.await(1, TimeUnit.SECONDS);
+
+    assertThatThrownBy(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer())
+        .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldNotRecordInstanceAvailabilityWhenNotAvailable() throws InterruptedException {
+    // given
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    availabilityChecker =
+        (list) -> {
+          countDownLatch.countDown();
+          // return empty list to simulate no available instances
+          return CompletableFuture.completedFuture(List.of());
+        };
+
+    // when
+    processInstanceStartMeter.start();
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    countDownLatch.await(1, TimeUnit.SECONDS);
+
+    assertThatThrownBy(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer())
+        .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldNotRecordInstanceAvailabilityWhenNotStarted() {
+    // given
+    processInstanceStartMeter =
+        new ProcessInstanceStartMeter(
+            meterRegistry,
+            Executors.newScheduledThreadPool(1),
+            Duration.ZERO,
+            CompletableFuture::completedFuture);
+
+    // when
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+
+    // then
+    assertThatThrownBy(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer())
+        .hasMessageContaining("No meter with name 'starter.data.availability.latency' was found.");
+  }
+
+  @Test
+  public void shouldOnlyRecordAvailableInstances() throws InterruptedException {
+    // given
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    availabilityChecker =
+        (list) -> {
+          if (countDownLatch.getCount() == 1) {
+            countDownLatch.countDown();
+            return CompletableFuture.completedFuture(List.of(list.getFirst()));
+          }
+          return CompletableFuture.completedFuture(List.of());
+        };
+
+    // when
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 1), System.nanoTime());
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 2), System.nanoTime());
+    processInstanceStartMeter.recordProcessInstanceStart(
+        Protocol.encodePartitionId(1, 3), System.nanoTime());
+    processInstanceStartMeter.start();
+
+    // then
+    countDownLatch.await(1, TimeUnit.SECONDS);
+    await()
+        .ignoreExceptions()
+        .until(
+            () ->
+                meterRegistry
+                    .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                    .timer()
+                    .count(),
+            (count) -> count == 1);
+
+    assertThat(
+            meterRegistry
+                .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS))
+        .isGreaterThan(1);
+  }
+}

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
@@ -41,7 +41,12 @@ public class ProcessInstanceStartMeterTest {
   @BeforeEach
   public void setUp() {
     meterRegistry = new SimpleMeterRegistry();
-    availabilityChecker = CompletableFuture::completedFuture;
+    availabilityChecker =
+        (list) -> {
+          final var piKeys =
+              list.stream().map(businessKey -> Protocol.encodePartitionId(1, businessKey)).toList();
+          return CompletableFuture.completedFuture(piKeys);
+        };
     processInstanceStartMeter =
         new ProcessInstanceStartMeter(
             meterRegistry,
@@ -63,7 +68,7 @@ public class ProcessInstanceStartMeterTest {
     // when
     processInstanceStartMeter.start();
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 1), System.nanoTime());
+        Protocol.encodePartitionId(1, 1), 1, System.nanoTime());
 
     // then
     await()
@@ -122,7 +127,7 @@ public class ProcessInstanceStartMeterTest {
     // when
     processInstanceStartMeter.start();
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 1), System.nanoTime());
+        Protocol.encodePartitionId(1, 1), 1, System.nanoTime());
 
     // then
     countDownLatch.await(1, TimeUnit.SECONDS);
@@ -147,7 +152,7 @@ public class ProcessInstanceStartMeterTest {
 
     // when
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 1), System.nanoTime());
+        Protocol.encodePartitionId(1, 1), 1, System.nanoTime());
 
     // then
     assertThatThrownBy(
@@ -166,18 +171,19 @@ public class ProcessInstanceStartMeterTest {
         (list) -> {
           if (countDownLatch.getCount() == 1) {
             countDownLatch.countDown();
-            return CompletableFuture.completedFuture(List.of(list.getFirst()));
+            return CompletableFuture.completedFuture(
+                List.of(Protocol.encodePartitionId(1, list.getFirst())));
           }
           return CompletableFuture.completedFuture(List.of());
         };
 
     // when
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 1), System.nanoTime());
+        Protocol.encodePartitionId(1, 1), 1, System.nanoTime());
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 2), System.nanoTime());
+        Protocol.encodePartitionId(1, 2), 2, System.nanoTime());
     processInstanceStartMeter.recordProcessInstanceStart(
-        Protocol.encodePartitionId(1, 3), System.nanoTime());
+        Protocol.encodePartitionId(1, 3), 3, System.nanoTime());
     processInstanceStartMeter.start();
 
     // then

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -32,6 +32,8 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.isMonitorDataAvailability()).isTrue();
+    assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
 
     // starter
     final var starterCfg = appCfg.getStarter();
@@ -79,6 +81,8 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.isMonitorDataAvailability()).isFalse();
+    assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(50);
 
     // starter
     final var starterCfg = appCfg.getStarter();

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -32,7 +32,7 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
-    assertThat(appCfg.isMonitorDataAvailability()).isTrue();
+    assertThat(appCfg.isMonitorDataAvailability()).isFalse();
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
 
     // starter
@@ -81,7 +81,7 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
-    assertThat(appCfg.isMonitorDataAvailability()).isFalse();
+    assertThat(appCfg.isMonitorDataAvailability()).isTrue();
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(50);
 
     // starter

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -1,6 +1,8 @@
 app {
   brokerUrl = "localhost:26500"
   brokerUrl = ${?ZEEBE_ADDRESS}
+  brokerRestUrl = "http://localhost:8080"
+  brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
   monitoringPort = 9600
   monitorDataAvailability = false

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -3,6 +3,8 @@ app {
   brokerUrl = ${?ZEEBE_ADDRESS}
   tls = false
   monitoringPort = 9600
+  monitorDataAvailability = false
+  monitorDataAvailabilityInterval = 50ms
 
   starter {
     processId = "benchmark"

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -5,7 +5,7 @@ app {
   brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
   monitoringPort = 9600
-  monitorDataAvailability = false
+  monitorDataAvailability = true
   monitorDataAvailabilityInterval = 50ms
 
   starter {


### PR DESCRIPTION
## Description

> [!Note]
>
> Cleaned PR https://github.com/camunda/camunda/pull/44043


This PR backports the changes of https://github.com/camunda/camunda/pull/42788 to stable/8.7.

> [!Important]
>
> This commit 428a05d5472cb6f19513ba0cbb99101a40275969 is effectively just backported of https://github.com/camunda/camunda/pull/42553, the rest are fixes to get it working with the version


First try was to get process instances with business key variables, due to limitation of our Query API this doesn't worked out. This would be the ideal solution, as it would be quite similar to what we have on main. I kept the commit for future reference. 

Approache has changed to make use of paging, and request all process instances. We need to keep the paging object, and reuse it on the next requests. This allows to continue request new instances.

We had to add Operate again to the 8.7 load tests, as the REST API needs Operate ELS incides to work. Operate can be enabled in our load tests via an GitHub Workflow input, but is disabled by default to reduce impact of the changes to a minimum (and only deploy it if it is really needed).

## Example

<img width="1885" height="732" alt="87-data-avail" src="https://github.com/user-attachments/assets/825ded14-d822-4c10-a37d-0e3e54614202" />

In comparison to `main`

<img width="1891" height="727" alt="main-89-data-avail" src="https://github.com/user-attachments/assets/25c521e0-b24e-47b1-8041-ed0e4dde785a" />


## Related issues

related https://github.com/camunda/camunda/issues/38890
closes https://github.com/camunda/camunda/issues/43887
slack thread https://camunda.slack.com/archives/C0807665N8G/p1768674316260169
