### PR TITLE
[Backport stable/8.8] fix: open java.base in all modules for tests & spring-boot 

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1048,6 +1048,9 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <jvmArguments>--add-opens=java.base/java.io=ALL-UNNAMED</jvmArguments>
+        </configuration>
         <executions>
           <execution>
             <id>build-info</id>
@@ -1063,6 +1066,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2457,6 +2457,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.surefire}</version>
           <configuration>
+            <!-- Required to access the raw file descriptor from FileDescriptor for NativeFS -->
+            <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
             <!-- by default, exclude performance and strace tests -->
             <excludedGroups>performance, strace</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
@@ -2495,6 +2497,8 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${plugin.version.failsafe}</version>
           <configuration>
+            <!-- Required to access the raw file descriptor from FileDescriptor for NativeFS -->
+            <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -169,25 +169,6 @@
           </usedDependencies>
         </configuration>
       </plugin>
-
-      <!--      NEED to open java.base for FFI -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- required to access the raw file descriptor from FileDescriptor -->
-          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <!-- required to access the raw file descriptor from FileDescriptor -->
-          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
# Description
Backport of #44257 to `stable/8.8`.

relates to 