### PR TITLE
docs: extend resource deletion API description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -121,9 +121,17 @@ paths:
       operationId: deleteResource
       summary: Delete resource
       description: |
-        Deletes a deployed resource.
-        This can be a process definition, decision requirements definition, or form definition
-        deployed using the deploy resources endpoint. Specify the resource you want to delete in the `resourceKey` parameter.
+        Deletes a deployed resource. This can be a process definition, decision requirements
+        definition, or form definition deployed using the deploy resources endpoint. Specify the
+        resource you want to delete in the `resourceKey` parameter.
+
+        Once a resource has been deleted it cannot be recovered. If the resource needs to be
+        available again, a new deployment of the resource is required.
+
+        By default, only the resource itself is deleted from the runtime state. To also delete the
+        historic data associated with a resource, set the `deleteHistory` flag in the request body
+        to `true`. The historic data is deleted asynchronously via a batch operation. The details of
+        the created batch operation are included in the response.
       parameters:
         - name: resourceKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -120,7 +120,7 @@ paths:
         - Resource
       operationId: deleteResource
       summary: Delete resource
-      description: |
+      description: |-
         Deletes a deployed resource. This can be a process definition, decision requirements
         definition, or form definition deployed using the deploy resources endpoint. Specify the
         resource you want to delete in the `resourceKey` parameter.
@@ -131,7 +131,9 @@ paths:
         By default, only the resource itself is deleted from the runtime state. To also delete the
         historic data associated with a resource, set the `deleteHistory` flag in the request body
         to `true`. The historic data is deleted asynchronously via a batch operation. The details of
-        the created batch operation are included in the response.
+        the created batch operation are included in the response. Note that history deletion is only
+        supported for process resources; for other resource types this flag is ignored and no history
+        will be deleted.
       parameters:
         - name: resourceKey
           in: path


### PR DESCRIPTION
## Description

Extends the description for resource deletion to clarify the following:
- This only deletes from the runtime state by default.
- If a resource was deleted, new instances of it cannot be created without a redeployment.
- Deleting history is opt-in.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related to https://github.com/camunda/camunda/issues/44436
