### PR TITLE
fix: handle CREATED state for migrated user tasks in UserTaskHandler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -189,7 +189,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     if (entity.getState() != null) {
       updateFields.put(TaskTemplate.STATE, entity.getState());
       // Add update fields for migrated user tasks
-      if (entity.getState() == TaskState.CREATING) {
+      if (entity.getState() == TaskState.CREATING || entity.getState() == TaskState.CREATED) {
         updateFields.put(TaskTemplate.KEY, entity.getKey());
         if (entity.getImplementation() != null) {
           updateFields.put(TaskTemplate.IMPLEMENTATION, entity.getImplementation());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -854,6 +854,7 @@ public class UserTaskHandlerTest {
 
     underTest.flush(taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
@@ -897,6 +898,7 @@ public class UserTaskHandlerTest {
 
     underTest.flush(taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
     expectedUpdates.put(TaskTemplate.ASSIGNEE, null);
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
@@ -992,6 +994,7 @@ public class UserTaskHandlerTest {
 
     underTest.flush(taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
     expectedUpdates.put(TaskTemplate.FOLLOW_UP_DATE, taskEntity.getFollowUpDate());
     expectedUpdates.put(TaskTemplate.DUE_DATE, taskEntity.getDueDate());
@@ -1064,6 +1067,7 @@ public class UserTaskHandlerTest {
 
     underTest.flush(taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.KEY, taskEntity.getKey());
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("priority", "assignee"));


### PR DESCRIPTION
## Description

Handle CREATED state for migrated user tasks in UserTaskHandler.

## Related issues

closes https://github.com/camunda/camunda/issues/44431
