### PR TITLE
fix: process memory usage was not appearing after renaming of statefulset

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1703,7 +1703,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"}",
+              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe|camunda).*\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1715,7 +1715,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"})",
+              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe|camunda).*\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "limit",
@@ -1726,7 +1726,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe).*\"})",
+              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\".*(orchestration|zeebe|camunda).*\"})",
               "interval": "",
               "legendFormat": "request",
               "refId": "C"
@@ -5658,7 +5658,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"}",
+              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe|camunda).*\", container=~\".*(orchestration|zeebe|camunda).*\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -5673,7 +5673,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"})",
+              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe|camunda).*\", container=~\".*(orchestration|zeebe|camunda).*\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "limit",
@@ -5686,7 +5686,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe).*\", container=~\".*(orchestration|zeebe).*\"})",
+              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*(orchestration|zeebe|camunda).*\", container=~\".*(orchestration|zeebe|camunda).*\"})",
               "interval": "",
               "legendFormat": "request",
               "range": true,


### PR DESCRIPTION
## Description
The statefulset is now named `camunda` not `orchestration` anymore


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #43768
