### PR TITLE
Document description as not mandatory for update requests

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -642,7 +642,6 @@ components:
           description: The new description of the group.
       required:
         - name
-        - description
 
     GroupUpdateResult:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -718,7 +718,6 @@ components:
           description: The description of the new role.
       required:
         - name
-        - description
 
     RoleUpdateResult:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -779,7 +779,6 @@ components:
           description: The new description of the tenant.
       required:
         - name
-        - description
 
     TenantUpdateResult:
       type: object


### PR DESCRIPTION
## Description

Since we allow descriptions to be empty on role/tenant/group update, openApi spec also has to be updated.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44649
