### PR TITLE
fix: stop user entity from overriding get/set ID

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/AbstractExporterEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/AbstractExporterEntity.java
@@ -23,12 +23,12 @@ public abstract class AbstractExporterEntity<T extends AbstractExporterEntity<T>
   private String id;
 
   @Override
-  public String getId() {
+  public final String getId() {
     return id;
   }
 
   @Override
-  public T setId(final String id) {
+  public final T setId(final String id) {
     this.id = id;
     return (T) this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/UserEntity.java
@@ -13,23 +13,11 @@ import io.camunda.webapps.schema.entities.BeforeVersion880;
 public class UserEntity extends AbstractExporterEntity<UserEntity> {
 
   public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
-  @BeforeVersion880 private String id;
   @BeforeVersion880 private Long key;
   @BeforeVersion880 private String username;
   @BeforeVersion880 private String name;
   @BeforeVersion880 private String email;
   @BeforeVersion880 private String password;
-
-  @Override
-  public String getId() {
-    return id;
-  }
-
-  @Override
-  public UserEntity setId(final String id) {
-    this.id = id;
-    return this;
-  }
 
   public Long getKey() {
     return key;


### PR DESCRIPTION
as it means it is setting a shadowed ID field, which is not used for equals and hashcode (so all `UserEntity` objects will be considered equal).

refs: #42387