### PR TITLE
fix: include pod in legend for external auth calls to understand where a request is coming from

### DIFF
--- a/monitor/grafana/dashboards/identity/overview.json
+++ b/monitor/grafana/dashboards/identity/overview.json
@@ -151,11 +151,11 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(camunda_authentication_external_requests_seconds_count{domain=\"identity\", namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])",
+          "expr": "sum (\n  rate(camunda_authentication_external_requests_seconds_count{domain=\"identity\", namespace=~\"$namespace\", service=~\"$service\", pod=~\"$pod\"}[$__rate_interval])\n) by (namespace, service, status, uri)",
           "format": "time_series",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
-          "legendFormat": "[{{status}}] {{uri}}",
+          "legendFormat": "{{namespace}} | {{service}} | [{{status}}] {{uri}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -945,5 +945,5 @@
   "timezone": "browser",
   "title": "Identity Overview",
   "uid": "identity",
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On int the legend for the external auth call visualisation is hard to read:

<img width="1060" height="376" alt="Screenshot 2026-01-19 at 17 04 44" src="https://github.com/user-attachments/assets/fd6061a9-2cc8-4931-b3fc-60798bbc4120" />

This PR adds `{{pod}}` to the legend so rootcausing is easier, example:

<img width="1066" height="385" alt="Screenshot 2026-01-19 at 17 05 08" src="https://github.com/user-attachments/assets/6bd324ab-1cc2-4f0f-931c-3ffbea726a2c" />

