### PR TITLE
[Backport stable/8.6] Introduce timeout for all FEEL expression evaluations

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -21,6 +21,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private AuthorizationsCfg authorizations = new AuthorizationsCfg();
   private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
+  private ExpressionCfg expression = new ExpressionCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -30,6 +31,7 @@ public final class EngineCfg implements ConfigurationEntry {
     validators.init(globalConfig, brokerBase);
     authorizations.init(globalConfig, brokerBase);
     distribution.init(globalConfig, brokerBase);
+    expression.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -88,6 +90,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.maxProcessDepth = maxProcessDepth;
   }
 
+  public ExpressionCfg getExpression() {
+    return expression;
+  }
+
+  public void setExpression(final ExpressionCfg expression) {
+    this.expression = expression;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -105,6 +115,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + distribution
         + ", maxProcessDepth="
         + maxProcessDepth
+        + ", expression="
+        + expression
         + '}';
   }
 
@@ -122,6 +134,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setCommandRedistributionInterval(distribution.getRedistributionInterval())
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
-        .setMaxProcessDepth(getMaxProcessDepth());
+        .setMaxProcessDepth(getMaxProcessDepth())
+        .setExpressionEvaluationTimeout(expression.getTimeout());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ExpressionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ExpressionCfg.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.time.Duration;
+
+public final class ExpressionCfg implements ConfigurationEntry {
+
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(1);
+  private Duration timeout = DEFAULT_TIMEOUT;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    if (timeout == null || !timeout.isPositive()) {
+      throw new IllegalArgumentException(
+          "Expression timeout must be positive but was %s".formatted(timeout));
+    }
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
+  }
+
+  @Override
+  public String toString() {
+    return "ExpressionCfg{" + "timeout=" + timeout + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ExpressionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ExpressionCfg.java
@@ -9,12 +9,12 @@ package io.camunda.zeebe.broker.system.configuration.engine;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import java.time.Duration;
 
 public final class ExpressionCfg implements ConfigurationEntry {
 
-  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(1);
-  private Duration timeout = DEFAULT_TIMEOUT;
+  private Duration timeout = EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -46,7 +46,7 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION);
-    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
   }
 
   @Test
@@ -71,6 +71,6 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
-    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(2));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -46,6 +46,7 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION);
+    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(1));
   }
 
   @Test
@@ -70,5 +71,6 @@ final class EngineCfgTest {
     assertThat(configuration.getCommandRedistributionInterval()).isEqualTo(Duration.ofSeconds(60));
     assertThat(configuration.getCommandRedistributionMaxBackoff())
         .isEqualTo(Duration.ofMinutes(20));
+    assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -18,3 +18,5 @@ zeebe:
           redistributionInterval: 60s
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
+        expression:
+          timeout: 5s

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -19,4 +19,4 @@ zeebe:
           maxBackoffDuration: 20m
         maxProcessDepth: 2000
         expression:
-          timeout: 5s
+          timeout: 2s

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -33,7 +33,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
       Duration.ofMinutes(5);
-  public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(1);
+  public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(5);
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -33,6 +33,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
       Duration.ofMinutes(5);
+  public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(1);
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
@@ -53,6 +54,8 @@ public final class EngineConfiguration {
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
   private Duration commandRedistributionMaxBackoff =
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
+
+  private Duration expressionEvaluationTimeout = DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -174,6 +177,16 @@ public final class EngineConfiguration {
   public EngineConfiguration setCommandRedistributionMaxBackoff(
       final Duration commandRedistributionMaxBackoff) {
     this.commandRedistributionMaxBackoff = commandRedistributionMaxBackoff;
+    return this;
+  }
+
+  public Duration getExpressionEvaluationTimeout() {
+    return expressionEvaluationTimeout;
+  }
+
+  public EngineConfiguration setExpressionEvaluationTimeout(
+      final Duration expressionEvaluationTimeout) {
+    this.expressionEvaluationTimeout = expressionEvaluationTimeout;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -117,7 +117,8 @@ public final class EngineProcessors {
             jobMetrics,
             decisionBehavior,
             clock,
-            transientProcessMessageSubscriptionState);
+            transientProcessMessageSubscriptionState,
+            config);
 
     final var commandDistributionBehavior =
         new CommandDistributionBehavior(
@@ -240,7 +241,8 @@ public final class EngineProcessors {
       final JobProcessingMetrics jobMetrics,
       final DecisionBehavior decisionBehavior,
       final InstantSource clock,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final EngineConfiguration config) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -251,7 +253,8 @@ public final class EngineProcessors {
         timerChecker,
         jobStreamer,
         clock,
-        transientProcessMessageSubscriptionState);
+        transientProcessMessageSubscriptionState,
+        config);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
@@ -63,11 +64,13 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final DueDateTimerChecker timerChecker,
       final JobStreamer jobStreamer,
       final InstantSource clock,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final EngineConfiguration config) {
     expressionBehavior =
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(new ZeebeFeelEngineClock(clock)),
-            new VariableStateEvaluationContextLookup(processingState.getVariableState()));
+            new VariableStateEvaluationContextLookup(processingState.getVariableState()),
+            config.getExpressionEvaluationTimeout());
 
     variableBehavior =
         new VariableBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -471,7 +471,7 @@ public final class ExpressionProcessor {
       final var message =
           "Expected to evaluate expression '%s', but an exception was thrown"
               .formatted(expression.getExpression());
-      throw new EvaluationException(message, e);
+      throw new EvaluationException(message, e.getCause());
     }
 
     return result.isFailure()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -49,11 +49,6 @@ public final class ExpressionProcessor {
   private final Duration expressionEvaluationTimeout;
 
   public ExpressionProcessor(
-      final ExpressionLanguage expressionLanguage, final EvaluationContextLookup lookup) {
-    this(expressionLanguage, lookup, EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT);
-  }
-
-  public ExpressionProcessor(
       final ExpressionLanguage expressionLanguage,
       final EvaluationContextLookup lookup,
       final Duration expressionEvaluationTimeout) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -22,10 +22,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -34,7 +34,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ExpressionProcessor {
 
-  private static final Executor VIRTUAL_THREAD_EXECUTOR =
+  private static final ExecutorService VIRTUAL_THREAD_EXECUTOR =
       Executors.newVirtualThreadPerTaskExecutor();
   private static final List<ResultType> INTERVAL_RESULT_TYPES =
       List.of(ResultType.DURATION, ResultType.PERIOD, ResultType.STRING);
@@ -442,9 +442,8 @@ public final class ExpressionProcessor {
 
   private Either<Failure, EvaluationResult> evaluateExpressionAsEither(
       final Expression expression, final long variableScopeKey) {
-    final CompletableFuture<EvaluationResult> future =
-        CompletableFuture.supplyAsync(
-            () -> evaluateExpression(expression, variableScopeKey), VIRTUAL_THREAD_EXECUTOR);
+    final Future<EvaluationResult> future =
+        VIRTUAL_THREAD_EXECUTOR.submit(() -> evaluateExpression(expression, variableScopeKey));
 
     final EvaluationResult result;
     try {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
@@ -40,7 +41,6 @@ public final class ExpressionProcessor {
       List.of(ResultType.NULL, ResultType.DATE_TIME, ResultType.STRING);
 
   private static final EvaluationContext EMPTY_EVALUATION_CONTEXT = x -> null;
-  private static final Duration EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(1);
 
   private final DirectBuffer resultView = new UnsafeBuffer();
 
@@ -50,7 +50,7 @@ public final class ExpressionProcessor {
 
   public ExpressionProcessor(
       final ExpressionLanguage expressionLanguage, final EvaluationContextLookup lookup) {
-    this(expressionLanguage, lookup, Duration.ofSeconds(1));
+    this(expressionLanguage, lookup, EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT);
   }
 
   public ExpressionProcessor(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ScriptTaskExpressionTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
@@ -36,7 +37,15 @@ import org.junit.Test;
 
 public final class ScriptTaskExpressionTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              e -> {
+                // Set it low to speed up shouldCreateIncidentIfScriptExpressionEvaluationTimesOut
+                // But not too low to accidentally timeout during other tests
+                e.setExpressionEvaluationTimeout(Duration.ofMillis(300));
+              });
 
   private static final String PROCESS_ID = "process";
   private static final String TASK_ID = "task";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -10,14 +10,22 @@ package io.camunda.zeebe.engine.processing.common;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 
 import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
 import io.camunda.zeebe.util.Either;
+import java.time.Duration;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -221,6 +229,237 @@ class ExpressionProcessorTest {
               Expected result of the expression 'x' to be 'OBJECT', but was 'NULL'. \
               The evaluation reported the following warnings:
               [NO_VARIABLE_FOUND] No variable found with name 'x'""");
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class EvaluationErrorsTest {
+
+    /**
+     * This test case uses an expression language implementation that blocks until released. It
+     * verifies that the processor returns a Failure (left) when the evaluation times out.
+     */
+    @ParameterizedTest(name = "{1} returns Failure on timeout")
+    @MethodSource("processorEvaluationMethods")
+    void shouldReturnFailureWhenEvaluationTimesOut(
+        final ProcessorMethod evaluationMethod, final String methodName) {
+      // given
+      final var blockingEL = new FakeBlockingExpressionLanguage();
+      final var processor =
+          new ExpressionProcessor(blockingEL, DEFAULT_CONTEXT_LOOKUP, Duration.ofMillis(1));
+      final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
+
+      try {
+        // when
+        final var result = evaluationMethod.evaluate(processor, expression);
+
+        // then
+        assertThat(result)
+            .as("should return failure for %s", methodName)
+            .isLeft()
+            .extracting(Either::getLeft)
+            .extracting(Failure::getMessage)
+            .isEqualTo("Expected to evaluate expression but timed out after 1 ms: 'foo'");
+      } finally {
+        // release the blocking EL to avoid leaking threads
+        blockingEL.release();
+      }
+    }
+
+    /**
+     * This test case uses an expression language implementation that always throws a specific
+     * exception when evaluating an expression. It verifies that the processor catches this
+     * exception and rethrows it as an EvaluationException with the expected message and cause.
+     */
+    @ParameterizedTest(name = "{1} throws EvaluationException on error")
+    @MethodSource("processorEvaluationMethods")
+    void shouldThrowEvaluationExceptionWhenExceptionThrown(final ProcessorMethod evaluationMethod) {
+      // given
+      final var processor =
+          new ExpressionProcessor(
+              new FakeThrowingExpressionLanguage(new CustomException("custom failure")),
+              DEFAULT_CONTEXT_LOOKUP);
+      final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
+
+      // when & then
+      Assertions.assertThatThrownBy(() -> evaluationMethod.evaluate(processor, expression))
+          .isInstanceOf(EvaluationException.class)
+          .hasMessage("Expected to evaluate expression 'foo', but an exception was thrown")
+          .hasCauseInstanceOf(CustomException.class)
+          .hasRootCauseMessage("custom failure");
+    }
+
+    /**
+     * This test case uses an expression language implementation that blocks indefinitely when
+     * evaluating an expression. The test starts the evaluation in a separate thread, waits until
+     * the evaluation has started, then interrupts the thread and verifies that the processor
+     * responds to the interruption by throwing an EvaluationException.
+     */
+    @ParameterizedTest(name = "{1} throws EvaluationException on interruption")
+    @MethodSource("processorEvaluationMethods")
+    void shouldThrowEvaluationExceptionWhenInterrupted(
+        final ProcessorMethod evaluationMethod, final String methodName) throws Exception {
+      // given
+      final var blockingEL = new FakeBlockingExpressionLanguage();
+      final var processor = new ExpressionProcessor(blockingEL, DEFAULT_CONTEXT_LOOKUP);
+      final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
+
+      final var failure = new AtomicReference<Throwable>();
+      final var evaluationThread =
+          new Thread(
+              () -> {
+                try {
+                  evaluationMethod.evaluate(processor, expression);
+                } catch (final Throwable t) {
+                  failure.set(t);
+                }
+              },
+              "expression-processor-interrupt-test");
+
+      // when
+      evaluationThread.start();
+
+      Assertions.assertThat(blockingEL.awaitEntered(5, TimeUnit.SECONDS))
+          .as("evaluation should start and block for %s", methodName)
+          .isTrue();
+
+      evaluationThread.interrupt();
+      blockingEL.release(); // unblock EL so it can notice interrupt/fail fast
+      evaluationThread.join(TimeUnit.SECONDS.toMillis(5));
+
+      // then
+      Assertions.assertThat(evaluationThread.isAlive())
+          .as("evaluation thread should terminate after interruption for %s", methodName)
+          .isFalse();
+
+      Assertions.assertThat(failure.get())
+          .isInstanceOf(EvaluationException.class)
+          .hasMessage("Expected to evaluate expression 'foo', but the evaluation was interrupted")
+          .hasCauseInstanceOf(InterruptedException.class);
+    }
+
+    Stream<Arguments> processorEvaluationMethods() {
+      return Stream.of(
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateStringExpression(expression, -1L),
+              "evaluateStringExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) ->
+                      processor.evaluateStringExpressionAsDirectBuffer(expression, -1L),
+              "evaluateStringExpressionAsDirectBuffer"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateLongExpression(expression, -1L),
+              "evaluateLongExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateBooleanExpression(expression, -1L),
+              "evaluateBooleanExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateIntervalExpression(expression, -1L),
+              "evaluateIntervalExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateDateTimeExpression(expression, -1L),
+              "evaluateDateTimeExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) ->
+                      processor.evaluateDateTimeExpression(expression, -1L, false),
+              "evaluateDateTimeExpression(nullableFlag)"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateAnyExpression(expression, -1L),
+              "evaluateAnyExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateArrayExpression(expression, -1L),
+              "evaluateArrayExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) ->
+                      processor.evaluateArrayOfStringsExpression(expression, -1L),
+              "evaluateArrayOfStringsExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) ->
+                      processor.evaluateMessageCorrelationKeyExpression(expression, -1L),
+              "evaluateMessageCorrelationKeyExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) -> processor.evaluateIntegerExpression(expression, -1L),
+              "evaluateIntegerExpression"),
+          Arguments.of(
+              (ProcessorMethod)
+                  (processor, expression) ->
+                      processor.evaluateVariableMappingExpression(expression, -1L),
+              "evaluateVariableMappingExpression"));
+    }
+
+    private static final class FakeBlockingExpressionLanguage implements ExpressionLanguage {
+      private final CountDownLatch entered = new CountDownLatch(1);
+      private final CountDownLatch release = new CountDownLatch(1);
+
+      @SuppressWarnings("SameParameterValue")
+      boolean awaitEntered(final long timeout, final TimeUnit unit) throws InterruptedException {
+        return entered.await(timeout, unit);
+      }
+
+      void release() {
+        release.countDown();
+      }
+
+      @Override
+      public Expression parseExpression(final String expression) {
+        // not used in these tests
+        return null;
+      }
+
+      @Override
+      public EvaluationResult evaluateExpression(
+          final Expression expression, final EvaluationContext context) {
+        entered.countDown();
+        try {
+          // deterministically block until the test releases; if interrupted while waiting,
+          // propagate
+          release.await();
+          return null; // not relevant for this test
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    private static class CustomException extends RuntimeException {
+      public CustomException(final String message) {
+        super(message);
+      }
+    }
+
+    private record FakeThrowingExpressionLanguage(RuntimeException throwsException)
+        implements ExpressionLanguage {
+
+      @Override
+      public Expression parseExpression(final String expression) {
+        // not used in these tests
+        return null;
+      }
+
+      @Override
+      public EvaluationResult evaluateExpression(
+          final Expression expression, final EvaluationContext context) {
+        throw throwsException;
+      }
+    }
+
+    @FunctionalInterface
+    private interface ProcessorMethod {
+      Either<Failure, ?> evaluate(ExpressionProcessor processor, Expression expression);
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -371,8 +371,12 @@ class ExpressionProcessorTest {
           .isTrue();
 
       evaluationThread.interrupt();
-      blockingEL.release(); // unblock EL so it can notice interrupt/fail fast
-      evaluationThread.join(TimeUnit.SECONDS.toMillis(5));
+      try {
+        evaluationThread.join(TimeUnit.SECONDS.toMillis(5));
+      } finally {
+        // ensure we release the blocking EL to avoid leaking threads
+        blockingEL.release();
+      }
 
       // then
       Assertions.assertThat(evaluationThread.isAlive())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -282,6 +283,35 @@ class ExpressionProcessorTest {
     }
 
     /**
+     * This test case uses an expression language implementation that blocks until released. It
+     * verifies that the processor interrupts the evaluation thread when the evaluation times out.
+     */
+    @ParameterizedTest(name = "{1} interrupts thread on timeout")
+    @MethodSource("processorEvaluationMethods")
+    void shouldInterruptBlockedThreadOnTimeout(
+        final ProcessorMethod evaluationMethod, final String methodName)
+        throws InterruptedException {
+      // given
+      final var interruptedLatch = new CountDownLatch(1);
+
+      final var blockingEL =
+          new FakeBlockingExpressionLanguage(onInterrupted -> interruptedLatch.countDown());
+
+      final var processor =
+          new ExpressionProcessor(blockingEL, DEFAULT_CONTEXT_LOOKUP, Duration.ofMillis(10));
+      final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
+
+      // when
+      final var result = evaluationMethod.evaluate(processor, expression);
+
+      // then
+      assertThat(result).as("should return failure for %s", methodName).isLeft();
+      Assertions.assertThat(interruptedLatch.await(5, TimeUnit.SECONDS))
+          .describedAs("Expected the evaluation thread to be interrupted upon timeout")
+          .isTrue();
+    }
+
+    /**
      * This test case uses an expression language implementation that always throws a specific
      * exception when evaluating an expression. It verifies that the processor catches this
      * exception and rethrows it as an EvaluationException with the expected message and cause.
@@ -419,6 +449,15 @@ class ExpressionProcessorTest {
     private static final class FakeBlockingExpressionLanguage implements ExpressionLanguage {
       private final CountDownLatch entered = new CountDownLatch(1);
       private final CountDownLatch release = new CountDownLatch(1);
+      private final Consumer<InterruptedException> onInterrupted;
+
+      public FakeBlockingExpressionLanguage() {
+        this(ignored -> {});
+      }
+
+      public FakeBlockingExpressionLanguage(final Consumer<InterruptedException> onInterrupted) {
+        this.onInterrupted = onInterrupted;
+      }
 
       @SuppressWarnings("SameParameterValue")
       boolean awaitEntered(final long timeout, final TimeUnit unit) throws InterruptedException {
@@ -445,6 +484,7 @@ class ExpressionProcessorTest {
           release.await();
           return null; // not relevant for this test
         } catch (final InterruptedException e) {
+          onInterrupted.accept(e);
           Thread.currentThread().interrupt();
           throw new RuntimeException(e);
         }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
@@ -41,6 +42,8 @@ class ExpressionProcessorTest {
           new ZeebeFeelEngineClock(InstantSource.system()));
   private static final EvaluationContext EMPTY_LOOKUP = x -> null;
   private static final EvaluationContextLookup DEFAULT_CONTEXT_LOOKUP = scope -> EMPTY_LOOKUP;
+  private static final Duration DEFAULT_TIMEOUT =
+      EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
 
   @Nested
   @TestInstance(Lifecycle.PER_CLASS)
@@ -49,7 +52,8 @@ class ExpressionProcessorTest {
     @ParameterizedTest
     @MethodSource("arrayOfStringsExpressions")
     void testSuccessfulEvaluations(final String expression, final List<String> expected) {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
       assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
           .isRight()
@@ -60,7 +64,8 @@ class ExpressionProcessorTest {
     @ParameterizedTest
     @MethodSource("notArrayOfStringsExpressions")
     void testFailingEvaluations(final String expression, final String message) {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
       assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
           .isLeft()
@@ -105,7 +110,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testStringExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateStringExpression(parsedExpression, -1L))
           .isLeft()
@@ -119,7 +125,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testLongExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateLongExpression(parsedExpression, -1L))
           .isLeft()
@@ -133,7 +140,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testBooleanExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateBooleanExpression(parsedExpression, -1L))
           .isLeft()
@@ -147,7 +155,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testIntervalExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateIntervalExpression(parsedExpression, -1L))
           .isLeft()
@@ -161,7 +170,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testDateTimeExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateDateTimeExpression(parsedExpression, -1L))
           .isLeft()
@@ -175,7 +185,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testArrayExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateArrayExpression(parsedExpression, -1L))
           .isLeft()
@@ -189,7 +200,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testStringArrayExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=[x]");
       assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
           .isLeft()
@@ -204,7 +216,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testMessageCorrelationKeyExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateMessageCorrelationKeyExpression(parsedExpression, -1L))
           .isLeft()
@@ -219,7 +232,8 @@ class ExpressionProcessorTest {
 
     @Test
     void testVariableMappingExpression() {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression("=x");
       assertThat(processor.evaluateVariableMappingExpression(parsedExpression, -1L))
           .isLeft()
@@ -279,7 +293,8 @@ class ExpressionProcessorTest {
       final var processor =
           new ExpressionProcessor(
               new FakeThrowingExpressionLanguage(new CustomException("custom failure")),
-              DEFAULT_CONTEXT_LOOKUP);
+              DEFAULT_CONTEXT_LOOKUP,
+              DEFAULT_TIMEOUT);
       final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
 
       // when & then
@@ -302,7 +317,8 @@ class ExpressionProcessorTest {
         final ProcessorMethod evaluationMethod, final String methodName) throws Exception {
       // given
       final var blockingEL = new FakeBlockingExpressionLanguage();
-      final var processor = new ExpressionProcessor(blockingEL, DEFAULT_CONTEXT_LOOKUP);
+      final var processor =
+          new ExpressionProcessor(blockingEL, DEFAULT_CONTEXT_LOOKUP, DEFAULT_TIMEOUT);
       final var expression = EXPRESSION_LANGUAGE.parseExpression("foo");
 
       final var failure = new AtomicReference<Throwable>();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
@@ -74,7 +75,11 @@ public class ProcessValidationUtil {
         ExpressionLanguageFactory.createExpressionLanguage(
             new ZeebeFeelEngineClock(InstantSource.system()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
-    final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
+    final var expressionProcessor =
+        new ExpressionProcessor(
+            expressionLanguage,
+            emptyLookup,
+            EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT);
     final ValidationVisitor visitor =
         new ValidationVisitor(
             Stream.of(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
@@ -517,7 +518,11 @@ public final class ZeebeRuntimeValidationTest {
         ExpressionLanguageFactory.createExpressionLanguage(
             new ZeebeFeelEngineClock(InstantSource.system()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
-    final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
+    final var expressionProcessor =
+        new ExpressionProcessor(
+            expressionLanguage,
+            emptyLookup,
+            EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT);
     final ValidationVisitor visitor =
         new ValidationVisitor(
             ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor));


### PR DESCRIPTION
# Description
Backport of #43883 to `stable/8.6`.

relates to #41764
closes #44442

---

Full backport of the timeout with only partial configuration options:
- ~~New property: `camunda.expression.timeout`~~
- Legacy property: `zeebe.broker.experimental.engine.expression.timeout`