### PR TITLE
Send a notification to #zeebe-ci when the QA creation fails

### DIFF
--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -61,3 +61,35 @@ jobs:
         }
       branch: ${{ inputs.branch }}
     secrets: inherit
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ qa ]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Starting QA run failed for ${{ inputs.branch }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Right now we only notice due to a success message missing. We should post a message when the CI fails so we don't miss this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

N/A
