### PR TITLE
feat: fix resource deletion request body schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/resource.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/resource.ts
@@ -74,7 +74,7 @@ type CreateDeploymentResponseBody = z.infer<typeof createDeploymentResponseBodyS
 
 const deleteResourceRequestBodySchema = z
 	.object({
-		operationReference: z.number().int().min(1),
+		operationReference: z.number().int().min(1).optional(),
 		deleteHistory: z.boolean().optional().default(false),
 	})
 	.optional();


### PR DESCRIPTION
## Description

make `operationReference` optional since `deleteHistory` is introduced as optional and wrapper object `DeleteResourceRequestBody` is also optional

## Related issues

relates #31690
