### PR TITLE
feat: optimized the ProcessDefinitionFlowNodeStatisticsAggregation query

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer.java
@@ -11,51 +11,58 @@ import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsA
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_CANCELED;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_COMPLETED;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_INCIDENTS;
+import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FILTERS;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODE_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TO_PARENT_PI;
 
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
-import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity.Builder;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.function.BiConsumer;
 
 public class ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer
     implements AggregationResultTransformer<ProcessDefinitionFlowNodeStatisticsAggregationResult> {
-
-  private void processFilter(
-      final AggregationResult aggregationResult,
-      final Map<String, ProcessFlowNodeStatisticsEntity.Builder> resultMap,
-      final BiConsumer<ProcessFlowNodeStatisticsEntity.Builder, Long> resultConsumer) {
-
-    final var group = aggregationResult.aggregations().get(AGGREGATION_GROUP_FLOW_NODE_ID);
-    group
-        .aggregations()
-        .forEach(
-            (flowNodeId, result) -> {
-              final var parents = result.aggregations().get(AGGREGATION_TO_PARENT_PI);
-              final var entity =
-                  resultMap.getOrDefault(
-                      flowNodeId,
-                      new ProcessFlowNodeStatisticsEntity.Builder().flowNodeId(flowNodeId));
-              resultConsumer.accept(entity, parents.docCount());
-              resultMap.put(flowNodeId, entity);
-            });
-  }
 
   @Override
   public ProcessDefinitionFlowNodeStatisticsAggregationResult apply(
       final Map<String, AggregationResult> aggregations) {
 
-    final var entitiesMap = new HashMap<String, Builder>();
-    processFilter(aggregations.get(AGGREGATION_FILTER_ACTIVE), entitiesMap, Builder::active);
-    processFilter(aggregations.get(AGGREGATION_FILTER_COMPLETED), entitiesMap, Builder::completed);
-    processFilter(aggregations.get(AGGREGATION_FILTER_CANCELED), entitiesMap, Builder::canceled);
-    processFilter(aggregations.get(AGGREGATION_FILTER_INCIDENTS), entitiesMap, Builder::incidents);
+    // Get the top-level terms aggregation (grouped by flow node ID)
+    final var termsAgg = aggregations.get(AGGREGATION_GROUP_FLOW_NODE_ID);
 
-    return new ProcessDefinitionFlowNodeStatisticsAggregationResult(
-        entitiesMap.values().stream().map(Builder::build).toList());
+    final var items = new ArrayList<ProcessFlowNodeStatisticsEntity>();
+
+    // Iterate through each flow node bucket
+    termsAgg
+        .aggregations()
+        .forEach(
+            (flowNodeId, termsResult) -> {
+              // Get the filters aggregation for this flow node
+              final var filtersAgg = termsResult.aggregations().get(AGGREGATION_GROUP_FILTERS);
+
+              // Get each state's filter bucket and extract the parent aggregation doc count
+              final var activeBucket = filtersAgg.aggregations().get(AGGREGATION_FILTER_ACTIVE);
+              final var completedBucket =
+                  filtersAgg.aggregations().get(AGGREGATION_FILTER_COMPLETED);
+              final var canceledBucket = filtersAgg.aggregations().get(AGGREGATION_FILTER_CANCELED);
+              final var incidentsBucket =
+                  filtersAgg.aggregations().get(AGGREGATION_FILTER_INCIDENTS);
+
+              // Build entity with all state counts in one pass
+              items.add(
+                  new ProcessFlowNodeStatisticsEntity.Builder()
+                      .flowNodeId(flowNodeId)
+                      .active(activeBucket.aggregations().get(AGGREGATION_TO_PARENT_PI).docCount())
+                      .completed(
+                          completedBucket.aggregations().get(AGGREGATION_TO_PARENT_PI).docCount())
+                      .canceled(
+                          canceledBucket.aggregations().get(AGGREGATION_TO_PARENT_PI).docCount())
+                      .incidents(
+                          incidentsBucket.aggregations().get(AGGREGATION_TO_PARENT_PI).docCount())
+                      .build());
+            });
+
+    return new ProcessDefinitionFlowNodeStatisticsAggregationResult(items);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionFlowNodeStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionFlowNodeStatisticsAggregation.java
@@ -13,8 +13,9 @@ public record ProcessDefinitionFlowNodeStatisticsAggregation(
     ProcessDefinitionStatisticsFilter filter) implements AggregationBase {
 
   public static final int AGGREGATION_TERMS_SIZE = 10000;
-  public static final String AGGREGATION_TO_PARENT_PI = "parents-process-instances";
+  public static final String AGGREGATION_GROUP_FILTERS = "group-filters";
   public static final String AGGREGATION_GROUP_FLOW_NODE_ID = "terms-flow-nodes";
+  public static final String AGGREGATION_TO_PARENT_PI = "parents-process-instances";
   public static final String AGGREGATION_FILTER_ACTIVE = "active";
   public static final String AGGREGATION_FILTER_COMPLETED = "completed";
   public static final String AGGREGATION_FILTER_CANCELED = "canceled";


### PR DESCRIPTION
### Summary
Optimized the ProcessDefinitionFlowNodeStatisticsAggregation query to use a consolidated filters aggregation pattern instead of 4 separate top-level filter aggregations.

### Changes
- Refactored aggregation structure from 4 separate filter aggregations to a single terms → filters → parent hierarchy
- Simplified result transformer to single-pass iteration (no HashMap merging)

### Performance Improvements
| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Reserved bucket slots | 40,000 | 10,000 | 4x reduction |
| Top-level aggregations | 4 | 1 | 4x reduction |
| Document traversal | Multiple passes | Single pass | Reduced I/O |
| Result merging | 4 iterations + HashMap | Single iteration | Simpler/faster |