### PR TITLE
refactor: add or() connector to Authorization.Builder for readability

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -387,7 +387,9 @@ public class UserTaskIT {
                                 b.userTask()
                                     .read()
                                     .authorizedByAssignee()
+                                    .or()
                                     .authorizedByCandidateUsers()
+                                    .or()
                                     .authorizedByCandidateGroups())),
                     TenantCheck.disabled(),
                     CamundaAuthentication.of(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DefaultResourceAccessProviderTest.java
@@ -339,8 +339,12 @@ class DefaultResourceAccessProviderTest {
         CamundaAuthentication.of(a -> a.user("trevor").groupIds(List.of("managers")));
     final var authorization =
         Authorization.of(
-            (Authorization.Builder<UserTaskEntity> a) ->
-                a.userTask().readUserTask().authorizedByAssignee().authorizedByCandidateGroups());
+            a ->
+                a.userTask()
+                    .readUserTask()
+                    .authorizedByAssignee()
+                    .or()
+                    .authorizedByCandidateGroups());
 
     final var userTask = createUserTask("trevor");
 
@@ -370,9 +374,7 @@ class DefaultResourceAccessProviderTest {
     // given
     final var authentication = CamundaAuthentication.of(a -> a.user("jimmy").groupIds(List.of()));
     final var authorization =
-        Authorization.of(
-            (Authorization.Builder<UserTaskEntity> a) ->
-                a.userTask().readUserTask().authorizedByAssignee());
+        Authorization.of(a -> a.userTask().readUserTask().authorizedByAssignee());
 
     final var userTask = createUserTask("jimmy");
 
@@ -397,9 +399,7 @@ class DefaultResourceAccessProviderTest {
     final var authentication =
         CamundaAuthentication.of(a -> a.user("franklin").groupIds(List.of()));
     final var authorization =
-        Authorization.of(
-            (Authorization.Builder<UserTaskEntity> a) ->
-                a.userTask().readUserTask().authorizedByAssignee());
+        Authorization.of(a -> a.userTask().readUserTask().authorizedByAssignee());
 
     // User task is assigned to someone else
     final var userTask = createUserTask("michael");
@@ -426,10 +426,11 @@ class DefaultResourceAccessProviderTest {
     final var authentication = CamundaAuthentication.of(a -> a.user("martin"));
     final var authorization =
         Authorization.of(
-            (Authorization.Builder<TestResource> a) ->
+            a ->
                 a.processDefinition()
                     .readProcessDefinition()
                     .authorizedByProperty("anotherValue")
+                    .or()
                     .authorizedByProperty("unknownProperty"));
 
     final var resource = new TestResource("id123", "value456");

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -581,7 +581,9 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
                 a.userTask()
                     .read()
                     .authorizedByAssignee()
+                    .or()
                     .authorizedByCandidateUsers()
+                    .or()
                     .authorizedByCandidateGroups());
     final var authorizationCheck = AuthorizationCheck.enabled(authorization);
     final var resourceAccessChecks =

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -322,6 +322,14 @@ public record Authorization<T>(
       return authorizedByProperty(PROP_CANDIDATE_GROUPS);
     }
 
+    /**
+     * Fluent connector indicating the next condition is an OR alternative. This is purely for
+     * readability.
+     */
+    public Builder<T> or() {
+      return this;
+    }
+
     public Authorization<T> build() {
       return new Authorization<>(
           resourceType,

--- a/security/security-core/src/test/java/io/camunda/security/reader/ResourceAccessChecksTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/reader/ResourceAccessChecksTest.java
@@ -227,8 +227,7 @@ class ResourceAccessChecksTest {
       // given
       final var authorization =
           Authorization.of(
-              builder ->
-                  builder.userTask().read().authorizedByAssignee().authorizedByCandidateUsers());
+              b -> b.userTask().read().authorizedByAssignee().or().authorizedByCandidateUsers());
       final var condition = AuthorizationConditions.single(authorization);
       final var checks =
           ResourceAccessChecks.of(AuthorizationCheck.enabled(condition), TenantCheck.disabled());
@@ -248,15 +247,14 @@ class ResourceAccessChecksTest {
       // given
       final var first =
           Authorization.of(
-              builder ->
-                  builder.userTask().read().authorizedByAssignee().authorizedByCandidateUsers());
+              b -> b.userTask().read().authorizedByAssignee().or().authorizedByCandidateUsers());
       final var second =
           Authorization.of(
-              builder ->
-                  builder
-                      .userTask()
+              b ->
+                  b.userTask()
                       .updateUserTask() // different permission
                       .authorizedByCandidateUsers() // duplicate
+                      .or()
                       .authorizedByCandidateGroups());
       final var condition = AuthorizationConditions.anyOf(first, second);
       final var checks =
@@ -279,12 +277,10 @@ class ResourceAccessChecksTest {
       // given
       final var userTaskAuth =
           Authorization.of(
-              builder ->
-                  builder.userTask().read().authorizedByAssignee().authorizedByCandidateUsers());
+              b -> b.userTask().read().authorizedByAssignee().or().authorizedByCandidateUsers());
       final var processDefAuth =
           Authorization.of(
-              builder ->
-                  builder.processDefinition().readUserTask().authorizedByProperty("tenantId"));
+              b -> b.processDefinition().readUserTask().authorizedByProperty("tenantId"));
       final var condition = AuthorizationConditions.anyOf(userTaskAuth, processDefAuth);
       final var checks =
           ResourceAccessChecks.of(AuthorizationCheck.enabled(condition), TenantCheck.disabled());

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -104,7 +104,9 @@ public abstract class Authorizations {
               a.userTask()
                   .read()
                   .authorizedByAssignee()
+                  .or()
                   .authorizedByCandidateUsers()
+                  .or()
                   .authorizedByCandidateGroups());
 
   public static final Authorization<VariableEntity> VARIABLE_READ_AUTHORIZATION =


### PR DESCRIPTION
## Description

This PR adds a fluent `or()` connector method to `Authorization.Builder` and applies it to PROPERTY-based authorization definitions to improve code readability.

### Why?

Currently, when multiple properties methods for authorization are chained together, the code reads ambiguously:

```java
.authorizedByAssignee()
.authorizedByCandidateUsers()
.authorizedByCandidateGroups()
```

This looks like all conditions must be met (AND logic), but in reality these are OR-based checks - a user only needs to satisfy any one of these to be authorized.

As [noted](https://github.com/camunda/camunda/pull/44404/changes#r2713628417) by @Ben-Sheppard, adding an explicit `or()` connector will make the intention clear:

```java
.authorizedByAssignee()
.or()
.authorizedByCandidateUsers()
.or()
.authorizedByCandidateGroups()
```

### Changes
- Added `or()` method to `Authorization.Builder` that returns `this` (purely for readability)
- Updated `USER_TASK_READ_BY_PROPERTIES_AUTHORIZATION` constant to use `or()` connector
- Updated test with authorization definitions to use `or()` connector

### Impact
- No behavioral changes, purely improves API expressiveness
- Makes OR semantics explicit for PROPERTY-based authorization definitions

## Related issues
relates to: #40128, #41682
