### PR TITLE
FS backup store delete empty parents

### DIFF
--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
@@ -70,8 +70,8 @@ final class FileSetManager {
     final var fileSetPath = fileSetPath(id, fileSetName);
     try {
       FileUtil.deleteFolder(fileSetPath);
-      FilesystemBackupStore.backtrackDeleteEmptyParents(
-          fileSetPath.getParent(), String.valueOf(id.partitionId()));
+      final var dirLimit = contentsPath.resolve(String.valueOf(id.partitionId()));
+      FilesystemBackupStore.backtrackDeleteEmptyParents(fileSetPath.getParent(), dirLimit);
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown fileset {} in backup {}", fileSetName, id);
     } catch (final IOException e) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
@@ -70,7 +70,8 @@ final class FileSetManager {
     final var fileSetPath = fileSetPath(id, fileSetName);
     try {
       FileUtil.deleteFolder(fileSetPath);
-      FileUtil.flushDirectory(fileSetPath.getParent());
+      FilesystemBackupStore.backtrackDeleteEmptyParents(
+          fileSetPath.getParent(), String.valueOf(id.partitionId()));
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown fileset {} in backup {}", fileSetName, id);
     } catch (final IOException e) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -263,6 +263,28 @@ public final class FilesystemBackupStore implements BackupStore {
     }
   }
 
+  /**
+   * Backtracks from the given path up to the limit and deletes any empty parent directories.
+   *
+   * @param path the initial path
+   * @param limitDir the limit directory name to stop backtracking at
+   * @throws IOException
+   */
+  static void backtrackDeleteEmptyParents(final Path path, final String limitDir)
+      throws IOException {
+    var traversePath = path;
+    while (!traversePath.endsWith(limitDir)) {
+      try (final var dirStream = Files.list(traversePath)) {
+        if (dirStream.findAny().isPresent()) {
+          break;
+        }
+      }
+      Files.delete(traversePath);
+      traversePath = traversePath.getParent();
+    }
+    FileUtil.flushDirectory(traversePath.getParent());
+  }
+
   public static BackupStore of(final FilesystemBackupConfig storeConfig) {
     return new FilesystemBackupStore(storeConfig);
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -268,12 +268,10 @@ public final class FilesystemBackupStore implements BackupStore {
    *
    * @param path the initial path
    * @param limitDir the limit directory name to stop backtracking at
-   * @throws IOException
    */
-  static void backtrackDeleteEmptyParents(final Path path, final String limitDir)
-      throws IOException {
+  static void backtrackDeleteEmptyParents(final Path path, final Path limitDir) throws IOException {
     var traversePath = path;
-    while (!traversePath.endsWith(limitDir)) {
+    while (!traversePath.equals(limitDir)) {
       try (final var dirStream = Files.list(traversePath)) {
         if (dirStream.findAny().isPresent()) {
           break;
@@ -282,7 +280,7 @@ public final class FilesystemBackupStore implements BackupStore {
       Files.delete(traversePath);
       traversePath = traversePath.getParent();
     }
-    FileUtil.flushDirectory(traversePath.getParent());
+    FileUtil.flushDirectory(traversePath);
   }
 
   public static BackupStore of(final FilesystemBackupConfig storeConfig) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -151,8 +151,8 @@ public final class ManifestManager {
     try {
       final var path = manifestPath(manifest);
       Files.delete(path);
-      FilesystemBackupStore.backtrackDeleteEmptyParents(
-          path.getParent(), String.valueOf(id.partitionId()));
+      final var dirLimit = manifestsPath.resolve(String.valueOf(id.partitionId()));
+      FilesystemBackupStore.backtrackDeleteEmptyParents(path.getParent(), dirLimit);
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown manifest with id {}", id);
     } catch (final IOException e) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -151,7 +151,8 @@ public final class ManifestManager {
     try {
       final var path = manifestPath(manifest);
       Files.delete(path);
-      FileUtil.flushDirectory(path.getParent());
+      FilesystemBackupStore.backtrackDeleteEmptyParents(
+          path.getParent(), String.valueOf(id.partitionId()));
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown manifest with id {}", id);
     } catch (final IOException e) {

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -16,9 +16,11 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.testkit.BackupStoreTestKit;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -28,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -138,6 +141,29 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         backupDir.resolve("manifests").resolve(String.valueOf(backup.id().partitionId()));
     assertThat(partitionContentsDir).isEmptyDirectory();
     assertThat(partitionManifestsDir).isEmptyDirectory();
+  }
+
+  @Test
+  void parentDirectoriesShouldNotBeDeletedIfNotEmpty() throws IOException {
+    // given
+    final var node1BackupId = new BackupIdentifierImpl(1, 2, 3);
+    final var node2BackupId = new BackupIdentifierImpl(2, 2, 3);
+    final var node1Backup = TestBackupProvider.simpleBackupWithId(node1BackupId);
+    final var node2Backup = TestBackupProvider.simpleBackupWithId(node2BackupId);
+
+    getStore().save(node1Backup).join();
+    getStore().save(node2Backup).join();
+
+    // when
+    getStore().delete(node1Backup.id()).join();
+
+    // then
+    final var partitionContentsDir =
+        backupDir.resolve("contents").resolve(String.valueOf(node2Backup.id().partitionId()));
+    final var partitionManifestsDir =
+        backupDir.resolve("manifests").resolve(String.valueOf(node2Backup.id().partitionId()));
+    assertThat(partitionContentsDir).isNotEmptyDirectory();
+    assertThat(partitionManifestsDir).isNotEmptyDirectory();
   }
 
   void uploadInProgressManifest(final Backup backup) {

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -124,7 +124,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
 
   @ParameterizedTest
   @MethodSource("provideBackups")
-  void parentDirectoriesAreDeletedAfterDeletion(final Backup backup) throws IOException {
+  void parentDirectoriesAreDeletedAfterDeletion(final Backup backup) {
     // given
     getStore().save(backup).join();
 
@@ -136,10 +136,8 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         backupDir.resolve("contents").resolve(String.valueOf(backup.id().partitionId()));
     final var partitionManifestsDir =
         backupDir.resolve("manifests").resolve(String.valueOf(backup.id().partitionId()));
-    assertThat(partitionContentsDir).isDirectory();
-    assertThat(Files.list(partitionContentsDir)).isEmpty();
-    assertThat(partitionManifestsDir).isDirectory();
-    assertThat(Files.list(partitionManifestsDir)).isEmpty();
+    assertThat(partitionContentsDir).isEmptyDirectory();
+    assertThat(partitionManifestsDir).isEmptyDirectory();
   }
 
   void uploadInProgressManifest(final Backup backup) {

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -122,6 +122,26 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
                 but was in state 'IN_PROGRESS'""");
   }
 
+  @ParameterizedTest
+  @MethodSource("provideBackups")
+  void parentDirectoriesAreDeletedAfterDeletion(final Backup backup) throws IOException {
+    // given
+    getStore().save(backup).join();
+
+    // when
+    getStore().delete(backup.id()).join();
+
+    // then
+    final var partitionContentsDir =
+        backupDir.resolve("contents").resolve(String.valueOf(backup.id().partitionId()));
+    final var partitionManifestsDir =
+        backupDir.resolve("manifests").resolve(String.valueOf(backup.id().partitionId()));
+    assertThat(partitionContentsDir).isDirectory();
+    assertThat(Files.list(partitionContentsDir)).isEmpty();
+    assertThat(partitionManifestsDir).isDirectory();
+    assertThat(Files.list(partitionManifestsDir)).isEmpty();
+  }
+
   void uploadInProgressManifest(final Backup backup) {
     final var manifest = Manifest.createInProgress(backup);
     final byte[] serializedManifest;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
On FS backup store only manifest and snapshot/segment files were being deleted. This resulted in leaving empty parent directories that would never be pruned.

This PR adds a backtracking deletion for empty parents up to the _partitionId_ directory. 

Before:
```
/tmp/junit-10427042643472813250/
├── contents
│   └── 2
│       └── 3
│           └── 1
├── manifests
│   └── 2
│       └── 3
│           └── 1
└── ranges
```
After: 
```
/tmp/junit-5749292605427580990/
├── contents
│   └── 2
├── manifests
│   └── 2
└── ranges
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
