### PR TITLE
feat: return operation details to pi list

### DIFF
--- a/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
@@ -25,6 +25,7 @@ const createMockBatchOperationItems = (
   options?: {
     withErrors?: boolean;
     state?: BatchOperationItem['state'];
+    operationType?: BatchOperationItem['operationType'];
   },
 ): BatchOperationItem[] => {
   return Array.from({length: count}, (_, i) => ({
@@ -32,7 +33,7 @@ const createMockBatchOperationItems = (
     itemKey: `item-${i + 1}`,
     processInstanceKey: `2251799813685${250 + i}`,
     state: options?.state ?? 'COMPLETED',
-    operationType: 'MIGRATE_PROCESS_INSTANCE',
+    operationType: options?.operationType ?? 'CANCEL_PROCESS_INSTANCE',
     processedDate: '2023-11-22T09:03:29.564+0100',
     errorMessage: options?.withErrors
       ? `Error processing item ${i + 1}`

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
@@ -14,13 +14,13 @@ import {useCancelProcessInstance} from 'modules/mutations/processInstance/useCan
 import {useDeleteProcessInstance} from 'modules/mutations/processInstance/useDeleteProcessInstance';
 import {useResolveProcessInstanceIncidents} from 'modules/mutations/processInstance/useResolveProcessInstanceIncidents';
 import type {OperationConfig} from 'modules/components/Operations/types';
-import type {OperationEntityType} from 'modules/types/operate';
+import type {BatchOperationType} from '@camunda/camunda-api-zod-schemas/8.8';
 
 type Props = {
   processInstanceKey: string;
   hasIncident: boolean;
   isInstanceActive: boolean;
-  activeOperations: OperationEntityType[];
+  activeOperations: BatchOperationType[];
 };
 
 const InstanceOperations: React.FC<Props> = ({

--- a/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/InstancesTable/InstanceOperations.tsx
@@ -14,17 +14,20 @@ import {useCancelProcessInstance} from 'modules/mutations/processInstance/useCan
 import {useDeleteProcessInstance} from 'modules/mutations/processInstance/useDeleteProcessInstance';
 import {useResolveProcessInstanceIncidents} from 'modules/mutations/processInstance/useResolveProcessInstanceIncidents';
 import type {OperationConfig} from 'modules/components/Operations/types';
+import type {OperationEntityType} from 'modules/types/operate';
 
 type Props = {
   processInstanceKey: string;
   hasIncident: boolean;
   isInstanceActive: boolean;
+  activeOperations: OperationEntityType[];
 };
 
 const InstanceOperations: React.FC<Props> = ({
   processInstanceKey,
   hasIncident,
   isInstanceActive,
+  activeOperations,
 }) => {
   const handleOperationSuccess = useHandleOperationSuccess();
 
@@ -83,6 +86,7 @@ const InstanceOperations: React.FC<Props> = ({
   });
 
   const isLoading =
+    activeOperations.length > 0 ||
     isCancelProcessInstancePending ||
     isResolveIncidentsPending ||
     isDeletePending;
@@ -93,7 +97,9 @@ const InstanceOperations: React.FC<Props> = ({
     operations.push({
       type: 'RESOLVE_INCIDENT',
       onExecute: () => resolveProcessInstanceIncidents(),
-      disabled: isResolveIncidentsPending,
+      disabled:
+        isResolveIncidentsPending ||
+        activeOperations.includes('RESOLVE_INCIDENT'),
     });
   }
 
@@ -101,7 +107,9 @@ const InstanceOperations: React.FC<Props> = ({
     operations.push({
       type: 'CANCEL_PROCESS_INSTANCE',
       onExecute: () => cancelProcessInstance(),
-      disabled: isCancelProcessInstancePending,
+      disabled:
+        isCancelProcessInstancePending ||
+        activeOperations.includes('CANCEL_PROCESS_INSTANCE'),
     });
   }
 
@@ -109,7 +117,8 @@ const InstanceOperations: React.FC<Props> = ({
     operations.push({
       type: 'DELETE_PROCESS_INSTANCE',
       onExecute: () => deleteProcessInstance(),
-      disabled: isDeletePending,
+      disabled:
+        isDeletePending || activeOperations.includes('DELETE_PROCESS_INSTANCE'),
     });
   }
 

--- a/operate/client/src/modules/queries/batch-operations/useActiveOperationItemsForInstances.ts
+++ b/operate/client/src/modules/queries/batch-operations/useActiveOperationItemsForInstances.ts
@@ -39,7 +39,9 @@ const useActiveOperationItemsForInstances = (processInstanceKeys: string[]) => {
           state: {$eq: 'ACTIVE'},
         },
         page: {
-          limit: processInstanceKeys.length * 3, // Allow up to 3 operations per instance
+          // Limit based on assumption that instances typically have ~3 active operations
+          // Provides reasonable buffer while preventing over-fetching
+          limit: processInstanceKeys.length * 3,
         },
       });
 

--- a/operate/client/src/modules/queries/batch-operations/useActiveOperationItemsForInstances.ts
+++ b/operate/client/src/modules/queries/batch-operations/useActiveOperationItemsForInstances.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {queryBatchOperationItems} from 'modules/api/v2/batchOperations/queryBatchOperationItems';
+import type {
+  BatchOperationItem,
+  QueryBatchOperationItemsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {queryKeys} from '../queryKeys';
+
+const useActiveOperationItemsForInstances = (processInstanceKeys: string[]) => {
+  return useQuery({
+    queryKey: [
+      ...queryKeys.batchOperationItems.query({
+        filter: {
+          processInstanceKey:
+            processInstanceKeys.length > 0
+              ? {$in: processInstanceKeys}
+              : undefined,
+          state: {$eq: 'ACTIVE'},
+        },
+      }),
+      {processInstanceKeys},
+    ],
+    queryFn: async (): Promise<QueryBatchOperationItemsResponseBody> => {
+      if (processInstanceKeys.length === 0) {
+        return {items: [] as BatchOperationItem[], page: {totalItems: 0}};
+      }
+
+      const {response, error} = await queryBatchOperationItems({
+        filter: {
+          processInstanceKey: {$in: processInstanceKeys},
+          state: {$eq: 'ACTIVE'},
+        },
+        page: {
+          limit: processInstanceKeys.length * 3, // Allow up to 3 operations per instance
+        },
+      });
+
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled: processInstanceKeys.length > 0,
+    refetchInterval: (query) => {
+      const hasActiveOperations = (query.state.data?.items.length ?? 0) > 0;
+      return hasActiveOperations ? 5000 : false;
+    },
+  });
+};
+
+export {useActiveOperationItemsForInstances};

--- a/operate/client/src/modules/queries/batch-operations/useOperationItemsForInstances.ts
+++ b/operate/client/src/modules/queries/batch-operations/useOperationItemsForInstances.ts
@@ -8,10 +8,7 @@
 
 import {useQuery} from '@tanstack/react-query';
 import {queryBatchOperationItems} from 'modules/api/v2/batchOperations/queryBatchOperationItems';
-import type {
-  BatchOperationItem,
-  QueryBatchOperationItemsResponseBody,
-} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {QueryBatchOperationItemsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {queryKeys} from '../queryKeys';
 
 const useOperationItemsForInstances = (
@@ -34,13 +31,9 @@ const useOperationItemsForInstances = (
       {batchOperationKey, processInstanceKeys},
     ],
     queryFn: async (): Promise<QueryBatchOperationItemsResponseBody> => {
-      if (!batchOperationKey || processInstanceKeys.length === 0) {
-        return {items: [] as BatchOperationItem[], page: {totalItems: 0}};
-      }
-
       const {response, error} = await queryBatchOperationItems({
         filter: {
-          batchOperationKey: {$eq: batchOperationKey},
+          batchOperationKey: {$eq: batchOperationKey!},
           processInstanceKey: {$in: processInstanceKeys},
         },
         page: {

--- a/operate/client/src/modules/queries/batch-operations/useOperationItemsForInstances.ts
+++ b/operate/client/src/modules/queries/batch-operations/useOperationItemsForInstances.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {queryBatchOperationItems} from 'modules/api/v2/batchOperations/queryBatchOperationItems';
+import type {
+  BatchOperationItem,
+  QueryBatchOperationItemsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
+import {queryKeys} from '../queryKeys';
+
+const useOperationItemsForInstances = (
+  batchOperationKey: string | undefined,
+  processInstanceKeys: string[],
+) => {
+  return useQuery({
+    queryKey: [
+      ...queryKeys.batchOperationItems.query({
+        filter: {
+          batchOperationKey: batchOperationKey
+            ? {$eq: batchOperationKey}
+            : undefined,
+          processInstanceKey:
+            processInstanceKeys.length > 0
+              ? {$in: processInstanceKeys}
+              : undefined,
+        },
+      }),
+      {batchOperationKey, processInstanceKeys},
+    ],
+    queryFn: async (): Promise<QueryBatchOperationItemsResponseBody> => {
+      if (!batchOperationKey || processInstanceKeys.length === 0) {
+        return {items: [] as BatchOperationItem[], page: {totalItems: 0}};
+      }
+
+      const {response, error} = await queryBatchOperationItems({
+        filter: {
+          batchOperationKey: {$eq: batchOperationKey},
+          processInstanceKey: {$in: processInstanceKeys},
+        },
+        page: {
+          limit: processInstanceKeys.length,
+        },
+      });
+
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled: !!batchOperationKey && processInstanceKeys.length > 0,
+  });
+};
+
+export {useOperationItemsForInstances};

--- a/operate/client/src/modules/utils/filter/v2/processInstancesSearch.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstancesSearch.ts
@@ -61,12 +61,10 @@ const parseProcessInstancesSearchFilter = (
 ): ProcessInstancesSearchFilter | undefined => {
   const filter = parseProcessInstancesFilter(search);
 
-  if (
-    !filter.active &&
-    !filter.completed &&
-    !filter.canceled &&
-    !filter.incidents
-  ) {
+  const hasStateFilters =
+    filter.active || filter.completed || filter.canceled || filter.incidents;
+
+  if (!hasStateFilters && !filter.operationId) {
     return undefined;
   }
 


### PR DESCRIPTION
## Description

Re-introduce operation status tracking and display for the process instances list view to the PI list with readjustments related to v2 approach
-  Operations are fetched in bulk for all instances in the current table view
-  Implements 5-second polling when active operations are detected, automatically stops polling when no active operations exist
- Shows operation state (ACTIVE/FAILED/COMPLETED) when filtering by `?operationId=id`
- Loading indicators for pending operations(as we separatly fetch for operation details, while in v1 all operations array was part of pi)
- Operations menu buttons are now disabled when the same operation type is already active on an instance

## Checklist

## Related issues

closes #43698 
