### PR TITLE
docs: include benchmark ownership section in monorepo-docs

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -161,6 +161,16 @@ For [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-proc
 
 More details on how benchmark tests work can be found in our [reliability testing documentation](https://github.com/camunda/camunda/blob/main/docs/testing/reliability-testing.md).
 
+**👨‍🔧 Release Manager Ownership for Benchmark Issues**
+
+Owner during releases: The zeebe-release-manager owns benchmark/load-test issues for the release (for as long as this role exists).
+
+When a release benchmark fails, the release manager (RM) must:
+- Include: failing CI job link, version/RC + release line, and Grafana dashboard link.
+- If it's deploy/infra/Helm/cluster health, ping Reliability/Testing (and reference medics).
+- If it's an application-level regression, escalate to the owning product team (usually Core Features first), CC Reliability/Testing if infra may be involved.
+- Make sure medics are aware, since they watch daily/weekly/release load tests until alerts are in place.
+
 ### Camunda 8 Testing Clusters
 
 Camunda 8 testing clusters provide isolated environments for validating release builds, executing targeted test flows, and verifying features and bug fixes across all core components. The cluster creation and management processes can be manual or automated depending on the test type and the stage of the monorepo release process.


### PR DESCRIPTION
## Description
This pull request updates the release documentation for the Benchmark tests to clarify the responsibilities of the release manager regarding benchmark and load-test issues. The main change is the addition of a new section that outlines ownership and escalation procedures for benchmark failures during releases.

Release process documentation improvements:

* Added a new section specifying that the `zeebe-release-manager` is responsible for benchmark/load-test issues during releases, including steps for escalation and communication when benchmarks fail.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
