### PR TITLE
feat: implement logic to validate global checkpoint w/ exporter positions

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.restore;
 import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration;
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
@@ -45,7 +46,10 @@ import org.springframework.context.annotation.Import;
       UnifiedConfiguration.class,
       BrokerBasedPropertiesOverride.class,
       RestorePropertiesOverride.class,
-      WorkingDirectoryConfiguration.class
+      WorkingDirectoryConfiguration.class,
+      // RDBMS Configuration - conditional on secondary storage type being RDBMS.
+      // When active, provides ExporterPositionMapper for RDBMS-aware restore.
+      RdbmsConfiguration.class,
     })
 public class RestoreApp implements ApplicationRunner {
 

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -96,6 +96,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
     </dependency>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.util.Optionals;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -64,4 +66,10 @@ public interface BackupDescriptor {
    * @return the type of the checkpoint that triggered the backup
    */
   CheckpointType checkpointType();
+
+  @JsonIgnore
+  default Optional<Interval<Long>> getLogPositionInterval() {
+    return Optionals.boxed(firstLogPosition())
+        .map(logPos -> new Interval<>(logPos, checkpointPosition()));
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -23,29 +23,29 @@ public sealed interface BackupRange {
   SequencedCollection<Long> checkpoints();
 
   /** A complete backup range without deletions. */
-  record Complete(Interval<Long> interval) implements BackupRange {
+  record Complete(Interval<Long> checkpointInterval) implements BackupRange {
     public Complete(final long startCheckpointId, final long endCheckpointId) {
       this(new Interval<>(startCheckpointId, endCheckpointId));
     }
 
     @Override
-    public boolean contains(final Interval<Long> other) {
-      return interval().contains(other);
-    }
-
-    @Override
     public long firstCheckpointId() {
-      return interval().start();
+      return checkpointInterval().start();
     }
 
     @Override
     public long lastCheckpointId() {
-      return interval.end();
+      return checkpointInterval.end();
+    }
+
+    @Override
+    public boolean contains(final Interval<Long> other) {
+      return checkpointInterval().contains(other);
     }
 
     @Override
     public SequencedCollection<Long> checkpoints() {
-      return interval.values();
+      return checkpointInterval.values();
     }
   }
 
@@ -53,7 +53,7 @@ public sealed interface BackupRange {
    * A backup range with deletions. Verification of all contained backups is required to determine
    * whether the range is effectively complete or not.
    */
-  record Incomplete(Interval<Long> interval, Set<Long> deletedCheckpointIds)
+  record Incomplete(Interval<Long> checkpontInterval, Set<Long> deletedCheckpointIds)
       implements BackupRange {
     public Incomplete(
         final long startCheckpointId,
@@ -70,31 +70,31 @@ public sealed interface BackupRange {
       deletedCheckpointIds = Set.copyOf(deletedCheckpointIds);
     }
 
-    @Override
-    public boolean contains(final Interval<Long> other) {
-      return interval.contains(other) && !isInDeletionRange(other);
-    }
-
-    @Override
-    public SequencedCollection<Long> checkpoints() {
-      return Stream.concat(interval.values().stream(), deletedCheckpointIds.stream())
-          .sorted()
-          .distinct()
-          .toList();
-    }
-
     private boolean isInDeletionRange(final Interval<Long> interval) {
       return deletedCheckpointIds.stream().anyMatch(interval::contains);
     }
 
     @Override
     public long firstCheckpointId() {
-      return interval().start();
+      return checkpontInterval().start();
     }
 
     @Override
     public long lastCheckpointId() {
-      return interval.end();
+      return checkpontInterval.end();
+    }
+
+    @Override
+    public boolean contains(final Interval<Long> other) {
+      return checkpontInterval.contains(other) && !isInDeletionRange(other);
+    }
+
+    @Override
+    public SequencedCollection<Long> checkpoints() {
+      return Stream.concat(checkpontInterval.values().stream(), deletedCheckpointIds.stream())
+          .sorted()
+          .distinct()
+          .toList();
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -20,7 +20,7 @@ public sealed interface BackupRange {
   /** A complete backup range without deletions. */
   record Complete(Interval<Long> checkpointInterval) implements BackupRange {
     public Complete(final long startCheckpointId, final long endCheckpointId) {
-      this(new Interval<>(startCheckpointId, endCheckpointId));
+      this(Interval.closed(startCheckpointId, endCheckpointId));
     }
 
     @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -35,7 +35,7 @@ public sealed interface BackupRange {
 
     @Override
     public long lastCheckpointId() {
-      return checkpointInterval.end();
+      return checkpointInterval().end();
     }
 
     @Override
@@ -45,7 +45,7 @@ public sealed interface BackupRange {
 
     @Override
     public SequencedCollection<Long> checkpoints() {
-      return checkpointInterval.values();
+      return checkpointInterval().values();
     }
   }
 
@@ -53,7 +53,7 @@ public sealed interface BackupRange {
    * A backup range with deletions. Verification of all contained backups is required to determine
    * whether the range is effectively complete or not.
    */
-  record Incomplete(Interval<Long> checkpontInterval, Set<Long> deletedCheckpointIds)
+  record Incomplete(Interval<Long> checkpointInterval, Set<Long> deletedCheckpointIds)
       implements BackupRange {
     public Incomplete(
         final long startCheckpointId,
@@ -76,22 +76,22 @@ public sealed interface BackupRange {
 
     @Override
     public long firstCheckpointId() {
-      return checkpontInterval().start();
+      return checkpointInterval.start();
     }
 
     @Override
     public long lastCheckpointId() {
-      return checkpontInterval.end();
+      return checkpointInterval.end();
     }
 
     @Override
     public boolean contains(final Interval<Long> other) {
-      return checkpontInterval.contains(other) && !isInDeletionRange(other);
+      return checkpointInterval.contains(other) && !isInDeletionRange(other);
     }
 
     @Override
     public SequencedCollection<Long> checkpoints() {
-      return Stream.concat(checkpontInterval.values().stream(), deletedCheckpointIds.stream())
+      return Stream.concat(checkpointInterval.values().stream(), deletedCheckpointIds.stream())
           .sorted()
           .distinct()
           .toList();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -8,9 +8,7 @@
 package io.camunda.zeebe.backup.api;
 
 import java.util.Objects;
-import java.util.SequencedCollection;
 import java.util.Set;
-import java.util.stream.Stream;
 
 public sealed interface BackupRange {
   long firstCheckpointId();
@@ -18,9 +16,6 @@ public sealed interface BackupRange {
   long lastCheckpointId();
 
   boolean contains(Interval<Long> other);
-
-  /** Returns the checkpoints range extremes in order */
-  SequencedCollection<Long> checkpoints();
 
   /** A complete backup range without deletions. */
   record Complete(Interval<Long> checkpointInterval) implements BackupRange {
@@ -41,11 +36,6 @@ public sealed interface BackupRange {
     @Override
     public boolean contains(final Interval<Long> other) {
       return checkpointInterval().contains(other);
-    }
-
-    @Override
-    public SequencedCollection<Long> checkpoints() {
-      return checkpointInterval().values();
     }
   }
 
@@ -87,14 +77,6 @@ public sealed interface BackupRange {
     @Override
     public boolean contains(final Interval<Long> other) {
       return checkpointInterval.contains(other) && !isInDeletionRange(other);
-    }
-
-    @Override
-    public SequencedCollection<Long> checkpoints() {
-      return Stream.concat(checkpointInterval.values().stream(), deletedCheckpointIds.stream())
-          .sorted()
-          .distinct()
-          .toList();
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
@@ -11,16 +11,31 @@ import java.time.Instant;
 import java.util.Optional;
 
 /** Represents the status of a backup. */
-public interface BackupStatus {
+public interface BackupStatus extends Comparable<BackupStatus> {
   BackupIdentifier id();
 
   Optional<BackupDescriptor> descriptor();
 
   BackupStatusCode statusCode();
 
+  default boolean isCompleted() {
+    return statusCode() == BackupStatusCode.COMPLETED;
+  }
+
   Optional<String> failureReason();
 
   Optional<Instant> created();
 
+  default Instant createdOrThrow() {
+    return created()
+        .orElseThrow(
+            () -> new IllegalStateException("Backup %s missing created field".formatted(this)));
+  }
+
   Optional<Instant> lastModified();
+
+  @Override
+  default int compareTo(final BackupStatus backupStatus) {
+    return Long.compare(id().checkpointId(), backupStatus.id().checkpointId());
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -204,13 +204,13 @@ public record Interval<T extends Comparable<T>>(
    * next, using the provided factory to determine the interval type (e.g., closed, half-open).
    *
    * <p>Example with {@code Interval::closedOpen}: points [1, 3, 5, 7] produces intervals [1,3),
-   * [3,5), [5,7)
+   * [3,5), [5,7), [7,7]
    *
    * @param points the ordered sequence of points (must be in ascending order)
    * @param intervalFactory factory function to create intervals, e.g., {@code Interval::closed} or
    *     {@code Interval::closedOpen}
    * @return list of intervals spanning consecutive points, or empty list if fewer than 2 points
-   * @param <T> the type of the points, must be comparable
+   * @param <T> the type of the points must be comparable
    */
   public static <T extends Comparable<T>> List<Interval<T>> fromPoints(
       final List<T> points, final Interval.Factory<T> intervalFactory) {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
@@ -310,6 +310,68 @@ final class IntervalPropertyTest {
     }
   }
 
+  @Property(tries = 100)
+  void containsWithMapperIsEquivalentToMapThenContains(
+      @ForAll("intervals") final Interval<Integer> a, @ForAll("values") final Integer value) {
+    // contains(value, mapper) should be equivalent to map(mapper).contains(value)
+    final var mapperResult = a.contains(value * 2L, i -> i * 2L);
+    final var mapThenContainsResult = a.map(i -> i * 2L).contains(value * 2L);
+
+    assertThat(mapperResult)
+        .describedAs("contains with mapper should equal map().contains()")
+        .isEqualTo(mapThenContainsResult);
+  }
+
+  @Property(tries = 100)
+  void containsIntervalWithMapperIsEquivalentToMapThenContains(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // contains(interval, mapper) should be equivalent to map(mapper).contains(mapped interval)
+    final var mappedB = b.map(i -> i * 2L);
+    final var mapperResult = a.contains(mappedB, i -> i * 2L);
+    final var mapThenContainsResult = a.map(i -> i * 2L).contains(mappedB);
+
+    assertThat(mapperResult)
+        .describedAs("contains interval with mapper should equal map().contains()")
+        .isEqualTo(mapThenContainsResult);
+  }
+
+  @Property(tries = 100)
+  void smallestCoverWithMapperReturnsEquivalentIntervals(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // smallestCover with mapper should return the same intervals (by index) as
+    // mapping the query and calling smallestCover on mapped intervals
+    final var mapper = (java.util.function.Function<Integer, Long>) Integer::longValue;
+    final var mappedQuery = query.map(mapper);
+    final var mappedIntervals = intervals.stream().map(i -> i.map(mapper)).toList();
+
+    // Get result using mapper version
+    final var mapperResult = mappedQuery.smallestCover(intervals, mapper);
+    // Get result by mapping everything first
+    final var mappedResult = mappedQuery.smallestCover(mappedIntervals);
+
+    // Results should have the same size
+    assertThat(mapperResult)
+        .describedAs("Mapper result should have same size as mapped result")
+        .hasSameSizeAs(mappedResult);
+
+    // Results should correspond to the same indices in the original list
+    final var mapperIndices = new ArrayList<Integer>();
+    for (final var interval : mapperResult) {
+      mapperIndices.add(intervals.indexOf(interval));
+    }
+
+    final var mappedIndices = new ArrayList<Integer>();
+    for (final var mappedInterval : mappedResult) {
+      mappedIndices.add(mappedIntervals.indexOf(mappedInterval));
+    }
+
+    assertThat(mapperIndices)
+        .describedAs("Mapper result should correspond to same indices as mapped result")
+        .isEqualTo(mappedIndices);
+  }
+
   // ==================== SmallestCover ====================
 
   @Property(tries = 100)
@@ -501,6 +563,102 @@ final class IntervalPropertyTest {
       assertThat(result)
           .describedAs("Intersection of %s (container) and %s (contained) should be %s", a, b, b)
           .contains(b);
+    }
+  }
+
+  // ==================== FromPoints ====================
+
+  @Provide
+  Arbitrary<List<Integer>> sortedPoints() {
+    return Arbitraries.integers()
+        .between(-500, 500)
+        .list()
+        .ofMinSize(0)
+        .ofMaxSize(10)
+        .map(points -> points.stream().distinct().sorted().toList());
+  }
+
+  @Property(tries = 100)
+  void fromPointsReturnsCorrectNumberOfIntervals(
+      @ForAll("sortedPoints") final List<Integer> points,
+      @ForAll final boolean startInclusive,
+      @ForAll final boolean endInclusive) {
+    final var result =
+        Interval.fromPoints(points, Interval.Factory.of(startInclusive, endInclusive));
+
+    var expectedSize = Math.max(0, points.size() - 1);
+    if (expectedSize > 0) {
+      if (!startInclusive) {
+        expectedSize++;
+      }
+      if (!endInclusive) {
+        expectedSize++;
+      }
+    }
+    assertThat(result).hasSize(expectedSize);
+  }
+
+  @Property(tries = 100)
+  void fromPointsIntervalsAreContiguous(@ForAll("sortedPoints") final List<Integer> points) {
+    final var result = Interval.fromPoints(points, Interval::closedOpen);
+
+    if (result.size() > 1) {
+      for (int i = 0; i < result.size() - 1; i++) {
+        final var current = result.get(i);
+        final var next = result.get(i + 1);
+        assertThat(current.end())
+            .describedAs("Interval %s end should equal interval %s start", current, next)
+            .isEqualTo(next.start());
+      }
+    }
+  }
+
+  @Property(tries = 100)
+  void fromPointsIntervalsSpanAllPoints(
+      @ForAll("sortedPoints") final List<Integer> points,
+      @ForAll final boolean startInclusive,
+      @ForAll final boolean endInclusive) {
+    if (points.size() < 2) {
+      return;
+    }
+
+    final var result =
+        Interval.fromPoints(points, Interval.Factory.of(startInclusive, endInclusive));
+
+    // First interval starts at first point
+    assertThat(result.getFirst().start()).isEqualTo(points.getFirst());
+    // Last interval ends at last point
+    assertThat(result.getLast().end()).isEqualTo(points.getLast());
+
+    // first & last point must be included once
+    if (!points.isEmpty()) {
+      for (final var point : List.of(points.getFirst(), points.getLast())) {
+        assertThat(result.stream().filter(i -> i.contains(point)).toList())
+            .describedAs("Point %s should be present once in %s", point, result)
+            .hasSize(1);
+      }
+    }
+  }
+
+  @Property(tries = 100)
+  void fromPointsEachIntervalSpansConsecutivePoints(
+      @ForAll("sortedPoints") final List<Integer> points,
+      @ForAll final boolean startInclusive,
+      @ForAll final boolean endInclusive) {
+    final var result =
+        Interval.fromPoints(points, Interval.Factory.of(startInclusive, endInclusive));
+
+    for (int i = 0; i < result.size(); i++) {
+      final var interval = result.get(i);
+      if (!startInclusive || !endInclusive) {
+        continue;
+      }
+      assertThat(interval.start())
+          .describedAs("Interval %d start should be point %d", i, i)
+          .isEqualTo(points.get(i));
+      assertThat(interval.end())
+          .describedAs("Interval %d end should be point %d", i, i + 1)
+          .isEqualTo(points.get(i + 1));
     }
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
@@ -141,6 +141,106 @@ public class IntervalTest {
   }
 
   @Nested
+  class ContainsValueWithMapper {
+
+    @Test
+    void shouldContainMappedValueInMiddle() {
+      final var interval = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+
+      assertThat(interval.contains(150L, Event::timestamp)).isTrue();
+    }
+
+    @Test
+    void shouldNotContainMappedValueOutside() {
+      final var interval = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+
+      assertThat(interval.contains(50L, Event::timestamp)).isFalse();
+      assertThat(interval.contains(250L, Event::timestamp)).isFalse();
+    }
+
+    @Test
+    void shouldRespectStartInclusiveness() {
+      final var closedInterval = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      final var openInterval = Interval.open(new Event("start", 100L), new Event("end", 200L));
+
+      assertThat(closedInterval.contains(100L, Event::timestamp)).isTrue();
+      assertThat(openInterval.contains(100L, Event::timestamp)).isFalse();
+    }
+
+    @Test
+    void shouldRespectEndInclusiveness() {
+      final var closedInterval = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      final var openInterval = Interval.open(new Event("start", 100L), new Event("end", 200L));
+
+      assertThat(closedInterval.contains(200L, Event::timestamp)).isTrue();
+      assertThat(openInterval.contains(200L, Event::timestamp)).isFalse();
+    }
+
+    @Test
+    void shouldWorkWithDifferentMapperTypes() {
+      final var interval = Interval.closed(new Event("alpha", 100L), new Event("zeta", 200L));
+
+      // Map to String for comparison (different from the Comparable<Event> implementation)
+      assertThat(interval.contains("beta", Event::name)).isTrue();
+      assertThat(interval.contains("aaa", Event::name)).isFalse();
+    }
+
+    // Event is Comparable by timestamp, but we can also compare by other fields using mapper
+    record Event(String name, long timestamp) implements Comparable<Event> {
+      @Override
+      public int compareTo(final Event other) {
+        return Long.compare(timestamp, other.timestamp);
+      }
+    }
+  }
+
+  @Nested
+  class ContainsIntervalWithMapper {
+
+    @Test
+    void shouldContainSmallerMappedInterval() {
+      final var outer = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      final var inner = Interval.closed(120L, 180L);
+
+      assertThat(outer.contains(inner, Event::timestamp)).isTrue();
+    }
+
+    @Test
+    void shouldNotContainLargerMappedInterval() {
+      final var outer = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      final var inner = Interval.closed(50L, 250L);
+
+      assertThat(outer.contains(inner, Event::timestamp)).isFalse();
+    }
+
+    @Test
+    void shouldRespectBoundInclusiveness() {
+      // Closed interval contains open interval with same bounds
+      final var closed = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      assertThat(closed.contains(Interval.open(100L, 200L), Event::timestamp)).isTrue();
+
+      // Open interval does not contain closed interval with same bounds
+      final var open = Interval.open(new Event("start", 100L), new Event("end", 200L));
+      assertThat(open.contains(Interval.closed(100L, 200L), Event::timestamp)).isFalse();
+    }
+
+    @Test
+    void shouldContainEqualMappedInterval() {
+      final var interval = Interval.closed(new Event("start", 100L), new Event("end", 200L));
+      final var other = Interval.closed(100L, 200L);
+
+      assertThat(interval.contains(other, Event::timestamp)).isTrue();
+    }
+
+    record Event(String name, long timestamp) implements Comparable<Event> {
+      @Override
+      public int compareTo(final Event other) {
+        return Long.compare(timestamp, other.timestamp);
+      }
+    }
+  }
+
+  @Nested
   class ContainsInterval {
 
     @Test
@@ -338,6 +438,120 @@ public class IntervalTest {
       // then - should return [1, 5), [5, 10) and skip [10, 15]
       assertThat(result).containsExactly(Interval.closedOpen(1, 5), Interval.closedOpen(5, 10));
     }
+
+    @Test
+    void shouldNotCreateCoverLargerThanNeeded() {
+      // given
+      final var intervals = Interval.fromPoints(List.of(1, 5, 10, 15), Interval::closedOpen);
+      final var query = Interval.closedOpen(5, 10);
+
+      // when
+      final var cover = query.smallestCover(intervals);
+
+      // then
+      assertThat(cover).hasSize(1);
+      assertThat(cover.getFirst()).isEqualTo(query);
+    }
+  }
+
+  @Nested
+  class SmallestCoverWithMapper {
+
+    @Test
+    void shouldReturnOriginalIntervalsWhenMapped() {
+      // given - intervals of Event, query by Long timestamp
+      final var event1 = new Event("a", 100L);
+      final var event2 = new Event("b", 200L);
+      final var event3 = new Event("c", 300L);
+
+      final var intervals =
+          List.of(Interval.closedOpen(event1, event2), Interval.closed(event2, event3));
+
+      final var query = Interval.closed(150L, 250L);
+
+      // when
+      final var result = query.smallestCover(intervals, Event::timestamp);
+
+      // then - returns original Event intervals, not mapped Long intervals
+      assertThat(result)
+          .containsExactly(Interval.closedOpen(event1, event2), Interval.closed(event2, event3));
+
+      // verify they are the actual Event intervals
+      assertThat(result.getFirst().start().name()).isEqualTo("a");
+      assertThat(result.getLast().end().name()).isEqualTo("c");
+    }
+
+    @Test
+    void shouldSkipNonOverlappingIntervalsAtBeginning() {
+      final var event1 = new Event("a", 100L);
+      final var event2 = new Event("b", 200L);
+      final var event3 = new Event("c", 300L);
+      final var event4 = new Event("d", 400L);
+
+      final var intervals =
+          List.of(
+              Interval.closedOpen(event1, event2),
+              Interval.closedOpen(event2, event3),
+              Interval.closed(event3, event4));
+
+      // Query that only overlaps with last two intervals
+      final var query = Interval.closed(250L, 350L);
+
+      final var result = query.smallestCover(intervals, Event::timestamp);
+
+      assertThat(result)
+          .containsExactly(Interval.closedOpen(event2, event3), Interval.closed(event3, event4));
+    }
+
+    @Test
+    void shouldSkipNonOverlappingIntervalsAtEnd() {
+      final var event1 = new Event("a", 100L);
+      final var event2 = new Event("b", 200L);
+      final var event3 = new Event("c", 300L);
+      final var event4 = new Event("d", 400L);
+
+      final var intervals =
+          List.of(
+              Interval.closedOpen(event1, event2),
+              Interval.closedOpen(event2, event3),
+              Interval.closed(event3, event4));
+
+      // Query that only overlaps with first two intervals
+      final var query = Interval.closed(150L, 250L);
+
+      final var result = query.smallestCover(intervals, Event::timestamp);
+
+      assertThat(result)
+          .containsExactly(
+              Interval.closedOpen(event1, event2), Interval.closedOpen(event2, event3));
+    }
+
+    @Test
+    void shouldThrowWhenIntervalsAreNotContiguous() {
+      final var event1 = new Event("a", 100L);
+      final var event2 = new Event("b", 200L);
+      final var event3 = new Event("c", 300L);
+      final var event4 = new Event("d", 400L);
+
+      // Gap between intervals: [event1, event2) and [event3, event4] don't share a boundary
+      final var intervals =
+          List.of(
+              Interval.closedOpen(event1, event2),
+              Interval.closed(event3, event4)); // Not contiguous - gap at event2/event3
+
+      final var query = Interval.closed(150L, 350L);
+
+      assertThatThrownBy(() -> query.smallestCover(intervals, Event::timestamp))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected intervals to be contiguous");
+    }
+
+    record Event(String name, long timestamp) implements Comparable<Event> {
+      @Override
+      public int compareTo(final Event other) {
+        return Long.compare(timestamp, other.timestamp);
+      }
+    }
   }
 
   @Nested
@@ -431,6 +645,61 @@ public class IntervalTest {
       final var result = Interval.intersection(List.of(first, second));
 
       assertThat(result.isPresent()).isEqualTo(hasResult);
+    }
+  }
+
+  @Nested
+  class FromPoints {
+
+    @Test
+    void shouldReturnEmptyListForEmptyInput() {
+      final List<Integer> emptyPoints = List.of();
+      final var result = Interval.fromPoints(emptyPoints, Interval::closed);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyListForSinglePoint() {
+      final var result = Interval.fromPoints(List.of(1), Interval::closed);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldCreateSingleIntervalFromTwoPoints() {
+      final var result = Interval.fromPoints(List.of(1, 5), Interval::closed);
+
+      assertThat(result).containsExactly(Interval.closed(1, 5));
+    }
+
+    @Test
+    void shouldCreateIntervalsFromMultiplePoints() {
+      final var result = Interval.fromPoints(List.of(1, 3, 5, 7), Interval::closedOpen);
+
+      assertThat(result)
+          .containsExactly(
+              Interval.closedOpen(1, 3),
+              Interval.closedOpen(3, 5),
+              Interval.closedOpen(5, 7),
+              Interval.point(7));
+    }
+
+    @Test
+    void shouldUseProvidedIntervalFactory() {
+      // Using closed intervals
+      final var closedResult = Interval.fromPoints(List.of(1, 2, 3), Interval::closed);
+      assertThat(closedResult).containsExactly(Interval.closed(1, 2), Interval.closed(2, 3));
+
+      // Using half-open intervals
+      final var halfOpenResult = Interval.fromPoints(List.of(1, 2, 3), Interval::closedOpen);
+      assertThat(halfOpenResult)
+          .containsExactly(Interval.closedOpen(1, 2), Interval.closedOpen(2, 3), Interval.point(3));
+
+      // Using open-closed intervals
+      final var openClosedResult = Interval.fromPoints(List.of(1, 2, 3), Interval::openClosed);
+      assertThat(openClosedResult)
+          .containsExactly(Interval.point(1), Interval.openClosed(1, 2), Interval.openClosed(2, 3));
     }
   }
 

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -103,6 +103,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -111,6 +117,10 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-db-rdbms</artifactId>
     </dependency>
 
   </dependencies>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupNotFoundException.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupNotFoundException.java
@@ -12,4 +12,10 @@ public class BackupNotFoundException extends RuntimeException {
   public BackupNotFoundException(final long backupId) {
     super("Could not find a completed backup with id %d.".formatted(backupId));
   }
+
+  public BackupNotFoundException(final long backupId, final int partitionId) {
+    super(
+        "Could not find a completed backup with id %d for partition %d."
+            .formatted(backupId, partitionId));
+  }
 }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -184,6 +184,10 @@ public final class BackupRangeResolver {
             backup ->
                 backup
                     .descriptor()
+                    // NOTE: we just need to be able to start exporting from a backup whose
+                    // snapshot position is <= exportedPosition. However, to do that we would need
+                    // to open the backup. It's simpler to just use the checkpointPosition.
+                    // We might be able to use `firstLogPosition` as an optimization in the future.
                     .map(ds -> ds.checkpointPosition() <= exportedPosition)
                     .orElse(false))
         .map(backup -> backup.id().checkpointId())

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -378,6 +378,13 @@ public final class BackupRangeResolver {
             "Partition %d: first backup checkpoint %d is after safe start %d."
                 .formatted(partition, backupStatuses.getFirst().id().checkpointId(), safeStart));
       }
+
+      final var firstCheckpointId = backupStatuses.getFirst().id().checkpointId();
+      if (firstCheckpointId > safeStart) {
+        throw new IllegalStateException(
+            "Partition %d: first backup at checkpoint %d is after safe start %d"
+                .formatted(partition, firstCheckpointId, safeStart));
+      }
     }
 
     private void validateGlobalCheckpointConsistency(final long globalCheckpointId) {
@@ -385,15 +392,6 @@ public final class BackupRangeResolver {
         throw new IllegalStateException(
             "Partition %d has no backups in range [%d, %d]"
                 .formatted(partition, safeStart, globalCheckpointId));
-      }
-
-      final var firstCheckpointId = backupStatuses.getFirst().id().checkpointId();
-      final var lastCheckpointId = backupStatuses.getLast().id().checkpointId();
-
-      if (firstCheckpointId > safeStart) {
-        throw new IllegalStateException(
-            "Partition %d: first backup at checkpoint %d is after safe start %d"
-                .formatted(partition, firstCheckpointId, safeStart));
       }
 
       if (backupStatuses.getLast().id().checkpointId() != globalCheckpointId) {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -177,18 +177,9 @@ public final class BackupRangeResolver {
                 bs -> bs.statusCode() == BackupStatusCode.COMPLETED && bs.descriptor().isPresent())
             .collect(
                 Collectors.toMap(bs -> bs.id().checkpointId(), Function.identity(), (a, b) -> a));
-    // From a sequence of N BackupStatus, generate a List of N-1 Interval<BackupStatus>
     final var completedBackups = completedBackupsMap.values().stream().sorted().toList();
-    final var backupsIntervals = Interval.fromPoints(completedBackups, Interval::closedOpen);
-    final var cover =
-        interval.smallestCover(
-            backupsIntervals,
-            s ->
-                // we filtered out backups w/o descriptor
-                s.descriptor().get().checkpointTimestamp());
-    // Use Interval::values to get all the BackupStatus that make up the intervals and remove
-    // duplicates
-    return cover.stream().flatMap(i -> i.points().stream()).distinct().sorted().toList();
+    return interval.smallestCover(
+        completedBackups, bs -> bs.descriptor().get().checkpointTimestamp());
   }
 
   /**

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
+import io.camunda.zeebe.backup.api.BackupRange;
+import io.camunda.zeebe.backup.api.BackupRange.Complete;
+import io.camunda.zeebe.backup.api.BackupRanges;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.api.Interval;
+import io.camunda.zeebe.util.collection.Tuple;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SequencedCollection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * The {@code BackupRangeResolver} class provides methods to resolve backup ranges and backup
+ * statuses for a given partition, time interval, or exported position. This class interacts with a
+ * {@link BackupStore} to fetch and manage backup data required for restoring partitions or
+ * determining safe starting checkpoints.
+ */
+public final class BackupRangeResolver {
+
+  private final BackupStore store;
+
+  public BackupRangeResolver(final BackupStore store) {
+    this.store = store;
+  }
+
+  /**
+   * @return the {@link PartitionRestoreInfo} for each partition in parallel, using a Virtual Thread
+   *     per task
+   */
+  public CompletableFuture<GlobalRestoreInfo> getRestoreInfoForAllPartitions(
+      final Interval<Instant> interval,
+      final int partitionCount,
+      final Map<Integer, Long> exportedPositions,
+      final Executor executor) {
+    // Get backup ranges from the store for each partition
+    return FuturesUtil.parTraverse(
+            IntStream.rangeClosed(1, partitionCount).boxed().toList(),
+            partition ->
+                CompletableFuture.supplyAsync(
+                    () ->
+                        getInformationPerPartition(
+                            partition, interval, exportedPositions.get(partition)),
+                    executor))
+        .thenApply(
+            restoreInfos -> {
+              final var globalCheckpointId = computeGlobalCheckpointId(restoreInfos);
+              // validate all partitions can safely restore to the global checkpoint
+              PartitionRestoreInfo.validatePartitions(restoreInfos, globalCheckpointId);
+              final var backupIdsByPartition =
+                  PartitionRestoreInfo.backupIdsByPartition(restoreInfos);
+              return new GlobalRestoreInfo(globalCheckpointId, restoreInfos, backupIdsByPartition);
+            });
+  }
+
+  public PartitionRestoreInfo getInformationPerPartition(
+      final int partition, final Interval<Instant> interval, final long lastExportedPosition) {
+    final var rangeMarkers = store.rangeMarkers(partition).join();
+    final var ranges = BackupRanges.fromMarkers(rangeMarkers);
+
+    // finds the BackupRange that entirely covers the interval `[from, to]`
+    final var statusInterval =
+        findBackupRangeCoveringInterval(interval, ranges, partition)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "No complete backup range found for partition %d in interval %s, ranges=%s"
+                            .formatted(partition, interval, ranges)));
+
+    // Retrieve all BackupStatus in the BackupRange
+    // note that all backups must be retrieved as we only know the extremes, not every backup inside
+    // the range
+    final var backups = getAllBackups(interval, statusInterval.getRight(), partition);
+
+    // Find valid safe points using RDBMS exported positions
+    final var safeStart =
+        findSafeStartCheckpoint(lastExportedPosition, backups)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "No safe start checkpoint found for partition %d with exported position %d"
+                            .formatted(partition, lastExportedPosition)));
+
+    final var filteredBackups =
+        backups.stream().filter(bs -> bs.id().checkpointId() >= safeStart).toList();
+    return new PartitionRestoreInfo(
+        partition, safeStart, statusInterval.getLeft(), filteredBackups);
+  }
+
+  /**
+   * Finds the backup range that completely covers the given time interval.
+   *
+   * <p>The method iterates through the provided collection of backup ranges in reverse
+   * chronological order. For each backup range, it checks if it is a complete backup range and
+   * determines if its corresponding interval of backup statuses fully contains the specified time
+   * interval. If such a range is found, it is returned along with its corresponding backup status
+   * interval. If no range meets the criteria, an empty {@code Optional} is returned.
+   *
+   * @param interval the target time interval that needs to be covered
+   * @param ranges a chronologically ordered collection of backup ranges to search
+   * @param partitionId the partition ID used for mapping backup checkpoints to their statuses
+   * @return an {@code Optional} containing a tuple of the matching complete backup range and its
+   *     corresponding status interval if found; otherwise, an empty {@code Optional}
+   */
+  public Optional<Tuple<Complete, Interval<BackupStatus>>> findBackupRangeCoveringInterval(
+      final Interval<Instant> interval,
+      final SequencedCollection<BackupRange> ranges,
+      final int partitionId) {
+    // ranges are ordered chronologically, so we start from the latest one, going backwards in time
+    for (final var range : ranges.reversed()) {
+      if (range instanceof final BackupRange.Complete completeRange) {
+        // get the BackupStatuses from the store
+        final Interval<BackupStatus> statusInterval =
+            completeRange.checkpointInterval().map(c -> toBackupStatus(partitionId, c));
+        final Interval<Instant> timeInterval = statusInterval.map(BackupStatus::createdOrThrow);
+        if (timeInterval.contains(interval)) {
+          return Optional.of(new Tuple<>(completeRange, statusInterval));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  public List<BackupStatus> getAllBackups(
+      final Interval<Instant> interval,
+      final Interval<BackupStatus> statusInterval,
+      final int partitionId) {
+    final var backups =
+        store
+            .list(
+                BackupIdentifierWildcard.forPartition(
+                    partitionId,
+                    CheckpointPattern.ofInterval(statusInterval.map(s -> s.id().checkpointId()))))
+            .join();
+
+    final var completedBackups =
+        backups.stream()
+            .filter(
+                bs -> bs.statusCode() == BackupStatusCode.COMPLETED && bs.descriptor().isPresent())
+            .sorted()
+            .toList();
+    // From a sequence of N BackupStatus, generate a List of N-1 Interval<BackupStatus>
+    final var backupsIntervals = Interval.fromPoints(completedBackups, Interval::closedOpen);
+    final var cover = interval.smallestCover(backupsIntervals, BackupStatus::createdOrThrow);
+    // Use Interval::values to get all the BackupStatus that make up the intervals and remove
+    // duplicates
+    return cover.stream().flatMap(i -> i.points().stream()).distinct().sorted().toList();
+  }
+
+  /**
+   * Finds the safe starting checkpoint for a partition based on its exported position.
+   *
+   * @param exportedPosition the last position exported to RDBMS for this partition
+   * @param availableBackups collection of all available backups
+   * @return the largest checkpoint ID where checkpointPosition <= exportedPosition, or empty if no
+   *     such checkpoint exists
+   */
+  public static Optional<Long> findSafeStartCheckpoint(
+      final long exportedPosition, final Collection<BackupStatus> availableBackups) {
+    return availableBackups.stream()
+        .filter(BackupStatus::isCompleted)
+        .filter(
+            backup ->
+                backup
+                    .descriptor()
+                    .map(ds -> ds.checkpointPosition() <= exportedPosition)
+                    .orElse(false))
+        .map(backup -> backup.id().checkpointId())
+        .max(Long::compareTo);
+  }
+
+  /**
+   * Computes the global checkpoint ID and validates that all partitions can safely restore to it.
+   *
+   * <p>This method finds the maximum checkpoint ID that exists across ALL partitions and validates
+   * that each partition can restore to it. This is critical for cluster consistency: during
+   * restore, all nodes must restore to the same global checkpoint.
+   *
+   * <p>Computation:
+   *
+   * <ol>
+   *   <li>For each partition, extract the set of checkpoint IDs from its backup statuses
+   *   <li>Compute the intersection of all these sets (checkpoints present in every partition)
+   *   <li>Return the maximum checkpoint ID from the intersection
+   * </ol>
+   *
+   * <p>Validation ensures:
+   *
+   * <ul>
+   *   <li>Each partition has a safe start checkpoint where checkpointPosition <= exportedPosition
+   *   <li>For all partitions, there is a continuous backup range from safe start to the global
+   *       checkpoint
+   *   <li>If ANY partition cannot reach the global checkpoint, the entire restore fails
+   * </ul>
+   *
+   * @param restoreInfos collection of restore information for all partitions
+   * @return the maximum checkpoint ID that is common to all partitions
+   * @throws IllegalStateException if no common checkpoint exists or validation fails
+   */
+  public static long computeGlobalCheckpointId(
+      final Collection<PartitionRestoreInfo> restoreInfos) {
+    return restoreInfos.stream()
+        .map(
+            info ->
+                info.backupStatuses().stream()
+                    .map(bs -> bs.id().checkpointId())
+                    .collect(Collectors.toSet()))
+        .reduce(
+            (set1, set2) -> {
+              set1.retainAll(set2);
+              return set1;
+            })
+        .flatMap(commonCheckpoints -> commonCheckpoints.stream().max(Long::compareTo))
+        .orElseThrow(
+            () -> new IllegalStateException("No common checkpoint found across all partitions"));
+  }
+
+  private BackupStatus toBackupStatus(final int partitionId, final long checkpoint) {
+    final var wildcard =
+        BackupIdentifierWildcard.forPartition(partitionId, CheckpointPattern.of(checkpoint));
+    // TODO check if there's more than one
+    final var backup =
+        store.list(wildcard).join().stream().filter(BackupStatus::isCompleted).findFirst();
+    if (backup.isPresent()) {
+      return backup.get();
+    } else {
+      throw new BackupNotFoundException(checkpoint, partitionId);
+    }
+  }
+
+  /**
+   * @param partition The identifier of the partition being restored
+   * @param safeStart The highest checkpoint ID that can be used as the start of the backup range
+   * @param backupRange The original {@link BackupRange} where {@param backupStatuses} were
+   *     extracted from
+   * @param backupStatuses The collection of backup statuses to restore for this partition
+   */
+  public record PartitionRestoreInfo(
+      int partition, long safeStart, BackupRange backupRange, List<BackupStatus> backupStatuses) {
+
+    public void validate(final long globalCheckpointId) {
+      if (safeStart > globalCheckpointId) {
+        throw new IllegalStateException(
+            "Partition %d: safe start checkpoint %d is beyond global checkpoint %d."
+                .formatted(partition, safeStart, globalCheckpointId));
+      }
+
+      switch (backupRange) {
+        case null ->
+            throw new IllegalStateException(
+                "Partition %d: no backup range found".formatted(partition));
+        case final BackupRange.Incomplete incomplete ->
+            throw new IllegalStateException(
+                "Partition %d: backup range [%d, %d] has deletions: %s"
+                    .formatted(
+                        partition,
+                        incomplete.checkpontInterval().start(),
+                        incomplete.checkpontInterval().end(),
+                        incomplete.deletedCheckpointIds()));
+        case final BackupRange.Complete complete -> {
+          validateRangeCoverage(globalCheckpointId, complete);
+          validateLogPositionContiguity(globalCheckpointId);
+        }
+      }
+    }
+
+    public static void validatePartitions(
+        final Collection<PartitionRestoreInfo> restoreInfos, final long globalCheckpointId) {
+      // Validate all partitions can restore to the global checkpoint
+      final var failures = new ArrayList<String>();
+      restoreInfos.forEach(
+          info -> {
+            try {
+              info.validate(globalCheckpointId);
+            } catch (final RuntimeException e) {
+              failures.add(e.getMessage());
+            }
+          });
+
+      if (!failures.isEmpty()) {
+        throw new IllegalStateException(
+            String.format(
+                "Cannot restore to global checkpoint %d. Failures:\n  - %s",
+                globalCheckpointId, String.join("\n  - ", failures)));
+      }
+    }
+
+    /**
+     * Returns the backup IDs to restore for each partition.
+     *
+     * <p>For each partition, this returns a sorted array of checkpoint IDs that are within the
+     * range [safeStart, globalCheckpointId]. Each partition may have different backup IDs based on
+     * its safe start position, but all must reach the global checkpoint.
+     *
+     * @return map from partition ID to sorted array of backup checkpoint IDs
+     */
+    public static Map<Integer, long[]> backupIdsByPartition(
+        final Collection<PartitionRestoreInfo> restoreInfos) {
+      return restoreInfos.stream()
+          .collect(
+              Collectors.toMap(
+                  PartitionRestoreInfo::partition,
+                  info ->
+                      info.backupStatuses().stream()
+                          .mapToLong(bs -> bs.id().checkpointId())
+                          .toArray()));
+    }
+
+    private void validateRangeCoverage(
+        final long globalCheckpointId, final BackupRange.Complete range) {
+      if (range.checkpointInterval().start() > safeStart
+          || range.checkpointInterval().end() < globalCheckpointId) {
+        throw new IllegalStateException(
+            "Partition %d: backup range [%d, %d] does not cover required range [%d, %d]"
+                .formatted(
+                    partition,
+                    range.checkpointInterval().start(),
+                    range.checkpointInterval().end(),
+                    safeStart,
+                    globalCheckpointId));
+      }
+      if (backupStatuses.isEmpty()) {
+        throw new IllegalStateException("Partition %d: no backups found".formatted(partition));
+      }
+
+      if (backupStatuses.getLast().id().checkpointId() != globalCheckpointId) {
+        throw new IllegalStateException(
+            "Partition %d: last backup checkpoint %d is not equal to global checkpoint %d."
+                .formatted(
+                    partition, backupStatuses.getLast().id().checkpointId(), globalCheckpointId));
+      }
+      if (backupStatuses.getFirst().id().checkpointId() > safeStart) {
+        throw new IllegalStateException(
+            "Partition %d: first backup checkpoint %d is before safe start %d."
+                .formatted(partition, backupStatuses.getFirst().id().checkpointId(), safeStart));
+      }
+    }
+
+    private void validateLogPositionContiguity(final long globalCheckpointId) {
+
+      if (backupStatuses.isEmpty()) {
+        throw new IllegalStateException(
+            "Partition %d has no backups in range [%d, %d]"
+                .formatted(partition, safeStart, globalCheckpointId));
+      }
+
+      final var firstCheckpointId = backupStatuses.getFirst().id().checkpointId();
+      final var lastCheckpointId = backupStatuses.getLast().id().checkpointId();
+
+      if (firstCheckpointId > safeStart) {
+        throw new IllegalStateException(
+            "Partition %ds first backup at checkpoint %d is after safe start %d"
+                .formatted(partition, firstCheckpointId, safeStart));
+      }
+
+      if (lastCheckpointId < globalCheckpointId) {
+        throw new IllegalStateException(
+            "Partition %d: last backup at checkpoint %d is before global checkpoint %d"
+                .formatted(partition, lastCheckpointId, globalCheckpointId));
+      }
+
+      validateBackupChainOverlaps(partition, backupStatuses);
+    }
+
+    private void validateBackupChainOverlaps(
+        final int partitionId, final List<BackupStatus> sortedBackups) {
+
+      for (var i = 1; i < sortedBackups.size(); i++) {
+        final var prevBackup = sortedBackups.get(i - 1);
+        final var currBackup = sortedBackups.get(i);
+
+        final var prevPositionInterval = getLogPositionInterval(prevBackup);
+        final var currPositionInterval = getLogPositionInterval(currBackup);
+
+        if (!(currPositionInterval.overlapsWith(
+            prevPositionInterval.withEnd(prevPositionInterval.end() + 1)))) {
+          throw new IllegalStateException(
+              "Partition %d: has gap in log positions - checkpoint %d @ %s, checkpoint %d @ %s"
+                  .formatted(
+                      partitionId,
+                      prevBackup.id().checkpointId(),
+                      prevPositionInterval,
+                      currBackup.id().checkpointId(),
+                      currPositionInterval));
+        }
+      }
+    }
+
+    private static Interval<Long> getLogPositionInterval(final BackupStatus backup) {
+      return backup
+          .descriptor()
+          .flatMap(BackupDescriptor::getLogPositionInterval)
+          .orElseThrow(
+              () ->
+                  new IllegalStateException("No log position interval for backup " + backup.id()));
+    }
+  }
+
+  public record GlobalRestoreInfo(
+      long globalCheckpointId,
+      Collection<PartitionRestoreInfo> restoreInfos,
+      Map<Integer, long[]> backupsByPartitionId) {}
+}

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.restore;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
@@ -34,7 +35,10 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -47,32 +51,54 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.agrona.collections.MutableBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RestoreManager {
+public class RestoreManager implements CloseableSilently {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
   private final BrokerCfg configuration;
   private final BackupStore backupStore;
+  private final BackupRangeResolver rangeResolver;
   private final MeterRegistry meterRegistry;
   private final CheckpointIdGenerator checkpointIdGenerator;
+  private final ExporterPositionMapper exporterPositionMapper;
+  private final ExecutorService executor;
+
+  @VisibleForTesting
+  RestoreManager(
+      final BrokerCfg configuration,
+      final BackupStore backupStore,
+      final MeterRegistry meterRegistry) {
+    this(configuration, backupStore, null, meterRegistry);
+  }
 
   public RestoreManager(
       final BrokerCfg configuration,
       final BackupStore backupStore,
+      final ExporterPositionMapper exporterPositionMapper,
       final MeterRegistry meterRegistry) {
     checkpointIdGenerator =
         new CheckpointIdGenerator(configuration.getData().getBackup().getOffset());
     this.configuration = configuration;
     this.backupStore = backupStore;
+    rangeResolver = new BackupRangeResolver(backupStore);
+    this.exporterPositionMapper = exporterPositionMapper;
     this.meterRegistry = meterRegistry;
+    executor =
+        Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("zeebe-restore-", 0).factory());
   }
 
   public void restore(
@@ -82,6 +108,43 @@ public class RestoreManager {
   }
 
   public void restore(
+      final Instant from,
+      final Instant to,
+      final boolean validateConfig,
+      final List<String> ignoreFilesInTarget)
+      throws IOException, ExecutionException, InterruptedException {
+    if (exporterPositionMapper == null) {
+      restoreTimeRange(from, to, validateConfig, ignoreFilesInTarget);
+    } else {
+      restoreRdbms(from, to, validateConfig, ignoreFilesInTarget);
+    }
+  }
+
+  private void restoreRdbms(
+      final Instant from,
+      final Instant to,
+      final boolean validateConfig,
+      final List<String> ignoreFilesInTarget)
+      throws IOException, ExecutionException, InterruptedException {
+    final var partitionCount = configuration.getCluster().getPartitionsCount();
+
+    final var exportedPositions = exportedPositions(partitionCount).join();
+    final var interval = Interval.closed(from, to);
+    final var restoreInfos =
+        rangeResolver
+            .getRestoreInfoForAllPartitions(interval, partitionCount, exportedPositions, executor)
+            .join();
+
+    LOG.info(
+        "Restoring RDBMS backups in range [{},{}] to global checkpoint {}",
+        from,
+        to,
+        restoreInfos.globalCheckpointId());
+
+    restore(restoreInfos.backupsByPartitionId(), validateConfig, ignoreFilesInTarget);
+  }
+
+  public void restoreTimeRange(
       final Instant from,
       final Instant to,
       final boolean validateConfig,
@@ -124,18 +187,53 @@ public class RestoreManager {
   public void restore(
       final long[] backupIds, final boolean validateConfig, final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
+    restore(toBackupIdsByPartition(backupIds), validateConfig, ignoreFilesInTarget);
+  }
+
+  /**
+   * Converts a common array of backup IDs to a map where each partition uses the same backup IDs.
+   *
+   * @param backupIds the backup IDs to use for all partitions
+   * @return a map from partition ID to backup IDs
+   */
+  private Map<Integer, long[]> toBackupIdsByPartition(final long[] backupIds) {
+    final var partitionCount = configuration.getCluster().getPartitionsCount();
+    return IntStream.rangeClosed(1, partitionCount)
+        .boxed()
+        .collect(Collectors.toMap(partition -> partition, partition -> backupIds));
+  }
+
+  /**
+   * Restores partitions from backups, where each partition may restore from different backup IDs.
+   *
+   * <p>This is useful when partitions have different safe start checkpoints based on their exported
+   * positions, but all need to reach the same global checkpoint.
+   *
+   * @param backupIdsByPartition map from partition ID to the backup IDs to restore for that
+   *     partition
+   * @param validateConfig whether to validate the backup configuration
+   * @param ignoreFilesInTarget files to ignore when checking if the data directory is empty
+   */
+  public void restore(
+      final Map<Integer, long[]> backupIdsByPartition,
+      final boolean validateConfig,
+      final List<String> ignoreFilesInTarget)
+      throws IOException, ExecutionException, InterruptedException {
     final var dataDirectory = Path.of(configuration.getData().getDirectory());
 
     verifyDataFolderIsEmpty(dataDirectory, ignoreFilesInTarget);
 
-    verifyBackupIdsAreContinuous(backupIds);
+    verifyBackupIdsAreContinuous(backupIdsByPartition);
 
-    final var partitionsToRestore = collectPartitions();
-    try (final var executor =
-        Executors.newThreadPerTaskExecutor(
-            Thread.ofVirtual().name("zeebe-restore-", 0).factory())) {
+    try {
+      final var partitionsToRestore = collectPartitions();
       final var tasks = new ArrayList<Callable<Void>>(partitionsToRestore.size());
       for (final var partition : partitionsToRestore) {
+        final var partitionId = partition.partition().id().id();
+        final var backupIds = backupIdsByPartition.get(partitionId);
+        if (backupIds == null || backupIds.length == 0) {
+          throw new IllegalArgumentException("No backup IDs provided for partition " + partitionId);
+        }
         tasks.add(
             () -> {
               restorePartition(partition, backupIds, validateConfig);
@@ -243,15 +341,17 @@ public class RestoreManager {
         factory.createRaftPartition(metadata, partitionRegistry), partitionRegistry);
   }
 
-  private void verifyBackupIdsAreContinuous(final long[] backupIds) {
-    final var partitionCount = configuration.getCluster().getPartitionsCount();
-
+  private void verifyBackupIdsAreContinuous(final Map<Integer, long[]> backupIdsByPartition) {
     final MutableBoolean validBackupRange = new MutableBoolean(true);
-    if (backupIds.length > 1) {
-      final var minBackup = Arrays.stream(backupIds).min().orElseThrow();
-      final var maxBackup = Arrays.stream(backupIds).max().orElseThrow();
 
-      for (int partition = 1; partition <= partitionCount; partition++) {
+    for (final var entry : backupIdsByPartition.entrySet()) {
+      final var partition = entry.getKey();
+      final var backupIds = entry.getValue();
+
+      if (backupIds.length > 1) {
+        final var minBackup = Arrays.stream(backupIds).min().orElseThrow();
+        final var maxBackup = Arrays.stream(backupIds).max().orElseThrow();
+
         final var ranges = BackupRanges.fromMarkers(backupStore.rangeMarkers(partition).join());
         final var validRange =
             ranges.stream()
@@ -300,6 +400,37 @@ public class RestoreManager {
           .filter(path -> ignoreFilesInTarget.stream().noneMatch(path::endsWith))
           .findFirst()
           .isEmpty();
+    }
+  }
+
+  private CompletableFuture<Map<Integer, Long>> exportedPositions(final int partitionCount) {
+    return FuturesUtil.parTraverse(
+            IntStream.rangeClosed(1, partitionCount).boxed().toList(),
+            partition ->
+                CompletableFuture.supplyAsync(
+                    () -> {
+                      final var positionModel = exporterPositionMapper.findOne(partition);
+                      if (positionModel == null || positionModel.lastExportedPosition() == null) {
+                        throw new IllegalArgumentException(
+                            "No exported position found for partition " + partition + " in RDBMS");
+                      }
+
+                      return Map.entry(partition, positionModel.lastExportedPosition());
+                    }))
+        .thenApply(
+            s -> s.stream().collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue)));
+  }
+
+  @Override
+  public void close() {
+    try {
+      executor.shutdown();
+      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (final InterruptedException ignored) {
+      // Not much we can do here, just report in case it's a bug in the shutdown process.
+      LOG.warn("Interrupted while waiting for executor to shutdown", ignored);
     }
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -200,7 +200,9 @@ public class RestoreManager implements CloseableSilently {
     final var partitionCount = configuration.getCluster().getPartitionsCount();
     return IntStream.rangeClosed(1, partitionCount)
         .boxed()
-        .collect(Collectors.toMap(partition -> partition, partition -> backupIds));
+        .collect(
+            Collectors.toMap(
+                partition -> partition, partition -> Arrays.copyOf(backupIds, backupIds.length)));
   }
 
   /**
@@ -416,7 +418,8 @@ public class RestoreManager implements CloseableSilently {
                       }
 
                       return Map.entry(partition, positionModel.lastExportedPosition());
-                    }))
+                    },
+                    executor))
         .thenApply(
             s -> s.stream().collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue)));
   }
@@ -431,6 +434,7 @@ public class RestoreManager implements CloseableSilently {
     } catch (final InterruptedException ignored) {
       // Not much we can do here, just report in case it's a bug in the shutdown process.
       LOG.warn("Interrupted while waiting for executor to shutdown", ignored);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -337,7 +337,7 @@ final class BackupRangeResolverTest {
         .hasCauseInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             String.format(
-                "No complete backup range found for partition %d in interval [2026-01-20T10:30:00Z, 2026-01-20T11:00:00Z], ranges=[Incomplete[checkpontInterval=[100, 300], deletedCheckpointIds=[300]]]",
+                "No complete backup range found for partition %d in interval [2026-01-20T10:30:00Z, 2026-01-20T11:00:00Z], ranges=[Incomplete[checkpointInterval=[100, 300], deletedCheckpointIds=[300]]]",
                 partitionWithDeletion));
   }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -1,0 +1,678 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupRangeMarker;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.api.Interval;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.restore.BackupRangeResolver.GlobalRestoreInfo;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+final class BackupRangeResolverTest {
+
+  private static final int NODE_ID = 0;
+  private static final Instant BASE_TIME = Instant.parse("2026-01-20T10:00:00Z");
+
+  /** Direct executor for synchronous test execution */
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  private TestBackupStore store;
+  private BackupRangeResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    store = new TestBackupStore();
+    resolver = new BackupRangeResolver(store);
+  }
+
+  @Test
+  void shouldRestoreSinglePartitionWithContiguousBackups() {
+    // given - single partition with 3 contiguous backups
+    // Time interval covers all backups
+    store
+        .forPartition(1)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30))
+        .addBackup(300, 3000, 2001, minutesAfterBase(60));
+
+    // when - time interval covers all backups [0, 60]
+    final var result = resolve(1, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 3500L));
+
+    // then
+    assertThat(result.globalCheckpointId()).isEqualTo(300L);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(300L);
+  }
+
+  @Test
+  void shouldRestoreMultiplePartitionsWithSharedCheckpoints() {
+    // given - 3 partitions, all have checkpoints [100, 200, 300]
+    for (int p = 1; p <= 3; p++) {
+      store
+          .forPartition(p)
+          .withRange(100, 300)
+          .addBackup(100, 1000, 1, minutesAfterBase(0))
+          .addBackup(200, 2000, 1001, minutesAfterBase(30))
+          .addBackup(300, 3000, 2001, minutesAfterBase(60));
+    }
+
+    // when - time interval covers all backups
+    final var result =
+        resolve(3, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L, 2, 2500L, 3, 2500L));
+
+    // then
+    assertThat(result.globalCheckpointId()).isEqualTo(300L);
+    for (int p = 1; p <= 3; p++) {
+      assertThat(result.backupsByPartitionId().get(p)).containsExactly(200L, 300L);
+    }
+  }
+
+  @Test
+  void shouldFindGlobalCheckpointAsMaxCommonAcrossPartitions() {
+    // given - partitions have different checkpoint sets
+    // P1: [100, 200, 300] - all within time window
+    // P2: [100, 200, 300] - same
+    // P3: [100, 200, 300] - same
+    // All share [100, 200, 300], max common = 300
+    store
+        .forPartition(1)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40));
+
+    store
+        .forPartition(2)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40));
+
+    store
+        .forPartition(3)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40));
+
+    // when
+    final var result =
+        resolve(3, minutesAfterBase(0), minutesAfterBase(40), Map.of(1, 2500L, 2, 2500L, 3, 2500L));
+
+    // then - global checkpoint is 300 (max common across all partitions)
+    assertThat(result.globalCheckpointId()).isEqualTo(300L);
+  }
+
+  @Test
+  void shouldSelectBackupsBasedOnTimeInterval() {
+    // given - partition has backups [100, 200, 300, 400]
+    // But time interval only covers [200, 300]
+    store
+        .forPartition(1)
+        .withRange(100, 400)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40))
+        .addBackup(400, 4000, 3001, minutesAfterBase(60));
+
+    // when - time interval [20, 40] covers only checkpoints 200 and 300
+    final var result = resolve(1, minutesAfterBase(20), minutesAfterBase(40), Map.of(1, 2500L));
+
+    // then - only backups within time interval are returned
+    assertThat(result.globalCheckpointId()).isEqualTo(300L);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(200L, 300L);
+  }
+
+  @Test
+  void shouldHandleDifferentSafeStartsPerPartition() {
+    // given - partitions have different exported positions, so different safe starts
+    store
+        .forPartition(1)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30))
+        .addBackup(300, 3000, 2001, minutesAfterBase(60));
+
+    store
+        .forPartition(2)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30))
+        .addBackup(300, 3000, 2001, minutesAfterBase(60));
+
+    // when - P1 has higher exported position (safe start = 200), P2 lower (safe start = 100)
+    final var result =
+        resolve(2, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L, 2, 1500L));
+
+    // then
+    assertThat(result.globalCheckpointId()).isEqualTo(300L);
+    // Both partitions return all backups in the time interval
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(200L, 300L);
+    assertThat(result.backupsByPartitionId().get(2)).containsExactly(100L, 200L, 300L);
+  }
+
+  @Test
+  void shouldFailWhenNoBackupRangeExists() {
+    // given - no range markers added for partition
+    // (store is empty)
+
+    // when/then
+    assertThatThrownBy(
+            () -> resolve(1, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[]");
+  }
+
+  @Test
+  void shouldFailWhenTimeIntervalNotCoveredByBackupRange() {
+    // given - backup range exists but doesn't cover requested time interval
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30));
+
+    // when/then - requesting interval before backups exist
+    assertThatThrownBy(
+            () ->
+                resolve(
+                    1,
+                    BASE_TIME.minus(Duration.ofHours(2)),
+                    BASE_TIME.minus(Duration.ofHours(1)),
+                    Map.of(1, 2500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "No complete backup range found for partition 1 in interval [2026-01-20T08:00:00Z, 2026-01-20T09:00:00Z], ranges=[Complete[checkpointInterval=[100, 200]]]");
+  }
+
+  @Test
+  void shouldFailWhenNoSafeStartCheckpointExists() {
+    // given - backup exists but exported position is too low
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30));
+
+    // when/then - exported position 500 is below all checkpoint positions
+    assertThatThrownBy(() -> resolve(1, minutesAfterBase(0), minutesAfterBase(30), Map.of(1, 500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No safe start checkpoint found for partition 1");
+  }
+
+  // ============================================================================
+  // Error cases - No common checkpoint across partitions
+  // ============================================================================
+
+  @Test
+  void shouldFailWhenNoCommonCheckpointExistsAcrossPartitions() {
+    // given - partitions have non-overlapping checkpoint sets
+    // P1: [100, 200] at times [0, 30]
+    // P2: [300, 400] at times [0, 30]
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30));
+
+    store
+        .forPartition(2)
+        .withRange(300, 400)
+        .addBackup(300, 3000, 1, minutesAfterBase(0))
+        .addBackup(400, 4000, 3001, minutesAfterBase(30));
+
+    // when/then
+    assertThatThrownBy(
+            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(30), Map.of(1, 2500L, 2, 4500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("No common checkpoint found across all partitions");
+  }
+
+  @Test
+  void shouldFailWhenOnePartitionHasNoBackupsInTimeInterval() {
+    // given - P1 has backups in interval, P2 has backups outside interval
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30));
+
+    store
+        .forPartition(2)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(120)) // outside requested interval
+        .addBackup(200, 2000, 1001, minutesAfterBase(150));
+
+    // when/then
+    assertThatThrownBy(
+            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L, 2, 2500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[Complete[checkpointInterval=[100, 200]]");
+  }
+
+  @Test
+  void shouldFailWhenPartitionHasLogPositionGap() {
+    // given - backup chain has gap in log positions
+    // checkpoint 100: [1, 1000], checkpoint 200 should start at 1001 but starts at 1100
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1100, minutesAfterBase(30)); // gap: expected <= 1001, got 1100
+
+    // when/then
+    assertThatThrownBy(
+            () -> resolve(1, minutesAfterBase(0), minutesAfterBase(30), Map.of(1, 1500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Partition 1")
+        .hasMessageContaining("has gap in log positions");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void shouldFailWhenAPartitionHasIncompleteBackupRange(final int partitionWithDeletion) {
+    // given a missing checkpoint for one partition
+    for (int i = 1; i <= 2; i++) {
+      store
+          .forPartition(i)
+          .withRange(100, 300)
+          .addBackup(100, 1000, 1, minutesAfterBase(0))
+          .addBackup(200, 2000, 1, minutesAfterBase(30))
+          .addBackup(300, 3000, 2001, minutesAfterBase(60));
+    }
+
+    store.forPartition(partitionWithDeletion).withDeletion(300);
+
+    // P1 exported position 3500 means safe start = 300 (beyond global checkpoint 200)
+    // when/then
+    assertThatThrownBy(
+            () ->
+                resolve(2, minutesAfterBase(30), minutesAfterBase(60), Map.of(1, 3500L, 2, 3500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            String.format(
+                "No complete backup range found for partition %d in interval [2026-01-20T10:30:00Z, 2026-01-20T11:00:00Z], ranges=[Incomplete[checkpontInterval=[100, 300], deletedCheckpointIds=[300]]]",
+                partitionWithDeletion));
+  }
+
+  @Test
+  void shouldFailWhenPartitionExporterIsLagging() {
+    // given a missing checkpoint for one partition
+    for (int i = 1; i <= 2; i++) {
+      store
+          .forPartition(i)
+          .withRange(100, 300)
+          .addBackup(100, 1000, 1, minutesAfterBase(0))
+          .addBackup(200, 2000, 1, minutesAfterBase(30))
+          .addBackup(300, 3000, 2001, minutesAfterBase(60));
+    }
+
+    // P1 exported position 3500 means safe start = 300 (beyond global checkpoint 200)
+    // when/then
+    assertThatThrownBy(
+            () -> resolve(2, minutesAfterBase(30), minutesAfterBase(60), Map.of(1, 3500L, 2, 500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "No safe start checkpoint found for partition 2 with exported position 500");
+  }
+
+  @Test
+  void shouldFailWhenFirstBackupInRangeIsAfterSafeStart() {
+    // given - backups in time interval start at 200, but safe start is 100
+    store
+        .forPartition(1)
+        .withRange(100, 300)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30))
+        .addBackup(300, 3000, 2001, minutesAfterBase(60));
+
+    // when - time interval [30, 60] returns backups [200, 300]
+    // but safe start based on exported position 1500 is checkpoint 100
+    // first backup in interval (200) > safe start (100) -> validation fails
+    assertThatThrownBy(
+            () -> resolve(1, minutesAfterBase(30), minutesAfterBase(60), Map.of(1, 1500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "No safe start checkpoint found for partition 1 with exported position 1500");
+  }
+
+  @Test
+  void shouldReportAllPartitionFailuresInSingleException() {
+    // given - multiple partitions with gaps in log positions
+    // P1: has gap
+    // P2: valid
+    // P3: has gap
+    store
+        .forPartition(1)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1100, minutesAfterBase(30)); // gap
+
+    store
+        .forPartition(2)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(30)); // valid
+
+    store
+        .forPartition(3)
+        .withRange(100, 200)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1200, minutesAfterBase(30)); // gap
+
+    // when/then - should report failures for P1 and P3
+    assertThatThrownBy(
+            () ->
+                resolve(
+                    3,
+                    minutesAfterBase(0),
+                    minutesAfterBase(30),
+                    Map.of(1, 1500L, 2, 1500L, 3, 1500L)))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Partition 1")
+        .hasMessageContaining("Partition 3")
+        .hasMessageContaining("has gap in log positions");
+  }
+
+  @Test
+  void shouldReturnLargestCheckpointBelowExportedPosition() {
+    // given - backups with checkpointPositions [100, 200, 300]
+    final var backups =
+        List.of(
+            createBackupStatus(1, 1, 100, 1), // checkpointId=1, checkpointPosition=100
+            createBackupStatus(1, 2, 200, 101), // checkpointId=2, checkpointPosition=200
+            createBackupStatus(1, 3, 300, 201)); // checkpointId=3, checkpointPosition=300
+
+    // when - exported position 250 means safe start is checkpoint 2 (position 200 <= 250)
+    final var result = BackupRangeResolver.findSafeStartCheckpoint(250L, backups);
+
+    // then
+    assertThat(result).contains(2L);
+  }
+
+  private GlobalRestoreInfo resolve(
+      final int partitionCount,
+      final Instant from,
+      final Instant to,
+      final Map<Integer, Long> exportedPositions) {
+    final var value =
+        resolver
+            .getRestoreInfoForAllPartitions(
+                Interval.closed(from, to), partitionCount, exportedPositions, DIRECT_EXECUTOR)
+            .join();
+    return value;
+  }
+
+  private static Instant minutesAfterBase(final int minutes) {
+    return BASE_TIME.plus(Duration.ofMinutes(minutes));
+  }
+
+  private static BackupStatus createBackupStatus(
+      final int partitionId,
+      final long checkpointId,
+      final long checkpointPosition,
+      final long firstLogPosition) {
+    final BackupIdentifier id = new BackupIdentifierImpl(NODE_ID, partitionId, checkpointId);
+    final BackupDescriptor descriptor =
+        new BackupDescriptorImpl(
+            Optional.of("snapshot-" + checkpointId),
+            OptionalLong.of(firstLogPosition),
+            checkpointPosition,
+            3,
+            "8.7.0",
+            Instant.now(),
+            CheckpointType.SCHEDULED_BACKUP);
+    return new BackupStatusImpl(
+        id,
+        Optional.of(descriptor),
+        BackupStatusCode.COMPLETED,
+        Optional.empty(),
+        Optional.of(Instant.now()),
+        Optional.of(Instant.now()));
+  }
+
+  /**
+   * Fluent test BackupStore that allows easy setup of partitions with backups and range markers.
+   *
+   * <p>Usage:
+   *
+   * <pre>{@code
+   * store
+   *     .forPartition(1)
+   *     .withRange(100, 300)
+   *     .addBackup(100, 1000, 1, timestamp1)
+   *     .addBackup(200, 2000, 1001, timestamp2)
+   *     .addBackup(300, 3000, 2001, timestamp3);
+   * }</pre>
+   */
+  private static final class TestBackupStore implements BackupStore {
+    private final Map<BackupIdentifier, Backup> backups = new HashMap<>();
+    private final Map<Integer, List<BackupRangeMarker>> rangeMarkersByPartition = new HashMap<>();
+
+    PartitionBuilder forPartition(final int partitionId) {
+      return new PartitionBuilder(this, partitionId);
+    }
+
+    private void addBackup(
+        final int partitionId,
+        final long checkpointId,
+        final long checkpointPosition,
+        final long firstLogPosition,
+        final Instant timestamp) {
+      final BackupIdentifier id = new BackupIdentifierImpl(NODE_ID, partitionId, checkpointId);
+      final BackupDescriptor descriptor =
+          new BackupDescriptorImpl(
+              Optional.of("snapshot-" + checkpointId),
+              OptionalLong.of(firstLogPosition),
+              checkpointPosition,
+              3,
+              "8.7.0",
+              timestamp,
+              CheckpointType.SCHEDULED_BACKUP);
+      backups.put(
+          id,
+          new BackupImpl(
+              id, descriptor, new NamedFileSetImpl(Map.of()), new NamedFileSetImpl(Map.of())));
+    }
+
+    private void addRangeMarker(final int partitionId, final BackupRangeMarker marker) {
+      rangeMarkersByPartition.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(marker);
+    }
+
+    @Override
+    public CompletableFuture<Void> save(final Backup backup) {
+      backups.put(backup.id(), backup);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+      final var backup = backups.get(id);
+      if (backup != null) {
+        return CompletableFuture.completedFuture(toStatus(backup));
+      }
+      return CompletableFuture.completedFuture(
+          new BackupStatusImpl(
+              id,
+              Optional.empty(),
+              BackupStatusCode.DOES_NOT_EXIST,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty()));
+    }
+
+    @Override
+    public CompletableFuture<Collection<BackupStatus>> list(
+        final BackupIdentifierWildcard wildcard) {
+      final var matchingBackups =
+          backups.values().stream()
+              .filter(backup -> wildcard.matches(backup.id()))
+              .map(this::toStatus)
+              .map(s -> (BackupStatus) s)
+              .toList();
+      return CompletableFuture.completedFuture(matchingBackups);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete(final BackupIdentifier id) {
+      backups.remove(id);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
+      return CompletableFuture.completedFuture(backups.get(id));
+    }
+
+    @Override
+    public CompletableFuture<BackupStatusCode> markFailed(
+        final BackupIdentifier id, final String failureReason) {
+      return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
+    }
+
+    @Override
+    public CompletableFuture<Collection<BackupRangeMarker>> rangeMarkers(final int partitionId) {
+      return CompletableFuture.completedFuture(
+          rangeMarkersByPartition.getOrDefault(partitionId, List.of()));
+    }
+
+    @Override
+    public CompletableFuture<Void> storeRangeMarker(
+        final int partitionId, final BackupRangeMarker marker) {
+      addRangeMarker(partitionId, marker);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteRangeMarker(
+        final int partitionId, final BackupRangeMarker marker) {
+      final var markers = rangeMarkersByPartition.get(partitionId);
+      if (markers != null) {
+        markers.remove(marker);
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    private BackupStatusImpl toStatus(final Backup backup) {
+      return new BackupStatusImpl(
+          backup.id(),
+          Optional.of(backup.descriptor()),
+          BackupStatusCode.COMPLETED,
+          Optional.empty(),
+          Optional.of(backup.descriptor().checkpointTimestamp()),
+          Optional.of(backup.descriptor().checkpointTimestamp()));
+    }
+
+    /** Fluent builder for setting up partition data */
+    private static final class PartitionBuilder {
+      private final TestBackupStore store;
+      private final int partitionId;
+
+      PartitionBuilder(final TestBackupStore store, final int partitionId) {
+        this.store = store;
+        this.partitionId = partitionId;
+      }
+
+      PartitionBuilder withRange(final long startCheckpoint, final long endCheckpoint) {
+        store.addRangeMarker(partitionId, new BackupRangeMarker.Start(startCheckpoint));
+        store.addRangeMarker(partitionId, new BackupRangeMarker.End(endCheckpoint));
+        return this;
+      }
+
+      PartitionBuilder withDeletion(final long deletedCheckpoint) {
+        store.addRangeMarker(partitionId, new BackupRangeMarker.Deletion(deletedCheckpoint));
+        return this;
+      }
+
+      PartitionBuilder addBackup(
+          final long checkpointId,
+          final long checkpointPosition,
+          final long firstLogPosition,
+          final Instant timestamp) {
+        store.addBackup(partitionId, checkpointId, checkpointPosition, firstLogPosition, timestamp);
+        return this;
+      }
+    }
+  }
+
+  @Nested
+  class FindSafeStartCheckpoint {
+    @Test
+    void shouldReturnEmptyWhenNoCheckpointBelowExportedPosition() {
+      // given
+      final var backups = List.of(createBackupStatus(1, 1, 100, 1));
+
+      // when - exported position 50 is below all checkpoints
+      final var result = BackupRangeResolver.findSafeStartCheckpoint(50L, backups);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyForEmptyBackupList() {
+      // given
+      final List<BackupStatus> backups = List.of();
+
+      // when
+      final var result = BackupRangeResolver.findSafeStartCheckpoint(100L, backups);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+}

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -151,7 +151,7 @@ final class RestoreManagerTest {
     try (final var restoreManager =
         new RestoreManager(configuration, backupStore, new SimpleMeterRegistry())) {
 
-      // when - trying to restore backups from baseTime to baseTime + 5 minutes
+      // when - trying to restore backups from 'from' to 'from' + 5 minutes
       // then - should fail because partition 2 doesn't have a continuous range
       final var to = from.plusSeconds(5 * 60);
       assertThatThrownBy(() -> restoreManager.restore(from, to, false, List.of()))

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Optionals.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Optionals.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public class Optionals {
+  public static Optional<Long> boxed(final OptionalLong optionalLong) {
+    if (optionalLong.isPresent()) {
+      return Optional.of(optionalLong.getAsLong());
+    }
+    return Optional.empty();
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Optionals.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Optionals.java
@@ -10,7 +10,11 @@ package io.camunda.zeebe.util;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-public class Optionals {
+public final class Optionals {
+
+  // utility class
+  private Optionals() {}
+
   public static Optional<Long> boxed(final OptionalLong optionalLong) {
     if (optionalLong.isPresent()) {
       return Optional.of(optionalLong.getAsLong());


### PR DESCRIPTION
## Summary
- Add BackupRangeResolver to compute the set of backups needed to restore a cluster to a consistent state based on exporter positions
- Extend Interval API with operations for computing covers and detecting overlaps
- Update RestoreManager to use the new backup range resolution logic

## Description
This PR introduces the ability to determine which backups are required to restore all partitions to a globally consistent checkpoint. The resolver takes into account:
- The time interval during which backups should be considered
- The current exporter positions to determine a safe starting checkpoint
- Validation that backup chains are contiguous (no gaps in log positions)

The Interval class has been extended with utility methods for working with collections of intervals, including finding the smallest cover of an interval and checking for overlaps.

## Related issues

relates to #40233
