### PR TITLE
feat: add global job statistics endpoint and related configurations

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
@@ -12,7 +12,9 @@ import io.camunda.db.rdbms.read.mapper.JobEntityMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.columns.JobSearchColumn;
 import io.camunda.search.clients.reader.JobReader;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
@@ -74,5 +76,11 @@ public class JobDbReader extends AbstractEntityReader<JobEntity> implements JobR
 
   public SearchQueryResult<JobEntity> search(final JobQuery query) {
     return search(query, ResourceAccessChecks.disabled());
+  }
+
+  @Override
+  public GlobalJobStatisticsEntity getGlobalJobStatistics(
+      final GlobalJobStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("Not implemented yet");
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -109,6 +109,23 @@ public final class SearchQueryRequestMapper {
                 .build());
   }
 
+  public static Either<ProblemDetail, io.camunda.search.query.GlobalJobStatisticsQuery>
+      toGlobalJobStatisticsQuery(final GlobalJobStatisticsQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.globalJobStatisticsSearchQuery().build());
+    }
+    final var filter = SearchQueryFilterMapper.toGlobalJobStatisticsFilter(request.getFilter());
+
+    if (filter.isLeft()) {
+      final var problem = RequestValidator.createProblemDetail(filter.getLeft());
+      if (problem.isPresent()) {
+        return Either.left(problem.get());
+      }
+    }
+    return Either.right(
+        SearchQueryBuilders.globalJobStatisticsSearchQuery().filter(filter.get()).build());
+  }
+
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
       final ProcessDefinitionSearchQuery request) {
     if (request == null) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -53,6 +53,8 @@ import io.camunda.gateway.protocol.model.ElementInstanceStateEnum;
 import io.camunda.gateway.protocol.model.EvaluatedDecisionInputItem;
 import io.camunda.gateway.protocol.model.EvaluatedDecisionOutputItem;
 import io.camunda.gateway.protocol.model.FormResult;
+import io.camunda.gateway.protocol.model.GlobalJobStatisticsItem;
+import io.camunda.gateway.protocol.model.GlobalJobStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.GroupClientResult;
 import io.camunda.gateway.protocol.model.GroupClientSearchResult;
 import io.camunda.gateway.protocol.model.GroupResult;
@@ -107,6 +109,7 @@ import io.camunda.gateway.protocol.model.RoleSearchQueryResult;
 import io.camunda.gateway.protocol.model.RoleUserResult;
 import io.camunda.gateway.protocol.model.RoleUserSearchResult;
 import io.camunda.gateway.protocol.model.SearchQueryPageResponse;
+import io.camunda.gateway.protocol.model.StatusMetric;
 import io.camunda.gateway.protocol.model.TenantClientResult;
 import io.camunda.gateway.protocol.model.TenantClientSearchResult;
 import io.camunda.gateway.protocol.model.TenantGroupResult;
@@ -141,6 +144,7 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -1491,6 +1495,35 @@ public final class SearchQueryResponseMapper {
                     SearchQueryResponseMapper
                         ::toProcessDefinitionMessageSubscriptionStatisticsQueryResponse)
                 .orElseGet(Collections::emptyList));
+  }
+
+  public static GlobalJobStatisticsQueryResult toGlobalJobStatisticsQueryResult(
+      final GlobalJobStatisticsEntity entity) {
+    final var items =
+        ofNullable(entity)
+            .map(GlobalJobStatisticsEntity::items)
+            .map(
+                list ->
+                    list.stream()
+                        .map(SearchQueryResponseMapper::toGlobalJobStatisticsItem)
+                        .toList())
+            .orElseGet(Collections::emptyList);
+
+    return new GlobalJobStatisticsQueryResult().items(items);
+  }
+
+  private static GlobalJobStatisticsItem toGlobalJobStatisticsItem(
+      final GlobalJobStatisticsEntity.StatisticsItem item) {
+    return new GlobalJobStatisticsItem()
+        .created(toStatusMetric(item.created()))
+        .completed(toStatusMetric(item.completed()))
+        .failed(toStatusMetric(item.failed()));
+  }
+
+  private static StatusMetric toStatusMetric(final GlobalJobStatisticsEntity.StatusMetric metric) {
+    return new StatusMetric()
+        .count(metric.count())
+        .lastUpdatedAt(formatDate(metric.lastUpdatedAt()));
   }
 
   // sometimes we've seen null for properties that should not be null; log a warning if that happens

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
@@ -8,7 +8,9 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
@@ -26,5 +28,11 @@ public class JobDocumentReader extends DocumentBasedReader implements JobReader 
       final JobQuery query, final ResourceAccessChecks resourceAccessChecks) {
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.JobEntity.class, resourceAccessChecks);
+  }
+
+  @Override
+  public GlobalJobStatisticsEntity getGlobalJobStatistics(
+      final GlobalJobStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException("Not implemented yet");
   }
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobReader.java
@@ -7,7 +7,14 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
 
-public interface JobReader extends SearchEntityReader<JobEntity, JobQuery> {}
+public interface JobReader extends SearchEntityReader<JobEntity, JobQuery> {
+
+  GlobalJobStatisticsEntity getGlobalJobStatistics(
+      GlobalJobStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -66,6 +67,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -370,6 +372,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
     return doSearchWithReader(readers.jobReader(), query);
+  }
+
+  @Override
+  public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
+    return doReadWithResourceAccessController(
+        access -> readers.jobReader().getGlobalJobStatistics(query, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.search.clients;
 
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
@@ -15,6 +17,8 @@ import io.camunda.security.auth.SecurityContext;
 public interface JobSearchClient {
 
   SearchQueryResult<JobEntity> searchJobs(JobQuery query);
+
+  GlobalJobStatisticsEntity getGlobalJobStatistics(GlobalJobStatisticsQuery query);
 
   JobSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -19,6 +19,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -56,6 +57,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -392,6 +394,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -21,6 +21,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -57,6 +58,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -395,5 +397,10 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
     return SearchQueryResult.empty();
+  }
+
+  @Override
+  public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
+    return new GlobalJobStatisticsEntity(List.of());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/GlobalJobStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/GlobalJobStatisticsAggregation.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+public class GlobalJobStatisticsAggregation implements AggregationBase {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalJobStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalJobStatisticsEntity.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record GlobalJobStatisticsEntity(List<StatisticsItem> items) {
+
+  public record StatisticsItem(StatusMetric created, StatusMetric completed, StatusMetric failed) {}
+
+  public record StatusMetric(long count, OffsetDateTime lastUpdatedAt) {}
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -337,4 +337,14 @@ public final class FilterBuilders {
               fn) {
     return fn.apply(incidentProcessInstanceStatisticsByDefinition()).build();
   }
+
+  public static GlobalJobStatisticsFilter.Builder globalJobStatistics() {
+    return new GlobalJobStatisticsFilter.Builder();
+  }
+
+  public static GlobalJobStatisticsFilter globalJobStatistics(
+      final Function<GlobalJobStatisticsFilter.Builder, ObjectBuilder<GlobalJobStatisticsFilter>>
+          fn) {
+    return fn.apply(globalJobStatistics()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GlobalJobStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GlobalJobStatisticsFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+
+public record GlobalJobStatisticsFilter(OffsetDateTime from, OffsetDateTime to, String jobType)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<GlobalJobStatisticsFilter> {
+    private OffsetDateTime from;
+    private OffsetDateTime to;
+    private String jobType;
+
+    public Builder from(final OffsetDateTime value) {
+      from = value;
+      return this;
+    }
+
+    public Builder to(final OffsetDateTime value) {
+      to = value;
+      return this;
+    }
+
+    public Builder jobType(final String value) {
+      jobType = value;
+      return this;
+    }
+
+    @Override
+    public GlobalJobStatisticsFilter build() {
+      return new GlobalJobStatisticsFilter(from, to, jobType);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/GlobalJobStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/GlobalJobStatisticsQuery.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.GlobalJobStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record GlobalJobStatisticsQuery(GlobalJobStatisticsFilter filter)
+    implements TypedSearchAggregationQuery<
+        GlobalJobStatisticsFilter, SortOption, GlobalJobStatisticsAggregation> {
+
+  public static GlobalJobStatisticsQuery of(
+      final Function<Builder, ObjectBuilder<GlobalJobStatisticsQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
+  }
+
+  public static final class Builder implements ObjectBuilder<GlobalJobStatisticsQuery> {
+    private static final GlobalJobStatisticsFilter EMPTY_FILTER =
+        FilterBuilders.globalJobStatistics().build();
+
+    private GlobalJobStatisticsFilter filter;
+
+    public Builder filter(final GlobalJobStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<GlobalJobStatisticsFilter.Builder, ObjectBuilder<GlobalJobStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.globalJobStatistics(fn));
+    }
+
+    @Override
+    public GlobalJobStatisticsQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      return new GlobalJobStatisticsQuery(filter);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -36,6 +36,10 @@ public final class SearchQueryBuilders {
     return new ProcessInstanceQuery.Builder();
   }
 
+  public static GlobalJobStatisticsQuery.Builder globalJobStatisticsSearchQuery() {
+    return new GlobalJobStatisticsQuery.Builder();
+  }
+
   public static ProcessInstanceQuery processInstanceSearchQuery(
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
     return fn.apply(processInstanceSearchQuery()).build();

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -10,9 +10,12 @@ package io.camunda.service;
 import static io.camunda.service.authorization.Authorizations.JOB_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.JobSearchClient;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
@@ -135,6 +138,15 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                     securityContextProvider.provideSecurityContext(
                         authentication, JOB_READ_AUTHORIZATION))
                 .searchJobs(query));
+  }
+
+  public GlobalJobStatisticsEntity getGlobalStatistics(final GlobalJobStatisticsQuery query) {
+    final var authJobSearchClient =
+        jobSearchClient.withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.system().readJobMetric())));
+
+    return authJobSearchClient.getGlobalJobStatistics(query);
   }
 
   public record ActivateJobsRequest(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -111,6 +111,10 @@ public final class EngineCfg implements ConfigurationEntry {
     this.globalListeners = globalListeners;
   }
 
+  public JobMetricsCfg getJobMetrics() {
+    return jobMetrics;
+  }
+
   public void setJobMetrics(final JobMetricsCfg jobMetrics) {
     this.jobMetrics = jobMetrics;
   }
@@ -126,7 +130,9 @@ public final class EngineCfg implements ConfigurationEntry {
   @Override
   public String toString() {
     return "EngineCfg{"
-        + "messages="
+        + "jobMetrics="
+        + jobMetrics
+        + ", messages="
         + messages
         + ", caches="
         + caches

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -1,0 +1,117 @@
+## Endpoint definitions
+
+paths:
+  /jobs/statistics/global:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Job metrics
+      operationId: getGlobalJobStatistics
+      summary: Global job statistics
+      description: |
+        Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GlobalJobStatisticsQuery'
+      responses:
+        "200":
+          description: Global job metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalJobStatisticsQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
+## Schema definitions
+
+components:
+  schemas:
+    GlobalJobStatisticsQuery:
+      type: object
+      additionalProperties: false
+      required:
+        - filter
+      properties:
+        filter:
+          $ref: '#/components/schemas/GlobalJobStatisticsFilter'
+
+    GlobalJobStatisticsFilter:
+      description: Filters for global job statistics query.
+      type: object
+      additionalProperties: false
+      required:
+        - from
+        - to
+      properties:
+        from:
+          description: |
+            Start of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-28T15:51:28.071Z"
+        to:
+          description: |
+            End of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+        jobType:
+          description: Optional job type to limit the aggregation to a single job type.
+          type: string
+          example: "fetch-customer-data"
+
+    GlobalJobStatisticsQueryResult:
+      description: Global job statistics query result.
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          description: List of aggregated job statistics.
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalJobStatisticsItem'
+
+    GlobalJobStatisticsItem:
+      description: Aggregated job metrics for a time bucket.
+      type: object
+      required:
+        - created
+        - completed
+        - failed
+      properties:
+        created:
+          $ref: '#/components/schemas/StatusMetric'
+        completed:
+          $ref: '#/components/schemas/StatusMetric'
+        failed:
+          $ref: '#/components/schemas/StatusMetric'
+
+    StatusMetric:
+      description: Metric for a single job status.
+      type: object
+      required:
+        - count
+        - lastUpdatedAt
+      properties:
+        count:
+          description: Number of jobs in this status.
+          type: integer
+          format: int64
+          example: 145
+        lastUpdatedAt:
+          description: ISO 8601 timestamp of the last update for this status.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -43,6 +43,7 @@ tags:
   - name: Group
   - name: Incident
   - name: Job
+  - name: Job metrics
   - name: License
   - name: Mapping rule
   - name: Message
@@ -219,6 +220,10 @@ paths:
     $ref: 'jobs.yaml#/paths/~1jobs~1{jobKey}~1error'
   /jobs/{jobKey}/failure:
     $ref: 'jobs.yaml#/paths/~1jobs~1{jobKey}~1failure'
+
+  # Job metrics endpoints
+  /jobs/statistics/global:
+    $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1global'
 
   # License endpoints
   /license:


### PR DESCRIPTION
## Description
[Epic](https://github.com/camunda/product-hub/issues/2787) 

This pull request introduces a new "Global Job Statistics" feature to the search and gateway layers, laying the groundwork for querying and representing aggregated job statistics. The changes add new entities, filters, queries, response mappers, and client methods for this feature, but the actual data retrieval is not yet implemented (methods currently throw `UnsupportedOperationException` or return empty results in stubs).

The most important changes are:

**Global Job Statistics Data Model and Filter:**
* Added the `GlobalJobStatisticsEntity` record to represent aggregated job statistics, including nested types for statistics items and status metrics.
* Introduced the `GlobalJobStatisticsFilter` record and builder for filtering job statistics queries by time range and job type.
* Added `GlobalJobStatisticsAggregation` as a marker for aggregation queries.

**Query and Client API Extensions:**
* Extended the `JobReader` and `JobSearchClient` interfaces (and related proxies) with a new `getGlobalJobStatistics` method, and implemented corresponding stubs in the client and proxy classes. [[1]](diffhunk://#diff-2d6a1e26d96b1ec247675665fbb265ad2300a04874ccf5510564a2a89fb04780R10-R20) [[2]](diffhunk://#diff-cb11a4b24fb6e9c25f887e4b2b02055b11b559dca7d87fdd650da35a5184df9eR21-R22) [[3]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R377-R382) [[4]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R399-R403) [[5]](diffhunk://#diff-c79d6b60e20a1f39b125755908386489c3f033508a294e45ef84feed9a285b1eR401-R405) [[6]](diffhunk://#diff-566b979f8f658b823b25703b169c45a32b81c2b8212de870886c30c4a61ed401R32-R37)
* Added the `GlobalJobStatisticsQuery` type and integrated it into the query filter builders. [[1]](diffhunk://#diff-36141f9bcdcfa826247a7d252359511ad2b72df4a2a9c4d9bfc54d1438035c54R15-R17) [[2]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R70) [[3]](diffhunk://#diff-88753fc522f7d9ad86f2a90b4167acc3b331686455923551cab4984a34d741a7R340-R349)

**Gateway Mapping and Response Handling:**
* Implemented request mapping and validation for `GlobalJobStatisticsQuery` requests, including date range checks.
* Added response mappers to convert `GlobalJobStatisticsEntity` results into the gateway protocol model, including mapping of statistics items and status metrics.

These changes are foundational and prepare the codebase for future implementation of actual job statistics aggregation and retrieval.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/43070
closes https://github.com/camunda/camunda/issues/43071
