### PR TITLE
fix: disabling cluster variable tenant option for saas

### DIFF
--- a/identity/client/src/pages/cluster-variables/modals/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modals/AddModal.tsx
@@ -22,6 +22,7 @@ import TextField from "src/components/form/TextField.tsx";
 import { searchTenant } from "src/utility/api/tenants";
 import JSONEditor from "src/components/form/JSONEditor.tsx";
 import { isValid } from "src/utility/components/editor/jsonUtils.ts";
+import { isSaaS } from "src/configuration";
 
 type FormData = {
   name: string;
@@ -136,6 +137,7 @@ const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                 checked={field.value === ScopeType.TENANT}
                 onClick={() => field.onChange(ScopeType.TENANT)}
                 labelText={<span>{t("clusterVariableScopeTypeTenant")}</span>}
+                disabled={isSaaS}
                 type="radio"
               />
             </RadioButtonGroup>


### PR DESCRIPTION
## Description

Disabling the tenant scope option when creating cluster variables in SaaS mode.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- ~[ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).~

## Related issues

closes #43017 
