### PR TITLE
Increase AlwaysGreen SaaS Workflow Timeout

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -359,7 +359,7 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [build-and-push, format-identifier]
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions: { }
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To prevent recurring timeouts in the upstream workflow caused by longer execution times in the downstream workflow, the timeout threshold has been increased to a value beyond expected runtime.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
