### PR TITLE
feat: add array mapping for postgres processInstanceKeys

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/OracleXmlArrayTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/OracleXmlArrayTypeHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+/**
+ * Type handler for Oracle that converts List&lt;Long&gt; to XML format for use with XMLTABLE. This
+ * allows efficient handling of large lists without hitting Oracle's 1000-item IN clause limit.
+ *
+ * <p>The list is converted to XML format:
+ * &lt;d&gt;&lt;r&gt;1&lt;/r&gt;&lt;r&gt;2&lt;/r&gt;&lt;/d&gt;
+ *
+ * <p>Usage in MyBatis XML:
+ *
+ * <pre>
+ * WHERE column IN (
+ *   SELECT COLUMN_VALUE
+ *   FROM XMLTABLE('/d/r'
+ *        PASSING XMLTYPE(#{list, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
+ *        COLUMNS COLUMN_VALUE NUMBER PATH 'text()')
+ * )
+ * </pre>
+ */
+public class OracleXmlArrayTypeHandler extends BaseTypeHandler<List<Long>> {
+
+  @Override
+  public void setNonNullParameter(
+      final PreparedStatement ps, final int i, final List<Long> parameter, final JdbcType jdbcType)
+      throws SQLException {
+    if (parameter.isEmpty()) {
+      // For empty lists, create an XML with a single null element to prevent SQL errors
+      ps.setString(i, "<d><r></r></d>");
+      return;
+    }
+
+    final StringBuilder xml = new StringBuilder("<d>");
+    for (final Long value : parameter) {
+      xml.append("<r>").append(value).append("</r>");
+    }
+    xml.append("</d>");
+    ps.setString(i, xml.toString());
+  }
+
+  @Override
+  public List<Long> getNullableResult(final ResultSet rs, final String columnName)
+      throws SQLException {
+    final String xml = rs.getString(columnName);
+    return parseXml(xml);
+  }
+
+  @Override
+  public List<Long> getNullableResult(final ResultSet rs, final int columnIndex)
+      throws SQLException {
+    final String xml = rs.getString(columnIndex);
+    return parseXml(xml);
+  }
+
+  @Override
+  public List<Long> getNullableResult(final CallableStatement cs, final int columnIndex)
+      throws SQLException {
+    final String xml = cs.getString(columnIndex);
+    return parseXml(xml);
+  }
+
+  private List<Long> parseXml(final String xml) {
+    if (xml == null || xml.isEmpty()) {
+      return null;
+    }
+
+    final List<Long> result = new ArrayList<>();
+    int startIndex = 0;
+
+    // Simple XML parsing for <r>value</r> pattern
+    while (true) {
+      final int openTag = xml.indexOf("<r>", startIndex);
+      if (openTag == -1) {
+        break;
+      }
+
+      final int closeTag = xml.indexOf("</r>", openTag);
+      if (closeTag == -1) {
+        break;
+      }
+
+      final String value = xml.substring(openTag + 3, closeTag).trim();
+      if (!value.isEmpty()) {
+        result.add(Long.parseLong(value));
+      }
+
+      startIndex = closeTag + 4;
+    }
+
+    return result.isEmpty() ? null : result;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/PostgresLongListToArrayTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/PostgresLongListToArrayTypeHandler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import java.sql.Array;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+
+/**
+ * MyBatis type handler that maps between a Java {@link java.util.List} of {@link java.lang.Long}
+ * values and a PostgreSQL {@code BIGINT[]} column.
+ *
+ * <p>Conversion rules:
+ *
+ * <ul>
+ *   <li>When writing parameters, the handler creates a JDBC {@link java.sql.Array} of type {@code
+ *       "bigint"} from the provided {@code List&lt;Long&gt;} and binds it to the prepared
+ *       statement.
+ *   <li>When reading results, the handler converts the JDBC {@link java.sql.Array} back into an
+ *       immutable {@code List&lt;Long&gt;} instance. If the underlying SQL value is {@code NULL},
+ *       this method returns {@code null}.
+ * </ul>
+ *
+ * <p>Typical MyBatis usage:
+ *
+ * <pre>{@code
+ * <!-- Parameter mapping -->
+ * <insert id="insertExample" parameterType="map">
+ *   INSERT INTO example_table (id_list)
+ *   VALUES (#{ids, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
+ * </insert>
+ *
+ * <!-- Result mapping -->
+ * <resultMap id="exampleResultMap" type="Example">
+ *   <result property="ids"
+ *           column="id_list"
+ *           typeHandler="io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler"/>
+ * </resultMap>
+ * }</pre>
+ */
+@MappedTypes(List.class)
+@MappedJdbcTypes(JdbcType.ARRAY)
+public class PostgresLongListToArrayTypeHandler extends BaseTypeHandler<List<Long>> {
+
+  @Override
+  public void setNonNullParameter(
+      final PreparedStatement ps, final int i, final List<Long> parameter, final JdbcType jdbcType)
+      throws SQLException {
+    final Array array = ps.getConnection().createArrayOf("bigint", parameter.toArray());
+    try {
+      ps.setArray(i, array);
+    } finally {
+      try {
+        array.free();
+      } catch (final SQLException ignored) {
+        // ignore exception on free to avoid masking earlier exceptions
+      }
+    }
+  }
+
+  @Override
+  public List<Long> getNullableResult(final ResultSet rs, final String columnName)
+      throws SQLException {
+    return toList(rs.getArray(columnName));
+  }
+
+  @Override
+  public List<Long> getNullableResult(final ResultSet rs, final int columnIndex)
+      throws SQLException {
+    return toList(rs.getArray(columnIndex));
+  }
+
+  @Override
+  public List<Long> getNullableResult(final CallableStatement cs, final int columnIndex)
+      throws SQLException {
+    return toList(cs.getArray(columnIndex));
+  }
+
+  private List<Long> toList(final Array array) throws SQLException {
+    if (array == null) {
+      return null;
+    }
+    try {
+      return List.of((Long[]) array.getArray());
+    } finally {
+      try {
+        array.free();
+      } catch (final SQLException ignored) {
+        // ignore exception on free to avoid masking earlier exceptions
+      }
+    }
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -223,31 +223,42 @@
       #{key}
     </foreach>
   </sql>
+
+  <!--
+    Special handling for Oracle to delete using row identifiers.
+    We also do not use an IN clause to select the process instance keys,
+    but use XMLTABLE to handle large lists of keys. Oracle has a natural limit of 1000 elements per IN clause.
+  -->
   <sql id="processInstanceHistoryDeletion" databaseId="oracle">
     <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'rowid'"/>
     DELETE
-    FROM ${prefix}${tableName}
-    WHERE ${keyColumn} IN (SELECT ${keyColumn}
-                    FROM ${prefix}${tableName}
-                    WHERE PARTITION_ID = #{partitionId}
-                      AND PROCESS_INSTANCE_KEY IN
-                    <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
-                      #{key}
-                    </foreach>
-                    AND ROWNUM &lt;= #{limit})
+    FROM ${prefix}${tableName} t1
+    WHERE ${keyColumn} IN (SELECT t2.${keyColumn}
+                           FROM ${prefix}${tableName} t2
+                           WHERE t2.PARTITION_ID = #{partitionId}
+                             AND t2.PROCESS_INSTANCE_KEY IN (
+                               SELECT COLUMN_VALUE
+                               FROM XMLTABLE('/d/r'
+                                    PASSING XMLTYPE(#{processInstanceKeys, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
+                                    COLUMNS COLUMN_VALUE NUMBER PATH 'text()')
+                             )
+                           AND ROWNUM &lt;= #{limit})
   </sql>
+
+  <!--
+    Special handling for PostgreSQL to delete using ctid or a specified primary key column.
+    This avoids issues with large IN clauses by using ANY with an array parameter.
+    -->
   <sql id="processInstanceHistoryDeletion" databaseId="postgresql">
     <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'ctid'"/>
     DELETE
-    FROM ${prefix}${tableName}
-    WHERE ${keyColumn} IN (SELECT ${keyColumn}
-                   FROM ${prefix}${tableName}
-                   WHERE PARTITION_ID = #{partitionId}
-                     AND PROCESS_INSTANCE_KEY IN
-                   <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
-                     #{key}
-                   </foreach>
-                   LIMIT #{limit})
+    FROM ${prefix}${tableName} t1
+    USING (SELECT ${keyColumn}
+           FROM ${prefix}${tableName}
+           WHERE PARTITION_ID = #{partitionId}
+             AND PROCESS_INSTANCE_KEY = ANY(#{processInstanceKeys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
+           LIMIT #{limit}) t2
+    WHERE t1.${keyColumn} = t2.${keyColumn}
   </sql>
 
   <resultMap id="flowNodeStatisticsResultMap"

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/OracleXmlArrayTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/OracleXmlArrayTypeHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OracleXmlArrayTypeHandlerTest {
+
+  private final OracleXmlArrayTypeHandler handler = new OracleXmlArrayTypeHandler();
+
+  @Test
+  void shouldConvertListToXml() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final List<Long> input = List.of(1L, 2L, 3L);
+
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(ps).setString(1, "<d><r>1</r><r>2</r><r>3</r></d>");
+  }
+
+  @Test
+  void shouldConvertSingleItemListToXml() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final List<Long> input = List.of(42L);
+
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(ps).setString(1, "<d><r>42</r></d>");
+  }
+
+  @Test
+  void shouldConvertEmptyListToXml() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final List<Long> input = List.of();
+
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(ps).setString(1, "<d><r></r></d>");
+  }
+
+  @Test
+  void shouldConvertLargeListToXml() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final List<Long> input = List.of(100L, 200L, 300L, 400L, 500L, 600L, 700L, 800L, 900L, 1000L);
+
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    final String expected =
+        "<d><r>100</r><r>200</r><r>300</r><r>400</r><r>500</r>"
+            + "<r>600</r><r>700</r><r>800</r><r>900</r><r>1000</r></d>";
+    verify(ps).setString(1, expected);
+  }
+
+  @Test
+  void shouldConvertXmlToList() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("col")).thenReturn("<d><r>10</r><r>20</r><r>30</r></d>");
+
+    final List<Long> result = handler.getNullableResult(rs, "col");
+
+    assertThat(result).containsExactly(10L, 20L, 30L);
+  }
+
+  @Test
+  void shouldConvertXmlWithWhitespaceToList() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("col")).thenReturn("<d>\n  <r>10</r>\n  <r>20</r>\n</d>");
+
+    final List<Long> result = handler.getNullableResult(rs, "col");
+
+    assertThat(result).containsExactly(10L, 20L);
+  }
+
+  @Test
+  void shouldReturnNullForNullXml() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString(1)).thenReturn(null);
+
+    final List<Long> result = handler.getNullableResult(rs, 1);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldReturnNullForEmptyXml() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString(1)).thenReturn("");
+
+    final List<Long> result = handler.getNullableResult(rs, 1);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldReturnNullForXmlWithOnlyEmptyElement() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getString("col")).thenReturn("<d><r></r></d>");
+
+    final List<Long> result = handler.getNullableResult(rs, "col");
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldHandleLargeNumbers() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final List<Long> input = List.of(Long.MAX_VALUE, Long.MIN_VALUE, 0L);
+
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(ps)
+        .setString(1, "<d><r>" + Long.MAX_VALUE + "</r><r>" + Long.MIN_VALUE + "</r><r>0</r></d>");
+  }
+
+  @Test
+  void shouldRoundTripConversion() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final ResultSet rs = mock(ResultSet.class);
+    final List<Long> original = List.of(123L, 456L, 789L, 1011L);
+
+    handler.setNonNullParameter(ps, 1, original, null);
+
+    final String expectedXml = "<d><r>123</r><r>456</r><r>789</r><r>1011</r></d>";
+    verify(ps).setString(1, expectedXml);
+
+    when(rs.getString("col")).thenReturn(expectedXml);
+    final List<Long> result = handler.getNullableResult(rs, "col");
+
+    assertThat(result).isEqualTo(original);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/PostgresLongListToArrayTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/PostgresLongListToArrayTypeHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.typehandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PostgresLongListToArrayTypeHandlerTest {
+
+  private final PostgresLongListToArrayTypeHandler handler =
+      new PostgresLongListToArrayTypeHandler();
+
+  @Test
+  void shouldConvertListToArray() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final Connection conn = mock(Connection.class);
+    final Array array = mock(Array.class);
+
+    when(ps.getConnection()).thenReturn(conn);
+    when(conn.createArrayOf(eq("bigint"), any())).thenReturn(array);
+
+    final List<Long> input = List.of(1L, 2L, 3L);
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(conn).createArrayOf(eq("bigint"), eq(new Long[] {1L, 2L, 3L}));
+    verify(ps).setArray(1, array);
+    verify(array).free();
+  }
+
+  @Test
+  void shouldConvertEmptyListToArray() throws Exception {
+    final PreparedStatement ps = mock(PreparedStatement.class);
+    final Connection conn = mock(Connection.class);
+    final Array array = mock(Array.class);
+
+    when(ps.getConnection()).thenReturn(conn);
+    when(conn.createArrayOf(eq("bigint"), any())).thenReturn(array);
+
+    final List<Long> input = List.of();
+    handler.setNonNullParameter(ps, 1, input, null);
+
+    verify(conn).createArrayOf(eq("bigint"), eq(new Long[] {}));
+    verify(ps).setArray(1, array);
+    verify(array).free();
+  }
+
+  @Test
+  void shouldConvertArrayToList() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    final Array array = mock(Array.class);
+
+    when(rs.getArray("col")).thenReturn(array);
+    when(array.getArray()).thenReturn(new Long[] {10L, 20L, 30L});
+
+    final List<Long> result = handler.getNullableResult(rs, "col");
+
+    assertThat(result).containsExactly(10L, 20L, 30L);
+    verify(array).free();
+  }
+
+  @Test
+  void shouldReturnNullForNullArray() throws Exception {
+    final ResultSet rs = mock(ResultSet.class);
+    when(rs.getArray(anyInt())).thenReturn(null);
+
+    final List<Long> result = handler.getNullableResult(rs, 1);
+
+    assertThat(result).isNull();
+  }
+}


### PR DESCRIPTION
## Description

Use special array typehandlers to pass a single list property instead of a long list of parameters for Oracle and PostgreSQL when cleaning up the history.

This has multiple advantages:
- each SQL has the same statement, regardless of the number of parameters. This means, the optimiser can cache the plan
- Oracle can use more than 1000 values

Note: Other RDBMS like MySQL and MSSQL have similar features but need additional types defined in DDL, so I first added these less invasive changes for only PostgreSQL and Oracle
