### PR TITLE
feat: Setup default task-worker role

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -188,7 +188,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeByCategoryWildcard(
       @Authenticated(USER_A_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(p -> p.limit(200)).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAuthorizationsIT.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
+import io.camunda.client.api.search.request.SearchRequestPage;
 import io.camunda.client.api.search.response.AuditLogResult;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -117,6 +119,10 @@ public class AuditLogAuthorizationsIT {
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_A_ID)),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_B_ID))));
 
+  // At test execution time, we already have 100+ audit log entries.
+  // Custom page limit ensures all entries are retrieved for test assertions.
+  private static final Consumer<SearchRequestPage> PAGE_CONFIG = p -> p.limit(200);
+
   private static CamundaClient adminClient;
 
   @BeforeAll
@@ -140,7 +146,7 @@ public class AuditLogAuthorizationsIT {
   void shouldNotAuthorizeWithoutPermissionsSearch(
       @Authenticated(USER_UNAUTHORIZED_NAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isEmpty();
@@ -151,7 +157,7 @@ public class AuditLogAuthorizationsIT {
       @Authenticated(USER_UNAUTHORIZED_NAME) final CamundaClient unauthorizedClient,
       @Authenticated(USER_A_USERNAME) final CamundaClient authorizedClient) {
     // when
-    final var logs = authorizedClient.newAuditLogSearchRequest().send().join();
+    final var logs = authorizedClient.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then - unauthorized client should throw exception when trying to get by key
     assertThat(logs.items()).isNotEmpty();
@@ -172,7 +178,7 @@ public class AuditLogAuthorizationsIT {
   @Test
   void shouldAuthorizeByTenant(@Authenticated(USER_A_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -188,7 +194,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeByCategoryWildcard(
       @Authenticated(USER_A_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().page(p -> p.limit(200)).execute();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -210,7 +216,7 @@ public class AuditLogAuthorizationsIT {
   @Test
   void shouldAuthorizeByCategory(@Authenticated(USER_AA_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -225,7 +231,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeByProcessIdWildcard(
       @Authenticated(USER_B_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -250,7 +256,7 @@ public class AuditLogAuthorizationsIT {
   @Test
   void shouldAuthorizeByProcessId(@Authenticated(USER_BB_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -265,7 +271,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeByUserTaskProcessIdWildcard(
       @Authenticated(USER_C_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -288,7 +294,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeByUserTaskProcessId(
       @Authenticated(USER_CC_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();
@@ -342,7 +348,7 @@ public class AuditLogAuthorizationsIT {
   void shouldAuthorizeWithCompositePermissions(
       @Authenticated(USER_D_USERNAME) final CamundaClient client) {
     // when
-    final var logs = client.newAuditLogSearchRequest().send().join();
+    final var logs = client.newAuditLogSearchRequest().page(PAGE_CONFIG).execute();
 
     // then
     assertThat(logs.items()).isNotEmpty();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
@@ -221,7 +221,7 @@ public class RoleIT {
                             .items())
                     .anyMatch(
                         auth ->
-                            auth.resourceId().equals("resourceId")
+                            "resourceId".equals(auth.resourceId())
                                 && auth.resourceType().equals(ResourceType.RESOURCE)
                                 && auth.ownerId().equals(roleId)));
 
@@ -244,7 +244,7 @@ public class RoleIT {
                             .items())
                     .noneMatch(
                         auth ->
-                            auth.resourceId().equals("resourceId")
+                            "resourceId".equals(auth.resourceId())
                                 && auth.resourceType().equals(ResourceType.RESOURCE)
                                 && auth.ownerId().equals(roleId)));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
@@ -17,19 +17,13 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.filter.AuthorizationFilter;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +37,6 @@ public class RoleIT {
   private static final String EXISTING_ROLE_NAME = "ARoleName";
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @BeforeAll
   static void setup() {
@@ -211,19 +204,23 @@ public class RoleIT {
         .send()
         .join();
 
-    // Verify it was created
-    Awaitility.await()
+    final Consumer<AuthorizationFilter> createdAuthorizationFilter =
+        af ->
+            af.resourceIds("resourceId")
+                .resourceType(ResourceType.RESOURCE)
+                .ownerType(OwnerType.ROLE)
+                .ownerId(roleId);
+
+    Awaitility.await("Authorization was created")
         .untilAsserted(
             () ->
                 assertThat(
-                        searchAuthorizations(
-                                camundaClient.getConfiguration().getRestAddress().toString())
+                        camundaClient
+                            .newAuthorizationSearchRequest()
+                            .filter(createdAuthorizationFilter)
+                            .execute()
                             .items())
-                    .anyMatch(
-                        auth ->
-                            "resourceId".equals(auth.resourceId())
-                                && auth.resourceType().equals(ResourceType.RESOURCE)
-                                && auth.ownerId().equals(roleId)));
+                    .isNotEmpty());
 
     camundaClient.newDeleteRoleCommand(roleId).send().join();
 
@@ -239,14 +236,12 @@ public class RoleIT {
         .untilAsserted(
             () ->
                 assertThat(
-                        searchAuthorizations(
-                                camundaClient.getConfiguration().getRestAddress().toString())
+                        camundaClient
+                            .newAuthorizationSearchRequest()
+                            .filter(createdAuthorizationFilter)
+                            .execute()
                             .items())
-                    .noneMatch(
-                        auth ->
-                            "resourceId".equals(auth.resourceId())
-                                && auth.resourceType().equals(ResourceType.RESOURCE)
-                                && auth.ownerId().equals(roleId)));
+                    .isEmpty());
   }
 
   private static void createRole(
@@ -329,28 +324,4 @@ public class RoleIT {
               assertThat(role.getDescription()).isEqualTo(description);
             });
   }
-
-  // TODO once available, this test should use the client to make the request
-  private AuthorizationSearchResponse searchAuthorizations(final String restAddress)
-      throws URISyntaxException, IOException, InterruptedException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(restAddress, "v2/authorizations/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .build();
-
-    final HttpResponse<String> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), AuthorizationSearchResponse.class);
-  }
-
-  private record AuthorizationSearchResponse(List<RoleIT.AuthorizationResponse> items) {}
-
-  private record AuthorizationResponse(
-      String ownerId,
-      OwnerType ownerType,
-      ResourceType resourceType,
-      String resourceId,
-      List<PermissionType> permissionTypes,
-      String authorizationKey) {}
 }

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -11,7 +11,8 @@ public enum DefaultRole {
   ADMIN("admin"),
   RPA("rpa"),
   CONNECTORS("connectors"),
-  APP_INTEGRATIONS("app-integrations");
+  APP_INTEGRATIONS("app-integrations"),
+  TASK_WORKER("task-worker");
 
   private final String id;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -83,9 +84,13 @@ final class IdentitySetupInitializerIT {
     final var passwordMatches = passwordEncoder.matches(password, createdUser.getPassword());
     assertThat(passwordMatches).isTrue();
 
-    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).limit(4))
+    assertThat(
+            RecordingExporter.roleRecords(RoleIntent.CREATED)
+                // all default roles from DefaultRole enum + "Readonly Admin"
+                .limit(DefaultRole.values().length + 1))
         .extracting(record -> record.getValue().getName())
-        .containsExactlyInAnyOrder("Readonly Admin", "Admin", "RPA", "Connectors");
+        .containsExactlyInAnyOrder(
+            "Readonly Admin", "Admin", "RPA", "Connectors", "App Integrations", "Task Worker");
 
     final var createdTenant =
         RecordingExporter.tenantRecords(TenantIntent.CREATED).getFirst().getValue();


### PR DESCRIPTION
## Description

This PR introduces a new default `task-worker` role that is automatically created during identity initialization.  The role enables restricted task authorization by granting property-based permissions for user task interactions.

### What this PR does

- Adds `TASK_WORKER` to the `DefaultRole` enum with id `"task-worker"`
- Creates the "Task Worker" role during platform identity setup with the following property-based authorizations:
  - **READ**, **CLAIM**, and **COMPLETE** permissions for `USER_TASK` resources
  - Permissions are scoped using property matchers for: 
    - `assignee` - allows interaction with tasks directly assigned to the user
    - `candidateUsers` - allows interaction with tasks where the user is in the candidate users list
    - `candidateGroups` - allows interaction with tasks where the user belongs to at least one candidate group
- Assigns the `task-worker` role to the default tenant

### Testing

- Dedicated tests were added to verify the new default "task-worker" role creation and its associated authorizations. 

#### CI Test Fixes

The following tests failed due to the new role creation and were fixed and improved:
- `RoleIT.shouldDeleteAuthorizationsWhenDeletingRole`
  - [fix commit](https://github.com/camunda/camunda/pull/44414/changes/6810002e18733b1bb42e0cda1620cd67dc5c92e6)
  - [refactoring](https://github.com/camunda/camunda/pull/44414/changes/a86c943d3fd95a6059fbadaac0d0cecab164fe73)
- `AuditLogAuthorizationsIT.shouldAuthorizeByCategoryWildcard`
  - [fix commit](https://github.com/camunda/camunda/pull/44414/changes/5bad7d9c30686681b50d64b58885ca9a64d91fff)
  - [improve tests stability](https://github.com/camunda/camunda/pull/44414/changes/db540b7676c57deea10c58d17265c20b1f3f785f)

### Why
- Users assigned to the `task-worker` role can interact with user tasks only when they have a relationship to the task, rather than having broad access to all tasks.
- By having this role, users don't require multiple ID-based authorizations for each individual task or process definition. Instead, this single role assignment allows users to have access to all tasks to which they are related, simplifying authorization management and reducing administrative overhead.

## Related issues

closes #40089 
