### PR TITLE
feat: added stream backoff supplier configuration setting

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -187,8 +187,8 @@ public interface JobWorkerBuilderStep1 {
     /**
      * Sets the backoff supplier. The supplier is called to determine the retry delay after each
      * failed request; the worker then waits until the returned delay has elapsed before sending the
-     * next request. Note that this is used <strong>only</strong> for the polling mechanism -
-     * failures in the {@link JobHandler} should be handled there, and retried there if need be.
+     * next request. Note that this is used <strong>only</strong> when activating jobs - failures in
+     * the {@link JobHandler} should be handled there, and retried there if need be.
      *
      * <p>By default, the supplier uses exponential back off, with an upper bound of 5 seconds. The
      * exponential backoff can be easily configured using {@link
@@ -198,6 +198,21 @@ public interface JobWorkerBuilderStep1 {
      * @return the builder for this worker
      */
     JobWorkerBuilderStep3 backoffSupplier(BackoffSupplier backoffSupplier);
+
+    /**
+     * Sets the stream backoff supplier. The supplier is called to determine the backoff delay after
+     * a successful poll request when job streaming is enabled; the worker then waits until the
+     * returned delay has elapsed before sending the next poll request. Note that this is used
+     * <strong>only</strong> when streaming is enabled.
+     *
+     * <p>By default, the supplier uses exponential back off, with an upper bound of 1 minute. The
+     * exponential backoff can be easily configured using {@link
+     * BackoffSupplier#newBackoffBuilder()}.
+     *
+     * @param streamBackoffSupplier supplies the backoff delay after a successful poll request
+     * @return the builder for this worker
+     */
+    JobWorkerBuilderStep3 streamBackoffSupplier(BackoffSupplier streamBackoffSupplier);
 
     /**
      * Opt-in feature flag to enable job streaming. If set as enabled, the job worker will use a mix

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -200,19 +200,21 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 backoffSupplier(BackoffSupplier backoffSupplier);
 
     /**
-     * Sets the stream backoff supplier. The supplier is called to determine the backoff delay after
-     * a successful poll request when job streaming is enabled; the worker then waits until the
-     * returned delay has elapsed before sending the next poll request. Note that this is used
-     * <strong>only</strong> when streaming is enabled.
+     * Sets the job activation backoff supplier to be used when polling yields no jobs, when
+     * streaming is enabled. The supplier is called to determine the backoff delay after a
+     * successful poll request with no activated jobs when job streaming is enabled; the worker then
+     * waits until the returned delay has elapsed before sending the next poll request.
+     *
+     * <p>Note, this is used <strong>only</strong> when streaming is enabled.
      *
      * <p>By default, the supplier uses exponential back off, with an upper bound of 1 minute. The
      * exponential backoff can be easily configured using {@link
      * BackoffSupplier#newBackoffBuilder()}.
      *
-     * @param streamBackoffSupplier supplies the backoff delay after a successful poll request
+     * @param streamNoJobsBackoffSupplier supplies the backoff delay after a successful poll request
      * @return the builder for this worker
      */
-    JobWorkerBuilderStep3 streamBackoffSupplier(BackoffSupplier streamBackoffSupplier);
+    JobWorkerBuilderStep3 streamNoJobsBackoffSupplier(BackoffSupplier streamNoJobsBackoffSupplier);
 
     /**
      * Opt-in feature flag to enable job streaming. If set as enabled, the job worker will use a mix

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -44,6 +44,8 @@ public final class JobWorkerBuilderImpl
 
   public static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().build();
+  public static final BackoffSupplier DEFAULT_STREAM_BACKOFF_SUPPLIER =
+      BackoffSupplier.newBackoffBuilder().maxDelay(Duration.ofMinutes(1).toMillis()).build();
   public static final Duration DEFAULT_STREAMING_TIMEOUT = Duration.ofHours(8);
   private final JobClient jobClient;
   private final ScheduledExecutorService scheduledExecutor;
@@ -60,6 +62,7 @@ public final class JobWorkerBuilderImpl
   private final List<String> defaultTenantIds;
   private final List<String> customTenantIds;
   private BackoffSupplier backoffSupplier;
+  private BackoffSupplier streamBackoffSupplier;
   private boolean enableStreaming;
   private Duration streamingTimeout;
   private JobWorkerMetrics metrics = JobWorkerMetrics.noop();
@@ -86,6 +89,7 @@ public final class JobWorkerBuilderImpl
     jobExceptionHandler = configuration.getDefaultJobWorkerExceptionHandler();
     customTenantIds = new ArrayList<>();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
+    streamBackoffSupplier = DEFAULT_STREAM_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
   }
 
@@ -150,6 +154,12 @@ public final class JobWorkerBuilderImpl
   @Override
   public JobWorkerBuilderStep3 backoffSupplier(final BackoffSupplier backoffSupplier) {
     this.backoffSupplier = backoffSupplier;
+    return this;
+  }
+
+  @Override
+  public JobWorkerBuilderStep3 streamBackoffSupplier(final BackoffSupplier streamBackoffSupplier) {
+    this.streamBackoffSupplier = streamBackoffSupplier;
     return this;
   }
 
@@ -231,6 +241,7 @@ public final class JobWorkerBuilderImpl
             jobPoller,
             jobStreamer,
             backoffSupplier,
+            streamBackoffSupplier,
             metrics,
             jobExecutor);
     closeables.add(jobWorker);

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -44,7 +44,7 @@ public final class JobWorkerBuilderImpl
 
   public static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().build();
-  public static final BackoffSupplier DEFAULT_STREAM_BACKOFF_SUPPLIER =
+  public static final BackoffSupplier DEFAULT_STREAM_NO_JOBS_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().maxDelay(Duration.ofMinutes(1).toMillis()).build();
   public static final Duration DEFAULT_STREAMING_TIMEOUT = Duration.ofHours(8);
   private final JobClient jobClient;
@@ -62,7 +62,7 @@ public final class JobWorkerBuilderImpl
   private final List<String> defaultTenantIds;
   private final List<String> customTenantIds;
   private BackoffSupplier backoffSupplier;
-  private BackoffSupplier streamBackoffSupplier;
+  private BackoffSupplier streamNoJobsBackoffSupplier;
   private boolean enableStreaming;
   private Duration streamingTimeout;
   private JobWorkerMetrics metrics = JobWorkerMetrics.noop();
@@ -89,7 +89,7 @@ public final class JobWorkerBuilderImpl
     jobExceptionHandler = configuration.getDefaultJobWorkerExceptionHandler();
     customTenantIds = new ArrayList<>();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
-    streamBackoffSupplier = DEFAULT_STREAM_BACKOFF_SUPPLIER;
+    streamNoJobsBackoffSupplier = DEFAULT_STREAM_NO_JOBS_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
   }
 
@@ -158,8 +158,9 @@ public final class JobWorkerBuilderImpl
   }
 
   @Override
-  public JobWorkerBuilderStep3 streamBackoffSupplier(final BackoffSupplier streamBackoffSupplier) {
-    this.streamBackoffSupplier = streamBackoffSupplier;
+  public JobWorkerBuilderStep3 streamNoJobsBackoffSupplier(
+      final BackoffSupplier streamNoJobsBackoffSupplier) {
+    this.streamNoJobsBackoffSupplier = streamNoJobsBackoffSupplier;
     return this;
   }
 
@@ -241,7 +242,7 @@ public final class JobWorkerBuilderImpl
             jobPoller,
             jobStreamer,
             backoffSupplier,
-            streamBackoffSupplier,
+            streamNoJobsBackoffSupplier,
             metrics,
             jobExecutor);
     closeables.add(jobWorker);

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -72,7 +72,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   private final long initialPollInterval;
   private final JobStreamer jobStreamer;
   private final BackoffSupplier backoffSupplier;
-  private final BackoffSupplier streamBackoffSupplier;
+  private final BackoffSupplier streamNoJobsBackoffSupplier;
   private final JobWorkerMetrics metrics;
 
   // state synchronization
@@ -91,7 +91,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       final JobPoller jobPoller,
       final JobStreamer jobStreamer,
       final BackoffSupplier backoffSupplier,
-      final BackoffSupplier streamBackoffSupplier,
+      final BackoffSupplier streamNoJobsBackoffSupplier,
       final JobWorkerMetrics metrics,
       final Executor jobExecutor) {
     this.maxJobsActive = maxJobsActive;
@@ -104,7 +104,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     this.jobStreamer = jobStreamer;
     initialPollInterval = pollInterval.toMillis();
     this.backoffSupplier = backoffSupplier;
-    this.streamBackoffSupplier = streamBackoffSupplier;
+    this.streamNoJobsBackoffSupplier = streamNoJobsBackoffSupplier;
     this.metrics = metrics;
 
     claimableJobPoller = new AtomicReference<>(jobPoller);
@@ -209,7 +209,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     if (jobStreamer.isOpen() && activatedJobs == 0) {
       // to keep polling requests to a minimum, if streaming is enabled, and the response is empty,
       // we back off on poll success responses.
-      backoff(jobPoller, streamBackoffSupplier);
+      backoff(jobPoller, streamNoJobsBackoffSupplier);
       LOG.trace("No jobs to activate via polling, will backoff and poll in {}", pollInterval);
     } else {
       pollInterval = initialPollInterval;

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -143,12 +143,12 @@ public final class JobWorkerImplTest {
     // given a gateway that responds with some jobs
     gateway.respondWith(TestData.jobs(0));
 
-    // and a client with stream enabled and retry delay supplier that is slowing down polling
+    // and a client with stream enabled and stream backoff supplier that is slowing down polling
     client
         .newWorker()
         .jobType("test")
         .handler(NOOP_JOB_HANDLER)
-        .backoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
+        .streamBackoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
         .streamEnabled(true)
         .open();
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -143,12 +143,13 @@ public final class JobWorkerImplTest {
     // given a gateway that responds with some jobs
     gateway.respondWith(TestData.jobs(0));
 
-    // and a client with stream enabled and stream backoff supplier that is slowing down polling
+    // and a client with stream enabled and a stream no jobs backoff supplier that is slowing down
+    // polling
     client
         .newWorker()
         .jobType("test")
         .handler(NOOP_JOB_HANDLER)
-        .streamBackoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
+        .streamNoJobsBackoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
         .streamEnabled(true)
         .open();
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
@@ -64,6 +64,7 @@ final class JobWorkerMetricsTest {
         poller,
         streamer,
         delay -> delay,
+        delay -> delay,
         metrics,
         executor);
   }


### PR DESCRIPTION
## Description

The stream backoff supplier is used when a poll was successful if streaming is enabled. The already available backoff supplier is only used when a poll was not successful.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #44737
