### PR TITLE
fix: updating cluster variable documentation link

### DIFF
--- a/identity/client/src/pages/cluster-variables/List.tsx
+++ b/identity/client/src/pages/cluster-variables/List.tsx
@@ -53,7 +53,7 @@ export default function List() {
     <PageHeader
       title={t("clusterVariables")}
       linkText={t("clusterVariables").toLowerCase()}
-      docsLinkPath="/docs/components/identity/cluster-variable/"
+      docsLinkPath="/docs/next/components/modeler/feel/cluster-variable/cluster-variable-overview/"
       shouldShowDocumentationLink={!shouldShowEmptyState}
     />
   );
@@ -64,7 +64,7 @@ export default function List() {
         {pageHeader}
         <PageEmptyState
           resourceTypeTranslationKey={"clusterVariable"}
-          docsLinkPath="/docs/components/identity/cluster-variable/"
+          docsLinkPath="/docs/next/components/modeler/feel/cluster-variable/cluster-variable-overview/"
           handleClick={addClusterVariable}
         />
         {addClusterVariableModal}


### PR DESCRIPTION
## Description

The cluster variables documentation page was created, so we need to update the links to point to the correct location.
https://docs.camunda.io/docs/next/components/modeler/feel/cluster-variable/cluster-variable-overview/

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- ~[ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).~

## Related issues

closes #43013 
