### PR TITLE
Introduce feature flag for RP-initiated logout

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -123,6 +123,10 @@ public class OidcAuthenticationConfigurationTest {
             OidcAuthenticationConfiguration.builder().build(),
             false),
         Arguments.of(
+            "idpLogoutEnabled is set",
+            OidcAuthenticationConfiguration.builder().idpLogoutEnabled(false).build(),
+            true),
+        Arguments.of(
             "issuerUri is set",
             OidcAuthenticationConfiguration.builder().issuerUri("issuer").build(),
             true),
@@ -259,6 +263,10 @@ public class OidcAuthenticationConfigurationTest {
         Arguments.of(
             "default scope is set",
             OidcAuthenticationConfiguration.builder().scope(List.of("openid", "profile")).build(),
+            false),
+        Arguments.of(
+            "default for idpLogoutEnabled is set",
+            OidcAuthenticationConfiguration.builder().idpLogoutEnabled(true).build(),
             false),
         Arguments.of(
             "default clientAuthenticationMethod is set",

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -54,6 +54,7 @@ public class OidcAuthenticationConfiguration {
   private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
   private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
   private Duration clockSkew = DEFAULT_CLOCK_SKEW;
+  private boolean idpLogoutEnabled = true;
 
   @PostConstruct
   public void validate() {
@@ -250,6 +251,14 @@ public class OidcAuthenticationConfiguration {
     this.clockSkew = clockSkew;
   }
 
+  public boolean isIdpLogoutEnabled() {
+    return idpLogoutEnabled;
+  }
+
+  public void setIdpLogoutEnabled(final boolean idpLogoutEnabled) {
+    this.idpLogoutEnabled = idpLogoutEnabled;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -280,7 +289,8 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidDigestAlgorithm() != KidDigestAlgorithm.SHA256
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
         || assertionConfiguration.getKidCase() != null
-        || !DEFAULT_CLOCK_SKEW.equals(clockSkew);
+        || !DEFAULT_CLOCK_SKEW.equals(clockSkew)
+        || idpLogoutEnabled;
   }
 
   public static Builder builder() {
@@ -311,6 +321,7 @@ public class OidcAuthenticationConfiguration {
     private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
+    private boolean idpLogoutEnabled;
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -424,6 +435,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder idpLogoutEnabled(final boolean idpLogoutEnabled) {
+      this.idpLogoutEnabled = idpLogoutEnabled;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -448,6 +464,7 @@ public class OidcAuthenticationConfiguration {
       config.setClientAuthenticationMethod(clientAuthenticationMethod);
       config.setAssertion(assertionConfiguration);
       config.setClockSkew(clockSkew);
+      config.setIdpLogoutEnabled(idpLogoutEnabled);
       return config;
     }
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -290,7 +290,7 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
         || assertionConfiguration.getKidCase() != null
         || !DEFAULT_CLOCK_SKEW.equals(clockSkew)
-        || idpLogoutEnabled;
+        || !idpLogoutEnabled;
   }
 
   public static Builder builder() {
@@ -321,7 +321,7 @@ public class OidcAuthenticationConfiguration {
     private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
-    private boolean idpLogoutEnabled;
+    private boolean idpLogoutEnabled = true;
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;


### PR DESCRIPTION
## Description
Introducing “feature flag” that would allow users to select to log users out of only the cluster or to perform a single logout. Single logout is enabled by default.

Motivation:
For SM customers upgrading from the previous version of Camunda to this one, we want to leave the existing behaviour as it where logout logs users out of only Camunda. Customers can choose to enable this capability should they wish to.

This flag is not currently used, so it will not break any functionality.

❓ My understanding is that the default value of this flag is `true`, but existing customers can explicitly set if to `false`. Please feel free to advice if it should be the other way around.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44484
