### PR TITLE
Feat docker support load test

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -28,7 +28,7 @@ on:
         default: ""
         required: false
       load-test-load:
-        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
+        description: 'Specifie which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       platform-helm-values:
         description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -33,7 +33,7 @@ on:
         required: false
         default: false
       load-test-load:
-        description: 'Specifie which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
       platform-helm-values:
         description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -27,6 +27,11 @@ on:
         type: string
         default: ""
         required: false
+      use-official-docker-images:
+        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
+        type: boolean
+        required: false
+        default: false
       load-test-load:
         description: 'Specifie which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100'
         required: false
@@ -66,6 +71,11 @@ on:
         type: string
         default: ""
         required: false
+      use-official-docker-images:
+        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
+        type: boolean
+        required: false
+        default: false
       platform-helm-values:
         description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
         type: string
@@ -191,7 +201,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.reuse-tag == '' && inputs.use-official-docker-images == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -300,8 +310,8 @@ jobs:
           --reset-then-reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set orchestration.image.registry=gcr.io
-          --set orchestration.image.repository=zeebe-io/zeebe
+          --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'gcr.io' }}
+          --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'zeebe-io/zeebe' }}
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -201,7 +201,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' && inputs.use-official-docker-images == false }}
+    if: ${{ inputs.reuse-tag == '' && inputs.use-official-docker-images == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag


### PR DESCRIPTION
## Description
This pull request updates the `camunda-load-test.yml` GitHub Actions workflow to add support for using official Camunda Docker images from Docker Hub instead of building images from source. The changes introduce a new input to control this behavior and adjust the workflow logic to use the appropriate image registry and repository based on the input.

**Support for using official Docker images:**

* Added a new boolean input parameter `use-official-docker-images` to the workflow, allowing users to choose between official Camunda images from Docker Hub and custom-built images.
* Updated the condition for the `build-load-test-images` job to run if either a new image build is needed or if the official images are to be used.
* Modified the Helm deployment step to dynamically set the image registry and repository based on the `use-official-docker-images` input, switching between Docker Hub and GCR as appropriate.

**Dynamic image selection logic:**

* Updated the Helm deployment command to conditionally set the Docker image registry and repository based on the value of `use-official-docker-images`. If enabled, it uses `docker.io/camunda/camunda`; otherwise, it defaults to `gcr.io/zeebe-io/zeebe`.

closes #41842

