### PR TITLE
ES/OS now supports multi-host

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -151,7 +151,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   private void validateUrlConfiguration() {
     final String url = super.getUrl();
     final List<String> urls = super.getUrls();
-    final boolean hasNonDefaultUrl = !url.equals("http://localhost:9200");
+    final boolean hasNonDefaultUrl = !"http://localhost:9200".equals(url);
     final boolean hasUrls = urls != null && !urls.isEmpty();
 
     if (hasNonDefaultUrl && hasUrls) {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -97,12 +97,19 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   @Override
   public String getUrl() {
+    validateUrlConfiguration();
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".url",
         super.getUrl(),
         String.class,
         BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
         legacyUrlProperties());
+  }
+
+  @Override
+  public List<String> getUrls() {
+    validateUrlConfiguration();
+    return super.getUrls();
   }
 
   @Override
@@ -133,6 +140,26 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   @Override
   public void setHistory(final DocumentBasedHistory history) {
     this.history = history;
+  }
+
+  /**
+   * Validates that both 'url' and 'urls' are not configured simultaneously. Having both configured
+   * is ambiguous and would lead to unexpected behavior.
+   *
+   * @throws IllegalArgumentException if both url (non-default) and urls (non-empty) are configured
+   */
+  private void validateUrlConfiguration() {
+    final String url = super.getUrl();
+    final List<String> urls = super.getUrls();
+    final boolean hasNonDefaultUrl = !url.equals("http://localhost:9200");
+    final boolean hasUrls = urls != null && !urls.isEmpty();
+
+    if (hasNonDefaultUrl && hasUrls) {
+      throw new IllegalArgumentException(
+          "Cannot configure both 'url' and 'urls' for "
+              + databaseName()
+              + ". Use 'url' for a single node or 'urls' for multiple nodes.");
+    }
   }
 
   public boolean isCreateSchema() {

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -20,10 +20,16 @@ import java.util.List;
  */
 public abstract class SecondaryStorageDatabase<T> {
 
-  /** Endpoint for the database configured as secondary storage. */
+  /**
+   * Endpoint for the database configured as secondary storage. Mutually exclusive with {@link
+   * #urls} - configure only one.
+   */
   private String url = "http://localhost:9200";
 
-  /** List of endpoints for the database configured as secondary storage. */
+  /**
+   * List of endpoints for the database configured as secondary storage. Use for multi-node cluster
+   * connectivity. Mutually exclusive with {@link #url} - configure only one.
+   */
   private List<String> urls = new ArrayList<>();
 
   /** Username for the database configured as secondary storage. */

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageDatabase.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Base class for configuration of databases used as secondary storage.
  *
@@ -20,6 +23,9 @@ public abstract class SecondaryStorageDatabase<T> {
   /** Endpoint for the database configured as secondary storage. */
   private String url = "http://localhost:9200";
 
+  /** List of endpoints for the database configured as secondary storage. */
+  private List<String> urls = new ArrayList<>();
+
   /** Username for the database configured as secondary storage. */
   private String username = "";
 
@@ -32,6 +38,14 @@ public abstract class SecondaryStorageDatabase<T> {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public String getUsername() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -59,6 +59,7 @@ public final class CamundaExporterConfigurationApplier {
     }
 
     target.setUrl(source.getUrl());
+    target.setUrls(source.getUrls());
     target.setClusterName(source.getClusterName());
     target.setDateFormat(source.getDateFormat());
     target.setSocketTimeout(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/OperatePropertiesOverride.java
@@ -82,6 +82,7 @@ public class OperatePropertiesOverride {
       final OperateProperties override, final SecondaryStorage database) {
     override.setDatabase(DatabaseType.Elasticsearch);
     override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+    override.getElasticsearch().setUrls(database.getElasticsearch().getUrls());
     override.getElasticsearch().setUsername(database.getElasticsearch().getUsername());
     override.getElasticsearch().setPassword(database.getElasticsearch().getPassword());
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
@@ -112,6 +113,7 @@ public class OperatePropertiesOverride {
       final OperateProperties override, final SecondaryStorage database) {
     override.setDatabase(DatabaseType.Opensearch);
     override.getOpensearch().setUrl(database.getOpensearch().getUrl());
+    override.getOpensearch().setUrls(database.getOpensearch().getUrls());
     override.getOpensearch().setUsername(database.getOpensearch().getUsername());
     override.getOpensearch().setPassword(database.getOpensearch().getPassword());
     override.getOpensearch().setClusterName(database.getOpensearch().getClusterName());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -86,6 +86,7 @@ public class SearchEngineConnectPropertiesOverride {
 
     override.setType(secondaryStorage.getType().name());
     override.setUrl(database.getUrl());
+    override.setUrls(database.getUrls());
 
     populateFromSecurity(override);
     populateFromInterceptorPlugins(override);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/TasklistPropertiesOverride.java
@@ -77,6 +77,7 @@ public class TasklistPropertiesOverride {
       final TasklistProperties override, final SecondaryStorage database) {
     override.setDatabase("elasticsearch");
     override.getElasticsearch().setUrl(database.getElasticsearch().getUrl());
+    override.getElasticsearch().setUrls(database.getElasticsearch().getUrls());
     override.getElasticsearch().setUsername(database.getElasticsearch().getUsername());
     override.getElasticsearch().setPassword(database.getElasticsearch().getPassword());
     override.getElasticsearch().setClusterName(database.getElasticsearch().getClusterName());
@@ -107,6 +108,7 @@ public class TasklistPropertiesOverride {
       final TasklistProperties override, final SecondaryStorage database) {
     override.setDatabase("opensearch");
     override.getOpenSearch().setUrl(database.getOpensearch().getUrl());
+    override.getOpenSearch().setUrls(database.getOpensearch().getUrls());
     override.getOpenSearch().setUsername(database.getOpensearch().getUsername());
     override.getOpenSearch().setPassword(database.getOpensearch().getPassword());
     override.getOpenSearch().setClusterName(database.getOpensearch().getClusterName());

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistElasticsearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -844,6 +845,70 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(searchEngineConnectProperties)
           .returns(null, SearchEngineConnectProperties::getSocketTimeout)
           .returns(null, SearchEngineConnectProperties::getConnectTimeout);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.urls=http://node1:9200,http://node2:9200,http://node3:9200",
+        "camunda.data.secondary-storage.elasticsearch.username=" + EXPECTED_USERNAME,
+        "camunda.data.secondary-storage.elasticsearch.password=" + EXPECTED_PASSWORD,
+      })
+  class WithUrlsConfigured {
+    private static final List<String> EXPECTED_URLS =
+        List.of("http://node1:9200", "http://node2:9200", "http://node3:9200");
+
+    final OperateProperties operateProperties;
+    final TasklistProperties tasklistProperties;
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithUrlsConfigured(
+        @Autowired final OperateProperties operateProperties,
+        @Autowired final TasklistProperties tasklistProperties,
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.operateProperties = operateProperties;
+      this.tasklistProperties = tasklistProperties;
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void testUrlsPropagatedToOperateProperties() {
+      assertThat(operateProperties.getElasticsearch().getUrls()).isEqualTo(EXPECTED_URLS);
+      assertThat(operateProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(operateProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+    }
+
+    @Test
+    void testUrlsPropagatedToTasklistProperties() {
+      assertThat(tasklistProperties.getElasticsearch().getUrls()).isEqualTo(EXPECTED_URLS);
+      assertThat(tasklistProperties.getElasticsearch().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(tasklistProperties.getElasticsearch().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+    }
+
+    @Test
+    void testUrlsPropagatedToCamundaExporterProperties() {
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+      assertThat(exporterConfiguration.getConnect().getUrls()).isEqualTo(EXPECTED_URLS);
+      assertThat(exporterConfiguration.getConnect().getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(exporterConfiguration.getConnect().getPassword()).isEqualTo(EXPECTED_PASSWORD);
+    }
+
+    @Test
+    void testUrlsPropagatedToSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getUrls()).isEqualTo(EXPECTED_URLS);
+      assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(EXPECTED_USERNAME);
+      assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(EXPECTED_PASSWORD);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -212,6 +213,33 @@ public class SecondaryStorageRdbmsTest {
       assertThat(args.get("flushInterval")).isEqualTo(Duration.ofMillis(500));
       assertThat(args.get("exportBatchOperationItemsOnCreation")).isEqualTo(true);
       assertThat(args.get("batchOperationItemInsertBlockSize")).isEqualTo(10000);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.secondary-storage.rdbms.urls=jdbc:postgresql://node1:5432/camunda,jdbc:postgresql://node2:5432/camunda",
+        "camunda.data.secondary-storage.rdbms.username=" + USERNAME,
+        "camunda.data.secondary-storage.rdbms.password=" + PASSWORD,
+      })
+  class WithUrlsConfigured {
+    private static final List<String> EXPECTED_URLS =
+        List.of("jdbc:postgresql://node1:5432/camunda", "jdbc:postgresql://node2:5432/camunda");
+
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithUrlsConfigured(
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void testUrlsPropagatedToSearchEngineConnectProperties() {
+      assertThat(searchEngineConnectProperties.getUrls()).isEqualTo(EXPECTED_URLS);
+      assertThat(searchEngineConnectProperties.getUsername()).isEqualTo(USERNAME);
+      assertThat(searchEngineConnectProperties.getPassword()).isEqualTo(PASSWORD);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageUrlValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageUrlValidationTest.java
@@ -22,7 +22,8 @@ import org.junit.jupiter.api.Test;
 public class SecondaryStorageUrlValidationTest {
 
   /** Test implementation of DocumentBasedSecondaryStorageDatabase for unit testing. */
-  private static class TestDocumentBasedDatabase extends DocumentBasedSecondaryStorageDatabase {
+  private static final class TestDocumentBasedDatabase
+      extends DocumentBasedSecondaryStorageDatabase {
 
     @Override
     public String databaseName() {

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageUrlValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageUrlValidationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for validating that 'url' and 'urls' configuration properties are mutually exclusive in
+ * document-based secondary storage databases.
+ */
+public class SecondaryStorageUrlValidationTest {
+
+  /** Test implementation of DocumentBasedSecondaryStorageDatabase for unit testing. */
+  private static class TestDocumentBasedDatabase extends DocumentBasedSecondaryStorageDatabase {
+
+    @Override
+    public String databaseName() {
+      return "TestDatabase";
+    }
+  }
+
+  @Nested
+  class WhenBothUrlAndUrlsAreConfigured {
+
+    @Test
+    void shouldThrowExceptionWhenAccessingUrl() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrl("http://custom-url:9200");
+      database.setUrls(List.of("http://node1:9200", "http://node2:9200"));
+
+      // when/then
+      assertThatThrownBy(database::getUrl)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot configure both 'url' and 'urls'")
+          .hasMessageContaining("TestDatabase");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAccessingUrls() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrl("http://custom-url:9200");
+      database.setUrls(List.of("http://node1:9200", "http://node2:9200"));
+
+      // when/then
+      assertThatThrownBy(database::getUrls)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot configure both 'url' and 'urls'")
+          .hasMessageContaining("TestDatabase");
+    }
+  }
+
+  @Nested
+  class WhenOnlyUrlIsConfigured {
+
+    @Test
+    void shouldAllowAccessingUrl() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrl("http://custom-url:9200");
+
+      // when/then
+      assertThatNoException().isThrownBy(database::getUrl);
+      assertThat(database.getUrl()).isEqualTo("http://custom-url:9200");
+    }
+
+    @Test
+    void shouldAllowAccessingUrls() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrl("http://custom-url:9200");
+
+      // when/then
+      assertThatNoException().isThrownBy(database::getUrls);
+      assertThat(database.getUrls()).isEmpty();
+    }
+  }
+
+  @Nested
+  class WhenOnlyUrlsIsConfigured {
+
+    @Test
+    void shouldAllowAccessingUrl() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrls(List.of("http://node1:9200", "http://node2:9200"));
+
+      // when/then - url is default, so no conflict
+      assertThatNoException().isThrownBy(database::getUrl);
+    }
+
+    @Test
+    void shouldAllowAccessingUrls() {
+      // given
+      final var database = new TestDocumentBasedDatabase();
+      database.setUrls(List.of("http://node1:9200", "http://node2:9200"));
+
+      // when/then
+      assertThatNoException().isThrownBy(database::getUrls);
+      assertThat(database.getUrls()).containsExactly("http://node1:9200", "http://node2:9200");
+    }
+  }
+}

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -222,7 +222,7 @@ public class OpensearchConnector {
 
     final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
-        new AuthScope(getHttpHost(osConfig)),
+        new AuthScope(null, -1),
         new UsernamePasswordCredentials(
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -43,6 +43,7 @@ public class ElasticsearchProperties {
   private boolean healthCheckEnabled = true;
 
   private String url;
+  private List<String> urls;
   private String username;
   private String password;
 
@@ -156,6 +157,14 @@ public class ElasticsearchProperties {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public Integer getSocketTimeout() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -43,6 +43,7 @@ public class OpensearchProperties {
   private boolean healthCheckEnabled = true;
 
   private String url;
+  private List<String> urls;
   private String username;
   private String password;
 
@@ -158,6 +159,14 @@ public class OpensearchProperties {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public Integer getSocketTimeout() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -25,6 +25,7 @@ public class ConnectConfiguration {
   private Integer socketTimeout;
   private Integer connectTimeout;
   private String url = URL_DEFAULT;
+  private List<String> urls = new ArrayList<>();
   private String username;
   private String password;
   private SecurityConfiguration security = new SecurityConfiguration();
@@ -100,6 +101,14 @@ public class ConnectConfiguration {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public String getUsername() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -91,8 +91,8 @@ public final class ElasticsearchConnector {
   }
 
   private RestClient createRestClient(final ConnectConfiguration configuration) {
-    final var httpHost = getHttpHost(configuration);
-    final var restClientBuilder = RestClient.builder(httpHost);
+    final var httpHosts = getHttpHosts(configuration);
+    final var restClientBuilder = RestClient.builder(httpHosts);
 
     if (configuration.getConnectTimeout() != null || configuration.getSocketTimeout() != null) {
       restClientBuilder.setRequestConfigCallback(
@@ -156,6 +156,23 @@ public final class ElasticsearchConnector {
     } catch (final Exception e) {
       throw new SearchClientConnectException("Error in url: " + elsConfig.getUrl(), e);
     }
+  }
+
+  private HttpHost[] getHttpHosts(final ConnectConfiguration elsConfig) {
+    final var urls = elsConfig.getUrls();
+    if (urls != null && !urls.isEmpty()) {
+      return urls.stream()
+          .map(
+              url -> {
+                try {
+                  return HttpHost.create(url);
+                } catch (final Exception e) {
+                  throw new SearchClientConnectException("Error in url: " + url, e);
+                }
+              })
+          .toArray(HttpHost[]::new);
+    }
+    return new HttpHost[] {getHttpHost(elsConfig)};
   }
 
   private void setupAuthentication(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -101,12 +101,12 @@ public final class OpensearchConnector {
   }
 
   private OpenSearchTransport createAWSBasedTransport(final ConnectConfiguration configuration) {
-    final var httpHost = getHttpHost(configuration);
+    final var hostname = getHttpHosts(configuration)[0].getHostName();
     final var region = new DefaultAwsRegionProviderChain().getRegion();
     final var httpClient = AwsCrtHttpClient.builder().build();
     return new AwsSdk2Transport(
         httpClient,
-        httpHost.getHostName(),
+        hostname,
         region,
         AwsSdk2TransportOptions.builder()
             .setMapper(new SearchRequestJacksonJsonpMapperWrapper(objectMapper))
@@ -114,8 +114,8 @@ public final class OpensearchConnector {
   }
 
   private OpenSearchTransport createDefaultTransport(final ConnectConfiguration configuration) {
-    final var host = getHttpHost(configuration);
-    final var builder = ApacheHttpClient5TransportBuilder.builder(host);
+    final var hosts = getHttpHosts(configuration);
+    final var builder = ApacheHttpClient5TransportBuilder.builder(hosts);
 
     builder.setHttpClientConfigCallback(
         httpClientBuilder -> {
@@ -158,6 +158,24 @@ public final class OpensearchConnector {
     } catch (final URISyntaxException e) {
       throw new SearchClientConnectException("Error in url: " + osConfig.getUrl(), e);
     }
+  }
+
+  private HttpHost[] getHttpHosts(final ConnectConfiguration osConfig) {
+    final var urls = osConfig.getUrls();
+    if (urls != null && !urls.isEmpty()) {
+      return urls.stream()
+          .map(
+              url -> {
+                try {
+                  final var uri = new URI(url);
+                  return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+                } catch (final URISyntaxException e) {
+                  throw new SearchClientConnectException("Error in url: " + url, e);
+                }
+              })
+          .toArray(HttpHost[]::new);
+    }
+    return new HttpHost[] {getHttpHost(osConfig)};
   }
 
   protected HttpAsyncClientBuilder configureHttpClient(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -219,7 +219,7 @@ public final class OpensearchConnector {
 
     final var credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
-        new AuthScope(getHttpHost(configuration)),
+        new AuthScope(null, -1),
         new UsernamePasswordCredentials(
             configuration.getUsername(), configuration.getPassword().toCharArray()));
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -178,7 +178,7 @@ public class OpenSearchConnector {
 
     final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
-        new AuthScope(getHttpHostForClient5(osConfig)),
+        new AuthScope(null, -1),
         new UsernamePasswordCredentials(
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -110,9 +110,9 @@ public class OpenSearchConnector {
     if (hasAwsCredentials()) {
       return getAwsClient(osConfig);
     }
-    final HttpHost host = getHttpHostForClient5(osConfig);
+    final HttpHost[] hosts = getHttpHostsForClient5(osConfig);
     final ApacheHttpClient5TransportBuilder builder =
-        ApacheHttpClient5TransportBuilder.builder(host);
+        ApacheHttpClient5TransportBuilder.builder(hosts);
 
     builder.setHttpClientConfigCallback(
         httpClientBuilder -> {
@@ -140,6 +140,24 @@ public class OpenSearchConnector {
   private HttpHost getHttpHostForClient5(final OpenSearchProperties osConfig) {
     final URI uri = getOsUri(osConfig);
     return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+  }
+
+  private HttpHost[] getHttpHostsForClient5(final OpenSearchProperties osConfig) {
+    final var urls = osConfig.getUrls();
+    if (urls != null && !urls.isEmpty()) {
+      return urls.stream()
+          .map(
+              url -> {
+                try {
+                  final URI uri = new URI(url);
+                  return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+                } catch (final URISyntaxException e) {
+                  throw new TasklistRuntimeException("Error in url: " + url, e);
+                }
+              })
+          .toArray(HttpHost[]::new);
+    }
+    return new HttpHost[] {getHttpHostForClient5(osConfig)};
   }
 
   private URI getOsUri(final OpenSearchProperties osConfig) {
@@ -338,7 +356,7 @@ public class OpenSearchConnector {
     final AwsSdk2Transport transport =
         new AwsSdk2Transport(
             httpClient,
-            osConfig.getHost(),
+            getHttpHostsForClient5(osConfig)[0].getHostName(),
             region,
             AwsSdk2TransportOptions.builder()
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -42,6 +42,7 @@ public class ElasticsearchProperties {
   private boolean createSchema = true;
 
   private String url;
+  private List<String> urls;
   private String username;
   private String password;
 
@@ -155,6 +156,14 @@ public class ElasticsearchProperties {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public Integer getSocketTimeout() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -42,6 +42,7 @@ public class OpenSearchProperties {
   private boolean createSchema = true;
 
   private String url;
+  private List<String> urls;
   private String username;
   private String password;
 
@@ -156,6 +157,14 @@ public class OpenSearchProperties {
 
   public void setUrl(final String url) {
     this.url = url;
+  }
+
+  public List<String> getUrls() {
+    return urls;
+  }
+
+  public void setUrls(final List<String> urls) {
+    this.urls = urls;
   }
 
   public Integer getSocketTimeout() {


### PR DESCRIPTION
## Description

Adds support for multihost to ES/OS

the multi host also propagates to configuration for RDBMS but the actual connection doesn't use multi host.

only supports tasklist+operate, optimize will be separate

## Related issues

closes https://github.com/camunda/camunda/issues/37406
