### PR TITLE
Adds optional filter by record value in the exporter

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -203,11 +203,12 @@ final class ExporterContainer implements Controller {
     return context.getConfiguration().getId();
   }
 
-  private boolean acceptRecord(final RecordMetadata metadata) {
+  private boolean acceptRecord(final RecordMetadata rawMetadata, final TypedRecord<?> typedEvent) {
     final Context.RecordFilter filter = context.getFilter();
-    return filter.acceptType(metadata.getRecordType())
-        && filter.acceptValue(metadata.getValueType())
-        && filter.acceptIntent(metadata.getIntent());
+    return filter.acceptType(rawMetadata.getRecordType())
+        && filter.acceptValue(rawMetadata.getValueType())
+        && filter.acceptIntent(rawMetadata.getIntent())
+        && filter.acceptRecord(typedEvent);
   }
 
   void configureExporter() throws Exception {
@@ -216,10 +217,10 @@ final class ExporterContainer implements Controller {
         () -> exporter.configure(context), exporter.getClass().getClassLoader());
   }
 
-  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord typedEvent) {
+  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord<?> typedEvent) {
     try {
       if (position < typedEvent.getPosition()) {
-        if (acceptRecord(rawMetadata)) {
+        if (acceptRecord(rawMetadata, typedEvent)) {
           export(typedEvent);
         } else {
           updatePositionOnSkipIfUpToDate(typedEvent.getPosition());

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.exporter.api.context;
 
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -63,7 +64,16 @@ public interface Context {
    */
   void setFilter(RecordFilter filter);
 
-  /** A filter to limit the records which are exported. */
+  /**
+   * A filter to limit the records which are exported.
+   *
+   * <p>This interface is used in two distinct phases of filtering:
+   *
+   * <ul>
+   *   <li>filtering on metadata to avoid deserialization (faster but limited data to filter on)
+   *   <li>filtering on fully deserialized records (slower but richer data to filter on)
+   * </ul>
+   */
   interface RecordFilter {
 
     /**
@@ -90,6 +100,15 @@ public interface Context {
      */
     default boolean acceptIntent(final Intent intent) {
       // default implementation accepts all intents
+      return true;
+    }
+
+    /**
+     * Filters a fully deserialized {@link Record}.
+     *
+     * <p>Used to filter using full record instead of just metadata
+     */
+    default boolean acceptRecord(final Record<?> record) {
       return true;
     }
   }

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -106,7 +106,14 @@ public interface Context {
     /**
      * Filters a fully deserialized {@link Record}.
      *
-     * <p>Used to filter using full record instead of just metadata
+     * <p>Use this when filtering needs access to the complete record data instead of just its
+     * metadata. This is less efficient than metadata-based filtering because it runs in the second
+     * phase of the filtering pipeline:
+     *
+     * <ul>
+     *   <li>Phase 1: filter on metadata to avoid deserialization (faster but limited information)
+     *   <li>Phase 2: filter on fully deserialized records (slower but with richer information)
+     * </ul>
      */
     default boolean acceptRecord(final Record<?> record) {
       return true;


### PR DESCRIPTION
## Description

In order to implement some of the filters required by the epic, it is necessary to access some of the deserialized record properties. This task aims to adds that option to the current filter capabilities.

## Related issues

[#44501](https://github.com/camunda/camunda/issues/44501)
