### PR TITLE
Unflake `ExpressionProcessorTest$EvaluationErrorTest`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -409,8 +409,12 @@ class ExpressionProcessorTest {
           .isTrue();
 
       evaluationThread.interrupt();
-      blockingEL.release(); // unblock EL so it can notice interrupt/fail fast
-      evaluationThread.join(TimeUnit.SECONDS.toMillis(5));
+      try {
+        evaluationThread.join(TimeUnit.SECONDS.toMillis(5));
+      } finally {
+        // ensure we release the blocking EL to avoid leaking threads
+        blockingEL.release();
+      }
 
       // then
       Assertions.assertThat(evaluationThread.isAlive())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The test case `ExpressionProcessorTest$EvaluationErrorTest.shouldThrowEvaluationExceptionWhenInterrupted` is flaky due to a race condition.

This test evaluates an expression (running in another thread) that blocks allowing the test to interrupt it. However, the test releases this blocking thread immediately after interrupting it but doesn't await the interruption to occur. So there's a race condition between the interruption and releasing the blocking of the thread.

How it slipped through is not clear to me, because it occurs often. After the fix I was unable to reproduce it anymore (note that the tests run fast, so I was able to test it thousands of times).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates to #41764 
