### PR TITLE
feat: include instructions about monorepo-docs backporting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 <!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
-- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).
+- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
 
 ## Related issues
 

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -578,6 +578,22 @@ If the CI change matches one of the following:
   * fixes incorrect information that would mislead AI agents or developers working on stable versions
   * adds new knowledge about practices, tools, or procedures that apply to stable branch development
   * corrects build, test, or development instructions that affect stable branch workflows
+
+### Documentation-specific backporting (monorepo-docs/* folders)
+
+When touching `monorepo-docs/*` folders, use these guidelines:
+
+**DO backport:**
+- Critical error corrections in docs
+- Security-related documentation updates  
+- Fixes preventing user confusion about that specific version
+
+**DON'T backport:**
+- New feature documentation
+- Reorganization/restructuring changes
+- Style/formatting improvements
+
+**Rationale:** Documentation in stable branches serves as AI context for developers working on that specific version. Only backport changes that fix critical errors or security issues, while avoiding feature additions that don't exist in that release.
 * is a new CI job for new product feature or test cases: backport **only if** the product feature is backported
 * is a new CI feature: backport **only if** required in the ticket
 * is related to an `on: schedule` GHA workflow: **no need** to backport, only works on `main`


### PR DESCRIPTION
## Description

This pull request updates the documentation and pull request template to clarify when documentation changes in the `monorepo-docs/*` folders should be backported. The goal is to ensure only critical documentation updates are backported to stable branches, while non-essential changes are not.

The in depth rational can be found here: https://github.com/camunda/camunda/issues/36946#issuecomment-3792241247

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
