### PR TITLE
feat: add a redirect from `/swagger` for better UX

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -152,6 +152,7 @@ public class WebSecurityConfig {
           "/health",
           "/startup",
           // swagger-ui endpoint
+          "/swagger/**",
           "/swagger-ui/**",
           "/v3/api-docs/**",
           "/v2/rest-api.yaml",

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/OpenApiResourceConfig.java
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.system.ApplicationHome;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @ConditionalOnRestGatewayEnabled
@@ -30,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
     name = "camunda.rest.swagger.enabled",
     havingValue = "true",
     matchIfMissing = true)
-public class OpenApiResourceConfig {
+public class OpenApiResourceConfig implements WebMvcConfigurer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiResourceConfig.class);
 
@@ -38,6 +40,12 @@ public class OpenApiResourceConfig {
 
   public OpenApiResourceConfig(final OpenApiConfigurer openApiConfigurer) {
     this.openApiConfigurer = openApiConfigurer;
+  }
+
+  @Override
+  public void addViewControllers(final ViewControllerRegistry registry) {
+    registry.addRedirectViewController("/swagger", "/swagger-ui/index.html");
+    registry.addRedirectViewController("/swagger/", "/swagger-ui/index.html");
   }
 
   @Bean

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -15,7 +15,6 @@ import io.camunda.search.filter.Operator;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.validation.IdentifierValidator;
-import io.camunda.zeebe.gateway.rest.config.JacksonConfig;
 import io.camunda.zeebe.gateway.rest.interceptor.SecondaryStorageInterceptor;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -26,20 +25,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.reactive.server.WebTestClient;
 
-@TestPropertySource(
-    properties = {
-      "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
-    })
-@Import({JacksonConfig.class, RestControllerTest.WebMvcTestConfig.class})
-public abstract class RestControllerTest {
+@Import({RestControllerTest.WebMvcTestConfig.class})
+public abstract class RestControllerTest extends RestTest {
   public static final List<List<Operation<Long>>> LONG_OPERATIONS =
       List.of(
           List.of(Operation.gt(5L)),
@@ -87,7 +79,6 @@ public abstract class RestControllerTest {
   protected static final CamundaAuthentication AUTHENTICATION_WITH_NON_DEFAULT_TENANT =
       CamundaAuthentication.of(a -> a.user("foo").group("groupId").tenant("tenantId"));
   private static final Pattern ID_PATTERN = Pattern.compile(SecurityConfiguration.DEFAULT_ID_REGEX);
-  @Autowired protected WebTestClient webClient;
   @MockitoBean protected SecondaryStorageInterceptor secondaryStorageInterceptor;
 
   @BeforeEach

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import io.camunda.zeebe.gateway.rest.config.JacksonConfig;
+import io.camunda.zeebe.gateway.rest.config.OpenApiConfigurer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@TestPropertySource(
+    properties = {
+      "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
+    })
+@Import({JacksonConfig.class})
+public abstract class RestTest {
+
+  @Autowired protected WebTestClient webClient;
+  @MockitoBean protected OpenApiConfigurer openApiConfigurer;
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/OpenApiResourceConfigTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/OpenApiResourceConfigTest.java
@@ -8,26 +8,25 @@
 package io.camunda.zeebe.gateway.rest.configuration;
 
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.zeebe.gateway.rest.config.OpenApiConfigurer;
-import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import io.camunda.zeebe.gateway.rest.RestTest;
+import io.camunda.zeebe.gateway.rest.config.OpenApiResourceConfig;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
  * Tests for OpenApiResourceConfig swagger redirect functionality. Verifies that the swagger
  * endpoint redirects are properly configured when swagger is enabled or disabled.
  */
-class OpenApiResourceConfigTest {
+class OpenApiResourceConfigTest extends RestTest {
 
   @Nested
-  @WebMvcTest(
-      value = {TopologyController.class},
-      properties = "camunda.rest.swagger.enabled=true")
-  class SwaggerEnabled extends RestApiConfigurationTest {
+  @WebMvcTest(useDefaultFilters = false, properties = "camunda.rest.swagger.enabled=true")
+  @Import(OpenApiResourceConfig.class)
+  class SwaggerEnabled extends RestTest {
 
-    @MockitoBean private OpenApiConfigurer openApiConfigurer;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
     @Test
@@ -58,10 +57,9 @@ class OpenApiResourceConfigTest {
   }
 
   @Nested
-  @WebMvcTest(
-      value = {TopologyController.class},
-      properties = "camunda.rest.swagger.enabled=false")
-  class SwaggerDisabled extends RestApiConfigurationTest {
+  @WebMvcTest(useDefaultFilters = false, properties = "camunda.rest.swagger.enabled=false")
+  @Import(OpenApiResourceConfig.class)
+  class SwaggerDisabled extends RestTest {
 
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
@@ -79,10 +77,10 @@ class OpenApiResourceConfigTest {
   }
 
   @Nested
-  @WebMvcTest(value = {TopologyController.class})
-  class SwaggerDefaultBehavior extends RestApiConfigurationTest {
+  @WebMvcTest(useDefaultFilters = false)
+  @Import(OpenApiResourceConfig.class)
+  class SwaggerDefaultBehavior extends RestTest {
 
-    @MockitoBean private OpenApiConfigurer openApiConfigurer;
     @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
 
     @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/OpenApiResourceConfigTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/OpenApiResourceConfigTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.zeebe.gateway.rest.config.OpenApiConfigurer;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Tests for OpenApiResourceConfig swagger redirect functionality. Verifies that the swagger
+ * endpoint redirects are properly configured when swagger is enabled or disabled.
+ */
+class OpenApiResourceConfigTest {
+
+  @Nested
+  @WebMvcTest(
+      value = {TopologyController.class},
+      properties = "camunda.rest.swagger.enabled=true")
+  class SwaggerEnabled extends RestApiConfigurationTest {
+
+    @MockitoBean private OpenApiConfigurer openApiConfigurer;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+    @Test
+    void shouldRedirectSwaggerToSwaggerUiIndexHtml() {
+      // when/then
+      webClient
+          .get()
+          .uri("/swagger")
+          .exchange()
+          .expectStatus()
+          .isFound()
+          .expectHeader()
+          .location("/swagger-ui/index.html");
+    }
+
+    @Test
+    void shouldRedirectSwaggerWithTrailingSlashToSwaggerUiIndexHtml() {
+      // when/then
+      webClient
+          .get()
+          .uri("/swagger/")
+          .exchange()
+          .expectStatus()
+          .isFound()
+          .expectHeader()
+          .location("/swagger-ui/index.html");
+    }
+  }
+
+  @Nested
+  @WebMvcTest(
+      value = {TopologyController.class},
+      properties = "camunda.rest.swagger.enabled=false")
+  class SwaggerDisabled extends RestApiConfigurationTest {
+
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+    @Test
+    void shouldNotRedirectSwaggerWhenDisabled() {
+      // when/then
+      webClient.get().uri("/swagger").exchange().expectStatus().isNotFound();
+    }
+
+    @Test
+    void shouldNotRedirectSwaggerWithTrailingSlashWhenDisabled() {
+      // when/then
+      webClient.get().uri("/swagger/").exchange().expectStatus().isNotFound();
+    }
+  }
+
+  @Nested
+  @WebMvcTest(value = {TopologyController.class})
+  class SwaggerDefaultBehavior extends RestApiConfigurationTest {
+
+    @MockitoBean private OpenApiConfigurer openApiConfigurer;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+    @Test
+    void shouldEnableSwaggerByDefaultWhenPropertyNotSet() {
+      // when/then - swagger should be enabled by default (matchIfMissing = true)
+      webClient
+          .get()
+          .uri("/swagger")
+          .exchange()
+          .expectStatus()
+          .isFound()
+          .expectHeader()
+          .location("/swagger-ui/index.html");
+    }
+
+    @Test
+    void shouldRedirectSwaggerWithTrailingSlashByDefault() {
+      // when/then
+      webClient
+          .get()
+          .uri("/swagger/")
+          .exchange()
+          .expectStatus()
+          .isFound()
+          .expectHeader()
+          .location("/swagger-ui/index.html");
+    }
+  }
+}


### PR DESCRIPTION
## Description

- `/swagger` redirects to `/swagger-ui/index.html`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #38040
