### PR TITLE
feat: access JobMetricsCfg from the JobController

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -18,6 +18,9 @@ public class Engine {
   @NestedConfigurationProperty
   private EngineBatchOperation batchOperations = new EngineBatchOperation();
 
+  /** Configuration properties for job metrics collection and export. */
+  @NestedConfigurationProperty private JobMetrics jobMetrics = new JobMetrics();
+
   public Distribution getDistribution() {
     return distribution;
   }
@@ -32,5 +35,13 @@ public class Engine {
 
   public void setBatchOperations(final EngineBatchOperation batchOperations) {
     this.batchOperations = batchOperations;
+  }
+
+  public JobMetrics getJobMetrics() {
+    return jobMetrics;
+  }
+
+  public void setJobMetrics(final JobMetrics jobMetrics) {
+    this.jobMetrics = jobMetrics;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/JobMetrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/JobMetrics.java
@@ -5,19 +5,37 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.broker.system.configuration.engine;
+package io.camunda.configuration;
 
-import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import java.time.Duration;
 
-public class JobMetricsCfg implements ConfigurationEntry {
-  private boolean enabled = true;
-  private Duration exportInterval = EngineConfiguration.DEFAULT_JOB_METRICS_EXPORT_INTERVAL;
-  private int maxWorkerNameLength = EngineConfiguration.DEFAULT_MAX_WORKER_NAME_LENGTH;
-  private int maxJobTypeLength = EngineConfiguration.DEFAULT_MAX_JOB_TYPE_LENGTH;
-  private int maxTenantIdLength = EngineConfiguration.DEFAULT_MAX_TENANT_ID_LENGTH;
-  private int maxUniqueKeys = EngineConfiguration.DEFAULT_MAX_UNIQUE_JOB_METRICS_KEYS;
+/** Configuration properties for job metrics collection and export. */
+public class JobMetrics {
+
+  private static final Duration DEFAULT_EXPORT_INTERVAL = Duration.ofMinutes(1);
+  private static final boolean DEFAULT_ENABLED = true;
+  private static final int DEFAULT_MAX_WORKER_NAME_LENGTH = 64;
+  private static final int DEFAULT_MAX_JOB_TYPE_LENGTH = 64;
+  private static final int DEFAULT_MAX_TENANT_ID_LENGTH = 64;
+  private static final int DEFAULT_MAX_UNIQUE_KEYS = 100;
+
+  /** Whether job metrics collection is enabled. */
+  private boolean enabled = DEFAULT_ENABLED;
+
+  /** The interval at which job metrics are exported. */
+  private Duration exportInterval = DEFAULT_EXPORT_INTERVAL;
+
+  /** Maximum length of worker names to track. Longer names will be truncated. */
+  private int maxWorkerNameLength = DEFAULT_MAX_WORKER_NAME_LENGTH;
+
+  /** Maximum length of job types to track. Longer types will be truncated. */
+  private int maxJobTypeLength = DEFAULT_MAX_JOB_TYPE_LENGTH;
+
+  /** Maximum length of tenant IDs to track. Longer IDs will be truncated. */
+  private int maxTenantIdLength = DEFAULT_MAX_TENANT_ID_LENGTH;
+
+  /** Maximum number of unique keys (jobType_tenantId combinations) to track. */
+  private int maxUniqueKeys = DEFAULT_MAX_UNIQUE_KEYS;
 
   public boolean isEnabled() {
     return enabled;
@@ -67,21 +85,8 @@ public class JobMetricsCfg implements ConfigurationEntry {
     this.maxUniqueKeys = maxUniqueKeys;
   }
 
-  @Override
-  public String toString() {
-    return "JobMetricsCfg{"
-        + "enabled="
-        + enabled
-        + ", exportInterval="
-        + exportInterval
-        + ", maxWorkerNameLength="
-        + maxWorkerNameLength
-        + ", maxJobTypeLength="
-        + maxJobTypeLength
-        + ", maxTenantIdLength="
-        + maxTenantIdLength
-        + ", maxUniqueKeys="
-        + maxUniqueKeys
-        + '}';
+  /** Returns the export interval in minutes. */
+  public long getResolutionMinutes() {
+    return exportInterval.toMinutes();
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -219,6 +219,7 @@ public class BrokerBasedPropertiesOverride {
   private void populateFromEngine(final BrokerBasedProperties override) {
     populateFromDistribution(override);
     populateFromBatchOperations(override);
+    populateFromJobMetrics(override);
   }
 
   private void populateFromDistribution(final BrokerBasedProperties override) {
@@ -238,6 +239,18 @@ public class BrokerBasedPropertiesOverride {
         .getEngine()
         .getBatchOperations()
         .setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
+  }
+
+  private void populateFromJobMetrics(final BrokerBasedProperties override) {
+    final var jobMetrics =
+        unifiedConfiguration.getCamunda().getProcessing().getEngine().getJobMetrics();
+    final var jobMetricsCfg = override.getExperimental().getEngine().getJobMetrics();
+    jobMetricsCfg.setEnabled(jobMetrics.isEnabled());
+    jobMetricsCfg.setExportInterval(jobMetrics.getExportInterval());
+    jobMetricsCfg.setMaxWorkerNameLength(jobMetrics.getMaxWorkerNameLength());
+    jobMetricsCfg.setMaxJobTypeLength(jobMetrics.getMaxJobTypeLength());
+    jobMetricsCfg.setMaxTenantIdLength(jobMetrics.getMaxTenantIdLength());
+    jobMetricsCfg.setMaxUniqueKeys(jobMetrics.getMaxUniqueKeys());
   }
 
   private void populateFromFlowControl(final BrokerBasedProperties override) {

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHan
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.clustering.ClusterConfigFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.JobMetricsCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
@@ -67,6 +68,11 @@ public class BrokerBasedConfiguration {
   public BrokerClientTimeoutConfiguration brokerClientConfig() {
     return new BrokerClientTimeoutConfiguration(
         properties.getGateway().getCluster().getRequestTimeout());
+  }
+
+  @Bean
+  public JobMetricsCfg jobMetricsConfig() {
+    return properties.getExperimental().getEngine().getJobMetrics();
   }
 
   @Bean

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -109,6 +109,10 @@ public final class EngineCfg implements ConfigurationEntry {
     this.globalListeners = globalListeners;
   }
 
+  public JobMetricsCfg getJobMetrics() {
+    return jobMetrics;
+  }
+
   public void setJobMetrics(final JobMetricsCfg jobMetrics) {
     this.jobMetrics = jobMetrics;
   }


### PR DESCRIPTION
## Description
This pull request introduces configuration and API support for job metrics collection and export, along with a new REST endpoint to retrieve global job statistics. The changes include adding a new `JobMetrics` configuration section, propagating its settings throughout the configuration system, and exposing global job statistics via the REST API.

**Configuration Enhancements:**

* Added a new `JobMetrics` configuration property to `Engine`, including support for enabling/disabling metrics, export interval, and limits for worker name, job type, tenant ID, and unique keys. Getters and setters were implemented for these properties. [[1]](diffhunk://#diff-e85d7db0ddf755904b750214caabcf40b97781fd41dd004fd78ff1c7e7b2dd80R21-R23) [[2]](diffhunk://#diff-e85d7db0ddf755904b750214caabcf40b97781fd41dd004fd78ff1c7e7b2dd80R39-R46) [[3]](diffhunk://#diff-94a67fe72713e57332966a318893fc5ebbed2c660670c2a718b6e9d865d90594R15-R29)
* Updated the configuration override logic to copy `JobMetrics` properties from the unified configuration into the broker-based configuration, ensuring these settings are correctly propagated. [[1]](diffhunk://#diff-6aa52d09da3ccd0bd838e24df2f388b661099188767d58930aba1506b5b386a2R222) [[2]](diffhunk://#diff-6aa52d09da3ccd0bd838e24df2f388b661099188767d58930aba1506b5b386a2R244-R255)
* Enhanced the string representation of `JobMetricsCfg` to include the new `enabled` flag for easier debugging and logging.

**REST API Additions:**

* Injected the new `JobMetricsCfg` into the `JobController` and added a new REST endpoint (`/statistics/global`) to retrieve global job statistics, leveraging the job metrics configuration. [[1]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR12-R21) [[2]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR35) [[3]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR55-R67) [[4]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR114-R121) [[5]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR197-R209)

**References:** [[1]](diffhunk://#diff-e85d7db0ddf755904b750214caabcf40b97781fd41dd004fd78ff1c7e7b2dd80R21-R23) [[2]](diffhunk://#diff-e85d7db0ddf755904b750214caabcf40b97781fd41dd004fd78ff1c7e7b2dd80R39-R46) [[3]](diffhunk://#diff-94a67fe72713e57332966a318893fc5ebbed2c660670c2a718b6e9d865d90594R15-R29) [[4]](diffhunk://#diff-6aa52d09da3ccd0bd838e24df2f388b661099188767d58930aba1506b5b386a2R222) [[5]](diffhunk://#diff-6aa52d09da3ccd0bd838e24df2f388b661099188767d58930aba1506b5b386a2R244-R255) [[6]](diffhunk://#diff-94a67fe72713e57332966a318893fc5ebbed2c660670c2a718b6e9d865d90594L64-R75) [[7]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR12-R21) [[8]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR35) [[9]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR55-R67) [[10]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR114-R121) [[11]](diffhunk://#diff-5bc8c2d49fc66c57f7a6392b3cd41ac8d6844a9a446b04d84894bb5840d258ceR197-R209)