### PR TITLE
feat: add process-instance modification request to 8.9 API schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.35
+
+### 🚀 Enhancements
+
+- add process-instance modification request to 8.9 API schema ([#44723](https://github.com/camunda/camunda/pull/44723))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.34
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/index.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/index.ts
@@ -8,7 +8,7 @@
 
 import {getAuditLog, queryAuditLogs} from './audit-log';
 import {queryUserTaskAuditLogs} from './user-task';
-import {deleteProcessInstance} from './process-instance';
+import {deleteProcessInstance, modifyProcessInstance} from './process-instance';
 import {createDeployment, deleteResource, getResource, getResourceContent} from './resource';
 import {
 	getIncidentProcessInstanceStatisticsByError,
@@ -20,6 +20,7 @@ const endpoints = {
 	getAuditLog,
 	queryUserTaskAuditLogs,
 	deleteProcessInstance,
+	modifyProcessInstance,
 	createDeployment,
 	deleteResource,
 	getResource,
@@ -64,7 +65,12 @@ export {
 	type QueryUserTaskAuditLogsResponseBody,
 } from './user-task';
 
-export {deleteProcessInstanceRequestBodySchema, type DeleteProcessInstanceRequestBody} from './process-instance';
+export {
+	deleteProcessInstanceRequestBodySchema,
+	modifyProcessInstanceRequestBodySchema,
+	type DeleteProcessInstanceRequestBody,
+	type ModifyProcessInstanceRequestBody,
+} from './process-instance';
 
 export {
 	createDeploymentResponseBodySchema,

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/process-instance.ts
@@ -63,6 +63,10 @@ const modifyProcessInstanceRequestBodySchema = z
 			(activateInstructions !== undefined && activateInstructions.length > 0) ||
 			(moveInstructions !== undefined && moveInstructions.length > 0) ||
 			(terminateInstructions !== undefined && terminateInstructions.length > 0),
+		{
+			message:
+				'At least one instruction (activateInstructions, moveInstructions, or terminateInstructions) must be provided with at least one element',
+		},
 	);
 type ModifyProcessInstanceRequestBody = z.infer<typeof modifyProcessInstanceRequestBodySchema>;
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/process-instance.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/process-instance.ts
@@ -47,8 +47,8 @@ const moveInstructionSchema = z.object({
 	variableInstructions: z.array(variableInstructionSchema).optional(),
 });
 const terminateInstructionSchema = z.union([
-	z.object({elementId: z.string()}),
-	z.object({elementInstanceKey: z.string()}),
+	z.object({elementId: z.string()}).strict(),
+	z.object({elementInstanceKey: z.string()}).strict(),
 ]);
 
 const modifyProcessInstanceRequestBodySchema = z

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.34",
+	"version": "0.0.35",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.0",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.34",
+        "@camunda/camunda-api-zod-schemas": "0.0.35",
         "@camunda/camunda-composite-components": "0.19.1",
         "@carbon/elements": "11.82.0",
         "@carbon/react": "1.99.0",
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.34.tgz",
-      "integrity": "sha512-dtRE/1a7hpyOQpxvHgAhlxQNnenImNtr2BMuqVFOnD9N5M40h6VsB0aKshrw6HDVcb0fn3R+xmA/GSJXgUk8yQ==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.35.tgz",
+      "integrity": "sha512-RwzsEAGBU9FJwNeobqFSDSS3ZKD5XIQ7DgwnZLik7+eLx/0EjVqihQlEaPyTI+0nQAdumyyk6gXgPz612KVo6g==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.0",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.34",
+    "@camunda/camunda-api-zod-schemas": "0.0.35",
     "@camunda/camunda-composite-components": "0.19.1",
     "@carbon/elements": "11.82.0",
     "@carbon/react": "1.99.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.18.0",
         "@bpmn-io/form-js-viewer": "1.18.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.34",
+        "@camunda/camunda-api-zod-schemas": "0.0.35",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.78.0",
         "@carbon/react": "1.94.2",
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.34.tgz",
-      "integrity": "sha512-dtRE/1a7hpyOQpxvHgAhlxQNnenImNtr2BMuqVFOnD9N5M40h6VsB0aKshrw6HDVcb0fn3R+xmA/GSJXgUk8yQ==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.35.tgz",
+      "integrity": "sha512-RwzsEAGBU9FJwNeobqFSDSS3ZKD5XIQ7DgwnZLik7+eLx/0EjVqihQlEaPyTI+0nQAdumyyk6gXgPz612KVo6g==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.18.0",
     "@bpmn-io/form-js-viewer": "1.18.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.34",
+    "@camunda/camunda-api-zod-schemas": "0.0.35",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.78.0",
     "@carbon/react": "1.94.2",


### PR DESCRIPTION
## Description

Adds the latest schema for the [modify process instance](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-decision-definitions/) endpoint to the v8.9 export.

## Checklist

- [ ] Changes have to be released.

## Related issues

relates #41143
