### PR TITLE
fix: include missing GH token and main branch checkout to access obeserve build status

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Cleanup orphaned documentation previews
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Fetch gh-pages branch
           git fetch origin gh-pages:gh-pages 2>/dev/null || {
@@ -92,6 +94,12 @@ jobs:
           file_pattern: "pr-preview/"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Checkout main branch for observe-build-status
+        if: always()
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: main
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description
This pull request makes improvements to the `.github/workflows/docs-preview-cleanup.yml` workflow to ensure environment variables are set correctly and to guarantee that the main branch is checked out before observing build status. These changes help improve the reliability and correctness of the workflow.

Workflow reliability and environment setup:

* Added the `GH_TOKEN` environment variable to the workflow so that the `gh` CLI tool can authenticate properly.

* Added a step to explicitly check out the `main` branch before running the "Observe build status" step, ensuring the correct context is used for status observation.

Failing run that motivated the fix: https://github.com/camunda/camunda/actions/runs/21294642134
Working run: https://github.com/camunda/camunda/actions/runs/21295060108/job/61298583927

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
