### PR TITLE
Add `endSessionEndpointUri` property to OIDC config

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -10,6 +10,8 @@ package io.camunda.authentication.config;
 import static io.camunda.security.configuration.OidcAuthenticationConfiguration.CLIENT_AUTHENTICATION_METHODS;
 
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration.Builder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
@@ -45,6 +47,12 @@ public final class ClientRegistrationFactory {
     }
     if (configuration.getAuthorizationUri() != null) {
       builder.authorizationUri(configuration.getAuthorizationUri());
+    }
+    if (configuration.getEndSessionEndpointUri() != null) {
+      // end_session_endpoint should be in the provider metadata
+      final Map<String, Object> metadata = new HashMap<>();
+      metadata.put("end_session_endpoint", configuration.getEndSessionEndpointUri());
+      builder.providerConfigurationMetadata(metadata);
     }
     if (configuration.getTokenUri() != null) {
       builder.tokenUri(configuration.getTokenUri());

--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -49,7 +49,9 @@ public final class ClientRegistrationFactory {
       builder.authorizationUri(configuration.getAuthorizationUri());
     }
     if (configuration.getEndSessionEndpointUri() != null) {
-      // end_session_endpoint should be in the provider metadata
+      // end_session_endpoint should be located in the provider metadata
+      // this will also override any other metadata provided by the builder previously
+      // there is no way to get the current builder metadata or merge into it
       final Map<String, Object> metadata = new HashMap<>();
       metadata.put("end_session_endpoint", configuration.getEndSessionEndpointUri());
       builder.providerConfigurationMetadata(metadata);

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -50,6 +50,12 @@ public class OidcAuthenticationConfigurationTest {
             OidcAuthenticationConfiguration.builder().authorizationUri("auth-uri").build(),
             true),
         Arguments.of(
+            "endSessionEndpointUri is set",
+            OidcAuthenticationConfiguration.builder()
+                .endSessionEndpointUri("end-session-endpoint-uri")
+                .build(),
+            true),
+        Arguments.of(
             "clientId is set",
             OidcAuthenticationConfiguration.builder().clientId("cid").build(),
             true),

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -40,6 +40,7 @@ public class OidcAuthenticationConfiguration {
   private List<String> scope = Arrays.asList("openid", "profile");
   private String jwkSetUri;
   private String authorizationUri;
+  private String endSessionEndpointUri;
   private String tokenUri;
   private AuthorizeRequestConfiguration authorizeRequestConfiguration =
       new AuthorizeRequestConfiguration();
@@ -147,6 +148,14 @@ public class OidcAuthenticationConfiguration {
     this.authorizationUri = authorizationUri;
   }
 
+  public String getEndSessionEndpointUri() {
+    return endSessionEndpointUri;
+  }
+
+  public void setEndSessionEndpointUri(final String endSessionEndpointUri) {
+    this.endSessionEndpointUri = endSessionEndpointUri;
+  }
+
   public String getTokenUri() {
     return tokenUri;
   }
@@ -252,6 +261,7 @@ public class OidcAuthenticationConfiguration {
         || !Arrays.asList("openid", "profile").equals(scope)
         || jwkSetUri != null
         || authorizationUri != null
+        || endSessionEndpointUri != null
         || tokenUri != null
         || authorizeRequestConfiguration == null
         || authorizeRequestConfiguration.isSet()
@@ -288,6 +298,7 @@ public class OidcAuthenticationConfiguration {
     private List<String> scope = Arrays.asList("openid", "profile");
     private String jwkSetUri;
     private String authorizationUri;
+    private String endSessionEndpointUri;
     private String tokenUri;
     private AuthorizeRequestConfiguration authorizeRequestConfiguration =
         new AuthorizeRequestConfiguration();
@@ -348,6 +359,11 @@ public class OidcAuthenticationConfiguration {
 
     public Builder authorizationUri(final String authorizationUri) {
       this.authorizationUri = authorizationUri;
+      return this;
+    }
+
+    public Builder endSessionEndpointUri(final String endSessionEndpointUri) {
+      this.endSessionEndpointUri = endSessionEndpointUri;
       return this;
     }
 
@@ -417,6 +433,7 @@ public class OidcAuthenticationConfiguration {
       config.setIdTokenAlgorithm(idTokenAlgorithm);
       config.setGrantType(grantType);
       config.setRedirectUri(redirectUri);
+      config.setEndSessionEndpointUri(endSessionEndpointUri);
       config.setScope(scope);
       config.setJwkSetUri(jwkSetUri);
       config.setAuthorizationUri(authorizationUri);


### PR DESCRIPTION
## Description

Adding `endSessionEndpointUri` to allow end session endpoint configuration. 
Currently it is not used so it won't break anything.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44479
