### PR TITLE
feat: disable variable modifications for root node

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
@@ -17,7 +17,6 @@ import {type FormRenderProps} from 'react-final-form';
 
 import {AddVariableButton, Form, VariablesContainer} from './styled';
 import {Variables} from '../Variables';
-import {useWillAllFlowNodesBeCanceled} from 'modules/hooks/modifications';
 import {
   useHasPendingCancelOrMoveModification,
   useIsPlaceholderSelected,
@@ -28,7 +27,6 @@ import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 
 const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
   ({handleSubmit, form, values}) => {
-    const willAllFlowNodesBeCanceled = useWillAllFlowNodesBeCanceled();
     const hasPendingCancelOrMoveModification =
       useHasPendingCancelOrMoveModification();
     const isPlaceholderSelected = useIsPlaceholderSelected();
@@ -47,12 +45,12 @@ const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
       useProcessInstanceElementSelection();
 
     const isVariableModificationAllowed = computed(() => {
-      if (!isModificationModeEnabled || selectedElementId === null) {
+      if (
+        !isModificationModeEnabled ||
+        selectedElementId === null ||
+        isRootNodeSelected
+      ) {
         return false;
-      }
-
-      if (isRootNodeSelected) {
-        return !willAllFlowNodesBeCanceled;
       }
 
       return (
@@ -65,13 +63,10 @@ const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
     const isVariableModificationAllowedV1 = computed(() => {
       if (
         !isModificationModeEnabled ||
-        flowNodeSelectionStore.state.selection === null
+        flowNodeSelectionStore.state.selection === null ||
+        isRootNodeSelected
       ) {
         return false;
-      }
-
-      if (isRootNodeSelected) {
-        return !willAllFlowNodesBeCanceled;
       }
 
       return (

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
@@ -148,7 +148,7 @@ describe('VariablePanel', () => {
     );
   });
 
-  it('should be readonly if root node is selected and applying modifications will cancel the whole process', async () => {
+  it('should be readonly if root node is selected in modification mode', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
@@ -199,22 +199,9 @@ describe('VariablePanel', () => {
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
-
-    expect(
-      await screen.findByTestId('edit-variable-value'),
-    ).toBeInTheDocument();
-
-    act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
-    });
-
-    await waitFor(() =>
-      expect(
-        screen.queryByTestId('edit-variable-value'),
-      ).not.toBeInTheDocument(),
-    );
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
   });
 
   it('should display readonly state for existing node if cancel modification is applied on the flow node and one new token is added', async () => {
@@ -264,10 +251,6 @@ describe('VariablePanel', () => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
 
     mockSearchVariables().withSuccess({
       items: [],
@@ -370,11 +353,6 @@ describe('VariablePanel', () => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
 
     mockSearchVariables().withSuccess({
       items: [],
@@ -487,12 +465,6 @@ describe('VariablePanel', () => {
     });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
-    expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
-    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
-
     mockSearchVariables().withSuccess({
       items: [
         createvariable({
@@ -577,12 +549,6 @@ describe('VariablePanel', () => {
       expect(screen.getByTestId('variables-list')).toBeInTheDocument();
     });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
-    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withSuccess({


### PR DESCRIPTION
## Description

As discussed in #41143, this PR disallows the modification of variables for the root node.

@vsgoulart I think this small change is already enough to achieve this. There is still a "normal" edit variable buttons, but edits cannot be saved. This behavior seems to have existed before as well when modifications is disallowed for a node... The only thing missing: 16 Tests are still failing, and they are super annoying to debug and fix. 

## Related issues

relates #41143
