### PR TITLE
feat: add MCP process instance search and get tools

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -503,6 +503,17 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::userSearchQuery);
   }
 
+  public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter filter,
+      final io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest page,
+      final List<ProcessInstanceSearchQuerySortRequest> sort) {
+    return toProcessInstanceQuery(
+        new ProcessInstanceSearchQuery()
+            .filter(SimpleSearchQueryMapper.toProcessInstanceFilter(filter))
+            .page(SimpleSearchQueryMapper.toPageRequest(page))
+            .sort(sort == null ? List.of() : sort));
+  }
+
   public static Either<ProblemDetail, IncidentQuery> toIncidentQuery(
       final io.camunda.gateway.protocol.model.simple.IncidentFilter filter,
       final io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest page,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -146,6 +146,17 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter filter,
+      final io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest page,
+      final List<ProcessInstanceSearchQuerySortRequest> sort) {
+    return toProcessInstanceQuery(
+        new ProcessInstanceSearchQuery()
+            .filter(SimpleSearchQueryMapper.toProcessInstanceFilter(filter))
+            .page(SimpleSearchQueryMapper.toPageRequest(page))
+            .sort(sort == null ? List.of() : sort));
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
       final ProcessInstanceSearchQuery request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.processInstanceSearchQuery().build());
@@ -501,17 +512,6 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyUserSortField);
     final var filter = SearchQueryFilterMapper.toUserFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::userSearchQuery);
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
-      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter filter,
-      final io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest page,
-      final List<ProcessInstanceSearchQuerySortRequest> sort) {
-    return toProcessInstanceQuery(
-        new ProcessInstanceSearchQuery()
-            .filter(SimpleSearchQueryMapper.toProcessInstanceFilter(filter))
-            .page(SimpleSearchQueryMapper.toPageRequest(page))
-            .sort(sort == null ? List.of() : sort));
   }
 
   public static Either<ProblemDetail, IncidentQuery> toIncidentQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -296,7 +296,7 @@ public class SimpleSearchQueryMapper {
 
   private static io.camunda.gateway.protocol.model.IntegerFilterProperty getIntegerFilter(
       final Integer value) {
-    return value == null ? null : new AdvancedIntegerFilter().$eq(value);
+    return new AdvancedIntegerFilter().$eq(value);
   }
 
   private static io.camunda.gateway.protocol.model.DateTimeFilterProperty getDateTimeFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -13,8 +13,11 @@ import static java.util.Optional.ofNullable;
 import static java.util.function.Predicate.not;
 
 import io.camunda.gateway.protocol.model.AdvancedDateTimeFilter;
+import io.camunda.gateway.protocol.model.AdvancedElementInstanceStateFilter;
 import io.camunda.gateway.protocol.model.AdvancedIncidentErrorTypeFilter;
 import io.camunda.gateway.protocol.model.AdvancedIncidentStateFilter;
+import io.camunda.gateway.protocol.model.AdvancedIntegerFilter;
+import io.camunda.gateway.protocol.model.AdvancedProcessInstanceStateFilter;
 import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.BasicStringFilter;
 import io.camunda.gateway.protocol.model.BasicStringFilterProperty;
@@ -22,7 +25,9 @@ import io.camunda.gateway.protocol.model.CursorBackwardPagination;
 import io.camunda.gateway.protocol.model.CursorForwardPagination;
 import io.camunda.gateway.protocol.model.LimitPagination;
 import io.camunda.gateway.protocol.model.OffsetPagination;
+import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
+import io.camunda.gateway.protocol.model.VariableValueFilterProperty;
 import io.camunda.gateway.protocol.model.simple.IncidentFilter;
 import io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest;
 import io.camunda.gateway.protocol.model.simple.SimpleDateTimeFilterProperty;
@@ -30,6 +35,7 @@ import io.camunda.service.exception.ServiceError;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -138,12 +144,159 @@ public class SimpleSearchQueryMapper {
     return filterModel;
   }
 
+  public static io.camunda.gateway.protocol.model.ProcessInstanceFilter toProcessInstanceFilter(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter filter) {
+    final var filterModel = new io.camunda.gateway.protocol.model.ProcessInstanceFilter();
+    if (filter != null) {
+      mapProcessInstanceFilterFields(filter, filterModel);
+      ofNullable(filter.get$Or())
+          .filter(not(List::isEmpty))
+          .ifPresent(
+              orGroups ->
+                  filterModel.$or(
+                      orGroups.stream()
+                          .map(
+                              fields -> {
+                                final var mapped = new ProcessInstanceFilterFields();
+                                mapProcessInstanceFilterFields(fields, mapped);
+                                return mapped;
+                              })
+                          .toList()));
+    }
+    return filterModel;
+  }
+
+  private static void mapProcessInstanceFilterFields(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter source,
+      final io.camunda.gateway.protocol.model.ProcessInstanceFilterFields target) {
+    mapProcessInstanceFilterFields(toProcessInstanceFilterFields(source), target);
+  }
+
+  private static void mapProcessInstanceFilterFields(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilterFields source,
+      final io.camunda.gateway.protocol.model.ProcessInstanceFilterFields target) {
+    ofNullable(source.getStartDate())
+        .map(SimpleSearchQueryMapper::getDateTimeFilter)
+        .ifPresent(target::startDate);
+    ofNullable(source.getEndDate())
+        .map(SimpleSearchQueryMapper::getDateTimeFilter)
+        .ifPresent(target::endDate);
+    ofNullable(source.getState())
+        .map(state -> new AdvancedProcessInstanceStateFilter().$eq(state))
+        .ifPresent(target::state);
+
+    ofNullable(source.getHasIncident()).ifPresent(target::hasIncident);
+
+    ofNullable(source.getTenantId())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::tenantId);
+
+    ofNullable(source.getVariables())
+        .filter(not(List::isEmpty))
+        .ifPresent(
+            vars ->
+                target.variables(
+                    vars.stream()
+                        .map(
+                            v ->
+                                new VariableValueFilterProperty(
+                                    v.getName(), getStringFilter(v.getValue())))
+                        .toList()));
+
+    ofNullable(source.getProcessInstanceKey())
+        .map(SimpleSearchQueryMapper::getBasicStringFilter)
+        .ifPresent(target::processInstanceKey);
+    ofNullable(source.getParentProcessInstanceKey())
+        .map(SimpleSearchQueryMapper::getBasicStringFilter)
+        .ifPresent(target::parentProcessInstanceKey);
+    ofNullable(source.getParentElementInstanceKey())
+        .map(SimpleSearchQueryMapper::getBasicStringFilter)
+        .ifPresent(target::parentElementInstanceKey);
+
+    ofNullable(source.getBatchOperationId())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::batchOperationId);
+    ofNullable(source.getErrorMessage())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::errorMessage);
+    ofNullable(source.getHasRetriesLeft()).ifPresent(target::hasRetriesLeft);
+    ofNullable(source.getElementInstanceState())
+        .map(state -> new AdvancedElementInstanceStateFilter().$eq(state))
+        .ifPresent(target::elementInstanceState);
+    ofNullable(source.getElementId())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::elementId);
+    ofNullable(source.getHasElementInstanceIncident())
+        .ifPresent(target::hasElementInstanceIncident);
+    ofNullable(source.getIncidentErrorHashCode())
+        .map(SimpleSearchQueryMapper::getIntegerFilter)
+        .ifPresent(target::incidentErrorHashCode);
+
+    ofNullable(source.getTags()).filter(not(Set::isEmpty)).ifPresent(target::tags);
+
+    ofNullable(source.getProcessDefinitionId())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::processDefinitionId);
+    ofNullable(source.getProcessDefinitionName())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::processDefinitionName);
+    ofNullable(source.getProcessDefinitionVersion())
+        .map(SimpleSearchQueryMapper::getIntegerFilter)
+        .ifPresent(target::processDefinitionVersion);
+    ofNullable(source.getProcessDefinitionVersionTag())
+        .map(SimpleSearchQueryMapper::getStringFilter)
+        .ifPresent(target::processDefinitionVersionTag);
+    ofNullable(source.getProcessDefinitionKey())
+        .map(SimpleSearchQueryMapper::getBasicStringFilter)
+        .ifPresent(target::processDefinitionKey);
+  }
+
+  private static io.camunda.gateway.protocol.model.simple.ProcessInstanceFilterFields
+      toProcessInstanceFilterFields(
+          final io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter source) {
+    final var fields = new io.camunda.gateway.protocol.model.simple.ProcessInstanceFilterFields();
+    if (source == null) {
+      return fields;
+    }
+
+    fields
+        .startDate(source.getStartDate())
+        .endDate(source.getEndDate())
+        .state(source.getState())
+        .hasIncident(source.getHasIncident())
+        .tenantId(source.getTenantId())
+        .variables(source.getVariables())
+        .processInstanceKey(source.getProcessInstanceKey())
+        .parentProcessInstanceKey(source.getParentProcessInstanceKey())
+        .parentElementInstanceKey(source.getParentElementInstanceKey())
+        .batchOperationId(source.getBatchOperationId())
+        .errorMessage(source.getErrorMessage())
+        .hasRetriesLeft(source.getHasRetriesLeft())
+        .elementInstanceState(source.getElementInstanceState())
+        .elementId(source.getElementId())
+        .hasElementInstanceIncident(source.getHasElementInstanceIncident())
+        .incidentErrorHashCode(source.getIncidentErrorHashCode())
+        .tags(source.getTags())
+        .processDefinitionId(source.getProcessDefinitionId())
+        .processDefinitionName(source.getProcessDefinitionName())
+        .processDefinitionVersion(source.getProcessDefinitionVersion())
+        .processDefinitionVersionTag(source.getProcessDefinitionVersionTag())
+        .processDefinitionKey(source.getProcessDefinitionKey());
+
+    return fields;
+  }
+
   private static StringFilterProperty getStringFilter(final String value) {
     return new AdvancedStringFilter().$eq(value);
   }
 
   private static BasicStringFilterProperty getBasicStringFilter(final String value) {
     return new BasicStringFilter().$eq(value);
+  }
+
+  private static io.camunda.gateway.protocol.model.IntegerFilterProperty getIntegerFilter(
+      final Integer value) {
+    return value == null ? null : new AdvancedIntegerFilter().$eq(value);
   }
 
   private static io.camunda.gateway.protocol.model.DateTimeFilterProperty getDateTimeFilter(

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -114,11 +114,6 @@
       <artifactId>jakarta.validation-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
     <!-- test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.gateway.protocol.model.ElementInstanceStateEnum;
+import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter;
+import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilterFields;
+import java.util.List;
+
+public class McpProcessInstanceFilter extends ProcessInstanceFilter {
+
+  @JsonIgnore
+  @Override
+  public String getTenantId() {
+    return super.getTenantId();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getParentProcessInstanceKey() {
+    return super.getParentProcessInstanceKey();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getParentElementInstanceKey() {
+    return super.getParentElementInstanceKey();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getBatchOperationId() {
+    return super.getBatchOperationId();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getErrorMessage() {
+    return super.getErrorMessage();
+  }
+
+  @JsonIgnore
+  @Override
+  public Boolean getHasRetriesLeft() {
+    return super.getHasRetriesLeft();
+  }
+
+  @JsonIgnore
+  @Override
+  public ElementInstanceStateEnum getElementInstanceState() {
+    return super.getElementInstanceState();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getElementId() {
+    return super.getElementId();
+  }
+
+  @JsonIgnore
+  @Override
+  public Boolean getHasElementInstanceIncident() {
+    return super.getHasElementInstanceIncident();
+  }
+
+  @JsonIgnore
+  @Override
+  public Integer getIncidentErrorHashCode() {
+    return super.getIncidentErrorHashCode();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getProcessDefinitionVersionTag() {
+    return super.getProcessDefinitionVersionTag();
+  }
+
+  @JsonIgnore
+  @Override
+  public List<ProcessInstanceFilterFields> get$Or() {
+    return super.get$Or();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceFilter.java
@@ -13,6 +13,10 @@ import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilter;
 import io.camunda.gateway.protocol.model.simple.ProcessInstanceFilterFields;
 import java.util.List;
 
+/**
+ * MCP-specific process instance filter extending the {@link ProcessInstanceFilter} to hide fields
+ * from MCP clients to avoid unnecessary context bloat.
+ */
 public class McpProcessInstanceFilter extends ProcessInstanceFilter {
 
   @JsonIgnore

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -27,6 +27,16 @@ public final class ToolDescriptions {
   public static final String EVENTUAL_CONSISTENCY_NOTE =
       "Note: Results are eventually consistent and may not immediately reflect recent changes.";
 
+  public static final String FILTER_DESCRIPTION = "Filter search by the given fields";
+  public static final String SORT_DESCRIPTION = "Sort criteria";
+  public static final String PAGE_DESCRIPTION = "Pagination criteria";
+
+  public static final String POSITIVE_NUMBER_MESSAGE = "must be a positive number.";
+  public static final String INCIDENT_KEY_POSITIVE_MESSAGE =
+      "Incident key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE =
+      "Process instance key " + POSITIVE_NUMBER_MESSAGE;
+
   private ToolDescriptions() {
     // Utility class
   }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -9,6 +9,10 @@ package io.camunda.gateway.mcp.tool.incident;
 
 import static io.camunda.gateway.mcp.mapper.CallToolResultMapper.mapErrorToResult;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.INCIDENT_KEY_POSITIVE_MESSAGE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
@@ -31,8 +35,6 @@ import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
@@ -42,8 +44,6 @@ import org.springframework.validation.annotation.Validated;
 @Component
 @Validated
 public class IncidentTools {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(IncidentTools.class);
 
   private final IncidentServices incidentServices;
   private final CamundaAuthenticationProvider authenticationProvider;
@@ -62,11 +62,11 @@ public class IncidentTools {
       description = "Search for incidents. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchIncidents(
-      @McpToolParam(description = "Filter search by the given fields", required = false)
+      @McpToolParam(description = FILTER_DESCRIPTION, required = false)
           final McpIncidentFilter filter,
-      @McpToolParam(description = "Sort criteria", required = false)
+      @McpToolParam(description = SORT_DESCRIPTION, required = false)
           final List<IncidentSearchQuerySortRequest> sort,
-      @McpToolParam(description = "Pagination criteria", required = false)
+      @McpToolParam(description = PAGE_DESCRIPTION, required = false)
           final McpSearchQueryPageRequest page) {
     try {
       final var incidentSearchQuery = SearchQueryRequestMapper.toIncidentQuery(filter, page, sort);
@@ -92,7 +92,7 @@ public class IncidentTools {
       @McpToolParam(
               description =
                   "The assigned key of the incident, which acts as a unique identifier for this incident.")
-          @Positive(message = "Incident key must be a positive number.")
+          @Positive(message = INCIDENT_KEY_POSITIVE_MESSAGE)
           final Long incidentKey) {
     try {
       return CallToolResultMapper.from(
@@ -108,7 +108,7 @@ public class IncidentTools {
   @McpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
   public CallToolResult resolveIncident(
       @McpToolParam(description = "Key of the incident to resolve.")
-          @Positive(message = "Incident key must be a positive number.")
+          @Positive(message = INCIDENT_KEY_POSITIVE_MESSAGE)
           final Long incidentKey) {
     try {
       return CallToolResultMapper.fromPrimitive(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -8,6 +8,10 @@
 package io.camunda.gateway.mcp.tool.process.instance;
 
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
@@ -44,11 +48,11 @@ public class ProcessInstanceTools {
       description = "Search for process instances. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchProcessInstances(
-      @McpToolParam(description = "Filter search by the given fields", required = false)
+      @McpToolParam(description = FILTER_DESCRIPTION, required = false)
           final McpProcessInstanceFilter filter,
-      @McpToolParam(description = "Sort criteria", required = false)
+      @McpToolParam(description = SORT_DESCRIPTION, required = false)
           final List<ProcessInstanceSearchQuerySortRequest> sort,
-      @McpToolParam(description = "Pagination criteria", required = false)
+      @McpToolParam(description = PAGE_DESCRIPTION, required = false)
           final McpSearchQueryPageRequest page) {
     try {
       final var query = SearchQueryRequestMapper.toProcessInstanceQuery(filter, page, sort);
@@ -73,7 +77,7 @@ public class ProcessInstanceTools {
       @McpToolParam(
               description =
                   "The assigned key of the process instance, which acts as a unique identifier for this process instance.")
-          @Positive(message = "Process instance key must be a positive number.")
+          @Positive(message = PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE)
           final Long processInstanceKey) {
     try {
       return CallToolResultMapper.from(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.instance;
+
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
+import io.camunda.gateway.mcp.model.McpProcessInstanceFilter;
+import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
+import io.camunda.gateway.protocol.model.ProcessInstanceSearchQuerySortRequest;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.ProcessInstanceServices;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Validated
+public class ProcessInstanceTools {
+
+  private final ProcessInstanceServices processInstanceServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public ProcessInstanceTools(
+      final ProcessInstanceServices processInstanceServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.processInstanceServices = processInstanceServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @McpTool(
+      description = "Search for process instances. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult searchProcessInstances(
+      @McpToolParam(description = "Filter search by the given fields", required = false)
+          final McpProcessInstanceFilter filter,
+      @McpToolParam(description = "Sort criteria", required = false)
+          final List<ProcessInstanceSearchQuerySortRequest> sort,
+      @McpToolParam(description = "Pagination criteria", required = false)
+          final McpSearchQueryPageRequest page) {
+    try {
+      final var query = SearchQueryRequestMapper.toProcessInstanceQuery(filter, page, sort);
+      if (query.isLeft()) {
+        return CallToolResultMapper.mapProblemToResult(query.getLeft());
+      }
+
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(
+              processInstanceServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .search(query.get())));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(
+      description = "Get process instance by key. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult getProcessInstance(
+      @McpToolParam(
+              description =
+                  "The assigned key of the process instance, which acts as a unique identifier for this process instance.")
+          @Positive(message = "Process instance key must be a positive number.")
+          final Long processInstanceKey) {
+    try {
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toProcessInstance(
+              processInstanceServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .getByKey(processInstanceKey)));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.tool.ToolsTest;
+import io.camunda.gateway.protocol.model.ProcessInstanceResult;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ContextConfiguration(classes = {ProcessInstanceTools.class})
+class ProcessInstanceToolsTest extends ToolsTest {
+
+  static final ProcessInstanceEntity PROCESS_INSTANCE_ENTITY =
+      new ProcessInstanceEntity(
+          123L,
+          null,
+          "demoProcess",
+          "Demo Process",
+          5,
+          "v5",
+          789L,
+          333L,
+          777L,
+          OffsetDateTime.parse("2024-01-01T00:00:00Z"),
+          null,
+          ProcessInstanceState.ACTIVE,
+          false,
+          "tenant",
+          "PI_123",
+          Set.of("tag1", "tag2"));
+
+  static final SearchQueryResult<ProcessInstanceEntity> SEARCH_QUERY_RESULT =
+      new Builder<ProcessInstanceEntity>()
+          .total(1L)
+          .items(List.of(PROCESS_INSTANCE_ENTITY))
+          .startCursor("f")
+          .endCursor("v")
+          .build();
+
+  @MockitoBean private ProcessInstanceServices processInstanceServices;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Captor private ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
+
+  @BeforeEach
+  void mockApiServices() {
+    mockApiServiceAuthentication(processInstanceServices);
+  }
+
+  @Test
+  void shouldGetProcessInstanceByKey() {
+    // given
+    when(processInstanceServices.getByKey(any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getProcessInstance")
+                .arguments(Map.of("processInstanceKey", 123L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var processInstance =
+        objectMapper.convertValue(result.structuredContent(), ProcessInstanceResult.class);
+    assertThat(processInstance)
+        .usingRecursiveComparison()
+        .isEqualTo(SearchQueryResponseMapper.toProcessInstance(PROCESS_INSTANCE_ENTITY));
+
+    verify(processInstanceServices).getByKey(123L);
+  }
+
+  @Test
+  void shouldFailGetProcessInstanceByKeyOnException() {
+    // given
+    when(processInstanceServices.getByKey(any()))
+        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getProcessInstance")
+                .arguments(Map.of("processInstanceKey", 123L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content()).isEmpty();
+    assertThat(result.structuredContent()).isNotNull();
+
+    final var problemDetail =
+        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+  }
+
+  @Test
+  void shouldFailGetProcessInstanceByKeyOnInvalidKey() {
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("getProcessInstance")
+                .arguments(Map.of("processInstanceKey", -3L))
+                .build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.structuredContent()).isNull();
+    assertThat(result.content())
+        .hasSize(1)
+        .first()
+        .isInstanceOfSatisfying(
+            TextContent.class,
+            textContent ->
+                assertThat(textContent.text())
+                    .contains("Process instance key must be a positive number."));
+  }
+
+  @Test
+  void shouldSearchProcessInstancesWithFilterSortAndPaging() {
+    // given
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder()
+                .name("searchProcessInstances")
+                .arguments(
+                    Map.of(
+                        "filter",
+                        Map.of(
+                            "state",
+                            "ACTIVE",
+                            "startDate",
+                            Map.of("from", "2024-01-01T00:00:00Z", "to", "2024-02-01T00:00:00Z"),
+                            "processDefinitionId",
+                            "demoProcess",
+                            "processDefinitionVersion",
+                            5,
+                            "tags",
+                            List.of("tag1")),
+                        "sort",
+                        List.of(Map.of("field", "processInstanceKey", "order", "DESC")),
+                        "page",
+                        Map.of("limit", 25, "after", "WzEwMjRd")))
+                .build());
+
+    // then
+    assertThat(result.isError()).isFalse();
+
+    verify(processInstanceServices).search(queryCaptor.capture());
+    final ProcessInstanceQuery capturedQuery = queryCaptor.getValue();
+
+    final ProcessInstanceFilter filter = capturedQuery.filter();
+    assertThat(filter.stateOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(tuple(Operator.EQUALS, "ACTIVE"));
+
+    assertThat(filter.processDefinitionIdOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(tuple(Operator.EQUALS, "demoProcess"));
+
+    assertThat(filter.processDefinitionVersionOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(tuple(Operator.EQUALS, 5));
+
+    assertThat(filter.startDateOperations())
+        .extracting(Operation::operator, Operation::value)
+        .containsExactly(
+            tuple(Operator.GREATER_THAN_EQUALS, OffsetDateTime.parse("2024-01-01T00:00:00Z")),
+            tuple(Operator.LOWER_THAN, OffsetDateTime.parse("2024-02-01T00:00:00Z")));
+
+    assertThat(filter.tags()).containsExactly("tag1");
+
+    assertThat(capturedQuery.sort().orderings())
+        .extracting(FieldSorting::field, FieldSorting::order)
+        .containsExactly(tuple("processInstanceKey", SortOrder.DESC));
+
+    assertThat(capturedQuery.page().size()).isEqualTo(25);
+    assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+  }
+
+  @Test
+  void shouldFailSearchProcessInstancesOnException() {
+    // given
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+    // when
+    final CallToolResult result =
+        mcpClient.callTool(
+            CallToolRequest.builder().name("searchProcessInstances").arguments(Map.of()).build());
+
+    // then
+    assertThat(result.isError()).isTrue();
+    assertThat(result.content()).isEmpty();
+
+    final var problemDetail =
+        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -22,6 +22,8 @@ import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.filter.UntypedOperation;
+import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
@@ -187,7 +189,9 @@ class ProcessInstanceToolsTest extends ToolsTest {
                             "processDefinitionVersion",
                             5,
                             "tags",
-                            List.of("tag1")),
+                            List.of("tag1"),
+                            "variables",
+                            List.of(Map.of("name", "orderId", "value", "123"))),
                         "sort",
                         List.of(Map.of("field", "processInstanceKey", "order", "DESC")),
                         "page",
@@ -220,6 +224,13 @@ class ProcessInstanceToolsTest extends ToolsTest {
             tuple(Operator.LOWER_THAN, OffsetDateTime.parse("2024-02-01T00:00:00Z")));
 
     assertThat(filter.tags()).containsExactly("tag1");
+
+    assertThat(filter.variableFilters()).hasSize(1);
+    final VariableValueFilter variableFilter = filter.variableFilters().getFirst();
+    assertThat(variableFilter.name()).isEqualTo("orderId");
+    assertThat(variableFilter.valueOperations())
+        .extracting(UntypedOperation::operator, UntypedOperation::value)
+        .containsExactly(tuple(Operator.EQUALS, 123L));
 
     assertThat(capturedQuery.sort().orderings())
         .extracting(FieldSorting::field, FieldSorting::order)

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -149,6 +149,7 @@
                 <typeMapping>ResourceKeyFilterProperty=String</typeMapping>
                 <typeMapping>ScopeKeyFilterProperty=String</typeMapping>
                 <typeMapping>StringFilterProperty=String</typeMapping>
+                <typeMapping>IntegerFilterProperty=Integer</typeMapping>
                 <typeMapping>VariableKeyFilterProperty=String</typeMapping>
                 <!-- map to custom model classes -->
                 <typeMapping>DateTimeFilterProperty=SimpleDateTimeFilterProperty</typeMapping>


### PR DESCRIPTION
## Description

Implements process instance search and get tools following the simple model setup implemented in #44123.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43608
