### PR TITLE
[Backport stable/8.7] Send a notification to #zeebe-ci when the QA creation fails

### DIFF
--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -57,3 +57,35 @@ jobs:
         }
       branch: ${{ inputs.branch }}
     secrets: inherit
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [ qa ]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Starting QA run failed for ${{ inputs.branch }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@zeebe-medic Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
# Description
Backport of #44363 to `stable/8.7`.

relates to 