### PR TITLE
build: add jspecify dependency in authentication

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>micrometer-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,6 +70,7 @@
     <version.jackson>2.21.0</version.jackson>
     <version.json-base>3.0.0</version.json-base>
     <version.json-flattener>0.18.0</version.json-flattener>
+    <version.jspecify>1.0.0</version.jspecify>
     <version.junit>5.14.2</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.3</version.log4j>
@@ -1174,6 +1175,11 @@
         <scope>import</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${version.jspecify}</version>
+      </dependency>
       <!--
         As this includes so-called "first party" dependencies" which may be of different versions,
         this must also be after most library-specific BOMs (but above Spring's)


### PR DESCRIPTION
## Description
Adds `jspecify` for nullness annotation to the monorepo. 
It's already used in module `authentication`, but not declared. 

For context, spring and micrometer have introduced it as the official annotation for nullness checks 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
