### PR TITLE
refactor: add anonymousUser field to CamundaAuthentication

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -161,6 +161,7 @@ public class SessionAuthenticationRefreshTest {
       return new CamundaAuthentication(
           TestUserDetailsService.DEMO_USERNAME,
           null,
+          false,
           Collections.emptyList(),
           Collections.emptyList(),
           Collections.emptyList(),

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -35,7 +35,7 @@ public class OidcFlowTestContext {
   public CamundaAuthenticationProvider createCamundaAuthenticationProvider() {
     return () ->
         new CamundaAuthentication(
-            "dummyUsername", null, List.of(), List.of(), List.of(), List.of(), Map.of());
+            "dummyUsername", null, false, List.of(), List.of(), List.of(), List.of(), Map.of());
   }
 
   @Bean

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
@@ -80,6 +80,7 @@ public class OperateSearchAbstractIT {
             new CamundaAuthentication(
                 DEFAULT_USER,
                 null,
+                false,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
@@ -106,6 +107,7 @@ public class OperateSearchAbstractIT {
             new CamundaAuthentication(
                 DEFAULT_USER,
                 null,
+                false,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateZeebeSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateZeebeSearchAbstractIT.java
@@ -95,6 +95,7 @@ public class OperateZeebeSearchAbstractIT {
             new CamundaAuthentication(
                 DEFAULT_USER,
                 null,
+                false,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
@@ -137,6 +138,7 @@ public class OperateZeebeSearchAbstractIT {
             new CamundaAuthentication(
                 DEFAULT_USER,
                 null,
+                false,
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),


### PR DESCRIPTION
## Description

Remove usage of constant `authorized_anonymous_user` imported from the engine to indicate an anonymous user.
Introduce the field `anonymousUser` instead.

## Related issues

closes #44599 
