### PR TITLE
fix: remove the refresh_interval on ES operate-list-view

### DIFF
--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -1,7 +1,6 @@
  {
 	"settings": {
 		"index": {
-			"refresh_interval": "2s",
 			"analysis": {
 				"normalizer": {
 					"case_insensitive": {


### PR DESCRIPTION
We do not have this set on any other indexes and it causes the ES tests to run slower than the equivalent OS ones as we have to wait longer for data to be visible in searches.

## Related issues

closes: #44202
