### PR TITLE
test: add a shutdownHook to delete temporary folders created in backup-store

### DIFF
--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -42,7 +42,7 @@ public final class TestBackupProvider {
                     try {
                       FileUtil.deleteFolderIfExists(tempDir);
                     } catch (final IOException e) {
-                      throw new RuntimeException(e);
+                      System.err.println("Failed to delete temp dir: " + tempDir);
                     }
                   }));
     } catch (final IOException e) {

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -30,19 +30,19 @@ import org.junit.jupiter.params.provider.Arguments;
 
 public class TestBackupProvider {
 
-  private static final Path tempDir;
+  private static final Path TEMP_DIR;
 
   static {
     try {
-      tempDir = Files.createTempDirectory(TestBackupProvider.class.getSimpleName());
+      TEMP_DIR = Files.createTempDirectory(TestBackupProvider.class.getSimpleName());
       Runtime.getRuntime()
           .addShutdownHook(
               new Thread(
                   () -> {
                     try {
-                      FileUtil.deleteFolderIfExists(tempDir);
+                      FileUtil.deleteFolderIfExists(TEMP_DIR);
                     } catch (final IOException e) {
-                      System.err.println("Failed to delete temp dir: " + tempDir);
+                      System.err.println("Failed to delete temp dir: " + TEMP_DIR);
                     }
                   }));
     } catch (final IOException e) {
@@ -61,7 +61,7 @@ public class TestBackupProvider {
   }
 
   public static Backup backupWithoutSnapshot(final String version) throws IOException {
-    final var backupDir = Files.createTempDirectory(tempDir, "backup");
+    final var backupDir = Files.createTempDirectory(TEMP_DIR, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
     final var seg2 = Files.createFile(backupDir.resolve("segments/segment-file-2"));
@@ -94,7 +94,7 @@ public class TestBackupProvider {
 
   public static Backup simpleBackupWithId(final BackupIdentifierImpl id, final String version)
       throws IOException {
-    final var backupDir = Files.createTempDirectory(tempDir, "backup");
+    final var backupDir = Files.createTempDirectory(TEMP_DIR, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
     final var seg2 = Files.createFile(backupDir.resolve("segments/segment-file-2"));
@@ -126,7 +126,7 @@ public class TestBackupProvider {
 
   public static Backup minimalBackupWithId(final BackupIdentifierImpl id, final String version)
       throws IOException {
-    final var backupDir = Files.createTempDirectory(tempDir, "backup");
+    final var backupDir = Files.createTempDirectory(TEMP_DIR, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
     Files.write(seg1, RandomUtils.nextBytes(1));

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.params.provider.Arguments;
 
-public final class TestBackupProvider {
+public class TestBackupProvider {
 
   private static final Path tempDir;
 
@@ -57,6 +57,10 @@ public final class TestBackupProvider {
   }
 
   public static Backup backupWithoutSnapshot() throws IOException {
+    return backupWithoutSnapshot(VersionUtil.getVersion());
+  }
+
+  public static Backup backupWithoutSnapshot(final String version) throws IOException {
     final var backupDir = Files.createTempDirectory(tempDir, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
@@ -69,7 +73,7 @@ public final class TestBackupProvider {
         new BackupDescriptorImpl(
             4,
             5,
-            VersionUtil.getVersion(),
+            version,
             Instant.now().truncatedTo(ChronoUnit.MILLIS),
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
@@ -80,7 +84,16 @@ public final class TestBackupProvider {
     return simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3));
   }
 
+  public static Backup simpleBackup(final String version) throws IOException {
+    return simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), version);
+  }
+
   public static Backup simpleBackupWithId(final BackupIdentifierImpl id) throws IOException {
+    return simpleBackupWithId(id, VersionUtil.getVersion());
+  }
+
+  public static Backup simpleBackupWithId(final BackupIdentifierImpl id, final String version)
+      throws IOException {
     final var backupDir = Files.createTempDirectory(tempDir, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
@@ -100,7 +113,7 @@ public final class TestBackupProvider {
             "test-snapshot-id",
             4,
             5,
-            VersionUtil.getVersion(),
+            version,
             Instant.now().truncatedTo(ChronoUnit.MILLIS),
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)),
@@ -108,6 +121,11 @@ public final class TestBackupProvider {
   }
 
   public static Backup minimalBackupWithId(final BackupIdentifierImpl id) throws IOException {
+    return minimalBackupWithId(id, VersionUtil.getVersion());
+  }
+
+  public static Backup minimalBackupWithId(final BackupIdentifierImpl id, final String version)
+      throws IOException {
     final var backupDir = Files.createTempDirectory(tempDir, "backup");
     Files.createDirectory(backupDir.resolve("segments/"));
     final var seg1 = Files.createFile(backupDir.resolve("segments/segment-file-1"));
@@ -118,7 +136,7 @@ public final class TestBackupProvider {
         new BackupDescriptorImpl(
             4,
             5,
-            VersionUtil.getVersion(),
+            version,
             Instant.now().truncatedTo(ChronoUnit.MILLIS),
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),


### PR DESCRIPTION
## Description
`TestBackupStore` was creating a lot of folders under `/tmp` without deleting them. 
A shutdownHook deletes the folders once the jvm terminates.

Tested it on my laptop, I no longer have any folder under `/tmp/backup*`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

