### PR TITLE
[Backport stable/8.8] 42387 ensure correct handler flush order in exporter for inconsistence entity id usage

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.config.ConnectionTypes;
@@ -118,7 +119,7 @@ import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -170,9 +171,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new CaffeineCacheStatsCounter(NAMESPACE, "form", meterRegistry));
 
-    exportHandlers = new HashSet<>();
+    exportHandlers = new LinkedHashSet<>();
     exportHandlers.addAll(
-        Set.of(
+        ImmutableSet.of(
             new RoleCreateUpdateHandler(
                 indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
             new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -21,16 +21,15 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiConsumer;
 
 /** Caches exporter entities of different types and provide the method to flush them in a batch. */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class ExporterBatchWriter {
-  private final Map<EntityIdAndEntityType, EntityAndHandlers> cachedEntities = new HashMap<>();
+  private final Map<EntityIdAndEntityType, ExporterEntity> cachedEntities = new HashMap<>();
+  private final List<EntityAndHandler> cachedEntitiesToFlush = new ArrayList<>();
   private final Map<EntityIdAndEntityType, Long> cachedEntitySizes = new HashMap<>();
   private final Map<Long, Long> cachedRecordTimestamps = new HashMap<>();
 
@@ -65,22 +64,20 @@ public final class ExporterBatchWriter {
       final Record<?> record, final ExportHandler handler, final String id) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
-    final EntityAndHandlers entityAndHandlers =
-        cachedEntities.computeIfAbsent(
-            cacheKey,
-            (k) -> {
-              final ExporterEntity entity = handler.createNewEntity(id);
-              return new EntityAndHandlers(entity, new LinkedHashSet<>());
-            });
+    final ExporterEntity entity =
+        cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
 
-    final var entity = entityAndHandlers.entity;
     handler.updateEntity(record, entity);
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
 
     cachedEntitySizes.put(cacheKey, EntitySizeEstimator.estimateEntitySize(entity));
 
-    // we store all handlers for an entity to make sure not to miss any flushes
-    entityAndHandlers.handlers.add(handler);
+    // we store all handlers for an entity to make sure not to miss any flushes.
+    // we flush them in the same order as they were originally run.
+    // in cases where we have bugs with writing to the same index + id, but with a different
+    // entity, this helps avoid race conditions that make that behavior non-deterministic.
+    // which would otherwise make spotting and fixing such bugs harder.
+    cachedEntitiesToFlush.add(new EntityAndHandler(entity, handler));
   }
 
   public void flush(final BatchRequest batchRequest) throws PersistenceException {
@@ -92,11 +89,8 @@ public final class ExporterBatchWriter {
       return;
     }
 
-    for (final var entityAndHandler : cachedEntities.values()) {
-      final ExporterEntity entity = entityAndHandler.entity();
-      for (final var handler : entityAndHandler.handlers()) {
-        handler.flush(entity, batchRequest);
-      }
+    for (final var toFlush : cachedEntitiesToFlush) {
+      toFlush.flush(batchRequest);
     }
 
     batchRequest.execute(customErrorHandler);
@@ -119,8 +113,14 @@ public final class ExporterBatchWriter {
     return cachedEntities.size();
   }
 
+  @VisibleForTesting
+  int getEntitiesToFlushSize() {
+    return cachedEntitiesToFlush.size();
+  }
+
   private void reset() {
     cachedEntities.clear();
+    cachedEntitiesToFlush.clear();
     cachedEntitySizes.clear();
   }
 
@@ -161,5 +161,9 @@ public final class ExporterBatchWriter {
 
   private record EntityIdAndEntityType(String entityId, Class<?> entityType) {}
 
-  private record EntityAndHandlers(ExporterEntity entity, Set<ExportHandler> handlers) {}
+  private record EntityAndHandler(ExporterEntity entity, ExportHandler handler) {
+    public void flush(final BatchRequest batchRequest) throws PersistenceException {
+      handler.flush(entity, batchRequest);
+    }
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -123,6 +123,7 @@ class ExporterBatchWriterTest {
 
     batchWriter.addRecord(record);
     assertThat(batchWriter.getBatchSize()).isEqualTo(1);
+    assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(1);
 
     // When
     final BatchRequest batchRequest = mock(BatchRequest.class);
@@ -133,5 +134,6 @@ class ExporterBatchWriterTest {
     verify(handler).flush(entity, batchRequest);
     verify(batchRequest).execute(any());
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
+    assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
# Description
Backport of #44206 to `stable/8.8`.

relates to #42387