### PR TITLE
[CPT] test: Add invoice approval test case

### DIFF
--- a/testing/camunda-process-test-example/src/test/resources/scenarios/invoice-approval.json
+++ b/testing/camunda-process-test-example/src/test/resources/scenarios/invoice-approval.json
@@ -172,6 +172,95 @@
       ]
     },
     {
+      "name": "Approval Timeout",
+      "description": "Path when there is a timeout on the approval",
+      "instructions": [
+        {
+          "type": "MOCK_JOB_WORKER_COMPLETE_JOB",
+          "jobType": "archive-invoice"
+        },
+        {
+          "type": "MOCK_JOB_WORKER_COMPLETE_JOB",
+          "jobType": "add-invoice-to-accounting"
+        },
+        {
+          "type": "CREATE_PROCESS_INSTANCE",
+          "processDefinitionSelector": {
+            "processDefinitionId": "Process_InvoiceApproval"
+          },
+          "variables": {
+            "approver": "Zee",
+            "invoice": {
+              "id": "INV-1001",
+              "amount": 12000,
+              "currency": "EUR",
+              "supplier": {
+                "id": "0815",
+                "name": "Acme GmbH"
+              },
+              "contactEmail": "accounting@acme.com"
+            }
+          }
+        },
+        {
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "processInstanceSelector": {
+            "processDefinitionId": "Process_InvoiceApproval"
+          },
+          "elementSelectors": [
+            {
+              "elementId": "UserTask_ApproveInvoice"
+            }
+          ],
+          "state": "IS_ACTIVE"
+        },
+        {
+          "type": "INCREASE_TIME",
+          "duration": "P5D"
+        },
+        {
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "processInstanceSelector": {
+            "processDefinitionId": "Process_InvoiceApproval"
+          },
+          "elementSelectors": [
+            {
+              "elementId": "StartEvent_InvoiceReceived"
+            },
+            {
+              "elementId": "ServiceTask_ArchiveInvoice"
+            },
+            {
+              "elementId": "ServiceTask_AddInvoiceAccounting"
+            },
+            {
+              "elementId": "EndEvent_InvoiceApproved"
+            }
+          ],
+          "state": "IS_COMPLETED_IN_ORDER"
+        },
+        {
+          "type": "ASSERT_ELEMENT_INSTANCES",
+          "processInstanceSelector": {
+            "processDefinitionId": "Process_InvoiceApproval"
+          },
+          "elementSelectors": [
+            {
+              "elementId": "UserTask_ApproveInvoice"
+            }
+          ],
+          "state": "IS_TERMINATED"
+        },
+        {
+          "type": "ASSERT_PROCESS_INSTANCE",
+          "processInstanceSelector": {
+            "processDefinitionId": "Process_InvoiceApproval"
+          },
+          "state": "IS_COMPLETED"
+        }
+      ]
+    },
+    {
       "name": "Archive system error",
       "description": "Path when the archive system raises an error",
       "instructions": [


### PR DESCRIPTION
## Description

This PR extends the scenario file for the invoice approval example with a case to verify the approval timeout. This case is equivalent to `io.camunda.InvoiceApprovalTest#testApprovalTimeout`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

follow-up of https://github.com/camunda/camunda/pull/43849
