### PR TITLE
Add SaaS Workflow Link to AlwaysGreen Workflow

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -428,6 +428,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
       - name: Wait for downstream workflow to finish
+        id: wait-downstream
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           TRIGGER_TIME: ${{ steps.trigger-time.outputs.trigger_time }}
@@ -445,6 +446,7 @@ jobs:
               --jq ".workflow_runs[] | select(.created_at > \"$TRIGGER_TIME\") | .id" | head -n1)
 
             if [[ -n "$RUN_ID" ]]; then
+              echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> $GITHUB_OUTPUT
               STATUS=$(gh api /repos/$TARGET_REPO/actions/runs/"$RUN_ID" --jq .status)
               CONCLUSION=$(gh api /repos/$TARGET_REPO/actions/runs/"$RUN_ID" --jq .conclusion)
               echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"
@@ -462,5 +464,16 @@ jobs:
           done
           echo "Timed out waiting for downstream workflow to complete."
           exit 1
+
+      - name: Add SaaS downstream workflow link to Job Summary
+        if: always()
+        run: |
+          if [ -n "${{ steps.wait-downstream.outputs.downstream_run_url }}" ]; then
+            echo "### SaaS Downstream Workflow Run" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "[Open the triggered SaaS E2E workflow run in camunda/c8-cross-component-e2e-tests](${{ steps.wait-downstream.outputs.downstream_run_url }})" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
 

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -446,7 +446,7 @@ jobs:
               --jq ".workflow_runs[] | select(.created_at > \"$TRIGGER_TIME\") | .id" | head -n1)
 
             if [[ -n "$RUN_ID" ]]; then
-              echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> $GITHUB_OUTPUT
+              echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> "$GITHUB_OUTPUT"
               STATUS=$(gh api /repos/$TARGET_REPO/actions/runs/"$RUN_ID" --jq .status)
               CONCLUSION=$(gh api /repos/$TARGET_REPO/actions/runs/"$RUN_ID" --jq .conclusion)
               echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"
@@ -469,11 +469,12 @@ jobs:
         if: always()
         run: |
           if [ -n "${{ steps.wait-downstream.outputs.downstream_run_url }}" ]; then
-            echo "### SaaS Downstream Workflow Run" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "[Open the triggered SaaS E2E workflow run in camunda/c8-cross-component-e2e-tests](${{ steps.wait-downstream.outputs.downstream_run_url }})" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "### SaaS Downstream Workflow Run"
+              echo ""
+              echo "[Open the triggered SaaS E2E workflow run in camunda/c8-cross-component-e2e-tests](${{ steps.wait-downstream.outputs.downstream_run_url }})"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
           fi
-
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To improve DevEx, the downstream SaaS workflow link which is triggered by the AlwaysGreen workflow should be added to the GitHub summary.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
