### PR TITLE
feat: Add export record filter chain with short-circuit AND semantics

### DIFF
--- a/zeebe/exporter-filter/pom.xml
+++ b/zeebe/exporter-filter/pom.xml
@@ -12,4 +12,31 @@
 
   <name>Zeebe Exporter Filter</name>
 
+  <dependencies>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Applies a chain of {@link ExporterRecordFilter}s to determine whether a record should be
+ * exported.
+ *
+ * <p>Filters are evaluated in order and combined with logical AND: the first filter that returns
+ * {@code false} causes the whole chain to reject the record.
+ */
+public final class ExportRecordFilterChain {
+
+  private final List<ExporterRecordFilter> recordFilters;
+
+  public ExportRecordFilterChain(final List<ExporterRecordFilter> recordFilters) {
+    this.recordFilters =
+        List.copyOf(Objects.requireNonNull(recordFilters, "recordFilters must not be null"));
+  }
+
+  /** Returns {@code true} if the record passes all configured filters. */
+  public boolean acceptRecord(final Record<?> record) {
+    for (final ExporterRecordFilter filter : recordFilters) {
+      if (!filter.accept(record)) {
+        // First rejecting filter short-circuits the chain.
+        return false;
+      }
+    }
+
+    // No filter rejected the record.
+    return true;
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
@@ -29,14 +29,7 @@ public final class ExportRecordFilterChain {
 
   /** Returns {@code true} if the record passes all configured filters. */
   public boolean acceptRecord(final Record<?> record) {
-    for (final ExporterRecordFilter filter : recordFilters) {
-      if (!filter.accept(record)) {
-        // First rejecting filter short-circuits the chain.
-        return false;
-      }
-    }
-
-    // No filter rejected the record.
-    return true;
+    return recordFilters.stream()
+      .allMatch(filter -> filter.accept(record));
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
@@ -29,7 +29,6 @@ public final class ExportRecordFilterChain {
 
   /** Returns {@code true} if the record passes all configured filters. */
   public boolean acceptRecord(final Record<?> record) {
-    return recordFilters.stream()
-      .allMatch(filter -> filter.accept(record));
+    return recordFilters.stream().allMatch(filter -> filter.accept(record));
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExporterRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExporterRecordFilter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+
+/**
+ * A filter to determine whether a given record should be exported or not.
+ *
+ * <p>Implementations of this interface can be used to filter records based on their content,
+ * metadata, or any other criteria defined by the user.
+ */
+@FunctionalInterface
+public interface ExporterRecordFilter {
+
+  boolean accept(Record<?> record);
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChainTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChainTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.camunda.zeebe.protocol.record.Record;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ExportRecordFilterChainTest {
+
+  private final Record<?> record = mock(Record.class);
+
+  @Test
+  void shouldThrowNpeIfFilterListIsNull() {
+    // when/then
+    assertThatThrownBy(() -> new ExportRecordFilterChain(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("recordFilters must not be null");
+  }
+
+  @Test
+  void shouldAcceptWhenNoFilters() {
+    // given
+    final var chain = new ExportRecordFilterChain(Collections.emptyList());
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptWhenAllFiltersAccept() {
+    // given
+    final var filter1 = mock(ExporterRecordFilter.class);
+    final var filter2 = mock(ExporterRecordFilter.class);
+    when(filter1.accept(record)).thenReturn(true);
+    when(filter2.accept(record)).thenReturn(true);
+    final var chain = new ExportRecordFilterChain(List.of(filter1, filter2));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+    verify(filter1).accept(record);
+    verify(filter2).accept(record);
+  }
+
+  @Test
+  void shouldRejectWhenFirstFilterRejects() {
+    // given
+    final var filter1 = mock(ExporterRecordFilter.class);
+    final var filter2 = mock(ExporterRecordFilter.class);
+    when(filter1.accept(record)).thenReturn(false);
+    final var chain = new ExportRecordFilterChain(List.of(filter1, filter2));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    verify(filter1).accept(record);
+    verify(filter2, never()).accept(any());
+  }
+
+  @Test
+  void shouldRejectWhenSecondFilterRejects() {
+    // given
+    final var filter1 = mock(ExporterRecordFilter.class);
+    final var filter2 = mock(ExporterRecordFilter.class);
+    when(filter1.accept(record)).thenReturn(true);
+    when(filter2.accept(record)).thenReturn(false);
+    final var chain = new ExportRecordFilterChain(List.of(filter1, filter2));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    verify(filter1).accept(record);
+    verify(filter2).accept(record);
+  }
+}


### PR DESCRIPTION
Introduce ExportRecordFilterChain to apply a chain of ExporterRecordFilter instances to exporter records. Filters are evaluated in order and combined with logical AND semantics, short-circuiting on the first filter that rejects a record. This ensures records are only exported if they pass all configured filters and avoids unnecessary filter evaluations.


closes #
[#44408](https://github.com/camunda/camunda/issues/44408)