### PR TITLE
[Backport stable/8.6] fix: Eliminate need for top_hits limit when fetching grouped processes

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreGroupedProcessesIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.it.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.ProcessEntity;
+import io.camunda.operate.schema.indices.ProcessIndex;
+import io.camunda.operate.store.ProcessStore;
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessStoreGroupedProcessesIT extends OperateSearchAbstractIT {
+
+  private static final String BPMN_PROCESS_ID = "processWithManyVersions";
+  private static final int TOTAL_VERSIONS = 120;
+
+  @Autowired private ProcessIndex processDefinitionIndex;
+
+  @Autowired private ProcessStore processStore;
+
+  @Override
+  protected void runAdditionalBeforeAllSetup() throws Exception {
+    for (int version = 1; version <= TOTAL_VERSIONS; version++) {
+      final long key = 9000000000000000L + version;
+      final ProcessEntity processEntity =
+          new ProcessEntity()
+              .setKey(key)
+              .setId(String.valueOf(key))
+              .setBpmnProcessId(BPMN_PROCESS_ID)
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+              .setName("Process with many versions")
+              .setVersion(version);
+      testSearchRepository.createOrUpdateDocumentFromObject(
+          processDefinitionIndex.getFullQualifiedName(), processEntity.getId(), processEntity);
+    }
+    searchContainerManager.refreshIndices("*operate*");
+  }
+
+  @Test
+  public void shouldReturnAllVersionsSortedDescending() {
+    // given
+    final ProcessStore.ProcessKey processKey =
+        new ProcessStore.ProcessKey(BPMN_PROCESS_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // when
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            TenantOwned.DEFAULT_TENANT_IDENTIFIER, Set.of(BPMN_PROCESS_ID));
+
+    // then
+    final List<ProcessEntity> versions = results.get(processKey);
+    assertThat(versions).hasSize(TOTAL_VERSIONS);
+    assertThat(versions.getFirst().getVersion()).isEqualTo(TOTAL_VERSIONS);
+    assertThat(versions.getLast().getVersion()).isEqualTo(1);
+
+    final Set<Integer> returnedVersions =
+        versions.stream()
+            .map(ProcessEntity::getVersion)
+            .collect(java.util.stream.Collectors.toSet());
+    for (int i = 1; i <= TOTAL_VERSIONS; i++) {
+      assertThat(returnedVersions).contains(i);
+    }
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -44,6 +44,8 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
   @Autowired private ProcessStore processStore;
 
   private ProcessEntity firstProcessDefinition;
+  private ProcessEntity firstProcessDefinitionV2;
+  private ProcessEntity firstProcessDefinitionV3;
   private ProcessEntity secondProcessDefinition;
   private ProcessEntity thirdProcessDefinition;
   private ProcessInstanceForListViewEntity firstProcessInstance;
@@ -61,6 +63,27 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             .setBpmnProcessId("demoProcess")
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Demo process")
+            .setVersion(1)
+            .setBpmnXml(resourceXml);
+
+    firstProcessDefinitionV2 =
+        new ProcessEntity()
+            .setKey(2251799813685250L)
+            .setId("2251799813685250")
+            .setBpmnProcessId("demoProcess")
+            .setTenantId(DEFAULT_TENANT_ID)
+            .setName("Demo process")
+            .setVersion(2)
+            .setBpmnXml(resourceXml);
+
+    firstProcessDefinitionV3 =
+        new ProcessEntity()
+            .setKey(2251799813685253L)
+            .setId("2251799813685253")
+            .setBpmnProcessId("demoProcess")
+            .setTenantId(DEFAULT_TENANT_ID)
+            .setName("Demo process")
+            .setVersion(3)
             .setBpmnXml(resourceXml);
 
     secondProcessDefinition =
@@ -125,7 +148,12 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             .setJoinRelation(new ListViewJoinRelation("processInstance"));
 
     final var definitionEntities =
-        List.of(firstProcessDefinition, secondProcessDefinition, thirdProcessDefinition);
+        List.of(
+            firstProcessDefinition,
+            firstProcessDefinitionV2,
+            firstProcessDefinitionV3,
+            secondProcessDefinition,
+            thirdProcessDefinition);
     for (final var entity : definitionEntities) {
       testSearchRepository.createOrUpdateDocumentFromObject(
           processDefinitionIndex.getFullQualifiedName(), entity.getId(), entity);
@@ -182,7 +210,7 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
                     new ProcessStore.ProcessKey(
                         firstProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID))
                 .size())
-        .isEqualTo(1);
+        .isEqualTo(3);
     assertThat(
             results
                 .get(
@@ -190,6 +218,66 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
                         secondProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID))
                 .size())
         .isEqualTo(1);
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNonExistentBpmnProcessIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            DEFAULT_TENANT_ID, Set.of("nonExistentProcess", "anotherFakeId"));
+
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNonExistentTenant() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(
+            "nonExistentTenant",
+            Set.of(
+                firstProcessDefinition.getBpmnProcessId(),
+                secondProcessDefinition.getBpmnProcessId()));
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNullTenantReturnsAllTenants() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(null, null);
+
+    assertThat(results).hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    firstProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID)))
+        .hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    secondProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID)))
+        .hasSize(1);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(thirdProcessDefinition.getBpmnProcessId(), "tenant2")))
+        .hasSize(1);
+  }
+
+  @Test
+  public void testGetProcessesGroupedWithNullAllowedBpmnProcessIds() {
+    final Map<ProcessStore.ProcessKey, List<ProcessEntity>> results =
+        processStore.getProcessesGrouped(DEFAULT_TENANT_ID, null);
+
+    assertThat(results).hasSize(2);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    firstProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID)))
+        .hasSize(3);
+    assertThat(
+            results.get(
+                new ProcessStore.ProcessKey(
+                    secondProcessDefinition.getBpmnProcessId(), DEFAULT_TENANT_ID)))
+        .hasSize(1);
   }
 
   @Test
@@ -203,8 +291,13 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
             "name",
             "bpmnProcessId",
             "key");
-    assertThat(results.size()).isEqualTo(2);
+    // 3 versions of firstProcessDefinition + 1 version of secondProcessDefinition = 4
+    assertThat(results.size()).isEqualTo(4);
     assertThat(results.get(firstProcessDefinition.getKey()).getBpmnProcessId())
+        .isEqualTo(firstProcessDefinition.getBpmnProcessId());
+    assertThat(results.get(firstProcessDefinitionV2.getKey()).getBpmnProcessId())
+        .isEqualTo(firstProcessDefinition.getBpmnProcessId());
+    assertThat(results.get(firstProcessDefinitionV3.getKey()).getBpmnProcessId())
         .isEqualTo(firstProcessDefinition.getBpmnProcessId());
     assertThat(results.get(secondProcessDefinition.getKey()).getBpmnProcessId())
         .isEqualTo(secondProcessDefinition.getBpmnProcessId());

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -31,8 +31,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinality;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
@@ -75,16 +73,12 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
-import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Cardinality;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
@@ -238,68 +232,43 @@ public class ElasticsearchProcessStore implements ProcessStore {
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
       final String tenantId, @Nullable final Set<String> allowedBPMNProcessIds) {
-    final String tenantsGroupsAggName = "group_by_tenantId";
-    final String groupsAggName = "group_by_bpmnProcessId";
-    final String processesAggName = "processes";
 
-    final AggregationBuilder agg =
-        terms(tenantsGroupsAggName)
-            .field(ProcessIndex.TENANT_ID)
-            .size(ElasticsearchUtil.TERMS_AGG_SIZE)
-            .subAggregation(
-                terms(groupsAggName)
-                    .field(ProcessIndex.BPMN_PROCESS_ID)
-                    .size(ElasticsearchUtil.TERMS_AGG_SIZE)
-                    .subAggregation(
-                        topHits(processesAggName)
-                            .fetchSource(
-                                new String[] {
-                                  ProcessIndex.ID,
-                                  ProcessIndex.NAME,
-                                  ProcessIndex.VERSION,
-                                  ProcessIndex.VERSION_TAG,
-                                  ProcessIndex.BPMN_PROCESS_ID,
-                                  ProcessIndex.TENANT_ID
-                                },
-                                null)
-                            .size(ElasticsearchUtil.TOPHITS_AGG_SIZE)
-                            .sort(ProcessIndex.VERSION, SortOrder.DESC)));
+    final SearchSourceBuilder sourceBuilder =
+        new SearchSourceBuilder()
+            .query(buildQuery(tenantId, allowedBPMNProcessIds))
+            .fetchSource(
+                new String[] {
+                  ProcessIndex.ID,
+                  ProcessIndex.NAME,
+                  ProcessIndex.VERSION,
+                  ProcessIndex.VERSION_TAG,
+                  ProcessIndex.BPMN_PROCESS_ID,
+                  ProcessIndex.TENANT_ID
+                },
+                null)
+            .sort(ProcessIndex.VERSION, SortOrder.DESC);
 
-    final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().aggregation(agg).size(0);
-    sourceBuilder.query(buildQuery(tenantId, allowedBPMNProcessIds));
     final SearchRequest searchRequest =
         new SearchRequest(processIndex.getAlias()).source(sourceBuilder);
 
     try {
-      final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
-      final Terms groups = searchResponse.getAggregations().get(tenantsGroupsAggName);
       final Map<ProcessKey, List<ProcessEntity>> result = new HashMap<>();
 
-      groups.getBuckets().stream()
-          .forEach(
-              b -> {
-                final String groupTenantId = b.getKeyAsString();
-                final Terms processGroups = b.getAggregations().get(groupsAggName);
+      final List<ProcessEntity> allProcesses =
+          tenantAwareClient.search(
+              searchRequest,
+              () ->
+                  ElasticsearchUtil.scroll(
+                      searchRequest, ProcessEntity.class, objectMapper, esClient));
 
-                processGroups.getBuckets().stream()
-                    .forEach(
-                        tenantB -> {
-                          final String bpmnProcessId = tenantB.getKeyAsString();
-                          final ProcessKey groupKey = new ProcessKey(bpmnProcessId, groupTenantId);
-                          result.put(groupKey, new ArrayList<>());
-
-                          final TopHits processes = tenantB.getAggregations().get(processesAggName);
-                          final SearchHit[] hits = processes.getHits().getHits();
-                          for (final SearchHit searchHit : hits) {
-                            final ProcessEntity processEntity =
-                                fromSearchHit(searchHit.getSourceAsString());
-                            result.get(groupKey).add(processEntity);
-                          }
-                        });
-              });
+      for (final ProcessEntity processEntity : allProcesses) {
+        final ProcessKey groupKey =
+            new ProcessKey(processEntity.getBpmnProcessId(), processEntity.getTenantId());
+        result.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(processEntity);
+      }
 
       return result;
-    } catch (final IOException e) {
+    } catch (final Exception e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining grouped processes: %s", e.getMessage());

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -9,14 +9,9 @@ package io.camunda.operate.store.opensearch;
 
 import static io.camunda.operate.schema.templates.FlowNodeInstanceTemplate.TREE_PATH;
 import static io.camunda.operate.schema.templates.ListViewTemplate.*;
-import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TERMS_AGG_SIZE;
-import static io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TOPHITS_AGG_SIZE;
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchRetryOperation.UPDATE_RETRY_COUNT;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.cardinalityAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.filtersAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.termAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.withTenantCheck;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
@@ -123,77 +118,45 @@ public class OpensearchProcessStore implements ProcessStore {
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
       final String tenantId, final Set<String> allowedBPMNProcessIds) {
-    final String tenantsGroupsAggName = "group_by_tenantId";
-    final String groupsAggName = "group_by_bpmnProcessId";
-    final String processesAggName = "processes";
-    final List<String> sourceFields =
-        List.of(
-            ProcessIndex.ID,
-            ProcessIndex.NAME,
-            ProcessIndex.VERSION,
-            ProcessIndex.VERSION_TAG,
-            ProcessIndex.BPMN_PROCESS_ID,
-            ProcessIndex.TENANT_ID);
+
     final Query query =
         allowedBPMNProcessIds == null
             ? matchAll()
-            : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowedBPMNProcessIds);
+            : stringTerms(ProcessIndex.BPMN_PROCESS_ID, allowedBPMNProcessIds);
+
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
             .query(withTenantCheck(withTenantIdQuery(tenantId, query)))
-            .size(0)
-            .aggregations(
-                tenantsGroupsAggName,
-                withSubaggregations(
-                    termAggregation(ProcessIndex.TENANT_ID, TERMS_AGG_SIZE),
-                    Map.of(
-                        groupsAggName,
-                        withSubaggregations(
-                            termAggregation(ProcessIndex.BPMN_PROCESS_ID, TERMS_AGG_SIZE),
-                            Map.of(
-                                processesAggName,
-                                topHitsAggregation(
-                                        sourceFields,
-                                        TOPHITS_AGG_SIZE,
-                                        sortOptions(ProcessIndex.VERSION, SortOrder.Desc))
-                                    ._toAggregation())))));
+            .source(
+                sourceInclude(
+                    ProcessIndex.ID,
+                    ProcessIndex.NAME,
+                    ProcessIndex.VERSION,
+                    ProcessIndex.VERSION_TAG,
+                    ProcessIndex.BPMN_PROCESS_ID,
+                    ProcessIndex.TENANT_ID))
+            .sort(sortOptions(ProcessIndex.VERSION, SortOrder.Desc));
 
-    final SearchResponse<Object> response =
-        richOpenSearchClient.doc().search(searchRequestBuilder, Object.class);
-    final Map<ProcessKey, List<ProcessEntity>> result = new HashMap<>();
+    try {
+      final Map<ProcessKey, List<ProcessEntity>> result = new HashMap<>();
 
-    response
-        .aggregations()
-        .get(tenantsGroupsAggName)
-        .sterms()
-        .buckets()
-        .array()
-        .forEach(
-            tenantBucket ->
-                tenantBucket
-                    .aggregations()
-                    .get(groupsAggName)
-                    .sterms()
-                    .buckets()
-                    .array()
-                    .forEach(
-                        bpmnProcessIdBucket -> {
-                          final String key = tenantBucket.key() + "_" + bpmnProcessIdBucket.key();
-                          final List<ProcessEntity> value =
-                              bpmnProcessIdBucket
-                                  .aggregations()
-                                  .get(processesAggName)
-                                  .topHits()
-                                  .hits()
-                                  .hits()
-                                  .stream()
-                                  .map(h -> h.source().to(ProcessEntity.class))
-                                  .toList();
+      final List<ProcessEntity> allProcesses =
+          richOpenSearchClient.doc().scrollValues(searchRequestBuilder, ProcessEntity.class);
 
-                          result.put(new ProcessKey(key, tenantId), value);
-                        }));
+      for (final ProcessEntity processEntity : allProcesses) {
+        final ProcessKey groupKey =
+            new ProcessKey(processEntity.getBpmnProcessId(), processEntity.getTenantId());
+        result.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(processEntity);
+      }
 
-    return result;
+      return result;
+    } catch (final Exception e) {
+      final String message =
+          String.format(
+              "Exception occurred, while obtaining grouped processes: %s", e.getMessage());
+      LOGGER.error(message, e);
+      throw new OperateRuntimeException(message, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #44448 to `stable/8.6`.

relates to #43503 camunda/camunda#41058