### PR TITLE
feat: use PK column in historyDeletion SQL for oracle and postgresql

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
@@ -18,5 +18,6 @@ public interface ProcessInstanceDependantMapper {
 
   int deleteProcessInstanceRelatedData(DeleteProcessInstanceRelatedDataDto dto);
 
-  record DeleteProcessInstanceRelatedDataDto(List<Long> processInstanceKeys, int limit) {}
+  record DeleteProcessInstanceRelatedDataDto(
+      int partitionId, List<Long> processInstanceKeys, int limit) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -164,43 +164,43 @@ public class HistoryCleanupService {
         numDeletedRecords.put(
             "flowNodeInstance",
             flowNodeInstanceWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "incident",
             incidentWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "userTask",
             userTaskWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "variable",
             variableInstanceWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "decisionInstance",
             decisionInstanceWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "job",
             jobWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "sequenceFlow",
             sequenceFlowWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "messageSubscription",
             messageSubscriptionWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "correlatedMessageSubscription",
             correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
         numDeletedRecords.put(
             "auditLog",
             auditLogWriter.deleteProcessInstanceRelatedData(
-                expiredProcessInstanceKeys, cleanupBatchSize));
+                partitionId, expiredProcessInstanceKeys, cleanupBatchSize));
 
         // Calculate total child entities deleted - if any deletion hit the batch size limit,
         // there might be more to delete. Otherwise, we can assume all children are gone.

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
@@ -21,8 +21,8 @@ public abstract class ProcessInstanceDependant {
   }
 
   public int deleteProcessInstanceRelatedData(
-      final List<Long> processInstanceKeys, final int limit) {
+      final int partitionId, final List<Long> processInstanceKeys, final int limit) {
     return processInstanceDependantMapper.deleteProcessInstanceRelatedData(
-        new DeleteProcessInstanceRelatedDataDto(processInstanceKeys, limit));
+        new DeleteProcessInstanceRelatedDataDto(partitionId, processInstanceKeys, limit));
   }
 }

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -343,6 +343,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'AUDIT_LOG'"/>
+    <bind name="primaryKeyColumn" value="'AUDIT_LOG_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -207,7 +207,8 @@
   <sql id="processInstanceHistoryDeletion">
     DELETE
     FROM ${prefix}${tableName}
-    WHERE PROCESS_INSTANCE_KEY IN
+    WHERE PARTITION_ID = #{partitionId}
+      AND PROCESS_INSTANCE_KEY IN
     <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
@@ -216,28 +217,33 @@
   <sql id="processInstanceHistoryDeletion" databaseId="mssql">
     DELETE TOP (#{limit})
     FROM ${prefix}${tableName}
-    WHERE PROCESS_INSTANCE_KEY IN
+    WHERE PARTITION_ID = #{partitionId}
+      AND PROCESS_INSTANCE_KEY IN
     <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
   </sql>
   <sql id="processInstanceHistoryDeletion" databaseId="oracle">
+    <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'rowid'"/>
     DELETE
     FROM ${prefix}${tableName}
-    WHERE rowid IN (SELECT rowid
+    WHERE ${keyColumn} IN (SELECT ${keyColumn}
                     FROM ${prefix}${tableName}
-                    WHERE PROCESS_INSTANCE_KEY IN
+                    WHERE PARTITION_ID = #{partitionId}
+                      AND PROCESS_INSTANCE_KEY IN
                     <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
                       #{key}
                     </foreach>
                     AND ROWNUM &lt;= #{limit})
   </sql>
   <sql id="processInstanceHistoryDeletion" databaseId="postgresql">
+    <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'ctid'"/>
     DELETE
     FROM ${prefix}${tableName}
-    WHERE ctid IN (SELECT ctid
+    WHERE ${keyColumn} IN (SELECT ${keyColumn}
                    FROM ${prefix}${tableName}
-                   WHERE PROCESS_INSTANCE_KEY IN
+                   WHERE PARTITION_ID = #{partitionId}
+                     AND PROCESS_INSTANCE_KEY IN
                    <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
                      #{key}
                    </foreach>

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -213,6 +213,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'CORRELATED_MESSAGE_SUBSCRIPTION'"/>
+    <bind name="primaryKeyColumn" value="''"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -328,6 +328,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'DECISION_INSTANCE'"/>
+    <bind name="primaryKeyColumn" value="'DECISION_INSTANCE_ID'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -260,6 +260,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'FLOW_NODE_INSTANCE'"/>
+    <bind name="primaryKeyColumn" value="'FLOW_NODE_INSTANCE_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -239,6 +239,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'INCIDENT'"/>
+    <bind name="primaryKeyColumn" value="'INCIDENT_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -301,6 +301,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'JOB'"/>
+    <bind name="primaryKeyColumn" value="'JOB_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -224,6 +224,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'MESSAGE_SUBSCRIPTION'"/>
+    <bind name="primaryKeyColumn" value="'MESSAGE_SUBSCRIPTION_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -219,6 +219,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'SEQUENCE_FLOW'"/>
+    <bind name="primaryKeyColumn" value="''"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -435,6 +435,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'USER_TASK'"/>
+    <bind name="primaryKeyColumn" value="'USER_TASK_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -177,6 +177,7 @@
 
   <delete id="deleteProcessInstanceRelatedData">
     <bind name="tableName" value="'VARIABLE'"/>
+    <bind name="primaryKeyColumn" value="'VAR_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -75,17 +75,23 @@ class HistoryCleanupServiceTest {
         .thenReturn(java.util.Collections.emptyList());
 
     // Mock deleteProcessInstanceRelatedData methods
-    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(incidentWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(userTaskWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(variableInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(jobWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt()))
+    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
         .thenReturn(0);
-    when(auditLogWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
+    when(incidentWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(userTaskWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(variableInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(jobWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(
+            anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(auditLogWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
 
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(0);
     when(usageMetricWriter.cleanupMetrics(anyInt(), any(), anyInt())).thenReturn(0);
@@ -137,17 +143,23 @@ class HistoryCleanupServiceTest {
     when(processInstanceReader.selectExpiredProcessInstances(anyInt(), any(), anyInt()))
         .thenReturn(expiredProcessInstanceKeys);
     // All child entities already deleted (return 0), so PIs can be deleted
-    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(incidentWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(userTaskWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(variableInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(jobWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt()))
+    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
         .thenReturn(0);
-    when(auditLogWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
+    when(incidentWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(userTaskWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(variableInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(jobWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(
+            anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(auditLogWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
     when(processInstanceWriter.deleteByKeys(any())).thenReturn(3);
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(1);
 
@@ -160,20 +172,25 @@ class HistoryCleanupServiceTest {
     verify(processInstanceReader).selectExpiredProcessInstances(PARTITION_ID, CLEANUP_DATE, 100);
     // Each writer called once per cleanup cycle
     verify(flowNodeInstanceWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(incidentWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(userTaskWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(incidentWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(userTaskWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     verify(variableInstanceWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     verify(decisionInstanceWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(jobWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(sequenceFlowWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(jobWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(sequenceFlowWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     verify(messageSubscriptionWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     verify(correlatedMessageSubscriptionWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(auditLogWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(auditLogWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     // PIs deleted since no child entities were found
     verify(processInstanceWriter).deleteByKeys(expiredProcessInstanceKeys);
     verify(batchOperationWriter).cleanupHistory(CLEANUP_DATE, 100);
@@ -186,17 +203,23 @@ class HistoryCleanupServiceTest {
     when(processInstanceReader.selectExpiredProcessInstances(anyInt(), any(), anyInt()))
         .thenReturn(expiredProcessInstanceKeys);
     // Some child entities still exist and are deleted
-    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(10);
-    when(incidentWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(5);
-    when(userTaskWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(variableInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(100);
-    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(jobWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(20);
-    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
-    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(any(), anyInt()))
+    when(flowNodeInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(10);
+    when(incidentWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(5);
+    when(userTaskWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(variableInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(100);
+    when(decisionInstanceWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
         .thenReturn(0);
-    when(auditLogWriter.deleteProcessInstanceRelatedData(any(), anyInt())).thenReturn(0);
+    when(jobWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
+    when(sequenceFlowWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(messageSubscriptionWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(correlatedMessageSubscriptionWriter.deleteProcessInstanceRelatedData(
+            anyInt(), any(), anyInt()))
+        .thenReturn(0);
+    when(auditLogWriter.deleteProcessInstanceRelatedData(anyInt(), any(), anyInt())).thenReturn(0);
     when(batchOperationWriter.cleanupHistory(any(), anyInt())).thenReturn(1);
 
     // when
@@ -208,11 +231,25 @@ class HistoryCleanupServiceTest {
     verify(processInstanceReader).selectExpiredProcessInstances(PARTITION_ID, CLEANUP_DATE, 100);
     // Each writer called once
     verify(flowNodeInstanceWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(incidentWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(incidentWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(userTaskWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     verify(variableInstanceWriter)
-        .deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
-    verify(jobWriter).deleteProcessInstanceRelatedData(expiredProcessInstanceKeys, 100);
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(decisionInstanceWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(jobWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(sequenceFlowWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(messageSubscriptionWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(correlatedMessageSubscriptionWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
+    verify(auditLogWriter)
+        .deleteProcessInstanceRelatedData(PARTITION_ID, expiredProcessInstanceKeys, 100);
     // PIs NOT deleted because child entities were found
     verify(processInstanceWriter, Mockito.never()).deleteByKeys(any());
     verify(batchOperationWriter).cleanupHistory(CLEANUP_DATE, 100);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -77,8 +77,9 @@ public class HistoryDeletionServiceTest {
         .deleteProcessInstanceRelatedData(
             argThat(
                 dto ->
-                    dto.processInstanceKeys()
-                        .equals(List.of(processInstanceKey1, processInstanceKey2))));
+                    dto.partitionId() == partitionId
+                        && dto.processInstanceKeys()
+                            .equals(List.of(processInstanceKey1, processInstanceKey2))));
     verify(rdbmsWritersMock.getProcessInstanceWriter())
         .deleteByKeys(List.of(processInstanceKey1, processInstanceKey2));
     verify(rdbmsWritersMock.getHistoryDeletionWriter())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historycleanup/HistoryCleanupIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.historycleanup;
+
+import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
+
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.service.HistoryCleanupService;
+import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class HistoryCleanupIT {
+
+  @TestTemplate
+  public void shouldExecuteHistoryCleanupSuccessfully(
+      final CamundaRdbmsTestApplication testApplication) {
+    final var writers = testApplication.getRdbmsService().createWriter(0);
+    final var historyCleanupService =
+        new HistoryCleanupService(
+            RdbmsWriterConfig.builder().build(),
+            writers,
+            testApplication.getRdbmsService().getProcessInstanceReader());
+
+    createAndSaveProcessInstance(
+        writers,
+        ProcessInstanceFixtures.createRandomized(
+            b -> b.partitionId(0).historyCleanupDate(OffsetDateTime.now().minusSeconds(1))));
+
+    historyCleanupService.cleanupHistory(0, OffsetDateTime.now());
+
+    // this test should only check that no exceptions are thrown during the cleanup and the SQLs are
+    // syntactically correct
+  }
+}


### PR DESCRIPTION
## Description

- Use the primary key of each table to select the rows in the subselect
- Sidequest: Add the partitionId to the query to be ready for partitioned tables

closes #44539 
