### PR TITLE
build: remove mutex argument from yarn install

### DIFF
--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -41,7 +41,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
+              <arguments>install</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
## Description

Optimize is the last project using yarn 1 so the mutex is not needed anymore, after being added in https://github.com/camunda/camunda/pull/26409

[Discussed on Slack](https://camunda.slack.com/archives/C08F5RD5X8B/p1769082473123639)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
