### PR TITLE
[Backport stable/8.7] Fix OpenSearch backup status startTime missing in API response

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -541,7 +541,7 @@ public class BackupManagerOpenSearch extends BackupManager {
     for (final SnapshotInfo snapshot : snapshots) {
       final GetBackupStateResponseDetailDto detail = new GetBackupStateResponseDetailDto();
       detail.setSnapshotName(snapshot.snapshot());
-      if (detail.getStartTime() != null) {
+      if (snapshot.startTimeInMillis() != null) {
         detail.setStartTime(
             OffsetDateTime.ofInstant(
                 Instant.ofEpochMilli(


### PR DESCRIPTION
# Description
Backport of #44327 to `stable/8.7`.

relates to camunda/camunda#43946