### PR TITLE
feat: Enforce user task PROPERTY-based permissions (search layer)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -79,13 +79,13 @@ class UserTaskAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(AUTHORIZATION, CREATE, List.of("*")),
-              new Permissions(AUTHORIZATION, READ, List.of("*")),
-              new Permissions(RESOURCE, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
+              Permissions.withWildcard(AUTHORIZATION, CREATE),
+              Permissions.withWildcard(AUTHORIZATION, READ),
+              Permissions.withWildcard(RESOURCE, CREATE),
+              Permissions.withWildcard(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE),
+              Permissions.withWildcard(PROCESS_DEFINITION, READ_PROCESS_DEFINITION),
+              Permissions.withWildcard(PROCESS_DEFINITION, READ_PROCESS_INSTANCE),
+              Permissions.withWildcard(PROCESS_DEFINITION, READ_USER_TASK)));
 
   @UserDefinition
   private static final TestUser USER_WITHOUT_PERMISSIONS_USER =
@@ -96,21 +96,21 @@ class UserTaskAuthorizationIT {
       new TestUser(
           USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_1,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_1))));
+          List.of(Permissions.withResourceId(PROCESS_DEFINITION, READ_USER_TASK, PROCESS_ID_1)));
 
   @UserDefinition
   private static final TestUser USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2_USER =
       new TestUser(
           USER_WITH_PROCESS_DEF_READ_USER_TASK_PROCESS_2,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_2))));
+          List.of(Permissions.withResourceId(PROCESS_DEFINITION, READ_USER_TASK, PROCESS_ID_2)));
 
   @UserDefinition
   private static final TestUser USER_WITH_USER_TASK_READ_WILDCARD_USER =
       new TestUser(
           USER_WITH_USER_TASK_READ_WILDCARD,
           "password",
-          List.of(new Permissions(USER_TASK, READ, List.of("*"))));
+          List.of(Permissions.withWildcard(USER_TASK, READ)));
 
   @UserDefinition
   private static final TestUser USER_WITH_USER_TASK_READ_PROCESS_1_FIRST_TASK_USER =

--- a/qa/acceptance-tests/src/test/resources/process/bpm_variable_test.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/bpm_variable_test.bpmn
@@ -14,6 +14,7 @@
         <zeebe:ioMapping>
           <zeebe:input source="=1" target="task02" />
         </zeebe:ioMapping>
+        <zeebe:assignmentDefinition candidateUsers="bob, userCandidateUser, simon" />
         <zeebe:userTask />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1ffbwjw</bpmn:incoming>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_form.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_form.bpmn
@@ -7,6 +7,7 @@
     <bpmn:userTask id="form_process" name="Form">
       <bpmn:extensionElements>
         <zeebe:formDefinition formId="test" />
+        <zeebe:assignmentDefinition assignee="userAssignee" candidateGroups="finance, candidateGroup, hr" />
         <zeebe:userTask />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_07v18s2</bpmn:incoming>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_form.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_form.bpmn
@@ -7,7 +7,7 @@
     <bpmn:userTask id="form_process" name="Form">
       <bpmn:extensionElements>
         <zeebe:formDefinition formId="test" />
-        <zeebe:assignmentDefinition assignee="userAssignee" candidateGroups="finance, candidateGroup, hr" />
+        <zeebe:assignmentDefinition assignee="userAssignee" candidateUsers="userWithoutPermissions" candidateGroups="finance, candidateGroup, hr" />
         <zeebe:userTask />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_07v18s2</bpmn:incoming>

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/Permissions.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/Permissions.java
@@ -58,6 +58,34 @@ public final class Permissions {
   }
 
   /**
+   * Creates a permission with a single resource ID.
+   *
+   * @param resourceType the resource type
+   * @param permissionType the permission type
+   * @param resourceId the resource ID
+   * @return a new Permissions instance with the specified resource ID
+   */
+  public static Permissions withResourceId(
+      final ResourceType resourceType,
+      final PermissionType permissionType,
+      final String resourceId) {
+    return Permissions.forResource(resourceType, permissionType).withResourceId(resourceId).build();
+  }
+
+  /**
+   * Creates a permission with wildcard resource ID (*) only for granting access to all resources of
+   * the specified type.
+   *
+   * @param resourceType the resource type
+   * @param permissionType the permission type
+   * @return a new Permissions instance with wildcard resource ID
+   */
+  public static Permissions withWildcard(
+      final ResourceType resourceType, final PermissionType permissionType) {
+    return withResourceId(resourceType, permissionType, "*");
+  }
+
+  /**
    * Creates a permission with a single property name.
    *
    * @param resourceType the resource type
@@ -104,6 +132,15 @@ public final class Permissions {
     public Builder withResourceIds(final List<String> resourceIds) {
       this.resourceIds.addAll(resourceIds);
       return this;
+    }
+
+    /**
+     * Adds wildcard resource ID (*) to grant access to all resources of the specified type.
+     *
+     * @return this Builder for method chaining
+     */
+    public Builder withWildcard() {
+      return withResourceId("*");
     }
 
     public Builder withProperty(final String propertyName) {

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/Permissions.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/Permissions.java
@@ -9,7 +9,119 @@ package io.camunda.qa.util.auth;
 
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import java.util.ArrayList;
 import java.util.List;
 
-public record Permissions(
-    ResourceType resourceType, PermissionType permissionType, List<String> resourceIds) {}
+public final class Permissions {
+
+  private final ResourceType resourceType;
+  private final PermissionType permissionType;
+  private final List<String> resourceIds;
+  private final List<String> resourcePropertyNames;
+
+  /** Constructor for backward compatibility - creates permissions with resource IDs only. */
+  public Permissions(
+      final ResourceType resourceType,
+      final PermissionType permissionType,
+      final List<String> resourceIds) {
+    this(resourceType, permissionType, resourceIds, null);
+  }
+
+  private Permissions(
+      final ResourceType resourceType,
+      final PermissionType permissionType,
+      final List<String> resourceIds,
+      final List<String> resourcePropertyNames) {
+    this.resourceType = resourceType;
+    this.permissionType = permissionType;
+    this.resourceIds = resourceIds != null ? resourceIds.stream().distinct().toList() : List.of();
+    this.resourcePropertyNames =
+        resourcePropertyNames != null
+            ? resourcePropertyNames.stream().distinct().toList()
+            : List.of();
+  }
+
+  public ResourceType resourceType() {
+    return resourceType;
+  }
+
+  public PermissionType permissionType() {
+    return permissionType;
+  }
+
+  public List<String> resourceIds() {
+    return resourceIds;
+  }
+
+  public List<String> resourcePropertyNames() {
+    return resourcePropertyNames;
+  }
+
+  /**
+   * Creates a permission with a single property name.
+   *
+   * @param resourceType the resource type
+   * @param permissionType the permission type
+   * @param propertyName the property name
+   * @return a new Permissions instance with the specified property name
+   */
+  public static Permissions withPropertyName(
+      final ResourceType resourceType,
+      final PermissionType permissionType,
+      final String propertyName) {
+    return Permissions.forResource(resourceType, permissionType).withProperty(propertyName).build();
+  }
+
+  /**
+   * Creates a builder for defining permissions with resource IDs and/or property names.
+   *
+   * @param resourceType the resource type
+   * @param permissionType the permission type
+   * @return a new Builder instance
+   */
+  public static Builder forResource(
+      final ResourceType resourceType, final PermissionType permissionType) {
+    return new Builder(resourceType, permissionType);
+  }
+
+  public static final class Builder {
+
+    private final ResourceType resourceType;
+    private final PermissionType permissionType;
+    private final List<String> resourceIds = new ArrayList<>();
+    private final List<String> resourcePropertyNames = new ArrayList<>();
+
+    private Builder(final ResourceType resourceType, final PermissionType permissionType) {
+      this.resourceType = resourceType;
+      this.permissionType = permissionType;
+    }
+
+    public Builder withResourceId(final String resourceId) {
+      resourceIds.add(resourceId);
+      return this;
+    }
+
+    public Builder withResourceIds(final List<String> resourceIds) {
+      this.resourceIds.addAll(resourceIds);
+      return this;
+    }
+
+    public Builder withProperty(final String propertyName) {
+      resourcePropertyNames.add(propertyName);
+      return this;
+    }
+
+    public Builder withProperties(final List<String> propertyNames) {
+      resourcePropertyNames.addAll(propertyNames);
+      return this;
+    }
+
+    public Permissions build() {
+      if (resourceIds.isEmpty() && resourcePropertyNames.isEmpty()) {
+        throw new IllegalStateException(
+            "At least one resourceId or resourcePropertyName must be specified");
+      }
+      return new Permissions(resourceType, permissionType, resourceIds, resourcePropertyNames);
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java
@@ -60,7 +60,7 @@ public class DefaultResourceAccessProvider implements ResourceAccessProvider {
     if (authorizationScopes.contains(WILDCARD)) {
       // no authorization check required, user can access
       // the respective resources.
-      return ResourceAccess.wildcard(authorization.with(WILDCARD.getResourceId()));
+      return ResourceAccess.wildcard(authorization.withResourceId(WILDCARD.getResourceId()));
     }
 
     final var authorizedResourceIds =

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -76,23 +76,16 @@ public record Authorization<T>(
 
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final String resourceId) {
-    return authorization.with(resourceId);
+    return authorization.withResourceId(resourceId);
   }
 
   public static <T> Authorization<T> withAuthorization(
       final Authorization<T> authorization, final Function<T, String> resourceIdSupplier) {
-    return authorization.with(resourceIdSupplier);
+    return authorization.withResourceIdSupplier(resourceIdSupplier);
   }
 
-  public Authorization<T> with(final String resourceId) {
-    return new Authorization<>(
-        resourceType(),
-        permissionType(),
-        List.of(resourceId),
-        resourceIdSupplier(),
-        resourcePropertyNames(),
-        condition(),
-        transitive());
+  public Authorization<T> withResourceId(final String resourceId) {
+    return withResourceIds(List.of(resourceId));
   }
 
   public Authorization<T> withResourceIds(final List<String> resourceIds) {
@@ -106,7 +99,7 @@ public record Authorization<T>(
         transitive());
   }
 
-  public Authorization<T> with(final Function<T, String> resourceIdSupplier) {
+  public Authorization<T> withResourceIdSupplier(final Function<T, String> resourceIdSupplier) {
     return new Authorization<>(
         resourceType(),
         permissionType(),

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -29,12 +29,12 @@ public class AuditLogServices
 
   private static final AuthorizationCondition AUDIT_LOG_AUTHORIZATIONS =
       AuthorizationConditions.anyOf(
-          AUDIT_LOG_READ_AUTHORIZATION.with(al -> al.category().name()),
+          AUDIT_LOG_READ_AUTHORIZATION.withResourceIdSupplier(al -> al.category().name()),
           AUDIT_LOG_READ_PROCESS_INSTANCE_AUTHORIZATION
-              .with(AuditLogEntity::processDefinitionId)
+              .withResourceIdSupplier(AuditLogEntity::processDefinitionId)
               .withCondition(al -> al.processDefinitionId() != null),
           AUDIT_LOG_READ_USER_TASK_AUTHORIZATION
-              .with(AuditLogEntity::processDefinitionId)
+              .withResourceIdSupplier(AuditLogEntity::processDefinitionId)
               .withCondition(
                   al ->
                       al.processDefinitionId() != null

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -13,6 +13,7 @@ import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION;
 
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
@@ -111,7 +112,9 @@ public final class UserTaskServices
         securityContextProvider.provideSecurityContext(
             authentication,
             AuthorizationConditions.anyOf(
-                PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION, USER_TASK_READ_AUTHORIZATION)));
+                PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION,
+                USER_TASK_READ_AUTHORIZATION,
+                USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION)));
   }
 
   private SearchQueryResult<UserTaskEntity> search(
@@ -208,7 +211,8 @@ public final class UserTaskServices
                                     PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION,
                                     UserTaskEntity::processDefinitionId),
                                 withAuthorization(
-                                    USER_TASK_READ_AUTHORIZATION, String.valueOf(userTaskKey)))))
+                                    USER_TASK_READ_AUTHORIZATION, String.valueOf(userTaskKey)),
+                                USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION)))
                     .getUserTask(userTaskKey));
 
     final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -10,7 +10,6 @@ package io.camunda.service;
 import static io.camunda.search.query.SearchQueryBuilders.auditLogSearchQuery;
 import static io.camunda.search.query.SearchQueryBuilders.userTaskSearchQuery;
 import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
-import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION;
@@ -28,6 +27,7 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.auth.condition.AuthorizationCondition;
 import io.camunda.security.auth.condition.AuthorizationConditions;
 import io.camunda.service.cache.ProcessCache;
 import io.camunda.service.cache.ProcessCacheItem;
@@ -55,6 +55,14 @@ public final class UserTaskServices
 
   private static final Predicate<UserTaskEntity> NEEDS_CACHE_ENRICHMENT =
       u -> !u.hasName() || !u.hasProcessName();
+
+  private static final AuthorizationCondition USER_TASK_AUTHORIZATIONS =
+      AuthorizationConditions.anyOf(
+          PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION.withResourceIdSupplier(
+              UserTaskEntity::processDefinitionId),
+          USER_TASK_READ_AUTHORIZATION.withResourceIdSupplier(
+              ut -> String.valueOf(ut.userTaskKey())),
+          USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION);
 
   private final UserTaskSearchClient userTaskSearchClient;
   private final FormServices formServices;
@@ -109,12 +117,7 @@ public final class UserTaskServices
   public SearchQueryResult<UserTaskEntity> search(final UserTaskQuery query) {
     return search(
         query,
-        securityContextProvider.provideSecurityContext(
-            authentication,
-            AuthorizationConditions.anyOf(
-                PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION,
-                USER_TASK_READ_AUTHORIZATION,
-                USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION)));
+        securityContextProvider.provideSecurityContext(authentication, USER_TASK_AUTHORIZATIONS));
   }
 
   private SearchQueryResult<UserTaskEntity> search(
@@ -205,14 +208,7 @@ public final class UserTaskServices
                 userTaskSearchClient
                     .withSecurityContext(
                         securityContextProvider.provideSecurityContext(
-                            authentication,
-                            AuthorizationConditions.anyOf(
-                                withAuthorization(
-                                    PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION,
-                                    UserTaskEntity::processDefinitionId),
-                                withAuthorization(
-                                    USER_TASK_READ_AUTHORIZATION, String.valueOf(userTaskKey)),
-                                USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION)))
+                            authentication, USER_TASK_AUTHORIZATIONS))
                     .getUserTask(userTaskKey));
 
     final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -98,6 +98,15 @@ public abstract class Authorizations {
   public static final Authorization<UserTaskEntity> USER_TASK_READ_AUTHORIZATION =
       Authorization.of(a -> a.userTask().read());
 
+  public static final Authorization<UserTaskEntity> USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION =
+      Authorization.of(
+          a ->
+              a.userTask()
+                  .read()
+                  .authorizedByAssignee()
+                  .authorizedByCandidateUsers()
+                  .authorizedByCandidateGroups());
+
   public static final Authorization<VariableEntity> VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.processDefinition().readProcessInstance());
 


### PR DESCRIPTION
## Description

This PR implements the second and final step of #41682 by enforcing `USER_TASK[READ]` PROPERTY-based permissions in addition to the existing `PROCESS_DEFINITION[READ_USER_TASK]` and `USER_TASK[READ]` ID-based permissions for user task APIs in the Search layer.

### Changes

Users can now read user tasks if they have either:
- `PROCESS_DEFINITION[READ_USER_TASK]` permission for the corresponding process definition (or wildcard `*` for all process definitions), **OR**
- `USER_TASK[READ]` permission for the specific user task key (or wildcard `*` for all user tasks), **OR**
- `USER_TASK[READ]` property-based permission matching one of the task properties: 
  - `assignee` - when the user is the task's assignee
  - `candidateUsers` - when the user is in the task's candidate users list
  - `candidateGroups` - when the user belongs to one of the task's candidate groups

This applies to the following endpoints:
- Search user tasks (`UserTaskServices.search`)
- Get user task by key (`UserTaskServices.getByKey`)

Refactoring & improvement:
- Refactored `Authorization.with(..)` methods to more descriptive names (`withResourceId(..)`, `withResourceIdSupplier(..)`)
- Extended `Permissions` test utility class from a record to a builder-pattern class supporting both `resourceIds` and `resourcePropertyNames`

### Implementation details

- Extended the `USER_TASK[READ]` authorization branch to include property-based authorization checks
- When the principal holds `matcher = PROPERTY`-scoped authorizations, the Search layer evaluates them and grants access only to matching tasks
- Extended `UserTaskAuthorizationIT` with test coverage for `USER_TASK[READ]` property-based permission checks

## Related issues

closes #41682
