### PR TITLE
feat: add MCP process definition search/get/get xml tools

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -110,6 +110,17 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
+      final io.camunda.gateway.protocol.model.simple.ProcessDefinitionFilter filter,
+      final io.camunda.gateway.protocol.model.simple.SearchQueryPageRequest page,
+      final List<ProcessDefinitionSearchQuerySortRequest> sort) {
+    return toProcessDefinitionQuery(
+        new ProcessDefinitionSearchQuery()
+            .filter(SimpleSearchQueryMapper.toProcessDefinitionFilter(filter))
+            .page(SimpleSearchQueryMapper.toPageRequest(page))
+            .sort(sort == null ? List.of() : sort));
+  }
+
+  public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
       final ProcessDefinitionSearchQuery request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.processDefinitionSearchQuery().build());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -286,6 +286,27 @@ public class SimpleSearchQueryMapper {
     return fields;
   }
 
+  public static io.camunda.gateway.protocol.model.ProcessDefinitionFilter toProcessDefinitionFilter(
+      final io.camunda.gateway.protocol.model.simple.ProcessDefinitionFilter filter) {
+    final var filterModel = new io.camunda.gateway.protocol.model.ProcessDefinitionFilter();
+    if (filter != null) {
+      ofNullable(filter.getName())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::name);
+      ofNullable(filter.getIsLatestVersion()).ifPresent(filterModel::isLatestVersion);
+      ofNullable(filter.getResourceName()).ifPresent(filterModel::resourceName);
+      ofNullable(filter.getVersion()).ifPresent(filterModel::version);
+      ofNullable(filter.getVersionTag()).ifPresent(filterModel::versionTag);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::processDefinitionId);
+      ofNullable(filter.getTenantId()).ifPresent(filterModel::tenantId);
+      ofNullable(filter.getProcessDefinitionKey()).ifPresent(filterModel::processDefinitionKey);
+      ofNullable(filter.getHasStartForm()).ifPresent(filterModel::hasStartForm);
+    }
+    return filterModel;
+  }
+
   public static io.camunda.gateway.protocol.model.VariableFilter toVariableFilter(
       final io.camunda.gateway.protocol.model.simple.VariableFilter filter) {
     final var filterModel = new io.camunda.gateway.protocol.model.VariableFilter();

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessDefinitionFilter.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessDefinitionFilter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.gateway.protocol.model.simple.ProcessDefinitionFilter;
+
+/**
+ * MCP-specific process definition filter extending the {@link ProcessDefinitionFilter} to hide
+ * fields from MCP clients to avoid unnecessary context bloat.
+ */
+public class McpProcessDefinitionFilter extends ProcessDefinitionFilter {
+
+  @JsonIgnore
+  @Override
+  public String getTenantId() {
+    return super.getTenantId();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/ToolDescriptions.java
@@ -31,6 +31,9 @@ public final class ToolDescriptions {
   public static final String SORT_DESCRIPTION = "Sort criteria";
   public static final String PAGE_DESCRIPTION = "Pagination criteria";
 
+  public static final String PROCESS_DEFINITION_KEY_DESCRIPTION =
+      "The assigned key of the process definition, which acts as a unique identifier for this process definition.";
+
   public static final String POSITIVE_NUMBER_MESSAGE = "must be a positive number.";
   public static final String INCIDENT_KEY_POSITIVE_MESSAGE =
       "Incident key " + POSITIVE_NUMBER_MESSAGE;
@@ -38,6 +41,8 @@ public final class ToolDescriptions {
       "Process instance key " + POSITIVE_NUMBER_MESSAGE;
   public static final String VARIABLE_KEY_POSITIVE_MESSAGE =
       "Variable key " + POSITIVE_NUMBER_MESSAGE;
+  public static final String PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE =
+      "Process definition key " + POSITIVE_NUMBER_MESSAGE;
 
   private ToolDescriptions() {
     // Utility class

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.definition;
+
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
+
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
+import io.camunda.gateway.mcp.model.McpProcessDefinitionFilter;
+import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
+import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQuerySortRequest;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Validated
+public class ProcessDefinitionTools {
+
+  private final ProcessDefinitionServices processDefinitionServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public ProcessDefinitionTools(
+      final ProcessDefinitionServices processDefinitionServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.processDefinitionServices = processDefinitionServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @McpTool(
+      description = "Search for process definitions. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult searchProcessDefinitions(
+      @McpToolParam(description = FILTER_DESCRIPTION, required = false)
+          final McpProcessDefinitionFilter filter,
+      @McpToolParam(description = SORT_DESCRIPTION, required = false)
+          final List<ProcessDefinitionSearchQuerySortRequest> sort,
+      @McpToolParam(description = PAGE_DESCRIPTION, required = false)
+          final McpSearchQueryPageRequest page) {
+    try {
+      final var query = SearchQueryRequestMapper.toProcessDefinitionQuery(filter, page, sort);
+      if (query.isLeft()) {
+        return CallToolResultMapper.mapProblemToResult(query.getLeft());
+      }
+
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toProcessDefinitionSearchQueryResponse(
+              processDefinitionServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .search(query.get())));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(
+      description = "Get process definition by key. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult getProcessDefinition(
+      @McpToolParam(description = PROCESS_DEFINITION_KEY_DESCRIPTION)
+          @Positive(message = PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE)
+          final Long processDefinitionKey) {
+    try {
+      return CallToolResultMapper.from(
+          SearchQueryResponseMapper.toProcessDefinition(
+              processDefinitionServices
+                  .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                  .getByKey(processDefinitionKey)));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  @McpTool(
+      description = "Get the BPMN XML of a process definition by key. " + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult getProcessDefinitionXml(
+      @McpToolParam(description = PROCESS_DEFINITION_KEY_DESCRIPTION)
+          @Positive(message = PROCESS_DEFINITION_KEY_POSITIVE_MESSAGE)
+          final Long processDefinitionKey) {
+    try {
+      final var xml =
+          processDefinitionServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .getProcessDefinitionXml(processDefinitionKey)
+              .orElseThrow(
+                  () ->
+                      new ServiceException(
+                          "The BPMN XML for this process definition is not available.",
+                          Status.NOT_FOUND));
+
+      return CallToolResult.builder().addTextContent(xml).build();
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mcp.tool.process.instance;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.FILTER_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PAGE_DESCRIPTION;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_DEFINITION_KEY_DESCRIPTION;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE;
 import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 
@@ -115,10 +116,7 @@ public class ProcessInstanceTools {
           of timeouts.
           """)
   public CallToolResult createProcessInstance(
-      @McpToolParam(
-              description =
-                  "The unique key identifying the process definition, for example, returned for a process in the deploy resources endpoint.",
-              required = false)
+      @McpToolParam(description = PROCESS_DEFINITION_KEY_DESCRIPTION, required = false)
           final String processDefinitionKey,
       @McpToolParam(
               description =

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.mcp.tool.ToolsTest;
+import io.camunda.gateway.protocol.model.ProcessDefinitionResult;
+import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQueryResult;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.ProcessDefinitionFilter;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ContextConfiguration(classes = {ProcessDefinitionTools.class})
+class ProcessDefinitionToolsTest extends ToolsTest {
+
+  static final ProcessDefinitionEntity PROCESS_DEFINITION_ENTITY =
+      new ProcessDefinitionEntity(
+          5L,
+          "Complex Process",
+          "complexProcess",
+          "<bpmn />",
+          "complexProcess.bpmn",
+          2,
+          "v2",
+          "tenantId",
+          "formId");
+
+  static final SearchQueryResult<ProcessDefinitionEntity> SEARCH_QUERY_RESULT =
+      new Builder<ProcessDefinitionEntity>()
+          .total(1L)
+          .items(List.of(PROCESS_DEFINITION_ENTITY))
+          .startCursor("f")
+          .endCursor("v")
+          .build();
+
+  @MockitoBean private ProcessDefinitionServices processDefinitionServices;
+
+  @Autowired private ObjectMapper objectMapper;
+  @Captor private ArgumentCaptor<ProcessDefinitionQuery> queryCaptor;
+
+  @BeforeEach
+  void mockApiServices() {
+    mockApiServiceAuthentication(processDefinitionServices);
+  }
+
+  private void assertExampleProcessDefinitionResult(ProcessDefinitionResult processDefinition) {
+    assertThat(processDefinition.getProcessDefinitionKey()).isEqualTo("5");
+    assertThat(processDefinition.getName()).isEqualTo("Complex Process");
+    assertThat(processDefinition.getProcessDefinitionId()).isEqualTo("complexProcess");
+    assertThat(processDefinition.getResourceName()).isEqualTo("complexProcess.bpmn");
+    assertThat(processDefinition.getVersion()).isEqualTo(2);
+    assertThat(processDefinition.getVersionTag()).isEqualTo("v2");
+    assertThat(processDefinition.getTenantId()).isEqualTo("tenantId");
+    assertThat(processDefinition.getHasStartForm()).isTrue();
+  }
+
+  @Nested
+  class GetProcessDefinition {
+
+    @Test
+    void shouldGetProcessDefinitionByKey() {
+      // given
+      when(processDefinitionServices.getByKey(5L)).thenReturn(PROCESS_DEFINITION_ENTITY);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinition")
+                  .arguments(Map.of("processDefinitionKey", 5L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var processDefinition =
+          objectMapper.convertValue(result.structuredContent(), ProcessDefinitionResult.class);
+      assertExampleProcessDefinitionResult(processDefinition);
+    }
+
+    @Test
+    void shouldFailGetProcessDefinitionByKeyOnInvalidKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinition")
+                  .arguments(Map.of("processDefinitionKey", -3L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .contains("Process definition key must be a positive number."));
+    }
+  }
+
+  @Nested
+  class SearchProcessDefinitions {
+
+    @Test
+    void shouldSearchProcessDefinitionsWithFilterSortAndPaging() {
+      // given
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+          .thenReturn(SEARCH_QUERY_RESULT);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessDefinitions")
+                  .arguments(
+                      Map.of(
+                          "filter",
+                          Map.of("processDefinitionId", "complexProcess"),
+                          "sort",
+                          List.of(Map.of("field", "processDefinitionKey", "order", "DESC")),
+                          "page",
+                          Map.of("limit", 25, "after", "WzEwMjRd")))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var response =
+          objectMapper.convertValue(
+              result.structuredContent(), ProcessDefinitionSearchQueryResult.class);
+      assertThat(response.getPage().getTotalItems()).isEqualTo(1L);
+      assertThat(response.getPage().getHasMoreTotalItems()).isFalse();
+      assertThat(response.getPage().getStartCursor()).isEqualTo("f");
+      assertThat(response.getPage().getEndCursor()).isEqualTo("v");
+      assertThat(response.getItems())
+          .hasSize(1)
+          .first()
+          .satisfies(ProcessDefinitionToolsTest.this::assertExampleProcessDefinitionResult);
+
+      verify(processDefinitionServices).search(queryCaptor.capture());
+      final ProcessDefinitionQuery capturedQuery = queryCaptor.getValue();
+
+      final ProcessDefinitionFilter filter = capturedQuery.filter();
+      assertThat(filter.processDefinitionIdOperations())
+          .extracting(Operation::operator, Operation::value)
+          .containsExactly(tuple(Operator.EQUALS, "complexProcess"));
+
+      assertThat(capturedQuery.sort().orderings())
+          .extracting(FieldSorting::field, FieldSorting::order)
+          .containsExactly(tuple("processDefinitionKey", SortOrder.DESC));
+
+      assertThat(capturedQuery.page().size()).isEqualTo(25);
+      assertThat(capturedQuery.page().after()).isEqualTo("WzEwMjRd");
+    }
+
+    @Test
+    void shouldFailSearchProcessDefinitionsOnException() {
+      // given
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+          .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("searchProcessDefinitions")
+                  .arguments(Map.of())
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.content()).isEmpty();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void shouldIgnoreTenantIdInFilter() {
+      // given
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+          .thenReturn(SEARCH_QUERY_RESULT);
+
+      // when (tenantId passed in arguments should be ignored by MCP filter schema)
+      mcpClient.callTool(
+          CallToolRequest.builder()
+              .name("searchProcessDefinitions")
+              .arguments(Map.of("filter", Map.of("tenantId", "tenantId")))
+              .build());
+
+      // then
+      verify(processDefinitionServices).search(queryCaptor.capture());
+      final ProcessDefinitionQuery capturedQuery = queryCaptor.getValue();
+      assertThat(capturedQuery.filter().tenantIds()).isEmpty();
+    }
+  }
+
+  @Nested
+  class GetProcessDefinitionXml {
+
+    @Test
+    void shouldGetProcessDefinitionXmlByKey() {
+      // given
+      when(processDefinitionServices.getProcessDefinitionXml(any()))
+          .thenReturn(Optional.of("<bpmn />"));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinitionXml")
+                  .arguments(Map.of("processDefinitionKey", 5L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent -> assertThat(textContent.text()).isEqualTo("<bpmn />"));
+    }
+
+    @Test
+    void shouldReturnErrorWhenNoProcessDefinitionXmlAvailable() {
+      // given
+      when(processDefinitionServices.getProcessDefinitionXml(any())).thenReturn(Optional.empty());
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessDefinitionXml")
+                  .arguments(Map.of("processDefinitionKey", 5L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail())
+          .isEqualTo("The BPMN XML for this process definition is not available.");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Implements MCP process definition search/get/getXml tools.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43609 
