### PR TITLE
feat: implement create process instance MCP tool

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -14,6 +14,7 @@ import io.camunda.application.commons.service.CamundaServicesConfiguration;
 import io.camunda.application.initializers.McpGatewayInitializer;
 import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ class McpGatewayConfigurationTest {
     WebApplicationContextRunner runner =
         new WebApplicationContextRunner()
             .withInitializer(new McpGatewayInitializer())
+            .withBean(MultiTenancyConfiguration.class, MultiTenancyConfiguration::new)
             .withUserConfiguration(McpGatewayConfiguration.class);
 
     final List<Class<?>> mockBeans = new ArrayList<>();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -944,6 +944,7 @@ public class RequestMapper {
                     validateCreateProcessInstanceRequest(request)
                         .map(Either::<ProblemDetail, String>left)
                         .orElseGet(() -> Either.right(tenant)));
+
     return validationResponse.map(
         tenantId ->
             new ProcessInstanceCreateRequest(
@@ -982,7 +983,13 @@ public class RequestMapper {
   public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
       final ProcessInstanceCreationInstructionByKey request, final boolean multiTenancyEnabled) {
     final Either<ProblemDetail, String> validationResponse =
-        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance");
+        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
+            .flatMap(
+                tenant ->
+                    validateCreateProcessInstanceRequest(request)
+                        .map(Either::<ProblemDetail, String>left)
+                        .orElseGet(() -> Either.right(tenant)));
+
     return validationResponse.map(
         tenantId ->
             new ProcessInstanceCreateRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
@@ -40,8 +40,7 @@ public class SimpleRequestMapper {
                   .startInstructions(
                       mapCreateProcessInstanceStartInstructions(request.getStartInstructions()))
                   .runtimeInstructions(
-                      mapCreateProcessInstanceRuntimeInstructions(
-                          request.getRuntimeInstructions()))
+                      mapCreateProcessInstanceRuntimeInstructions(request.getRuntimeInstructions()))
                   .awaitCompletion(request.getAwaitCompletion())
                   .fetchVariables(request.getFetchVariables())
                   .requestTimeout(request.getRequestTimeout())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http;
+
+import io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionByKey;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationStartInstruction;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.springframework.http.ProblemDetail;
+
+public class SimpleRequestMapper {
+
+  public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
+      final io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction request,
+      final boolean multiTenancyEnabled) {
+    final var validationError =
+        ProcessInstanceRequestValidator.validateSimpleCreateProcessInstanceRequest(request);
+    if (validationError.isPresent()) {
+      return Either.left(validationError.get());
+    }
+
+    if (request.getProcessDefinitionId() != null && !request.getProcessDefinitionId().isBlank()) {
+      return RequestMapper.toCreateProcessInstance(
+          (ProcessInstanceCreationInstruction)
+              new ProcessInstanceCreationInstructionById()
+                  .processDefinitionId(request.getProcessDefinitionId())
+                  .processDefinitionVersion(request.getProcessDefinitionVersion())
+                  .variables(request.getVariables())
+                  .tenantId(request.getTenantId())
+                  .operationReference(request.getOperationReference())
+                  .startInstructions(
+                      mapCreateProcessInstanceStartInstructions(request.getStartInstructions()))
+                  .runtimeInstructions(
+                      mapCreateProcessInstanceRuntimeInstructions(
+                          request.getRuntimeInstructions()))
+                  .awaitCompletion(request.getAwaitCompletion())
+                  .fetchVariables(request.getFetchVariables())
+                  .requestTimeout(request.getRequestTimeout())
+                  .tags(request.getTags()),
+          multiTenancyEnabled);
+    }
+
+    return RequestMapper.toCreateProcessInstance(
+        (ProcessInstanceCreationInstruction)
+            new ProcessInstanceCreationInstructionByKey()
+                .processDefinitionKey(request.getProcessDefinitionKey())
+                .variables(request.getVariables())
+                .startInstructions(
+                    mapCreateProcessInstanceStartInstructions(request.getStartInstructions()))
+                .runtimeInstructions(
+                    mapCreateProcessInstanceRuntimeInstructions(request.getRuntimeInstructions()))
+                .tenantId(request.getTenantId())
+                .operationReference(request.getOperationReference())
+                .awaitCompletion(request.getAwaitCompletion())
+                .requestTimeout(request.getRequestTimeout())
+                .fetchVariables(request.getFetchVariables())
+                .tags(request.getTags()),
+        multiTenancyEnabled);
+  }
+
+  private static List<ProcessInstanceCreationStartInstruction>
+      mapCreateProcessInstanceStartInstructions(
+          final List<
+                  io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationStartInstruction>
+              instructions) {
+    if (instructions == null) {
+      return List.of();
+    }
+    return instructions.stream()
+        .map(
+            instruction -> {
+              final var mapped =
+                  new io.camunda.gateway.protocol.model.ProcessInstanceCreationStartInstruction();
+              mapped.setElementId(instruction.getElementId());
+              return mapped;
+            })
+        .toList();
+  }
+
+  private static List<io.camunda.gateway.protocol.model.ProcessInstanceCreationTerminateInstruction>
+      mapCreateProcessInstanceRuntimeInstructions(
+          final List<
+                  io.camunda.gateway.protocol.model.simple
+                      .ProcessInstanceCreationTerminateInstruction>
+              instructions) {
+    if (instructions == null) {
+      return List.of();
+    }
+    return instructions.stream()
+        .map(
+            instruction -> {
+              final var mapped =
+                  new io.camunda.gateway.protocol.model
+                      .ProcessInstanceCreationTerminateInstruction();
+              mapped.setType(instruction.getType());
+              mapped.setAfterElementId(instruction.getAfterElementId());
+              return mapped;
+            })
+        .toList();
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction;
+import io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationStartInstruction;
+import io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationTerminateInstruction;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+class SimpleRequestMapperTest {
+
+  @Nested
+  class ProcessInstanceCreation {
+
+    @Test
+    void shouldRejectWhenNeitherIdNorKeyIsSet() {
+      // given
+      final var request = new ProcessInstanceCreationInstruction();
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail())
+          .isEqualTo("At least one of [processDefinitionId, processDefinitionKey] is required.");
+    }
+
+    @Test
+    void shouldRejectWhenBothIdAndKeyAreSet() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionId("process-id")
+              .processDefinitionKey("123");
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail())
+          .isEqualTo("Only one of [processDefinitionId, processDefinitionKey] is allowed.");
+    }
+
+    @Test
+    void shouldRejectVersionWhenUsingKey() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("123")
+              .processDefinitionVersion(1);
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail())
+          .isEqualTo("processDefinitionVersion can only be set when using processDefinitionId.");
+    }
+
+    @Test
+    void shouldValidateProcessDefinitionKeyFormat() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("abc")
+              .tenantId("<default>")
+              .awaitCompletion(false);
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail())
+          .isEqualTo(
+              "The provided processDefinitionKey 'abc' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.");
+    }
+
+    @Test
+    void shouldMapByKeyAndRunMultiTenancyValidation() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("123")
+              .tenantId("tenant-a")
+              .startInstructions(
+                  List.of(new ProcessInstanceCreationStartInstruction().elementId("start-element")))
+              .runtimeInstructions(
+                  List.of(
+                      new ProcessInstanceCreationTerminateInstruction()
+                          .type("TERMINATE_PROCESS_INSTANCE")
+                          .afterElementId("after-element")));
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      assertThat(result.getLeft().getStatus()).isEqualTo(400);
+      assertThat(result.getLeft().getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(result.getLeft().getDetail())
+          .isEqualTo(
+              "Expected to handle request Create Process Instance with tenant identifier 'tenant-a', but multi-tenancy is disabled");
+    }
+
+    @Test
+    void shouldMapById() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionId("process-id")
+              .processDefinitionVersion(2);
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mapped = result.get();
+      assertThat(mapped.bpmnProcessId()).isEqualTo("process-id");
+      assertThat(mapped.version()).isEqualTo(2);
+      assertThat(mapped.processDefinitionKey()).isEqualTo(-1L);
+    }
+
+    @Test
+    void shouldMapInstructions() {
+      // given
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("123")
+              .startInstructions(
+                  List.of(new ProcessInstanceCreationStartInstruction().elementId("start-element")))
+              .runtimeInstructions(
+                  List.of(
+                      new ProcessInstanceCreationTerminateInstruction()
+                          .type("TERMINATE_PROCESS_INSTANCE")
+                          .afterElementId("after-element")));
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mapped = result.get();
+      assertThat(mapped.processDefinitionKey()).isEqualTo(123L);
+      assertThat(mapped.startInstructions())
+          .hasSize(1)
+          .first()
+          .satisfies(i -> assertThat(i.getElementId()).isEqualTo("start-element"));
+      assertThat(mapped.runtimeInstructions())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              i -> {
+                assertThat(i.getAfterElementId()).isEqualTo("after-element");
+              });
+    }
+  }
+}

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -155,6 +155,11 @@
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -149,7 +149,7 @@ public class ProcessInstanceTools {
           final List<@NotBlank String> fetchVariables,
       @McpToolParam(
               description =
-                  "List of tags to apply to the process instance. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
+                  "List of tags to apply to the process instance. Tags must start with a letter, followed by letters, digits, or the special characters `_`, `-`, `:`, or `.`; length ≤ 100.",
               required = false)
           final Set<
                   @Pattern(regexp = "^[A-Za-z][A-Za-z0-9_\\-:.]{0,99}$") @Size(min = 1, max = 100)

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -13,6 +13,8 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 
+import io.camunda.gateway.mapping.http.ResponseMapper;
+import io.camunda.gateway.mapping.http.SimpleRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
@@ -20,10 +22,13 @@ import io.camunda.gateway.mcp.model.McpProcessInstanceFilter;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQuerySortRequest;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
@@ -35,12 +40,15 @@ import org.springframework.validation.annotation.Validated;
 public class ProcessInstanceTools {
 
   private final ProcessInstanceServices processInstanceServices;
+  private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
 
   public ProcessInstanceTools(
       final ProcessInstanceServices processInstanceServices,
+      final MultiTenancyConfiguration multiTenancyCfg,
       final CamundaAuthenticationProvider authenticationProvider) {
     this.processInstanceServices = processInstanceServices;
+    this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
   }
 
@@ -85,6 +93,108 @@ public class ProcessInstanceTools {
               processInstanceServices
                   .withAuthentication(authenticationProvider.getCamundaAuthentication())
                   .getByKey(processInstanceKey)));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(description = "Create process instance.")
+  public CallToolResult createProcessInstance(
+      @McpToolParam(
+              description =
+                  "The unique key identifying the process definition, for example, returned for a process in the deploy resources endpoint. ",
+              required = false)
+          final String processDefinitionKey,
+      @McpToolParam(
+              description =
+                  "The BPMN process id of the process definition to start an instance of. ",
+              required = false)
+          final String processDefinitionId,
+      @McpToolParam(
+              description =
+                  "The version of the process. By default, the latest version of the process is used. ",
+              required = false)
+          final Integer processDefinitionVersion,
+      @McpToolParam(
+              description =
+                  "JSON object that will instantiate the variables for the root variable scope of the process instance. ",
+              required = false)
+          final Map<String, Object> variables,
+      @McpToolParam(
+              description =
+                  "Wait for the process instance to complete. If the process instance completion does not occur within the requestTimeout, the request will be closed. This can lead to a 504 response status. Disabled by default. ",
+              required = false)
+          final Boolean awaitCompletion,
+      @McpToolParam(
+              description =
+                  "Timeout (in ms) the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied. ",
+              required = false)
+          final Long requestTimeout,
+      @McpToolParam(
+              description =
+                  "List of variables by name to be included in the response when awaitCompletion is set to true. If empty, all visible variables in the root scope will be returned. ",
+              required = false)
+          final List<String> fetchVariables,
+      @McpToolParam(
+              description =
+                  "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
+              required = false)
+          final Set<String> tags) {
+    try {
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var tenantId =
+          authentication.authenticatedTenantIds() == null
+                  || authentication.authenticatedTenantIds().isEmpty()
+              ? null
+              : authentication.authenticatedTenantIds().getFirst();
+
+      final var instruction =
+          new io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction()
+              .processDefinitionKey(processDefinitionKey)
+              .processDefinitionId(processDefinitionId)
+              .tenantId(tenantId);
+
+      if (processDefinitionVersion != null) {
+        instruction.processDefinitionVersion(processDefinitionVersion);
+      }
+      if (variables != null) {
+        instruction.variables(variables);
+      }
+
+      if (awaitCompletion != null) {
+        instruction.awaitCompletion(awaitCompletion);
+      }
+
+      if (requestTimeout != null) {
+        instruction.requestTimeout(requestTimeout);
+      }
+
+      if (fetchVariables != null) {
+        instruction.fetchVariables(fetchVariables);
+      }
+
+      if (tags != null) {
+        instruction.tags(tags);
+      }
+
+      final var request =
+          SimpleRequestMapper.toCreateProcessInstance(
+              instruction, multiTenancyCfg.isChecksEnabled());
+      if (request.isLeft()) {
+        return CallToolResultMapper.mapProblemToResult(request.getLeft());
+      }
+
+      final var svc = processInstanceServices.withAuthentication(authentication);
+
+      if (Boolean.TRUE.equals(awaitCompletion)) {
+        return CallToolResultMapper.from(
+            svc.createProcessInstanceWithResult(request.get()),
+            ResponseMapper::toCreateProcessInstanceWithResultResponse);
+      }
+
+      return CallToolResultMapper.from(
+          svc.createProcessInstance(request.get()),
+          ResponseMapper::toCreateProcessInstanceResponse);
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -327,7 +327,6 @@ class ProcessInstanceToolsTest extends ToolsTest {
       assertThat(capturedRequest.tenantId()).isEqualTo("<default>");
       assertThat(capturedRequest.variables()).containsExactly(entry("foo", "bar"));
       assertThat(capturedRequest.tags()).containsExactly("mcp-tool:abc");
-      assertThat(capturedRequest.variables()).containsEntry("foo", "bar");
 
       final var actualResult =
           objectMapper.convertValue(result.structuredContent(), CreateProcessInstanceResult.class);

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -29,6 +29,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
@@ -80,6 +81,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
           .build();
 
   @MockitoBean private ProcessInstanceServices processInstanceServices;
+  @MockitoBean private MultiTenancyConfiguration multiTenancyConfiguration;
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mcp.tool.process.instance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mcp.tool.ToolsTest;
+import io.camunda.gateway.protocol.model.CreateProcessInstanceResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceResult;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
@@ -31,8 +33,12 @@ import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -40,7 +46,10 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -86,181 +95,408 @@ class ProcessInstanceToolsTest extends ToolsTest {
   @Autowired private ObjectMapper objectMapper;
 
   @Captor private ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
+  @Captor private ArgumentCaptor<ProcessInstanceCreateRequest> createRequestCaptor;
 
   @BeforeEach
   void mockApiServices() {
     mockApiServiceAuthentication(processInstanceServices);
   }
 
-  @Test
-  void shouldGetProcessInstanceByKey() {
-    // given
-    when(processInstanceServices.getByKey(any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+  @Nested
+  class GetProcessInstance {
 
-    // when
-    final CallToolResult result =
-        mcpClient.callTool(
-            CallToolRequest.builder()
-                .name("getProcessInstance")
-                .arguments(Map.of("processInstanceKey", 123L))
-                .build());
+    @Test
+    void shouldGetProcessInstanceByKey() {
+      // given
+      when(processInstanceServices.getByKey(any())).thenReturn(PROCESS_INSTANCE_ENTITY);
 
-    // then
-    assertThat(result.isError()).isFalse();
-    assertThat(result.structuredContent()).isNotNull();
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessInstance")
+                  .arguments(Map.of("processInstanceKey", 123L))
+                  .build());
 
-    final var processInstance =
-        objectMapper.convertValue(result.structuredContent(), ProcessInstanceResult.class);
-    assertThat(processInstance)
-        .usingRecursiveComparison()
-        .isEqualTo(SearchQueryResponseMapper.toProcessInstance(PROCESS_INSTANCE_ENTITY));
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
 
-    verify(processInstanceServices).getByKey(123L);
+      final var processInstance =
+          objectMapper.convertValue(result.structuredContent(), ProcessInstanceResult.class);
+      assertThat(processInstance)
+          .usingRecursiveComparison()
+          .isEqualTo(SearchQueryResponseMapper.toProcessInstance(PROCESS_INSTANCE_ENTITY));
+
+      verify(processInstanceServices).getByKey(123L);
+    }
+
+    @Test
+    void shouldFailGetProcessInstanceByKeyOnException() {
+      // given
+      when(processInstanceServices.getByKey(any()))
+          .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessInstance")
+                  .arguments(Map.of("processInstanceKey", 123L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.content()).isEmpty();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void shouldFailGetProcessInstanceByKeyOnInvalidKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessInstance")
+                  .arguments(Map.of("processInstanceKey", -3L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .contains("Process instance key must be a positive number."));
+    }
   }
 
-  @Test
-  void shouldFailGetProcessInstanceByKeyOnException() {
-    // given
-    when(processInstanceServices.getByKey(any()))
-        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+  @Nested
+  class SearchProcessInstances {
 
-    // when
-    final CallToolResult result =
-        mcpClient.callTool(
-            CallToolRequest.builder()
-                .name("getProcessInstance")
-                .arguments(Map.of("processInstanceKey", 123L))
-                .build());
+    @Test
+    void shouldSearchProcessInstancesWithFilterSortAndPaging() {
+      // given
+      when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+          .thenReturn(SEARCH_QUERY_RESULT);
 
-    // then
-    assertThat(result.isError()).isTrue();
-    assertThat(result.content()).isEmpty();
-    assertThat(result.structuredContent()).isNotNull();
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessInstances")
+                  .arguments(
+                      Map.of(
+                          "filter",
+                          Map.of(
+                              "state",
+                              "ACTIVE",
+                              "startDate",
+                              Map.of("from", "2024-01-01T00:00:00Z", "to", "2024-02-01T00:00:00Z"),
+                              "processDefinitionId",
+                              "demoProcess",
+                              "processDefinitionVersion",
+                              5,
+                              "tags",
+                              List.of("tag1"),
+                              "variables",
+                              List.of(Map.of("name", "orderId", "value", "123"))),
+                          "sort",
+                          List.of(Map.of("field", "processInstanceKey", "order", "DESC")),
+                          "page",
+                          Map.of("limit", 25, "after", "WzEwMjRd")))
+                  .build());
 
-    final var problemDetail =
-        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
-    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
-    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+      // then
+      assertThat(result.isError()).isFalse();
+
+      verify(processInstanceServices).search(queryCaptor.capture());
+      final ProcessInstanceQuery capturedQuery = queryCaptor.getValue();
+
+      final ProcessInstanceFilter filter = capturedQuery.filter();
+      assertThat(filter.stateOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "ACTIVE"));
+
+      assertThat(filter.processDefinitionIdOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "demoProcess"));
+
+      assertThat(filter.processDefinitionVersionOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, 5));
+
+      assertThat(filter.startDateOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(
+              tuple(Operator.GREATER_THAN_EQUALS, OffsetDateTime.parse("2024-01-01T00:00:00Z")),
+              tuple(Operator.LOWER_THAN, OffsetDateTime.parse("2024-02-01T00:00:00Z")));
+
+      assertThat(filter.tags()).containsExactly("tag1");
+
+      assertThat(filter.variableFilters()).hasSize(1);
+      final VariableValueFilter variableFilter = filter.variableFilters().getFirst();
+      assertThat(variableFilter.name()).isEqualTo("orderId");
+      assertThat(variableFilter.valueOperations())
+          .extracting(UntypedOperation::operator, UntypedOperation::value)
+          .containsExactly(tuple(Operator.EQUALS, 123L));
+
+      assertThat(capturedQuery.sort().orderings())
+          .extracting(FieldSorting::field, FieldSorting::order)
+          .containsExactly(tuple("processInstanceKey", SortOrder.DESC));
+
+      assertThat(capturedQuery.page().size()).isEqualTo(25);
+      assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+    }
+
+    @Test
+    void shouldFailSearchProcessInstancesOnException() {
+      // given
+      when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+          .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("searchProcessInstances").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.content()).isEmpty();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+    }
   }
 
-  @Test
-  void shouldFailGetProcessInstanceByKeyOnInvalidKey() {
-    // when
-    final CallToolResult result =
-        mcpClient.callTool(
-            CallToolRequest.builder()
-                .name("getProcessInstance")
-                .arguments(Map.of("processInstanceKey", -3L))
-                .build());
+  @Nested
+  class CreateProcessInstance {
 
-    // then
-    assertThat(result.isError()).isTrue();
-    assertThat(result.structuredContent()).isNull();
-    assertThat(result.content())
-        .hasSize(1)
-        .first()
-        .isInstanceOfSatisfying(
-            TextContent.class,
-            textContent ->
-                assertThat(textContent.text())
-                    .contains("Process instance key must be a positive number."));
-  }
+    @Test
+    void shouldCreateProcessInstanceByKey() {
+      // given
+      when(multiTenancyConfiguration.isChecksEnabled()).thenReturn(false);
 
-  @Test
-  void shouldSearchProcessInstancesWithFilterSortAndPaging() {
-    // given
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
-        .thenReturn(SEARCH_QUERY_RESULT);
+      final var createResponse =
+          new ProcessInstanceCreationRecord()
+              .setProcessDefinitionKey(123L)
+              .setBpmnProcessId("testProcessId")
+              .setVersion(-1)
+              .setProcessInstanceKey(456L)
+              .setTenantId("<default>")
+              .setTags(Set.of());
 
-    // when
-    final CallToolResult result =
-        mcpClient.callTool(
-            CallToolRequest.builder()
-                .name("searchProcessInstances")
-                .arguments(
-                    Map.of(
-                        "filter",
-                        Map.of(
-                            "state",
-                            "ACTIVE",
-                            "startDate",
-                            Map.of("from", "2024-01-01T00:00:00Z", "to", "2024-02-01T00:00:00Z"),
-                            "processDefinitionId",
-                            "demoProcess",
-                            "processDefinitionVersion",
-                            5,
-                            "tags",
-                            List.of("tag1"),
-                            "variables",
-                            List.of(Map.of("name", "orderId", "value", "123"))),
-                        "sort",
-                        List.of(Map.of("field", "processInstanceKey", "order", "DESC")),
-                        "page",
-                        Map.of("limit", 25, "after", "WzEwMjRd")))
-                .build());
+      when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+          .thenReturn(CompletableFuture.completedFuture(createResponse));
 
-    // then
-    assertThat(result.isError()).isFalse();
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("createProcessInstance")
+                  .arguments(
+                      Map.of(
+                          "processDefinitionKey",
+                          "123",
+                          "variables",
+                          Map.of("foo", "bar"),
+                          "tags",
+                          Set.of("mcp-tool:abc")))
+                  .build());
 
-    verify(processInstanceServices).search(queryCaptor.capture());
-    final ProcessInstanceQuery capturedQuery = queryCaptor.getValue();
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
 
-    final ProcessInstanceFilter filter = capturedQuery.filter();
-    assertThat(filter.stateOperations())
-        .extracting(Operation::operator, Operation::value)
-        .containsExactly(tuple(Operator.EQUALS, "ACTIVE"));
+      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+      final var capturedRequest = createRequestCaptor.getValue();
+      assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
+      assertThat(capturedRequest.tenantId()).isEqualTo("<default>");
+      assertThat(capturedRequest.variables()).containsExactly(entry("foo", "bar"));
+      assertThat(capturedRequest.tags()).containsExactly("mcp-tool:abc");
+      assertThat(capturedRequest.variables()).containsEntry("foo", "bar");
 
-    assertThat(filter.processDefinitionIdOperations())
-        .extracting(Operation::operator, Operation::value)
-        .containsExactly(tuple(Operator.EQUALS, "demoProcess"));
+      final var actualResult =
+          objectMapper.convertValue(result.structuredContent(), CreateProcessInstanceResult.class);
+      assertThat(actualResult.getProcessDefinitionKey()).isEqualTo("123");
+      assertThat(actualResult.getProcessDefinitionId()).isEqualTo("testProcessId");
+      assertThat(actualResult.getProcessDefinitionVersion()).isEqualTo(-1);
+      assertThat(actualResult.getProcessInstanceKey()).isEqualTo("456");
+      assertThat(actualResult.getTenantId()).isEqualTo("<default>");
+      assertThat(actualResult.getVariables()).isEmpty();
+      assertThat(actualResult.getTags()).isEmpty();
+    }
 
-    assertThat(filter.processDefinitionVersionOperations())
-        .extracting(Operation::operator, Operation::value)
-        .containsExactly(tuple(Operator.EQUALS, 5));
+    @Test
+    void shouldCreateProcessInstanceById() {
+      // given
+      when(multiTenancyConfiguration.isChecksEnabled()).thenReturn(false);
 
-    assertThat(filter.startDateOperations())
-        .extracting(Operation::operator, Operation::value)
-        .containsExactly(
-            tuple(Operator.GREATER_THAN_EQUALS, OffsetDateTime.parse("2024-01-01T00:00:00Z")),
-            tuple(Operator.LOWER_THAN, OffsetDateTime.parse("2024-02-01T00:00:00Z")));
+      final var createResponse =
+          new ProcessInstanceCreationRecord()
+              .setProcessDefinitionKey(123L)
+              .setBpmnProcessId("testProcessId")
+              .setVersion(7)
+              .setProcessInstanceKey(456L)
+              .setTenantId("<default>")
+              .setTags(Set.of("mcp-tool:abc"));
 
-    assertThat(filter.tags()).containsExactly("tag1");
+      when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+          .thenReturn(CompletableFuture.completedFuture(createResponse));
 
-    assertThat(filter.variableFilters()).hasSize(1);
-    final VariableValueFilter variableFilter = filter.variableFilters().getFirst();
-    assertThat(variableFilter.name()).isEqualTo("orderId");
-    assertThat(variableFilter.valueOperations())
-        .extracting(UntypedOperation::operator, UntypedOperation::value)
-        .containsExactly(tuple(Operator.EQUALS, 123L));
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("createProcessInstance")
+                  .arguments(
+                      Map.of(
+                          "processDefinitionId",
+                          "testProcessId",
+                          "processDefinitionVersion",
+                          7,
+                          "variables",
+                          Map.of("foo", "bar"),
+                          "tags",
+                          Set.of("mcp-tool:abc")))
+                  .build());
 
-    assertThat(capturedQuery.sort().orderings())
-        .extracting(FieldSorting::field, FieldSorting::order)
-        .containsExactly(tuple("processInstanceKey", SortOrder.DESC));
+      // then
+      assertThat(result.isError()).isFalse();
 
-    assertThat(capturedQuery.page().size()).isEqualTo(25);
-    assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
-  }
+      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+      final var capturedRequest = createRequestCaptor.getValue();
+      assertThat(capturedRequest.bpmnProcessId()).contains("testProcessId");
+      assertThat(capturedRequest.version()).isEqualTo(7);
+      assertThat(capturedRequest.tenantId()).isEqualTo("<default>");
+      assertThat(capturedRequest.variables()).containsExactly(entry("foo", "bar"));
+      assertThat(capturedRequest.awaitCompletion()).isFalse();
+      assertThat(capturedRequest.tags()).containsExactly("mcp-tool:abc");
 
-  @Test
-  void shouldFailSearchProcessInstancesOnException() {
-    // given
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
-        .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+      final var actualResult =
+          objectMapper.convertValue(result.structuredContent(), CreateProcessInstanceResult.class);
+      assertThat(actualResult.getProcessDefinitionKey()).isEqualTo("123");
+      assertThat(actualResult.getProcessDefinitionId()).isEqualTo("testProcessId");
+      assertThat(actualResult.getProcessDefinitionVersion()).isEqualTo(7);
+      assertThat(actualResult.getProcessInstanceKey()).isEqualTo("456");
+      assertThat(actualResult.getTenantId()).isEqualTo("<default>");
+      assertThat(actualResult.getVariables()).isEmpty();
+      assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+    }
 
-    // when
-    final CallToolResult result =
-        mcpClient.callTool(
-            CallToolRequest.builder().name("searchProcessInstances").arguments(Map.of()).build());
+    @Test
+    void shouldCreateProcessInstanceWithAwaitCompletionAndFetchVariables() {
+      // given
+      when(multiTenancyConfiguration.isChecksEnabled()).thenReturn(false);
 
-    // then
-    assertThat(result.isError()).isTrue();
-    assertThat(result.content()).isEmpty();
+      final var variables = Map.of("foo", "bar", "nested", Map.of("x", 1));
+      final var createResponse =
+          new ProcessInstanceResultRecord()
+              .setProcessDefinitionKey(123L)
+              .setBpmnProcessId("testProcessId")
+              .setVersion(7)
+              .setProcessInstanceKey(456L)
+              .setTenantId("<default>")
+              .setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)))
+              .setTags(Set.of("mcp-tool:abc"));
 
-    final var problemDetail =
-        objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
-    assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
-    assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+      when(processInstanceServices.createProcessInstanceWithResult(
+              any(ProcessInstanceCreateRequest.class)))
+          .thenReturn(CompletableFuture.completedFuture(createResponse));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("createProcessInstance")
+                  .arguments(
+                      Map.of(
+                          "processDefinitionId",
+                          "testProcessId",
+                          "processDefinitionVersion",
+                          7,
+                          "variables",
+                          variables,
+                          "awaitCompletion",
+                          true,
+                          "fetchVariables",
+                          List.of("foo"),
+                          "tags",
+                          Set.of("mcp-tool:abc")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+
+      verify(processInstanceServices)
+          .createProcessInstanceWithResult(createRequestCaptor.capture());
+      final var capturedRequest = createRequestCaptor.getValue();
+      assertThat(capturedRequest.awaitCompletion()).isTrue();
+      assertThat(capturedRequest.fetchVariables()).containsExactly("foo");
+
+      final var actualResult =
+          objectMapper.convertValue(result.structuredContent(), CreateProcessInstanceResult.class);
+      assertThat(actualResult.getProcessDefinitionKey()).isEqualTo("123");
+      assertThat(actualResult.getProcessDefinitionId()).isEqualTo("testProcessId");
+      assertThat(actualResult.getProcessDefinitionVersion()).isEqualTo(7);
+      assertThat(actualResult.getProcessInstanceKey()).isEqualTo("456");
+      assertThat(actualResult.getTenantId()).isEqualTo("<default>");
+      assertThat(actualResult.getVariables())
+          .containsExactly(entry("foo", "bar"), entry("nested", Map.of("x", 1)));
+      assertThat(actualResult.getTags()).containsExactly("mcp-tool:abc");
+    }
+
+    @Test
+    void shouldFailCreateProcessInstanceWhenNoDefinitionProvided() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("createProcessInstance").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail())
+          .contains("At least one of [processDefinitionId, processDefinitionKey] is required");
+    }
+
+    @Test
+    void shouldFailCreateProcessInstanceWhenBothDefinitionKeyAndIdProvided() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("createProcessInstance")
+                  .arguments(
+                      Map.of("processDefinitionKey", "123", "processDefinitionId", "testProcessId"))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("INVALID_ARGUMENT");
+      assertThat(problemDetail.getDetail())
+          .contains("Only one of [processDefinitionId, processDefinitionKey] is allowed");
+    }
   }
 }


### PR DESCRIPTION
## Description

Implements a `createProcessInstance` MCP tool, allowing to start an instance with/without await completion.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44395 
