### PR TITLE
fix: rdbms exporter reschedules after exception in task

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -349,4 +349,12 @@ public class HistoryCleanupService {
   public Duration getHistoryCleanupInterval() {
     return defaultHistoryTTL;
   }
+
+  public Duration getCurrentCleanupInterval(final int partitionId) {
+    return lastCleanupInterval.get(partitionId);
+  }
+
+  public Duration getUsageMetricsHistoryCleanupInterval() {
+    return usageMetricsCleanup;
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -351,7 +351,7 @@ public class HistoryCleanupService {
   }
 
   public Duration getCurrentCleanupInterval(final int partitionId) {
-    return lastCleanupInterval.get(partitionId);
+    return lastCleanupInterval.getOrDefault(partitionId, minCleanupInterval);
   }
 
   public Duration getUsageMetricsHistoryCleanupInterval() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -177,4 +177,8 @@ public class HistoryDeletionService {
     }
     return currentDelayBetweenRuns;
   }
+
+  public Duration getCurrentDelayBetweenRuns() {
+    return currentDelayBetweenRuns;
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -399,6 +399,10 @@ public final class RdbmsExporter {
       currentHistoryDeletionTask =
           controller.scheduleCancellableTask(newDuration, this::deleteHistory);
     } catch (final Exception e) {
+      LOG.warn(
+          "[RDBMS Exporter P{}] Failed to delete history, retrying ... {}",
+          partitionId,
+          e.getMessage());
       currentHistoryDeletionTask =
           controller.scheduleCancellableTask(
               historyDeletionService.getCurrentDelayBetweenRuns(), this::deleteHistory);


### PR DESCRIPTION
## Description

Fixes RDBMS exporter scheduled tasks to not throw exceptions but to automatically reschedule for retry.

closes #44591
