### PR TITLE
[Backport stable/8.7] fix: Eliminate need for top_hits limit when fetching grouped processes

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.it.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.store.ProcessStore;
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessStoreGroupedProcessesIT extends OperateSearchAbstractIT {
+
+  private static final String BPMN_PROCESS_ID = "processWithManyVersions";
+  private static final int TOTAL_VERSIONS = 120;
+
+  @Autowired private ProcessIndex processDefinitionIndex;
+
+  @Autowired private ProcessStore processStore;
+
+  @Override
+  protected void runAdditionalBeforeAllSetup() throws Exception {
+    for (int version = 1; version <= TOTAL_VERSIONS; version++) {
+      final long key = 9000000000000000L + version;
+      final ProcessEntity processEntity =
+          new ProcessEntity()
+              .setKey(key)
+              .setId(String.valueOf(key))
+              .setBpmnProcessId(BPMN_PROCESS_ID)
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+              .setName("Process with many versions")
+              .setVersion(version);
+      testSearchRepository.createOrUpdateDocumentFromObject(
+          processDefinitionIndex.getFullQualifiedName(), processEntity.getId(), processEntity);
+    }
+    searchContainerManager.refreshIndices("*operate*");
+  }
+
+  @Test
+  public void shouldReturnAllVersionsSortedDescending() {
+    // given
+    final ProcessStore.ProcessKey processKey =
+        new ProcessStore.ProcessKey(BPMN_PROCESS_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // when
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of(BPMN_PROCESS_ID));
+
+    // then
+    final List<ProcessEntity> versions = results.get(processKey);
+    assertThat(versions).hasSize(TOTAL_VERSIONS);
+    assertThat(versions.getFirst().getVersion()).isEqualTo(TOTAL_VERSIONS);
+    assertThat(versions.getLast().getVersion()).isEqualTo(1);
+
+    final Set<Integer> returnedVersions =
+        versions.stream()
+            .map(ProcessEntity::getVersion)
+            .collect(java.util.stream.Collectors.toSet());
+    for (int i = 1; i <= TOTAL_VERSIONS; i++) {
+      assertThat(returnedVersions).contains(i);
+    }
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -44,6 +44,8 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
   @Autowired private ProcessStore processStore;
 
   private ProcessEntity firstProcessDefinition;
+  private ProcessEntity firstProcessDefinitionV2;
+  private ProcessEntity firstProcessDefinitionV3;
   private ProcessEntity secondProcessDefinition;
   private ProcessEntity thirdProcessDefinition;
   private ProcessInstanceForListViewEntity firstProcessInstance;
@@ -61,6 +63,27 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             .setBpmnProcessId("demoProcess")
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Demo process")
+            .setVersion(1)
+            .setBpmnXml(resourceXml);
+
+    firstProcessDefinitionV2 =
+        new ProcessEntity()
+            .setKey(2251799813685250L)
+            .setId("2251799813685250")
+            .setBpmnProcessId("demoProcess")
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .setName("Demo process")
+            .setVersion(2)
+            .setBpmnXml(resourceXml);
+
+    firstProcessDefinitionV3 =
+        new ProcessEntity()
+            .setKey(2251799813685253L)
+            .setId("2251799813685253")
+            .setBpmnProcessId("demoProcess")
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .setName("Demo process")
+            .setVersion(3)
             .setBpmnXml(resourceXml);
 
     secondProcessDefinition =
@@ -125,7 +148,12 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             .setJoinRelation(new ListViewJoinRelation("processInstance"));
 
     final var definitionEntities =
-        List.of(firstProcessDefinition, secondProcessDefinition, thirdProcessDefinition);
+        List.of(
+            firstProcessDefinition,
+            firstProcessDefinitionV2,
+            firstProcessDefinitionV3,
+            secondProcessDefinition,
+            thirdProcessDefinition);
     for (final var entity : definitionEntities) {
       testSearchRepository.createOrUpdateDocumentFromObject(
           processDefinitionIndex.getFullQualifiedName(), entity.getId(), entity);
@@ -182,7 +210,7 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
                     new ProcessStore.ProcessKey(
                         firstProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID))
                 .size())
-        .isEqualTo(1);
+        .isEqualTo(3);
     assertThat(
             results
                 .get(
@@ -190,6 +218,70 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
                         secondProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID))
                 .size())
         .isEqualTo(1);
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNonExistentBpmnProcessIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of("nonExistentProcess", "anotherFakeId"));
+
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNonExistentTenant() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            "nonExistentTenant",
+            Set.of(
+                firstProcessDefinition.getBpmnProcessId(),
+                secondProcessDefinition.getBpmnProcessId()));
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNullTenantReturnsAllTenants() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(null, null);
+
+    assertThat(results).hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    firstProcessDefinition.getBpmnProcessId(),
+                    TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
+        .hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    secondProcessDefinition.getBpmnProcessId(),
+                    TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
+        .hasSize(1);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(thirdProcessDefinition.getBpmnProcessId(), "tenant2")))
+        .hasSize(1);
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNullAllowedBpmnProcessIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(TenantOwned.DEFAULT_TENANT_IDENTIFIER, null);
+
+    assertThat(results).hasSize(2);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    firstProcessDefinition.getBpmnProcessId(),
+                    TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
+        .hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    secondProcessDefinition.getBpmnProcessId(),
+                    TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
+        .hasSize(1);
   }
 
   @Test
@@ -203,8 +295,13 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             "name",
             "bpmnProcessId",
             "key");
-    assertThat(results.size()).isEqualTo(2);
+    // 3 versions of firstProcessDefinition + 1 version of secondProcessDefinition = 4
+    assertThat(results.size()).isEqualTo(4);
     assertThat(results.get(firstProcessDefinition.getKey()).getBpmnProcessId())
+        .isEqualTo(firstProcessDefinition.getBpmnProcessId());
+    assertThat(results.get(firstProcessDefinitionV2.getKey()).getBpmnProcessId())
+        .isEqualTo(firstProcessDefinition.getBpmnProcessId());
+    assertThat(results.get(firstProcessDefinitionV3.getKey()).getBpmnProcessId())
         .isEqualTo(firstProcessDefinition.getBpmnProcessId());
     assertThat(results.get(secondProcessDefinition.getKey()).getBpmnProcessId())
         .isEqualTo(secondProcessDefinition.getBpmnProcessId());

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -10,13 +10,10 @@ package io.camunda.operate.store.opensearch;
 import static io.camunda.operate.schema.templates.FlowNodeInstanceTemplate.TREE_PATH;
 import static io.camunda.operate.schema.templates.ListViewTemplate.*;
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TERMS_AGG_SIZE;
-import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TOPHITS_AGG_SIZE;
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchRetryOperation.UPDATE_RETRY_COUNT;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.cardinalityAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.filtersAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.termAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.withTenantCheck;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
@@ -123,9 +120,8 @@ public class OpensearchProcessStore implements ProcessStore {
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
       final String tenantId, final Set<String> allowedBPMNProcessIds) {
-    final String tenantsGroupsAggName = "group_by_tenantId";
     final String groupsAggName = "group_by_bpmnProcessId";
-    final String processesAggName = "processes";
+
     final List<String> sourceFields =
         List.of(
             ProcessIndex.ID,
@@ -134,64 +130,49 @@ public class OpensearchProcessStore implements ProcessStore {
             ProcessIndex.VERSION_TAG,
             ProcessIndex.BPMN_PROCESS_ID,
             ProcessIndex.TENANT_ID);
+
     final Query query =
         allowedBPMNProcessIds == null
             ? matchAll()
             : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowedBPMNProcessIds);
-    final var searchRequestBuilder =
+
+    final var aggRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
             .query(withTenantCheck(withTenantIdQuery(tenantId, query)))
             .size(0)
             .aggregations(
-                tenantsGroupsAggName,
-                withSubaggregations(
-                    termAggregation(ProcessIndex.TENANT_ID, TERMS_AGG_SIZE),
-                    Map.of(
-                        groupsAggName,
-                        withSubaggregations(
-                            termAggregation(ProcessIndex.BPMN_PROCESS_ID, TERMS_AGG_SIZE),
-                            Map.of(
-                                processesAggName,
-                                topHitsAggregation(
-                                        sourceFields,
-                                        TOPHITS_AGG_SIZE,
-                                        sortOptions(ProcessIndex.VERSION, SortOrder.Desc))
-                                    ._toAggregation())))));
+                groupsAggName,
+                termAggregation(ProcessIndex.BPMN_PROCESS_ID, TERMS_AGG_SIZE)._toAggregation());
 
-    final SearchResponse<Object> response =
-        richOpenSearchClient.doc().search(searchRequestBuilder, Object.class);
+    final SearchResponse<Void> aggResponse =
+        richOpenSearchClient.doc().search(aggRequestBuilder, Void.class);
+
+    final List<String> bpmnProcessIds =
+        aggResponse.aggregations().get(groupsAggName).sterms().buckets().array().stream()
+            .map(b -> b.key())
+            .toList();
+
+    if (bpmnProcessIds.isEmpty()) {
+      return new HashMap<>();
+    }
+
+    final Query docsQuery = stringTerms(ListViewTemplate.BPMN_PROCESS_ID, bpmnProcessIds);
+
+    final var searchRequestBuilder =
+        searchRequestBuilder(processIndex.getAlias())
+            .query(withTenantCheck(withTenantIdQuery(tenantId, docsQuery)))
+            .source(sourceInclude(sourceFields))
+            .sort(sortOptions(ProcessIndex.VERSION, SortOrder.Desc));
+
+    final List<ProcessEntity> allProcesses =
+        richOpenSearchClient.doc().scrollValues(searchRequestBuilder, ProcessEntity.class);
+
     final Map<ProcessKey, List<ProcessEntity>> result = new HashMap<>();
-
-    response
-        .aggregations()
-        .get(tenantsGroupsAggName)
-        .sterms()
-        .buckets()
-        .array()
-        .forEach(
-            tenantBucket ->
-                tenantBucket
-                    .aggregations()
-                    .get(groupsAggName)
-                    .sterms()
-                    .buckets()
-                    .array()
-                    .forEach(
-                        bpmnProcessIdBucket -> {
-                          final String key = tenantBucket.key() + "_" + bpmnProcessIdBucket.key();
-                          final List<ProcessEntity> value =
-                              bpmnProcessIdBucket
-                                  .aggregations()
-                                  .get(processesAggName)
-                                  .topHits()
-                                  .hits()
-                                  .hits()
-                                  .stream()
-                                  .map(h -> h.source().to(ProcessEntity.class))
-                                  .toList();
-
-                          result.put(new ProcessKey(key, tenantId), value);
-                        }));
+    for (final ProcessEntity processEntity : allProcesses) {
+      final ProcessKey groupKey =
+          new ProcessKey(processEntity.getBpmnProcessId(), processEntity.getTenantId());
+      result.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(processEntity);
+    }
 
     return result;
   }


### PR DESCRIPTION
# Description
Backport of #43503 to `stable/8.7`.

relates to camunda/camunda#41058