### PR TITLE
test: skip test due to bug

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -111,7 +111,8 @@ test.describe('task panel page', () => {
     }).toPass({timeout: 5000});
   });
 
-  test('scrolling', async ({page, taskPanelPageV1}) => {
+  //Skipped due to bug 44583: https://github.com/camunda/camunda/issues/44583
+  test.skip('scrolling', async ({page, taskPanelPageV1}) => {
     // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
     // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -12,6 +12,7 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from '../../../utils/waitForAssertion';
 
 test.beforeAll(async ({resetData}) => {
   await resetData();
@@ -112,11 +113,19 @@ test.describe('task panel page', () => {
   });
 
   //Skipped due to bug 44583: https://github.com/camunda/camunda/issues/44583
-  test.skip('scrolling', async ({page, taskPanelPageV1}) => {
+  test('scrolling', async ({page, taskPanelPageV1}) => {
     // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
     // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();
-
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(page.getByText('usertask_to_be_assigned')).toHaveCount(0);
+      },
+      onFailure: async () => {
+        await page.reload();
+        await sleep(3000);
+      },
+    });
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);
     await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -113,7 +113,7 @@ test.describe('task panel page', () => {
   });
 
   //Skipped due to bug 44583: https://github.com/camunda/camunda/issues/44583
-  test('scrolling', async ({page, taskPanelPageV1}) => {
+  test.skip('scrolling', async ({page, taskPanelPageV1}) => {
     // TODO: This test fails in V2 mode - investigate if this is expected behavior or a bug
     // V2 mode may have different scrolling/pagination behavior that affects task count expectations
     test.slow();


### PR DESCRIPTION
## Description

- Added an assertion after completing the task at the beginning.
- Scrolling will fail at the end due to following bug.

Skipped test due to bug: https://github.com/camunda/camunda/issues/44583

[Successful run](https://github.com/camunda/camunda/actions/runs/21251302497) ✅ 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
