### PR TITLE
[Backport main] build: remove mutex argument from yarn install

### DIFF
--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -41,7 +41,7 @@
             </goals>
             <configuration>
               <skip>${skip.fe.build}</skip>
-              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
+              <arguments>install</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
# Description
Backport of #44580 to `main`.

relates to 