### PR TITLE
[Backport stable/8.8] fix: do not print entire stacktrace when NativeFS cannot be used

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/PosixFs.java
@@ -34,7 +34,9 @@ public final class PosixFs {
           MethodHandles.privateLookupIn(FileDescriptor.class, MethodHandles.lookup())
               .findVarHandle(FileDescriptor.class, "fd", int.class);
     } catch (final NoSuchFieldException | IllegalAccessException e) {
-      LOGGER.warn("Cannot look up file descriptor via reflection; NativeFS will be disabled", e);
+      LOGGER.warn(
+          "Cannot look up file descriptor via reflection; NativeFS will be disabled: {}",
+          e.getMessage());
       fileDescriptorFd = null;
     }
 


### PR DESCRIPTION
# Description
Backport of #44256 to `stable/8.8`.

relates to #44257