### PR TITLE
Pass fraction config in overrride

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -710,6 +710,7 @@ public class BrokerBasedPropertiesOverride {
         AccessMetricsConfiguration.Kind.valueOf(unifiedRocksDb.getAccessMetrics().name()));
     brokerRocksDb.setMemoryLimit(unifiedRocksDb.getMemoryLimit());
     brokerRocksDb.setMemoryAllocationStrategy(unifiedRocksDb.getMemoryAllocationStrategy());
+    brokerRocksDb.setMemoryFraction(unifiedRocksDb.getMemoryFraction());
     brokerRocksDb.setMaxOpenFiles(unifiedRocksDb.getMaxOpenFiles());
     brokerRocksDb.setMaxWriteBufferNumber(unifiedRocksDb.getMaxWriteBufferNumber());
     brokerRocksDb.setMinWriteBufferNumberToMerge(unifiedRocksDb.getMinWriteBufferNumberToMerge());

--- a/configuration/src/test/java/io/camunda/configuration/RocksDbPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RocksDbPropertiesTest.java
@@ -45,7 +45,8 @@ public class RocksDbPropertiesTest {
         "camunda.data.primary-storage.rocks-db.sst-partitioning-enabled=false",
         "camunda.data.primary-storage.rocks-db.column-family-options.max_write_buffer_number=12",
         "camunda.data.primary-storage.rocks-db.column-family-options.write_buffer_size=67108864",
-        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestSmallestSeqFirst"
+        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestSmallestSeqFirst",
+        "camunda.data.primary-storage.rocks-db.memory-fraction=0.5"
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -69,6 +70,11 @@ public class RocksDbPropertiesTest {
     void shouldSetMemoryAllocationStrategy() {
       assertThat(brokerCfg.getExperimental().getRocksdb().getMemoryAllocationStrategy())
           .isEqualTo(MemoryAllocationStrategy.BROKER);
+    }
+
+    @Test
+    void shouldSetMemoryFraction() {
+      assertThat(brokerCfg.getExperimental().getRocksdb().getMemoryFraction()).isEqualTo(0.5);
     }
 
     @Test
@@ -220,6 +226,7 @@ public class RocksDbPropertiesTest {
         "camunda.data.primary-storage.rocks-db.wal-disabled=false",
         "camunda.data.primary-storage.rocks-db.sst-partitioning-enabled=false",
         "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestSmallestSeqFirst",
+        "camunda.data.primary-storage.rocks-db.memory-fraction=0.6",
         // legacy properties (should be ignored when new ones are present)
         "zeebe.broker.experimental.rocksdb.enableStatistics=false",
         "zeebe.broker.experimental.rocksdb.accessMetrics=none",
@@ -230,7 +237,8 @@ public class RocksDbPropertiesTest {
         "zeebe.broker.experimental.rocksdb.ioRateBytesPerSecond=1048576",
         "zeebe.broker.experimental.rocksdb.disableWal=true",
         "zeebe.broker.experimental.rocksdb.enableSstPartitioning=true",
-        "zeebe.broker.experimental.rocksdb.columnFamilyOptions.compaction_pri=kMinOverlappingRatio"
+        "zeebe.broker.experimental.rocksdb.columnFamilyOptions.compaction_pri=kMinOverlappingRatio",
+        "zeebe.broker.experimental.rocksdb.memoryFraction=0.5"
       })
   class WithNewAndLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -275,6 +283,11 @@ public class RocksDbPropertiesTest {
     @Test
     void shouldSetDisableWalFromNew() {
       assertThat(brokerCfg.getExperimental().getRocksdb().isDisableWal()).isFalse();
+    }
+
+    @Test
+    void shouldSetMemoryFractionFromNew() {
+      assertThat(brokerCfg.getExperimental().getRocksdb().getMemoryFraction()).isEqualTo(0.6);
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR passes the RocksDB memory fraction config in BrokerBasedPropertiesOverride.java. This was not added before as an oversight.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
