### PR TITLE
fix: use more special replace strings in Makefile to avoid false-posi…

### DIFF
--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -1,5 +1,5 @@
-namespace ?= default
-secondary_storage ?= elasticsearch
+namespace ?= __NAMESPACE__
+secondary_storage ?= __STORAGE_TYPE__
 helm_chart ?= camunda-platform-8.9
 curl_image ?= curlimages/curl:7.87.0
 camunda_management_url ?= http://camunda:9600

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -89,8 +89,8 @@ cp -v ../prometheus-elasticsearch-exporter-values.yaml $namespace/
 cd $namespace
 
 # Update Makefile to use the namespace and secondary storage
-sed_inplace "s/default/$namespace/" Makefile
-sed_inplace "s/elasticsearch/$secondaryStorage/" Makefile
+sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
+sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
 
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update


### PR DESCRIPTION
## Description

Fixes the `sed` find/replace logic in the load-test makefile to use more special placeholders.

The previous solution replaced every occurrence of `elasticsearch` by `postgresql` and caused errors when setting up the prometheus exporter (which didn't exist for postgresql).