### PR TITLE
Update role and tenant test according to API changes

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
@@ -194,17 +194,25 @@ test.describe.parallel('Roles API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Update Role Missing Description Invalid Body 400', async ({
+  test('Update Role Missing Description Success 200', async ({
     request,
   }) => {
     const p = {roleId: state['roleId1'] as string};
+    const expectedBody = {
+      ...p,
+      name: 'missing description',
+      description: '',
+    };
     await expect(async () => {
       const res = await request.put(buildUrl('/roles/{roleId}', p), {
         headers: jsonHeaders(),
         data: {name: 'missing description'},
       });
 
-      await assertBadRequest(res, /.*\b(description)\b.*/i, 'INVALID_ARGUMENT');
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, roleRequiredFields);
+      assertEqualsForKeys(json, expectedBody, roleRequiredFields);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
@@ -187,17 +187,25 @@ test.describe.parallel('Tenants API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Update Tenant Missing Description Invalid Body 400', async ({
+  test('Update Tenant Missing Description success 200', async ({
     request,
   }) => {
     const p = {tenantId: state['tenantId1'] as string};
+    const expectedBody = {
+      ...p,
+      name: 'missing description',
+      description: '',
+    };
     await expect(async () => {
       const res = await request.put(buildUrl('/tenants/{tenantId}', p), {
         headers: jsonHeaders(),
         data: {name: 'missing description'},
       });
 
-      await assertBadRequest(res, /.*\b(description)\b.*/i, 'INVALID_ARGUMENT');
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      assertRequiredFields(json, tenantRequiredFields);
+      assertEqualsForKeys(json, expectedBody, tenantRequiredFields);
     }).toPass(defaultAssertionOptions);
   });
 


### PR DESCRIPTION
## Description

API was changed so now description is not required for updating. Was discussed here in [Slack](https://camunda.slack.com/archives/C08MRKHJ0CD/p1769167024237769).

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21287688027)