### PR TITLE
Add postgres to weekly test

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -58,6 +58,21 @@ jobs:
         --set starter.rate=50
         --set workers.worker.replicas=6
         --set starter.bpmnXmlPath="bpmn/typical_process.bpmn"
+  setup-postgres-typical-load-test:
+    name: Typical load test
+    needs:
+      - test-data
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.test-data.outputs.test }}-postgres-typical
+      ttl: 28
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
+      secondary-storage-type: 'postgresql'
+      load-test-load: >
+        --set starter.rate=50
+        --set workers.worker.replicas=6
+        --set starter.bpmnXmlPath="bpmn/typical_process.bpmn"
   setup-realistic-test:
     name: Realistic load test
     uses: ./.github/workflows/camunda-load-test.yml


### PR DESCRIPTION
## Description

Based on the [new data layer dashboard](https://grafana.dev.zeebe.io/d/chhnwwv/data-layer-medic-load-tests?orgId=1&from=now-24h&to=now&timezone=browser&var-DS_PROMETHEUS=prometheus&refresh=1m&showCategory=Stat%20styles) introduced with https://github.com/camunda/camunda/pull/44444 we can see our general performance (data availability). With this, we can see that the PostgreSQL secondary storage performs quite well (p99 is by factor 2 better! 🚀 ). To ensure this stays like this and even over longer time, we should enable it in our weekly tests.


Comparing two load tests:

Typical load test with ELS (calendar week 4)

<img width="2531" height="321" alt="compare-elasitc" src="https://github.com/user-attachments/assets/f21f73a3-3f3a-432f-abaf-ad1846e343af" />

Typical load test with Postgresql

<img width="2520" height="327" alt="postgresql" src="https://github.com/user-attachments/assets/337f28c8-3d1e-4927-8573-99e28a32e5fd" />

## PR contains


 * Add a new weekly load test using the PostgreSQL secondary storage option as an alternative to our existing Elasticsearch-based weekly load tests
 * This will make use of our typical load test for now https://github.com/camunda/camunda/pull/44444
 