### PR TITLE
Fix nightly fails on main

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -179,7 +179,9 @@ export class OperateFiltersPanelPage {
   }
 
   async selectVersion(option: string) {
+    await expect(this.processNameFilter).toBeVisible();
     await this.processVersionFilter.click();
+    await expect(this.getOptionByName(option)).toBeVisible();
     await this.getOptionByName(option).click({timeout: 30000});
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -59,7 +59,7 @@ class OperateProcessInstancePage {
   readonly incidentBannerButton: (count: number) => Locator;
   readonly incidentTypeFilter: Locator;
   readonly executionCountToggle: Locator;
-  readonly executionCountToggleButton: Locator;
+  readonly executionCountToggleLabel: Locator;
   readonly endDateField: Locator;
   readonly incidentsViewHeader: Locator;
   readonly modificationModeText: Locator;
@@ -158,12 +158,6 @@ class OperateProcessInstancePage {
     this.incidentTypeFilter = page.getByRole('combobox', {
       name: /filter by incident type/i,
     });
-    this.executionCountToggle = this.instanceHistory.locator(
-      '[aria-label="show execution count"], [aria-label="hide execution count"]',
-    );
-    this.executionCountToggleButton = this.instanceHistory.locator(
-      'button[aria-label="Execution count"][role="switch"]',
-    );
     this.endDateField = this.instanceHeader.getByTestId('end-date');
     this.incidentsViewHeader = page.getByText(/incidents\s+-\s+/i);
     this.modificationModeText = page.getByText(
@@ -193,6 +187,10 @@ class OperateProcessInstancePage {
     this.viewParentInstanceLink = page.getByRole('link', {
       name: /view parent instance/i,
     });
+    this.executionCountToggle = this.page.locator('#toggle-execution-count');
+    this.executionCountToggleLabel = this.page.locator(
+      '#toggle-execution-count_label',
+    );
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -564,18 +562,14 @@ class OperateProcessInstancePage {
   }
 
   async toggleExecutionCount(): Promise<void> {
-    await this.executionCountToggleButton.waitFor({state: 'visible'});
-    const isChecked =
-      await this.executionCountToggleButton.getAttribute('aria-checked');
-
-    if (isChecked === 'false') {
-      await this.executionCountToggleButton.click({force: true});
-      await expect(this.executionCountToggleButton).toHaveAttribute(
+    await this.executionCountToggle.waitFor({state: 'visible'});
+    if (
+      (await this.executionCountToggle.getAttribute('aria-checked')) !== 'true'
+    ) {
+      await this.executionCountToggleLabel.click();
+      await expect(this.executionCountToggle).toHaveAttribute(
         'aria-checked',
         'true',
-        {
-          timeout: 5000,
-        },
       );
     }
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -517,6 +517,7 @@ class OperateProcessInstancePage {
   }
 
   async clickTreeItem(name: string | RegExp, exact?: boolean): Promise<void> {
+    await expect(this.getTreeItem(name, exact)).toBeVisible();
     await this.getTreeItem(name, exact).click();
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -357,6 +357,7 @@ class OperateProcessesPage {
 
           // Wait for the element to be attached and stable
           await checkbox.waitFor({state: 'attached'});
+          await sleep(200);
           if (!(await checkbox.isChecked())) {
             await checkbox.click();
           }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -115,8 +115,10 @@ class TaskDetailsPage {
   }
 
   async clickAssignToMeButton() {
-    await expect(this.assignToMeButton).toBeVisible({timeout: 60000});
-    await this.assignToMeButton.click({timeout: 60000});
+    if (!(await this.assignedToMeText.isVisible())) {
+      await expect(this.assignToMeButton).toBeVisible({timeout: 60000});
+      await this.assignToMeButton.click({timeout: 60000});
+    }
   }
 
   async clickUnassignButton() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-delete-api.spec.ts
@@ -37,7 +37,7 @@ test.describe.parallel('Resource Delete API', () => {
       },
     );
 
-    await assertStatusCode(res, 204);
+    await assertStatusCode(res, 200);
   });
 
   test('Delete Resource - Not Found 404', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -77,7 +77,7 @@ test.beforeAll(async () => {
 
   const childProcessV2: ProcessDeployment = {
     bpmnProcessId: 'childProcess',
-    version: secondChildProcessVersion ? secondChildProcessVersion : 2,
+    version: secondChildProcessVersion ?? 2,
     processDefinitionKey: '',
   };
   expect(childProcessV2.version).toBe(childProcessV1.version + 1);
@@ -118,9 +118,6 @@ test.describe('Child Process Instance Migration', () => {
     const targetVersion = testProcesses.childProcessV2.version.toString();
     const targetBpmnProcessId = testProcesses.childProcessV2.bpmnProcessId;
     const parentInstanceKey = testProcesses.parentProcessInstanceKeys[0]!;
-    console.log('Parent Process:', testProcesses.parentProcess.version);
-    console.log('Child Process V1:', testProcesses.childProcessV1.version);
-    console.log('Child Process V2:', testProcesses.childProcessV2.version);
 
     await test.step('Navigate to parent process instance and view called child processes', async () => {
       await operateFiltersPanelPage.selectProcess(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -80,6 +80,7 @@ test.beforeAll(async () => {
     version: secondChildProcessVersion ? secondChildProcessVersion : 2,
     processDefinitionKey: '',
   };
+  expect(childProcessV2.version).toBe(childProcessV1.version + 1);
 
   testProcesses = {
     parentProcess,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -17,6 +17,7 @@ import {
 import {waitForProcessInstances} from 'utils/incidentsHelper';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {waitForAssertion} from '../../utils/waitForAssertion';
 
 let instanceIds: string[] = [];
 
@@ -163,9 +164,19 @@ test.describe('Dashboard', () => {
     });
   });
 
-  test('Select process instances by name', async ({operateDashboardPage}) => {
+  test('Select process instances by name', async ({
+    page,
+    operateDashboardPage,
+  }) => {
     await test.step('Select first process and verify total count', async () => {
-      await expect(operateDashboardPage.instancesByProcess).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateDashboardPage.instancesByProcess).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
 
       const firstInstanceByProcess =
         operateDashboardPage.instancesByProcessItem(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -250,7 +250,7 @@ test.describe('Process Instance', () => {
       await expect(
         diagram.getByText('fill form', {exact: false}),
       ).toBeVisible();
-      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 15000});
+      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 60000});
       await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -250,7 +250,7 @@ test.describe('Process Instance', () => {
       await expect(
         diagram.getByText('fill form', {exact: false}),
       ).toBeVisible();
-      await expect(operateDiagramPage.popover).toBeVisible();
+      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 15000});
       await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -220,6 +220,7 @@ test.describe('Process Instance', () => {
   test('Should render collapsed sub process and navigate between planes', async ({
     page,
     operateProcessInstancePage,
+    operateDiagramPage,
   }) => {
     const {diagram} = operateProcessInstancePage;
 
@@ -246,10 +247,10 @@ test.describe('Process Instance', () => {
     await test.step('Navigate to fill form flow node', async () => {
       await page.keyboard.press('ArrowRight');
       await operateProcessInstancePage.clickTreeItem(/fill form/i);
-
       await expect(
         diagram.getByText('fill form', {exact: false}),
       ).toBeVisible();
+      await expect(operateDiagramPage.popover).toBeVisible();
       await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -250,7 +250,18 @@ test.describe('Process Instance', () => {
       await expect(
         diagram.getByText('fill form', {exact: false}),
       ).toBeVisible();
-      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 120000});
+
+      await waitForAssertion({
+        assertion: async () => {
+          await operateDiagramPage.popover.waitFor({
+            state: 'visible',
+          });
+        },
+        onFailure: async () => {
+          await operateProcessInstancePage.clickTreeItem(/fill form/i);
+        },
+      });
+
       await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -250,7 +250,7 @@ test.describe('Process Instance', () => {
       await expect(
         diagram.getByText('fill form', {exact: false}),
       ).toBeVisible();
-      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 60000});
+      await operateDiagramPage.popover.waitFor({ state: 'visible' , timeout: 120000});
       await expect(page.getByText(/retries left/i)).toBeVisible();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -123,9 +123,9 @@ test.describe('Process Instance', () => {
         },
       });
 
-      await expect(operateProcessInstancePage.incidentsTableRows).toHaveCount(
-        1,
-      );
+      await expect
+        .poll(() => operateProcessInstancePage.incidentsTableRows.count())
+        .toBe(1);
 
       await expect(
         operateProcessInstancePage.incidentsTable.getByText(/is cool\?/i),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -248,6 +248,8 @@ test.describe('Processes', () => {
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );
 
+      await expect(page).toHaveURL(`${baseUrl}/operate/processes?process=testProcess&version=1`);
+
       await waitForAssertion({
         assertion: async () => {
           await expect(operateFiltersPanelPage.processNameFilter).toBeDisabled({
@@ -257,6 +259,7 @@ test.describe('Processes', () => {
         onFailure: async () => {
           page.reload();
         },
+        maxRetries: 5,
       });
 
       await expect(operateDiagramPage.diagramSpinner).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -159,7 +159,7 @@ test.describe('task panel page', () => {
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(isAdditionalTaskVisible ? 0 : 1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(isAdditionalTaskVisible? amountOfVisibleTasks+1 : amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -32,7 +32,7 @@ test.beforeAll(async ({resetData}) => {
   await createInstances('usertask_for_scrolling_1', 1, 1);
   await createInstances('usertask_to_be_assigned', 1, 1); // this task will be seen on top since it is created last
 
-  await sleep(500);
+  await sleep(5000);
 });
 
 test.describe('task panel page', () => {
@@ -118,47 +118,48 @@ test.describe('task panel page', () => {
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);
+
+    const isAdditionalTaskVisible = await taskPanelPageV1.availableTasks.getByText('usertask_to_be_assigned').isVisible();
+    let amountOfVisibleTasks = 49;
+    if (isAdditionalTaskVisible) {
+      amountOfVisibleTasks -= 1;
+    }
+    console.log('Amount of visible tasks:', amountOfVisibleTasks);
+
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
+    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(99);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
+    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(149);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
+    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(0);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(isAdditionalTaskVisible? amountOfVisibleTasks+1 : amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(1);
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
-    await waitForAssertion({
-      assertion: async () => {
-       await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-      },
-      onFailure: async () => {
-       await page.reload();
-       await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
-      },
-      maxRetries: 10,
-    });
-
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -12,6 +12,7 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
+import { waitForAssertion } from 'utils/waitForAssertion';
 
 test.beforeAll(async ({resetData}) => {
   await resetData();
@@ -146,8 +147,15 @@ test.describe('task panel page', () => {
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
-    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
-    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+        await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+        await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+      },
+      onFailure: async () => {
+       await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
+      },
+    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -158,7 +158,7 @@ test.describe('task panel page', () => {
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
-    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(isAdditionalTaskVisible ? 0 : 1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -150,12 +150,13 @@ test.describe('task panel page', () => {
     await waitForAssertion({
       assertion: async () => {
         await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-        await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
-        await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
       },
       onFailure: async () => {
        await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
       },
     });
+
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -149,9 +149,10 @@ test.describe('task panel page', () => {
 
     await waitForAssertion({
       assertion: async () => {
-        await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+       await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
       },
       onFailure: async () => {
+       await page.reload();
        await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
       },
       maxRetries: 10,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -31,7 +31,7 @@ test.beforeAll(async ({resetData}) => {
   await createInstances('usertask_for_scrolling_1', 1, 1);
   await createInstances('usertask_to_be_assigned', 1, 1); // this task will be seen on top since it is created last
 
-  await sleep(5000);
+  await sleep(500);
 });
 
 test.describe('task panel page', () => {
@@ -146,9 +146,7 @@ test.describe('task panel page', () => {
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
-    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1, {
-      timeout: 20000,
-    });
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -154,6 +154,7 @@ test.describe('task panel page', () => {
       onFailure: async () => {
        await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
       },
+      maxRetries: 10,
     });
 
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -12,7 +12,6 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
-import { waitForAssertion } from 'utils/waitForAssertion';
 
 test.beforeAll(async ({resetData}) => {
   await resetData();
@@ -118,48 +117,39 @@ test.describe('task panel page', () => {
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-
-    const isAdditionalTaskVisible = await taskPanelPageV1.availableTasks.getByText('usertask_to_be_assigned').isVisible();
-    let amountOfVisibleTasks = 49;
-    if (isAdditionalTaskVisible) {
-      amountOfVisibleTasks -= 1;
-    }
-    console.log('Amount of visible tasks:', amountOfVisibleTasks);
-
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
-    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(99);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
-    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(149);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
-    amountOfVisibleTasks += 50;
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
 
     await taskPanelPageV1.scrollToLastTask('usertask_for_scrolling_2');
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(0);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(isAdditionalTaskVisible? amountOfVisibleTasks+1 : amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(1);
 
     await taskPanelPageV1.scrollToFirstTask('usertask_for_scrolling_2');
 
-    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(isAdditionalTaskVisible ? 0 : 1);
-    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(isAdditionalTaskVisible? amountOfVisibleTasks+1 : amountOfVisibleTasks);
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1, {
+      timeout: 20000,
+    });
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Description

This PR covers test that failed on [this nightly run](https://github.com/camunda/camunda/actions/runs/21154801866) on main.

- Refactored migration test to be run multiple times by using process instance versions.
- Updated toggle locator to be clicked for incident tests.
- Added assertions and retries to reduce flakiness.

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21217788347/job/61043966987). 
❗Scrolling for v1 test failed. Checking it with the team [here](https://camunda.slack.com/archives/C08MRKHJ0CD/p1769002987572149) whether it's a known bug or not.  