### PR TITLE
test: add user task audit log test for property-based permissions

### DIFF
--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -272,8 +272,6 @@ public final class UserTaskServices
     return executeSearchRequest(
         () ->
             auditLogServices
-                // TODO: Implement authentication in issue:
-                // https://github.com/camunda/camunda/issues/41205
                 .withAuthentication(CamundaAuthentication.anonymous())
                 .search(auditLogWithUserTaskKeyFilter));
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds acceptance tests for user task audit log search request with property-based permissions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #41205
