### PR TITLE
feat: Add pom version update step and setting valid semver version

### DIFF
--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -175,19 +175,46 @@ jobs:
           HOTFIX_VERSION="${{ matrix.version }}-${{ needs.validate-inputs.outputs.support-ticket-id }}.${{ steps.get-sha.outputs.short-sha }}"
           echo "📋 Hotfix version: $HOTFIX_VERSION"
 
-          # Handle different version inheritance structures
-          if [[ "${{ matrix.component }}" == "optimize" && -f "optimize/pom.xml" ]] && ! grep -q "zeebe-parent" optimize/pom.xml; then
-            echo "🔧 Detected standalone optimize branch - updating optimize parent version..."
-            MVN_POM="optimize/pom.xml"
-          elif [[ -f "bom/pom.xml" ]]; then
-            echo "🔧 Updating version in BOM (parent and root will inherit automatically)..."
-            MVN_POM="bom/pom.xml"
+          # Update versions based on branch structure:
+          # - Unified branches (stable/8.8+, main): Have clients/java-deprecated
+          # - Dedicated branches (stable/optimize-8.6/8.7): No clients/java-deprecated
+          if [[ "${{ matrix.component }}" == "optimize" ]]; then
+            # For Optimize builds:
+            if [[ -d "clients/java-deprecated" ]]; then
+              # Unified branch (stable/8.8+): Update BOTH BOM and optimize/pom.xml
+              # BOM update: Zeebe modules get hotfix version
+              # optimize/pom.xml update: Optimize modules get hotfix version (separate parent hierarchy)
+              echo "🔧 Unified branch: updating BOM for Zeebe dependencies..."
+              ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "bom/pom.xml"
+              
+              if [[ ! -f "optimize/pom.xml" ]]; then
+                echo "❌ ERROR: optimize/pom.xml not found"
+                exit 1
+              fi
+              echo "🔧 Unified branch: updating optimize/pom.xml for Optimize modules..."
+              ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "optimize/pom.xml"
+              MVN_POM="optimize/pom.xml"
+            else
+              # Dedicated branch (stable/optimize-8.6/8.7): Update only optimize/pom.xml
+              # These branches use published Zeebe versions from Nexus
+              echo "🔧 Dedicated Optimize branch: updating optimize/pom.xml..."
+              if [[ ! -f "optimize/pom.xml" ]]; then
+                echo "❌ ERROR: optimize/pom.xml not found"
+                exit 1
+              fi
+              ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "optimize/pom.xml"
+              MVN_POM="optimize/pom.xml"
+            fi
           else
-            echo "❌ ERROR: Neither optimize/pom.xml nor bom/pom.xml found"
-            exit 1
+            # For Zeebe/Operate/Tasklist/Camunda: always use BOM (unified branches only)
+            if [[ ! -f "bom/pom.xml" ]]; then
+              echo "❌ ERROR: bom/pom.xml not found"
+              exit 1
+            fi
+            echo "🔧 Updating BOM version (propagates to Zeebe modules)..."
+            ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "bom/pom.xml"
+            MVN_POM="bom/pom.xml"
           fi
-
-          ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "$MVN_POM"
 
           echo "✅ Project version updated to $HOTFIX_VERSION"
           echo "🔍 Verifying version change..."
@@ -219,9 +246,23 @@ jobs:
                 exit 1
               fi
               
-              # Build optimize-distro with runAssembly profile
-              # Required for stable/optimize-8.6 and 8.7 branches; harmless on main and stable branches
-              ./mvnw clean package -T1C -DskipTests -DskipChecks -PrunAssembly -am -pl optimize-distro
+              # Branch detection: clients/java-deprecated only exists on unified branches (stable/8.8+)
+              # Older branches (stable/optimize-8.6/8.7) have bom and clients/java but not java-deprecated
+              if [[ -d "clients/java-deprecated" ]]; then
+                # Unified branch (stable/8.8+): Pre-build Zeebe dependencies to make them available at hotfix version
+                # This ensures zeebe-client, search-client, etc. are installed locally
+                # Note: Building both java and java-deprecated to support legacy zeebe-client-java artifact ID
+                echo "📦 Unified branch: Building Zeebe dependencies first..."
+                ./mvnw clean install -T1C -DskipTests -DskipChecks -am -pl clients/java,clients/java-deprecated
+                
+                # Build optimize-distro with install goal (installs to local repo)
+                echo "📦 Building Optimize distribution..."
+                ./mvnw install -T1C -DskipTests -DskipChecks -PrunAssembly -am -pl optimize-distro
+              else
+                # Dedicated/older branch (stable/optimize-8.6/8.7): Use published Zeebe dependencies from Nexus
+                echo "📦 Dedicated Optimize branch: Building with published dependencies..."
+                ./mvnw clean package -T1C -DskipTests -DskipChecks -PrunAssembly -am -pl optimize-distro
+              fi
               ;;
             *)
               echo "❌ Unknown component: ${{ matrix.component }}"

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -17,8 +17,8 @@
 # - Platforms are not configurable, they are by default set to linux/amd64 and linux/arm64
 #
 # The workflow validates inputs, builds the requested images, and pushes them to the Camunda hotfix registry following
-# the naming convention: registry.camunda.cloud/hotfixes/<image>:<application-version>-<support-issue-id>-<short-sha>
-# Example: registry.camunda.cloud/hotfixes/camunda:8.6.1-support-12345
+# the naming convention: registry.camunda.cloud/hotfixes/<image>:<application-version>-<support-issue-id>.<short-sha>
+# Example: registry.camunda.cloud/hotfixes/camunda:8.6.1-SUPPORT-12345.abc123
 name: Create Urgent Hotfix Image
 
 on:
@@ -67,7 +67,6 @@ jobs:
           COMMIT="${{ github.event.inputs.commit }}"
           TICKET_ID="${{ github.event.inputs.support-ticket-id }}"
           COMPONENTS="${{ github.event.inputs.components_with_versions }}"
-
 
           [[ -z "$BRANCH" && -z "$COMMIT" ]] && { echo "❌ Either branch or commit required"; exit 1; }
           [[ -n "$BRANCH" && "$BRANCH" =~ [[:space:]] ]] && { echo "❌ Branch name cannot contain whitespace"; exit 1; }
@@ -164,6 +163,31 @@ jobs:
           maven-mirrors: '[{"id": "camunda-nexus", "name": "Camunda Nexus", "url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "mirrorOf": "*"}]'  
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        
+      - name: Set project version
+        id: set-version
+        working-directory: build-repo
+        run: |
+          echo "🔧 Setting project version to ${{ matrix.version }}..."
+
+          # Create semver-compatible hotfix version: <version>-<ticket>.<sha>
+          # Format: 8.8.88-SUPPORT.12345.abc123 (dots instead of hyphens for semver compatibility)
+          HOTFIX_VERSION="${{ matrix.version }}-${{ needs.validate-inputs.outputs.support-ticket-id }}.${{ steps.get-sha.outputs.short-sha }}"
+          echo "📋 Hotfix version: $HOTFIX_VERSION"
+
+          # Set version in the BOM only - parent and root inherit from BOM through Maven inheritance
+          # Maven inheritance hierarchy: BOM -> Parent -> Root
+          # The parent/pom.xml and pom.xml inherit their versions and cannot be set directly
+          echo "🔧 Updating version in BOM (parent and root will inherit automatically)..."
+          ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f bom/pom.xml
+
+          echo "✅ Project version updated to $HOTFIX_VERSION"
+          echo "🔍 Verifying version change..."
+          ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+          
+          # Store the hotfix version for later steps
+          echo "hotfix-version=$HOTFIX_VERSION" >> "$GITHUB_OUTPUT"
+    
       - name: Build Maven artifacts
         working-directory: build-repo
         run: |
@@ -195,15 +219,10 @@ jobs:
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-          if [[ "${{ matrix.component }}" == "optimize" ]]; then
-            BUILD_ARGS="VERSION=*
-            DATE=$BUILD_DATE
-            REVISION=${{ steps.get-sha.outputs.full-sha }}"
-          else
-            BUILD_ARGS="VERSION=${{ matrix.version }}
-            DATE=$BUILD_DATE
-            REVISION=${{ steps.get-sha.outputs.full-sha }}"
-          fi
+          # Use the full semver-compatible hotfix version for consistency
+          BUILD_ARGS="VERSION=${{ steps.set-version.outputs.hotfix-version }}
+          DATE=$BUILD_DATE
+          REVISION=${{ steps.get-sha.outputs.full-sha }}"
 
           {
             echo "args<<EOF"
@@ -221,13 +240,13 @@ jobs:
           provenance: false
           build-args: ${{ steps.build-args.outputs.args }}
           tags: |
-            ${{ env.HOTFIX_REGISTRY }}/${{ matrix.component }}:${{ matrix.version }}-${{ needs.validate-inputs.outputs.support-ticket-id }}-${{ steps.get-sha.outputs.short-sha }}
+            ${{ env.HOTFIX_REGISTRY }}/${{ matrix.component }}:${{ steps.set-version.outputs.hotfix-version }}
           labels: |
             org.opencontainers.image.title=Camunda ${{ matrix.component }} ${{ matrix.version }} Hotfix
             org.opencontainers.image.description=Hotfix image for ${{ matrix.component }} ${{ matrix.version }} - Ticket: ${{ needs.validate-inputs.outputs.support-ticket-id }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.get-sha.outputs.full-sha }}
-            org.opencontainers.image.version=${{ matrix.version }}
+            org.opencontainers.image.version=${{ steps.set-version.outputs.hotfix-version }}
             camunda.hotfix.ticket-id=${{ needs.validate-inputs.outputs.support-ticket-id }}
             camunda.hotfix.component=${{ matrix.component }}
             camunda.hotfix.version=${{ matrix.version }}
@@ -268,7 +287,9 @@ jobs:
             for ITEM in "${COMP_ARRAY[@]}"; do
               ITEM=$(echo "$ITEM" | xargs)
               if [[ "$ITEM" =~ ^([^:]+):(.+)$ ]]; then
-                TAG="${{ env.HOTFIX_REGISTRY }}/${BASH_REMATCH[1]}:${BASH_REMATCH[2]}-${TICKET_ID}-${SHORT_SHA}"
+                # Use the same hotfix version format: version-ticket.sha
+                HOTFIX_TAG="${BASH_REMATCH[2]}-${TICKET_ID}.${SHORT_SHA}"
+                TAG="${{ env.HOTFIX_REGISTRY }}/${BASH_REMATCH[1]}:${HOTFIX_TAG}"
                 echo "- \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
               fi
             done

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -175,11 +175,14 @@ jobs:
           HOTFIX_VERSION="${{ matrix.version }}-${{ needs.validate-inputs.outputs.support-ticket-id }}.${{ steps.get-sha.outputs.short-sha }}"
           echo "📋 Hotfix version: $HOTFIX_VERSION"
 
-          # Set version in the BOM only - parent and root inherit from BOM through Maven inheritance
-          # Maven inheritance hierarchy: BOM -> Parent -> Root
-          # The parent/pom.xml and pom.xml inherit their versions and cannot be set directly
-          echo "🔧 Updating version in BOM (parent and root will inherit automatically)..."
-          ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f bom/pom.xml
+          # Handle different version inheritance structures
+          if [[ "${{ matrix.component }}" == "optimize" && -f "optimize/pom.xml" ]] && ! grep -q "zeebe-parent" optimize/pom.xml; then
+            echo "🔧 Detected standalone optimize branch - updating optimize parent version..."
+            ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f optimize/pom.xml
+          else
+            echo "🔧 Updating version in BOM (parent and root will inherit automatically)..."
+            ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f bom/pom.xml
+          fi
 
           echo "✅ Project version updated to $HOTFIX_VERSION"
           echo "🔍 Verifying version change..."

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   validate-inputs:
     name: Validate Inputs
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-default
     outputs:
       branch: ${{ steps.parse.outputs.branch }}
       commit: ${{ steps.parse.outputs.commit }}
@@ -171,22 +171,34 @@ jobs:
           echo "🔧 Setting project version to ${{ matrix.version }}..."
 
           # Create semver-compatible hotfix version: <version>-<ticket>.<sha>
-          # Format: 8.8.88-SUPPORT.12345.abc123 (dots instead of hyphens for semver compatibility)
+          # Format: 8.8.88-SUPPORT-12345.abc123 (ticket ID contains hyphen, then dot before SHA)
           HOTFIX_VERSION="${{ matrix.version }}-${{ needs.validate-inputs.outputs.support-ticket-id }}.${{ steps.get-sha.outputs.short-sha }}"
           echo "📋 Hotfix version: $HOTFIX_VERSION"
 
           # Handle different version inheritance structures
           if [[ "${{ matrix.component }}" == "optimize" && -f "optimize/pom.xml" ]] && ! grep -q "zeebe-parent" optimize/pom.xml; then
             echo "🔧 Detected standalone optimize branch - updating optimize parent version..."
-            ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f optimize/pom.xml
-          else
+            MVN_POM="optimize/pom.xml"
+          elif [[ -f "bom/pom.xml" ]]; then
             echo "🔧 Updating version in BOM (parent and root will inherit automatically)..."
-            ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f bom/pom.xml
+            MVN_POM="bom/pom.xml"
+          else
+            echo "❌ ERROR: Neither optimize/pom.xml nor bom/pom.xml found"
+            exit 1
           fi
+
+          ./mvnw versions:set -DnewVersion="$HOTFIX_VERSION" -DgenerateBackupPoms=false -f "$MVN_POM"
 
           echo "✅ Project version updated to $HOTFIX_VERSION"
           echo "🔍 Verifying version change..."
-          ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+          EVALUATED_VERSION="$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -f "$MVN_POM")"
+
+          if [[ "$EVALUATED_VERSION" != "$HOTFIX_VERSION" ]]; then
+            echo "❌ ERROR: Verified project version '$EVALUATED_VERSION' does not match expected hotfix version '$HOTFIX_VERSION'."
+            exit 1
+          fi
+
+          echo "✅ Verified project version: $EVALUATED_VERSION"
           
           # Store the hotfix version for later steps
           echo "hotfix-version=$HOTFIX_VERSION" >> "$GITHUB_OUTPUT"
@@ -257,7 +269,7 @@ jobs:
 
   summary:
     name: Build Summary
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-2-default
     needs: [validate-inputs, build-images]
     if: always()
     steps:


### PR DESCRIPTION
## Description

The aim of this PR to add the feature of setting the project version in the pom files during the workflow run of the urgent hotfix creation logic.

🗒️  Related confluence page will be updated accordingly after the approval and parallel with the merge of this PR

## Changes made
- The versions are updated during the mvn build, so the result artifacts will have the provided version number
- semver2 validation logic is added to the version creation and usage

## Validation
### stable/8.8
- [Workflow run](https://github.com/camunda/camunda/actions/runs/21717116830)
- 
#### camunda
<img width="1344" height="90" alt="image" src="https://github.com/user-attachments/assets/c9c329cb-15b5-4628-ba64-de84478a4176" />

#### zeebe
<img width="1342" height="85" alt="image" src="https://github.com/user-attachments/assets/d35cec8b-15b3-4fc9-a47c-1a5e8ed233c5" />

#### tasklist
<img width="1346" height="63" alt="image" src="https://github.com/user-attachments/assets/0b11a63e-ddba-48f3-8cca-2c800d7e9dbe" />

#### operate
<img width="1335" height="105" alt="image" src="https://github.com/user-attachments/assets/101d7854-193a-45db-856b-3fafc3e955e0" />


#### optimize
- image content
<img width="1341" height="48" alt="image" src="https://github.com/user-attachments/assets/7972dbd0-3d9f-46d1-ae5f-3c3735529ed7" />

### stable/8.7
- [Workflow run](https://github.com/camunda/camunda/actions/runs/21717145233)

#### camunda
<img width="1342" height="132" alt="image" src="https://github.com/user-attachments/assets/a82d4056-ddc4-4103-bcc4-dd74c37fb1c4" />

#### zeebe
<img width="1341" height="93" alt="image" src="https://github.com/user-attachments/assets/43062c3f-7c0f-432f-b58b-8bae5f9fb61f" />

#### tasklist
<img width="1339" height="105" alt="image" src="https://github.com/user-attachments/assets/3885f2f6-13a4-4467-8118-dc440bdcbf15" />

#### operate
<img width="1345" height="97" alt="image" src="https://github.com/user-attachments/assets/272748b0-306d-4d96-bbbb-845bf508fe25" />


## stable/optimize-8.7
- [Workflow run](https://github.com/camunda/camunda/actions/runs/21717160171)
- image content 
<img width="1345" height="52" alt="image" src="https://github.com/user-attachments/assets/cbd13efd-6825-429c-8303-f3cc5946d736" />


## stable/8.6
- [Workflow run](https://github.com/camunda/camunda/actions/runs/21717189091)

#### camunda
<img width="1349" height="123" alt="image" src="https://github.com/user-attachments/assets/afbf9aab-57b8-43ac-a5bf-906662447b11" />

#### zeebe
<img width="1344" height="86" alt="image" src="https://github.com/user-attachments/assets/c0c1aad8-77e7-4f07-b579-5d911c65a923" />

#### tasklist
<img width="1333" height="102" alt="image" src="https://github.com/user-attachments/assets/2863f0c5-6f17-4bfb-87f2-abcbd4143b69" />

#### operate
<img width="1343" height="102" alt="image" src="https://github.com/user-attachments/assets/2d2350be-fe18-4823-8a10-2c49764aad1c" />


## stable/optimize-8.6
- [Workflow run](https://github.com/camunda/camunda/actions/runs/21717209461)
- image content
<img width="1349" height="49" alt="image" src="https://github.com/user-attachments/assets/36e26690-225d-4e03-8d90-c75ba377969f" />

## Related issues
https://github.com/camunda/camunda/issues/42051
