### PR TITLE
fix: streamline type mappings for OpenAPI model generation

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -310,26 +310,28 @@
           <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
           <modelPackage>io.camunda.client.protocol.rest</modelPackage>
           <typeMappings>
+            <!-- map OffsetDateTime to String to avoid timezone issues and do validation manually -->
             <typeMapping>OffsetDateTime=String</typeMapping>
+            <!-- map complex String schemas to String -->
+            <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
             <typeMapping>ResourceKey=String</typeMapping>
-            <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
-            <typeMapping>DecisionDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>DecisionEvaluationInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>ElementInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>ProcessInstanceModificationActivateInstructionAncestorElementInstanceKey=String</typeMapping>
-            <typeMapping>ScopeKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>VariableKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>JobKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>MessageSubscriptionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>DeploymentKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>FormKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-            <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <!-- map specific filter properties to basic filter types -->
             <typeMapping>AuditLogEntityKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>AuditLogKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>DecisionDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>DecisionEvaluationInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>DecisionEvaluationKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>DecisionRequirementsKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>DeploymentKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ElementInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>FormKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>JobKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>MessageSubscriptionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ScopeKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>VariableKeyFilterProperty=BasicStringFilterProperty</typeMapping>
           </typeMappings>
           <generateApis>false</generateApis>
           <generateApiTests>false</generateApiTests>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -323,7 +323,7 @@ public class SimpleSearchQueryMapper {
           .map(SimpleSearchQueryMapper::getBasicStringFilter)
           .ifPresent(filterModel::variableKey);
       ofNullable(filter.getScopeKey())
-          .map(SimpleSearchQueryMapper::getStringFilter)
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
           .ifPresent(filterModel::scopeKey);
       ofNullable(filter.getProcessInstanceKey())
           .map(SimpleSearchQueryMapper::getBasicStringFilter)

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -99,7 +99,7 @@
                 <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
-                <typeMapping>ScopeKeyFilterProperty=StringFilterProperty</typeMapping>
+                <typeMapping>ScopeKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>VariableKeyFilterProperty=BasicStringFilterProperty</typeMapping>
               </typeMappings>
               <generateApis>false</generateApis>
@@ -139,12 +139,16 @@
                 <typeMapping>ResourceKey=String</typeMapping>
                 <!-- map specific filter properties to String for equality behavior -->
                 <typeMapping>AuditLogEntityKeyFilterProperty=String</typeMapping>
+                <typeMapping>AuditLogKeyFilterProperty=String</typeMapping>
                 <typeMapping>BasicStringFilterProperty=String</typeMapping>
                 <typeMapping>DecisionDefinitionKeyFilterProperty=String</typeMapping>
                 <typeMapping>DecisionEvaluationInstanceKeyFilterProperty=String</typeMapping>
+                <typeMapping>DecisionEvaluationKeyFilterProperty=String</typeMapping>
+                <typeMapping>DecisionRequirementsKeyFilterProperty=String</typeMapping>
                 <typeMapping>DeploymentKeyFilterProperty=String</typeMapping>
                 <typeMapping>ElementInstanceKeyFilterProperty=String</typeMapping>
                 <typeMapping>FormKeyFilterProperty=String</typeMapping>
+                <typeMapping>IntegerFilterProperty=Integer</typeMapping>
                 <typeMapping>JobKeyFilterProperty=String</typeMapping>
                 <typeMapping>MessageSubscriptionKeyFilterProperty=String</typeMapping>
                 <typeMapping>ProcessDefinitionKeyFilterProperty=String</typeMapping>
@@ -152,7 +156,6 @@
                 <typeMapping>ResourceKeyFilterProperty=String</typeMapping>
                 <typeMapping>ScopeKeyFilterProperty=String</typeMapping>
                 <typeMapping>StringFilterProperty=String</typeMapping>
-                <typeMapping>IntegerFilterProperty=Integer</typeMapping>
                 <typeMapping>VariableKeyFilterProperty=String</typeMapping>
                 <!-- map to custom model classes -->
                 <typeMapping>DateTimeFilterProperty=SimpleDateTimeFilterProperty</typeMapping>


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/camunda/camunda/pull/44437, orders the type mappings for OpenAPI model generation in the Java client.

Additionally, aligns the mapped types between all model generators.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

n/a
