### PR TITLE
Delete process definition from ES and OS

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -42,7 +42,6 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
-import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
@@ -414,12 +413,7 @@ public final class BackgroundTaskManagerFactory {
 
     return buildHistoryDeletionTask(
         new HistoryDeletionJob(
-            dependantTemplates,
-            executor,
-            historyDeletionRepository,
-            logger,
-            resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class),
-            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class)));
+            dependantTemplates, executor, historyDeletionRepository, logger, resourceProvider));
   }
 
   private ReschedulingTask buildHistoryDeletionTask(final BackgroundTask task) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
+import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
@@ -42,8 +43,7 @@ public class HistoryDeletionJob implements BackgroundTask {
       final Executor executor,
       final HistoryDeletionRepository historyDeletionRepository,
       final Logger logger,
-      final HistoryDeletionIndex historyDeletionIndex,
-      final ListViewTemplate listViewTemplate) {
+      final ExporterResourceProvider resourceProvider) {
     this.processInstanceDependants =
         processInstanceDependants.stream()
             .sorted(Comparator.comparing(ProcessInstanceDependant::getFullQualifiedName))
@@ -51,8 +51,8 @@ public class HistoryDeletionJob implements BackgroundTask {
     this.executor = executor;
     deleterRepository = historyDeletionRepository;
     this.logger = logger;
-    this.historyDeletionIndex = historyDeletionIndex;
-    this.listViewTemplate = listViewTemplate;
+    historyDeletionIndex = resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class);
+    listViewTemplate = resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -137,7 +137,7 @@ public class HistoryDeletionJob implements BackgroundTask {
 
     return deleterRepository
         .deleteDocumentsByField(
-            auditLogTemplate.getFullQualifiedName() + "*",
+            auditLogTemplate.getIndexPattern(),
             AuditLogTemplate.PROCESS_DEFINITION_KEY,
             processDefinitions)
         .thenCompose(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -127,7 +127,17 @@ public class HistoryDeletionJob implements BackgroundTask {
         .thenApply(ignored -> batch.getHistoryDeletionIds(HistoryDeletionType.PROCESS_INSTANCE));
   }
 
-  // TODO add javadoc
+  /**
+   * This method will delete a batch of process definitions in two steps:
+   *
+   * <ol>
+   *   <li>It deletes the process definition related data from the audit logs
+   *   <li>It deletes the process definitions from the process index
+   * </ol>
+   *
+   * @param batch The batch of entities to delete
+   * @return A future containing the list of history-deletion IDs that were processed
+   */
   private CompletionStage<List<String>> deleteProcessDefinitions(
       final HistoryDeletionBatch batch, final List<String> processInstanceDeletionIds) {
     final var processDefinitions = batch.getResourceKeys(HistoryDeletionType.PROCESS_DEFINITION);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,6 +21,8 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
@@ -40,6 +44,8 @@ final class HistoryDeletionJobTest {
   private List<ProcessInstanceDependant> dependants;
   private HistoryDeletionIndex historyDeletionIndex;
   private ListViewTemplate listViewTemplate;
+  private ProcessIndex processIndex;
+  private AuditLogTemplate auditLogTemplate;
 
   @BeforeEach
   void setUp() {
@@ -51,6 +57,10 @@ final class HistoryDeletionJobTest {
             .filter(ProcessInstanceDependant.class::isInstance)
             .map(ProcessInstanceDependant.class::cast)
             .toList();
+    historyDeletionIndex = resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class);
+    listViewTemplate = resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    processIndex = resourceProvider.getIndexDescriptor(ProcessIndex.class);
+    auditLogTemplate = resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class);
     job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
   }
 
@@ -191,6 +201,133 @@ final class HistoryDeletionJobTest {
             listViewTemplate.getIndexPattern(),
             ListViewTemplate.PROCESS_INSTANCE_KEY,
             List.of(entity.getResourceKey()));
+    verify(repository, never()).deleteDocumentsById(any(), any());
+  }
+
+  @Test
+  void shouldDeleteProcessDefinitionHistory() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then Process Definition is deleted
+    verify(repository, atMostOnce())
+        .deleteDocumentsByField(
+            auditLogTemplate.getIndexPattern(),
+            AuditLogTemplate.PROCESS_DEFINITION_KEY,
+            List.of(entity.getResourceKey()));
+    verify(repository, atMostOnce())
+        .deleteDocumentsById(
+            processIndex.getFullQualifiedName(), List.of(String.valueOf(entity.getResourceKey())));
+    verify(repository, atMostOnce())
+        .deleteDocumentsById(historyDeletionIndex.getFullQualifiedName(), List.of(entity.getId()));
+  }
+
+  @Test
+  void shouldNotDeleteProcessDefinitionIfAuditLogDeletionFailed() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed deleting")));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
+    verify(repository, never())
+        .deleteDocumentsById(
+            processIndex.getFullQualifiedName(), List.of(String.valueOf(entity.getResourceKey())));
+    verify(repository, never()).deleteDocumentsById(any(), any());
+  }
+
+  @Test
+  void shouldNotDeleteProcessDefinitionFromHistoryIndexIfDeletionFailed() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    verify(repository, atMostOnce())
+        .deleteDocumentsById(
+            processIndex.getFullQualifiedName(), List.of(String.valueOf(entity.getResourceKey())));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
+    verify(repository, atMostOnce())
+        .deleteDocumentsByField(
+            auditLogTemplate.getIndexPattern(),
+            AuditLogTemplate.PROCESS_DEFINITION_KEY,
+            List.of(entity.getResourceKey()));
+    verify(repository, atMostOnce())
+        .deleteDocumentsById(
+            processIndex.getFullQualifiedName(), List.of(String.valueOf(entity.getResourceKey())));
+    verify(repository, never())
+        .deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any());
+  }
+
+  @Test
+  void shouldNotDeleteProcessDefinitionIfProcessInstanceDeletionFailed() {
+    // given
+    final var entity1 =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var entity2 =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(2L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity1, entity2))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsByField(
+            listViewTemplate.getIndexPattern(),
+            ListViewTemplate.PROCESS_INSTANCE_KEY,
+            List.of(entity1.getResourceKey())))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed deleting")));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
     verify(repository, never()).deleteDocumentsById(any(), any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -276,9 +276,8 @@ final class HistoryDeletionJobTest {
         .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
     when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
         .thenReturn(CompletableFuture.completedFuture(List.of()));
-    verify(repository, atMostOnce())
-        .deleteDocumentsById(
-            processIndex.getFullQualifiedName(), List.of(String.valueOf(entity.getResourceKey())));
+    when(repository.deleteDocumentsById(eq(processIndex.getFullQualifiedName()), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed deleting")));
 
     // when
     job.execute().exceptionally(ex -> 0).toCompletableFuture().join();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -46,16 +46,12 @@ final class HistoryDeletionJobTest {
     repository = mock(HistoryDeletionRepository.class);
     final TestExporterResourceProvider resourceProvider =
         new TestExporterResourceProvider("", true);
-    historyDeletionIndex = resourceProvider.getIndexDescriptor(HistoryDeletionIndex.class);
-    listViewTemplate = resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
     dependants =
         resourceProvider.getIndexTemplateDescriptors().stream()
             .filter(ProcessInstanceDependant.class::isInstance)
             .map(ProcessInstanceDependant.class::cast)
             .toList();
-    job =
-        new HistoryDeletionJob(
-            dependants, executor, repository, LOGGER, historyDeletionIndex, listViewTemplate);
+    job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add support to the `HistoryDeletionJob` to delete process definitions from ES and OS

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #42084
closes #44184
