### PR TITLE
fix: support BUILD build-arg for Tasklist/Operate

### DIFF
--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -3,12 +3,22 @@ ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
 ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a5038e475"
 
 # If you don't have access to Minimus hardened base images, you can use public
-# base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.23.0"
-#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
+
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 
 # Prepare Operate Distribution
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
+FROM base-${BASE} AS prepare
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 WORKDIR /tmp/operate
 
@@ -23,7 +33,7 @@ RUN sed -i '/^exec /i cat /usr/local/operate/notice.txt' bin/operate
 # TARGETARCH is provided by buildkit
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS app
+FROM base-${BASE} AS app
 
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
-# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
 ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
 ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 ARG BASE="hardened"

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -3,11 +3,21 @@ ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
 ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a5038e475"
 
 # If you don't have access to Minimus hardened base images, you can use public
-# base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.23.0"
-#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
 
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
+
+FROM base-${BASE} AS base
 WORKDIR /
 
 ARG VERSION=""

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
-# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
 ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
 ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 ARG BASE="hardened"

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
-# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+# Simply pass `--build-arg BASE=public` in order to build with Alpine.
 ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
 ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
 ARG BASE="hardened"

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -3,12 +3,22 @@ ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
 ARG BASE_DIGEST="sha256:8a3a3df9e3db35af08f854c2837c68294abbbf2720a26da670a96c6a5038e475"
 
 # If you don't have access to Minimus hardened base images, you can use public
-# base images like this instead on your own risk:
-#ARG BASE_IMAGE="alpine:3.23.0"
-#ARG BASE_DIGEST="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
+ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE="hardened"
+
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 
 # Prepare Tasklist Distribution
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
+FROM base-${BASE} AS prepare
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 WORKDIR /tmp/tasklist
 
@@ -21,7 +31,7 @@ RUN sed -i '/^exec /i cat /usr/local/tasklist/notice.txt' bin/tasklist
 
 ### Application Image ###
 # hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS app
+FROM base-${BASE} AS app
 
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE


### PR DESCRIPTION
## Description

This PR fixes building public images for Operate, Tasklist, and Optimize, for third party contributors/forks. It ports the same build arg used in `Dockerfile` and `camunda.Dockerfile` to the other applications.