### PR TITLE
Ensure forms from the correct tenant are retrieved

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -72,17 +72,18 @@ public class FormStoreElasticSearch implements FormStore {
         version == null ? getFormEmbedded(id, processDefinitionId) : null;
     if (formEmbedded != null) {
       return formEmbedded;
-    } else if (isFormAssociatedToTask(id, processDefinitionId)) {
-      final var formLinked = getLinkedForm(id, version);
-      if (formLinked != null) {
-        return formLinked;
-      }
-    } else if (isFormAssociatedToProcess(id, processDefinitionId)) {
-      final var formLinked = getLinkedForm(id, version);
+    }
+
+    final Optional<String> tenantId =
+        getTenantIfFormAssociatedToTask(id, processDefinitionId)
+            .or(() -> getTenantIfFormAssociatedToProcess(id, processDefinitionId));
+    if (tenantId.isPresent()) {
+      final var formLinked = getLinkedForm(id, version, tenantId.get());
       if (formLinked != null) {
         return formLinked;
       }
     }
+
     throw new NotFoundException(String.format("form with id %s was not found", id));
   }
 
@@ -135,7 +136,8 @@ public class FormStoreElasticSearch implements FormStore {
     }
   }
 
-  private FormEntity getLinkedForm(final String formId, final Long formVersion) {
+  private FormEntity getLinkedForm(
+      final String formId, final Long formVersion, final String tenantId) {
     final SearchRequest searchRequest = new SearchRequest(formIndex.getFullQualifiedName());
     final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
@@ -159,7 +161,8 @@ public class FormStoreElasticSearch implements FormStore {
     searchRequest.source(searchSourceBuilder);
 
     try {
-      final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
+      final SearchResponse searchResponse =
+          tenantAwareClient.searchByTenantIds(searchRequest, List.of(tenantId));
 
       if (searchResponse.getHits().getHits().length > 0) {
         final Map<String, Object> sourceAsMap =
@@ -181,7 +184,8 @@ public class FormStoreElasticSearch implements FormStore {
     return null;
   }
 
-  private Boolean isFormAssociatedToTask(final String formId, final String processDefinitionId) {
+  private Optional<String> getTenantIfFormAssociatedToTask(
+      final String formId, final String processDefinitionId) {
     try {
       final BoolQueryBuilder boolQuery =
           QueryBuilders.boolQuery()
@@ -203,7 +207,13 @@ public class FormStoreElasticSearch implements FormStore {
 
       final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
 
-      return searchResponse.getHits().getTotalHits().value > 0;
+      if (searchResponse.getHits().getTotalHits().value > 0) {
+        return Optional.of(
+            (String)
+                searchResponse.getHits().getHits()[0].getSourceAsMap().get(TaskTemplate.TENANT_ID));
+      } else {
+        return Optional.empty();
+      }
     } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
@@ -211,7 +221,8 @@ public class FormStoreElasticSearch implements FormStore {
     }
   }
 
-  private Boolean isFormAssociatedToProcess(final String formId, final String processDefinitionId) {
+  private Optional<String> getTenantIfFormAssociatedToProcess(
+      final String formId, final String processDefinitionId) {
     try {
       final BoolQueryBuilder boolQuery =
           QueryBuilders.boolQuery()
@@ -227,7 +238,13 @@ public class FormStoreElasticSearch implements FormStore {
 
       final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
 
-      return searchResponse.getHits().getTotalHits().value > 0;
+      if (searchResponse.getHits().getTotalHits().value > 0) {
+        return Optional.of(
+            (String)
+                searchResponse.getHits().getHits()[0].getSourceAsMap().get(ProcessIndex.TENANT_ID));
+      } else {
+        return Optional.empty();
+      }
     } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);


### PR DESCRIPTION
## Description

This PR changes the implementation of  [`FormStore.getForm`](https://github.com/camunda/camunda/blob/8.7.22/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/FormStore.java#L16) in order to use the provided `processDefinitionKey` to filter returned forms by tenant id (using the same tenant as the associated task/process found by `processDefinitionKey`).

A task/process linking the form was already found by `isFormAssociatedToTask`/`isFormAssociatedToProcess` ([ElasticSearch](https://github.com/camunda/camunda/blob/8.7.22/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java#L184-L236)/[OpenSearch](https://github.com/camunda/camunda/blob/8.7.22/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java#L77-L161)) and from that it is possible to retrieve the tenant to which the task/process (and thus the form) was deployed.
This retrieved tenant ID is then used to perform the form query, using `tenantAwareClient.searchByTenantIds` instead of `tenantAwareClient.tenant`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44493 
