### PR TITLE
44202 change refresh interval in tests

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -41,6 +41,9 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** How many replicas Elasticsearch uses for all indices. */
   private int numberOfReplicas = 0;
 
+  /** What default refresh interval we will use for all indices */
+  private String refreshInterval;
+
   /** Variable size threshold for the database configured as secondary storage. */
   private int variableSizeThreshold = 8191;
 
@@ -49,6 +52,9 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   /** Per-index shard overrides. */
   private Map<String, Integer> numberOfShardsPerIndex = new HashMap<>();
+
+  /** Per-index refresh interval overrides. */
+  private Map<String, String> refreshIntervalByIndexName = new HashMap<>();
 
   /** Template priority for index templates. */
   private Integer templatePriority;
@@ -317,6 +323,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.numberOfReplicas = numberOfReplicas;
   }
 
+  public String getRefreshInterval() {
+    return refreshInterval;
+  }
+
+  public void setRefreshInterval(final String refreshInterval) {
+    this.refreshInterval = refreshInterval;
+  }
+
   public int getVariableSizeThreshold() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         prefix() + ".variable-size-threshold",
@@ -354,6 +368,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setNumberOfShardsPerIndex(final Map<String, Integer> numberOfShardsPerIndex) {
     this.numberOfShardsPerIndex = numberOfShardsPerIndex;
+  }
+
+  public Map<String, String> getRefreshIntervalByIndexName() {
+    return refreshIntervalByIndexName;
+  }
+
+  public void setRefreshIntervalByIndexName(final Map<String, String> refreshIntervalByIndexName) {
+    this.refreshIntervalByIndexName = refreshIntervalByIndexName;
   }
 
   public Integer getTemplatePriority() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -116,6 +116,7 @@ public final class CamundaExporterConfigurationApplier {
     final IndexConfiguration target = exporterConfiguration.getIndex();
     target.setNumberOfShards(source.getNumberOfShards());
     target.setNumberOfReplicas(source.getNumberOfReplicas());
+    target.setRefreshInterval(source.getRefreshInterval());
     target.setVariableSizeThreshold(source.getVariableSizeThreshold());
     if (source.getTemplatePriority() != null) {
       target.setTemplatePriority(source.getTemplatePriority());
@@ -125,6 +126,9 @@ public final class CamundaExporterConfigurationApplier {
     }
     if (!source.getNumberOfShardsPerIndex().isEmpty()) {
       target.setShardsByIndexName(source.getNumberOfShardsPerIndex());
+    }
+    if (!source.getRefreshIntervalByIndexName().isEmpty()) {
+      target.setRefreshIntervalByIndexName(source.getRefreshIntervalByIndexName());
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -58,6 +58,7 @@ public class SearchEngineIndexPropertiesOverride {
     override.setNumberOfShards(database.getNumberOfShards());
     override.setNumberOfReplicas(database.getNumberOfReplicas());
     override.setVariableSizeThreshold(database.getVariableSizeThreshold());
+    override.setRefreshInterval(database.getRefreshInterval());
 
     override.setTemplatePriority(database.getTemplatePriority());
     if (!database.getNumberOfReplicasPerIndex().isEmpty()) {
@@ -66,6 +67,10 @@ public class SearchEngineIndexPropertiesOverride {
     if (!database.getNumberOfShardsPerIndex().isEmpty()) {
       override.setShardsByIndexName(database.getNumberOfShardsPerIndex());
     }
+    if (!database.getRefreshIntervalByIndexName().isEmpty()) {
+      override.setRefreshIntervalByIndexName(database.getRefreshIntervalByIndexName());
+    }
+
     return override;
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -9,6 +9,7 @@ package io.camunda.qa.util.multidb;
 
 import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
 
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
@@ -78,6 +79,7 @@ public class MultiDbConfigurator {
                   .getElasticsearch()
                   .getHistory()
                   .setPolicyName(indexPrefix + "-ilm");
+              overrideRefreshInterval(cfg.getData().getSecondaryStorage().getElasticsearch());
             });
     testApplication.withExporter(
         CamundaExporter.class.getSimpleName().toLowerCase(),
@@ -194,6 +196,7 @@ public class MultiDbConfigurator {
                   .setPolicyName(indexPrefix + "-ilm");
               cfg.getData().getSecondaryStorage().getOpensearch().setUsername(userName);
               cfg.getData().getSecondaryStorage().getOpensearch().setPassword(userPassword);
+              overrideRefreshInterval(cfg.getData().getSecondaryStorage().getOpensearch());
             });
 
     testApplication.withExporter(
@@ -327,5 +330,10 @@ public class MultiDbConfigurator {
       sb.append(chars.charAt(random.nextInt(chars.length())));
     }
     return sb.toString();
+  }
+
+  private static void overrideRefreshInterval(final DocumentBasedSecondaryStorageDatabase db) {
+    // make refresh interval lower so tests can run a bit faster
+    db.setRefreshIntervalByIndexName(Map.of("list-view", "1s"));
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -451,7 +451,8 @@ public class SchemaManager implements CloseableSilently {
     settings.setNumberOfShards(templateShards);
     settings.setNumberOfReplicas(templateReplicas);
     settings.setTemplatePriority(config.index().getTemplatePriority());
-
+    final var refreshInterval = getRefreshIntervalFromConfig(indexName);
+    settings.setRefreshInterval(refreshInterval);
     return settings;
   }
 
@@ -460,6 +461,13 @@ public class SchemaManager implements CloseableSilently {
         .index()
         .getReplicasByIndexName()
         .getOrDefault(indexName, config.index().getNumberOfReplicas());
+  }
+
+  private String getRefreshIntervalFromConfig(final String indexName) {
+    return config
+        .index()
+        .getRefreshIntervalByIndexName()
+        .getOrDefault(indexName, config.index().getRefreshInterval());
   }
 
   private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndices(

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
@@ -16,10 +16,12 @@ public class IndexConfiguration {
 
   private Integer numberOfShards = 1;
   private Integer numberOfReplicas = 1;
+  private String refreshInterval;
   private Integer templatePriority;
 
   private Map<String, Integer> replicasByIndexName = new HashMap<>();
   private Map<String, Integer> shardsByIndexName = new HashMap<>();
+  private Map<String, String> refreshIntervalByIndexName = new HashMap<>();
 
   private Integer variableSizeThreshold = DEFAULT_VARIABLE_SIZE_THRESHOLD;
 
@@ -71,6 +73,22 @@ public class IndexConfiguration {
     this.shardsByIndexName = shardsByIndexName;
   }
 
+  public String getRefreshInterval() {
+    return refreshInterval;
+  }
+
+  public void setRefreshInterval(final String refreshInterval) {
+    this.refreshInterval = refreshInterval;
+  }
+
+  public Map<String, String> getRefreshIntervalByIndexName() {
+    return refreshIntervalByIndexName;
+  }
+
+  public void setRefreshIntervalByIndexName(final Map<String, String> refreshIntervalByIndexName) {
+    this.refreshIntervalByIndexName = refreshIntervalByIndexName;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -79,7 +97,9 @@ public class IndexConfiguration {
         templatePriority,
         replicasByIndexName,
         shardsByIndexName,
-        variableSizeThreshold);
+        variableSizeThreshold,
+        refreshInterval,
+        refreshIntervalByIndexName);
   }
 
   @Override
@@ -93,7 +113,9 @@ public class IndexConfiguration {
         && Objects.equals(templatePriority, that.templatePriority)
         && Objects.equals(replicasByIndexName, that.replicasByIndexName)
         && Objects.equals(shardsByIndexName, that.shardsByIndexName)
-        && Objects.equals(variableSizeThreshold, that.variableSizeThreshold);
+        && Objects.equals(variableSizeThreshold, that.variableSizeThreshold)
+        && Objects.equals(refreshInterval, that.refreshInterval)
+        && Objects.equals(refreshIntervalByIndexName, that.refreshIntervalByIndexName);
   }
 
   @Override
@@ -111,6 +133,10 @@ public class IndexConfiguration {
         + shardsByIndexName
         + ", variableSizeThreshold="
         + variableSizeThreshold
+        + ", refreshInterval="
+        + refreshInterval
+        + ", refreshIntervalByIndexName="
+        + refreshIntervalByIndexName
         + '}';
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -488,6 +488,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
               utils.new SchemaSettingsAppender(templateFile)
                   .withNumberOfReplicas(settings.getNumberOfReplicas())
                   .withNumberOfShards(settings.getNumberOfShards())
+                  .withRefreshInterval(settings.getRefreshInterval())
                   .build());
       return PutIndexTemplateRequest.of(
           b ->
@@ -519,7 +520,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var configuredSettings =
           utils.new SchemaSettingsAppender(templateFile)
               .withNumberOfShards(indexConfiguration.getNumberOfShards())
-              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas());
+              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas())
+              .withRefreshInterval(indexConfiguration.getRefreshInterval());
       final var configuredPriority =
           convertValue(indexConfiguration.getTemplatePriority(), Long::valueOf);
 
@@ -595,6 +597,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
               utils.new SchemaSettingsAppender(templateFile)
                   .withNumberOfReplicas(settings.getNumberOfReplicas())
                   .withNumberOfShards(settings.getNumberOfShards())
+                  .withRefreshInterval(settings.getRefreshInterval())
                   .build());
 
       return new CreateIndexRequest.Builder()

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -570,6 +570,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
               utils.new SchemaSettingsAppender(templateFile)
                   .withNumberOfShards(settings.getNumberOfShards())
                   .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .withRefreshInterval(settings.getRefreshInterval())
                   .build());
 
       return PutIndexTemplateRequest.of(
@@ -601,7 +602,8 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final var configuredSettings =
           utils.new SchemaSettingsAppender(templateFile)
               .withNumberOfShards(indexConfiguration.getNumberOfShards())
-              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas());
+              .withNumberOfReplicas(indexConfiguration.getNumberOfReplicas())
+              .withRefreshInterval(indexConfiguration.getRefreshInterval());
       final var configuredPriority = indexConfiguration.getTemplatePriority();
       if (areTemplateSettingsEqualToConfigured(
           currentTemplate, configuredSettings, configuredPriority)) {
@@ -686,6 +688,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
               utils.new SchemaSettingsAppender(templateFile)
                   .withNumberOfShards(settings.getNumberOfShards())
                   .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .withRefreshInterval(settings.getRefreshInterval())
                   .build());
 
       return new CreateIndexRequest.Builder()

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -82,6 +82,13 @@ public class SearchEngineClientUtils {
       return this;
     }
 
+    public SchemaSettingsAppender withRefreshInterval(final String refreshInterval) {
+      if (refreshInterval != null) {
+        indexBlock.put("refresh_interval", refreshInterval);
+      }
+      return this;
+    }
+
     public InputStream build() throws IOException {
       return new ByteArrayInputStream(objectMapper.writeValueAsBytes(map));
     }

--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.generic.Requests;
@@ -124,6 +126,30 @@ public class OpensearchEngineClientIT {
     SchemaTestUtil.validateMappings(
         createdTemplate.getFirst().indexTemplate().template().mappings(),
         template.getMappingsClasspathFilename());
+  }
+
+  @Test
+  void shouldSetRefreshIntervalFromConfigurationDuringIndexCreation() throws IOException {
+    final var index =
+        createTestIndexDescriptor("index_name" + ENGINE_CLIENT_TEST_MARKERS, "/mappings.json");
+
+    final var settings = new IndexConfiguration();
+    settings.setRefreshInterval("2s");
+    opensearchEngineClient.createIndex(index, settings);
+
+    final var indices =
+        openSearchClient.indices().get(req -> req.index(index.getFullQualifiedName()));
+
+    assertThat(indices.result().size()).isEqualTo(1);
+    assertThat(
+            indices
+                .result()
+                .get(index.getFullQualifiedName())
+                .settings()
+                .index()
+                .refreshInterval()
+                .time())
+        .isEqualTo("2s");
   }
 
   @Test
@@ -395,13 +421,13 @@ public class OpensearchEngineClientIT {
     verify(indicesSpy, never()).putIndexTemplate(any(PutIndexTemplateRequest.class));
   }
 
-  @Test
-  void shouldIssuePutIndexTemplateWhenSettingsChanged() throws IOException {
+  @ParameterizedTest
+  @MethodSource("changedTemplateConfiguration")
+  void shouldIssuePutIndexTemplateWhenSettingsChanged(final IndexConfiguration updated)
+      throws IOException {
     // given
     final var template = createTestTemplateDescriptor("template_change", "/mappings.json");
-    final var initialSettings = new IndexConfiguration();
-    initialSettings.setNumberOfReplicas(0);
-    initialSettings.setNumberOfShards(1);
+    final var initialSettings = indexConfiguration(0, 1, null);
 
     final var indicesSpy = spy(openSearchClient.indices());
     final var clientSpy = spy(openSearchClient);
@@ -411,15 +437,24 @@ public class OpensearchEngineClientIT {
     engineClient.createIndexTemplate(template, initialSettings, true);
     reset(indicesSpy); // ignore create
 
-    final var updated = new IndexConfiguration();
-    updated.setNumberOfReplicas(2); // change
-    updated.setNumberOfShards(1); // same
-
     // when
     engineClient.updateIndexTemplateSettings(template, updated);
 
     // then
     verify(indicesSpy, times(1)).putIndexTemplate(any(PutIndexTemplateRequest.class));
+  }
+
+  private static List<IndexConfiguration> changedTemplateConfiguration() {
+    return List.of(indexConfiguration(2, 1, null), indexConfiguration(0, 1, "2s"));
+  }
+
+  private static IndexConfiguration indexConfiguration(
+      final int replicas, final int shards, final String refreshInterval) {
+    final var config = new IndexConfiguration();
+    config.setNumberOfReplicas(replicas);
+    config.setNumberOfShards(shards);
+    config.setRefreshInterval(refreshInterval);
+    return config;
   }
 
   @Test


### PR DESCRIPTION
Rather than changing the `refresh_interval` for operate list view in the schemas I've opted to just override it during the tests.  This involved a fair bit of boilerplate to make this possible, but it's basically just following what real already do for things like replica count.

This should let us make the tests run a bit faster without having to worry about side-effects in prod.

I've created https://github.com/camunda/camunda/issues/44560 to see about changing that value for prod in the future, but we will want to do some load testing to see if it makes sense.  Plus we might actually want to change the value for opensearch as well - in which case we will definitely want to override it in the tests.

## Related issues

closes #44202
