### PR TITLE
Nightly fix stable/8.7

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -226,7 +226,9 @@ class OperateProcessesPage {
   }
 
   async clickProcessInstanceKeySortButton(): Promise<void> {
-    await this.processInstanceKeySortButton.click();
+    await expect(this.processInstanceKeySortButton).toBeVisible();
+    await expect(this.processInstanceKeySortButton).toBeEnabled();
+    await this.processInstanceKeySortButton.click({timeout: 30000});
   }
 
   async visibleKeys(): Promise<string[]> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -201,6 +201,7 @@ test.describe('Process Instances Table', () => {
       await operateFiltersPanelPage.selectProcess(
         'Process For Infinite Scroll',
       );
+      await operateFiltersPanelPage.selectVersion('1');
       await waitForAssertion({
         assertion: async () => {
           await expect(page.getByText('300 results')).toBeVisible();


### PR DESCRIPTION
## Description

This PR addresses the failure in this [nightly run](https://github.com/camunda/camunda/actions/runs/21154801866/job/60837528489)
This PR adds version selection and additional assertion for button to sort process instances. Also increases the timeout for button click.


## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21169722839)