### PR TITLE
test: increase history clean-up timeout for OS

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -39,7 +39,8 @@ public class HistoryCleanupIT {
   static void setup() {
     cleanupTimeout =
         switch (databaseType) {
-          case OS, AWS_OS -> Duration.ofSeconds(210); // OS cleanup can not be faster than 3min
+          // OS cleanup can not be faster than 3min, and can take more time.
+          case OS, AWS_OS -> Duration.ofMinutes(5);
           default -> Duration.ofSeconds(30);
         };
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
@@ -61,7 +61,8 @@ public class ProcessInstanceHistoryCleanupIT {
   static void setup() {
     cleanupTimeout =
         switch (databaseType) {
-          case OS, AWS_OS -> Duration.ofSeconds(210); // OS cleanup can not be faster than 3min
+          // OS cleanup can not be faster than 3min, and can take more time.
+          case OS, AWS_OS -> Duration.ofMinutes(5);
           default -> Duration.ofSeconds(30);
         };
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Due to [flakiness](https://github.com/camunda/camunda/actions/runs/21153040274/job/60832745049), resetting the clean-up timeout for OS to 5 minutes (as was previously done in 8.8, see [here](https://github.com/camunda/camunda/blob/d695a4091bc4e3289b255320e62113ef09a36e36/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java#L63-L64) )

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
