### PR TITLE
feat: Support PROPERTY-based auth creation from configuration

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.security.configuration.ConfiguredAuthorization;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+    classes = ConfiguredAuthorizationPropertiesTest.TestConfig.class,
+    properties = "spring.config.location=classpath:properties/application-authorization-props.yaml")
+class ConfiguredAuthorizationPropertiesTest {
+
+  @Autowired private CamundaSecurityProperties securityProperties;
+
+  @Test
+  void shouldLoadAuthorizationsFromYaml() {
+    // when
+    final var authorizations = securityProperties.getInitialization().getAuthorizations();
+
+    // then
+    assertThat(authorizations).hasSize(5);
+  }
+
+  @Test
+  void shouldMapIdBasedWildcardAuthorization() {
+    // when
+    final var auth = securityProperties.getInitialization().getAuthorizations().getFirst();
+
+    // then
+    assertThat(auth.ownerType()).isEqualTo(AuthorizationOwnerType.USER);
+    assertThat(auth.ownerId()).isEqualTo("john.doe");
+    assertThat(auth.resourceType()).isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
+    assertThat(auth.resourceId()).isEqualTo("*");
+    assertThat(auth.resourcePropertyName()).isNull();
+    assertThat(auth.permissions())
+        .containsExactlyInAnyOrder(
+            PermissionType.READ_PROCESS_INSTANCE, PermissionType.CREATE_PROCESS_INSTANCE);
+    assertThat(auth.isIdBased()).isTrue();
+    assertThat(auth.isPropertyBased()).isFalse();
+  }
+
+  @Test
+  void shouldMapIdBasedWithSpecificResourceIdAuthorization() {
+    // when
+    final var auth = securityProperties.getInitialization().getAuthorizations().get(1);
+
+    // then
+    assertThat(auth.ownerType()).isEqualTo(AuthorizationOwnerType.ROLE);
+    assertThat(auth.ownerId()).isEqualTo("developers");
+    assertThat(auth.resourceType()).isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
+    assertThat(auth.resourceId()).isEqualTo("order-process");
+    assertThat(auth.resourcePropertyName()).isNull();
+    assertThat(auth.permissions()).containsExactly(PermissionType.UPDATE_PROCESS_INSTANCE);
+    assertThat(auth.isIdBased()).isTrue();
+    assertThat(auth.isPropertyBased()).isFalse();
+  }
+
+  @Test
+  void shouldMapPropertyBasedAuthorization() {
+    // when
+    final var auth = securityProperties.getInitialization().getAuthorizations().get(2);
+
+    // then
+    assertThat(auth.ownerType()).isEqualTo(AuthorizationOwnerType.USER);
+    assertThat(auth.ownerId()).isEqualTo("jane.doe");
+    assertThat(auth.resourceType()).isEqualTo(AuthorizationResourceType.USER_TASK);
+    assertThat(auth.resourceId()).isNull();
+    assertThat(auth.resourcePropertyName()).isEqualTo("assignee");
+    assertThat(auth.permissions())
+        .containsExactlyInAnyOrder(PermissionType.UPDATE, PermissionType.READ);
+    assertThat(auth.isIdBased()).isFalse();
+    assertThat(auth.isPropertyBased()).isTrue();
+  }
+
+  @Test
+  void shouldMapInvalidAuthorizationWithBothResourceIdAndPropertyName() {
+    // Note: This invalid authorization is successfully mapped from YAML.
+    // The mutual exclusivity violation will be detected later during validation
+    // by AuthorizationConfigurer
+
+    // when
+    final ConfiguredAuthorization auth =
+        securityProperties.getInitialization().getAuthorizations().get(3);
+
+    // then
+    assertThat(auth.ownerType()).isEqualTo(AuthorizationOwnerType.USER);
+    assertThat(auth.ownerId()).isEqualTo("mark.smith");
+    assertThat(auth.resourceType()).isEqualTo(AuthorizationResourceType.USER_TASK);
+    assertThat(auth.resourceId()).isEqualTo("some-task");
+    assertThat(auth.resourcePropertyName()).isEqualTo("assignee");
+    assertThat(auth.permissions()).containsExactly(PermissionType.READ);
+    // Both helper methods return true, indicating the invalid state
+    assertThat(auth.isIdBased()).isTrue();
+    assertThat(auth.isPropertyBased()).isTrue();
+  }
+
+  @Test
+  void shouldMapInvalidAuthorizationWithNeitherResourceIdNorPropertyName() {
+    // Note: This invalid authorization is successfully mapped from YAML.
+    // The missing resource identifier violation will be detected later during validation
+    // by AuthorizationConfigurer
+
+    // when
+    final ConfiguredAuthorization auth =
+        securityProperties.getInitialization().getAuthorizations().get(4);
+
+    // then
+    assertThat(auth.ownerType()).isEqualTo(AuthorizationOwnerType.ROLE);
+    assertThat(auth.ownerId()).isEqualTo("sales-team");
+    assertThat(auth.resourceType()).isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
+    assertThat(auth.resourceId()).isNull();
+    assertThat(auth.resourcePropertyName()).isNull();
+    assertThat(auth.permissions()).containsExactly(PermissionType.CREATE_PROCESS_INSTANCE);
+    // Both helper methods return false, indicating the invalid state
+    assertThat(auth.isIdBased()).isFalse();
+    assertThat(auth.isPropertyBased()).isFalse();
+  }
+
+  @Configuration
+  @Import({CamundaSecurityConfiguration.class})
+  static class TestConfig {}
+}

--- a/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
@@ -50,8 +50,8 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.permissions())
         .containsExactlyInAnyOrder(
             PermissionType.READ_PROCESS_INSTANCE, PermissionType.CREATE_PROCESS_INSTANCE);
-    assertThat(auth.isIdBased()).isTrue();
-    assertThat(auth.isPropertyBased()).isFalse();
+    assertThat(auth.hasResourceId()).isTrue();
+    assertThat(auth.hasResourcePropertyName()).isFalse();
   }
 
   @Test
@@ -66,8 +66,8 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.resourceId()).isEqualTo("order-process");
     assertThat(auth.resourcePropertyName()).isNull();
     assertThat(auth.permissions()).containsExactly(PermissionType.UPDATE_PROCESS_INSTANCE);
-    assertThat(auth.isIdBased()).isTrue();
-    assertThat(auth.isPropertyBased()).isFalse();
+    assertThat(auth.hasResourceId()).isTrue();
+    assertThat(auth.hasResourcePropertyName()).isFalse();
   }
 
   @Test
@@ -83,8 +83,8 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.resourcePropertyName()).isEqualTo("assignee");
     assertThat(auth.permissions())
         .containsExactlyInAnyOrder(PermissionType.UPDATE, PermissionType.READ);
-    assertThat(auth.isIdBased()).isFalse();
-    assertThat(auth.isPropertyBased()).isTrue();
+    assertThat(auth.hasResourceId()).isFalse();
+    assertThat(auth.hasResourcePropertyName()).isTrue();
   }
 
   @Test
@@ -105,8 +105,8 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.resourcePropertyName()).isEqualTo("assignee");
     assertThat(auth.permissions()).containsExactly(PermissionType.READ);
     // Both helper methods return true, indicating the invalid state
-    assertThat(auth.isIdBased()).isTrue();
-    assertThat(auth.isPropertyBased()).isTrue();
+    assertThat(auth.hasResourceId()).isTrue();
+    assertThat(auth.hasResourcePropertyName()).isTrue();
   }
 
   @Test
@@ -127,8 +127,8 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.resourcePropertyName()).isNull();
     assertThat(auth.permissions()).containsExactly(PermissionType.CREATE_PROCESS_INSTANCE);
     // Both helper methods return false, indicating the invalid state
-    assertThat(auth.isIdBased()).isFalse();
-    assertThat(auth.isPropertyBased()).isFalse();
+    assertThat(auth.hasResourceId()).isFalse();
+    assertThat(auth.hasResourcePropertyName()).isFalse();
   }
 
   @Configuration

--- a/dist/src/test/resources/properties/application-authorization-props.yaml
+++ b/dist/src/test/resources/properties/application-authorization-props.yaml
@@ -1,0 +1,45 @@
+camunda:
+  security:
+    initialization:
+      authorizations:
+        # [0] Valid ID-based authorization with wildcard
+        - ownerType: USER
+          ownerId: john.doe
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - READ_PROCESS_INSTANCE
+            - CREATE_PROCESS_INSTANCE
+
+        # [1] Valid ID-based authorization with specific resource
+        - ownerType: ROLE
+          ownerId: developers
+          resourceType: PROCESS_DEFINITION
+          resourceId: order-process
+          permissions:
+            - UPDATE_PROCESS_INSTANCE
+
+        # [2] Valid PROPERTY-based authorization
+        - ownerType: USER
+          ownerId: jane.doe
+          resourceType: USER_TASK
+          resourcePropertyName: assignee
+          permissions:
+            - READ
+            - UPDATE
+
+        # [3] Invalid authorization with both resourceId and resourcePropertyName
+        - ownerType: USER
+          ownerId: mark.smith
+          resourceType: USER_TASK
+          resourceId: some-task
+          resourcePropertyName: assignee
+          permissions:
+            - READ
+
+        # [4] Invalid authorization with neither resourceId nor resourcePropertyName
+        - ownerType: ROLE
+          ownerId: sales-team
+          resourceType: PROCESS_DEFINITION
+          permissions:
+            - CREATE_PROCESS_INSTANCE

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AuthorizationRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AuthorizationRequestValidator.java
@@ -27,11 +27,12 @@ public final class AuthorizationRequestValidator {
   public Optional<ProblemDetail> validateIdBasedRequest(final AuthorizationIdBasedRequest request) {
     return validate(
         () ->
-            authorizationValidator.validateIdBased(
+            authorizationValidator.validate(
                 request.getOwnerId(),
                 request.getOwnerType(),
                 request.getResourceType(),
                 request.getResourceId(),
+                null,
                 Set.copyOf(request.getPermissionTypes())));
   }
 
@@ -39,10 +40,11 @@ public final class AuthorizationRequestValidator {
       final AuthorizationPropertyBasedRequest request) {
     return validate(
         () ->
-            authorizationValidator.validatePropertyBased(
+            authorizationValidator.validate(
                 request.getOwnerId(),
                 request.getOwnerType(),
                 request.getResourceType(),
+                null,
                 request.getResourcePropertyName(),
                 Set.copyOf(request.getPermissionTypes())));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeAuthorizationIT.java
@@ -43,7 +43,7 @@ class InitializeAuthorizationIT {
   private static final String DEFAULT_PASSWORD = "password";
 
   private static final ConfiguredAuthorization CONFIGURED_AUTH_1 =
-      new ConfiguredAuthorization(
+      ConfiguredAuthorization.idBased(
           AuthorizationOwnerType.USER,
           RESTRICTED,
           AuthorizationResourceType.PROCESS_DEFINITION,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeAuthorizationIT.java
@@ -43,11 +43,10 @@ class InitializeAuthorizationIT {
   private static final String DEFAULT_PASSWORD = "password";
 
   private static final ConfiguredAuthorization CONFIGURED_AUTH_1 =
-      ConfiguredAuthorization.idBased(
+      ConfiguredAuthorization.wildcard(
           AuthorizationOwnerType.USER,
           RESTRICTED,
           AuthorizationResourceType.PROCESS_DEFINITION,
-          "*",
           Set.of(PermissionType.READ_PROCESS_INSTANCE, PermissionType.CREATE_PROCESS_INSTANCE));
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidAuthorizationIT.java
@@ -24,11 +24,10 @@ import org.springframework.beans.factory.BeanCreationException;
 public class InitializeInvalidAuthorizationIT {
 
   private static final ConfiguredAuthorization INVALID_AUTH =
-      ConfiguredAuthorization.idBased(
+      ConfiguredAuthorization.wildcard(
           AuthorizationOwnerType.USER,
           "john.doe",
           null,
-          "*",
           Set.of(PermissionType.READ_PROCESS_INSTANCE, PermissionType.CREATE_PROCESS_INSTANCE));
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidAuthorizationIT.java
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.BeanCreationException;
 public class InitializeInvalidAuthorizationIT {
 
   private static final ConfiguredAuthorization INVALID_AUTH =
-      new ConfiguredAuthorization(
+      ConfiguredAuthorization.idBased(
           AuthorizationOwnerType.USER,
           "john.doe",
           null,

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -9,6 +9,7 @@ package io.camunda.security.configuration;
 
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 
@@ -28,6 +29,14 @@ public record ConfiguredAuthorization(
       final Set<PermissionType> permissions) {
     return new ConfiguredAuthorization(
         ownerType, ownerId, resourceType, resourceId, null, permissions);
+  }
+
+  public static ConfiguredAuthorization wildcard(
+      final AuthorizationOwnerType ownerType,
+      final String ownerId,
+      final AuthorizationResourceType resourceType,
+      final Set<PermissionType> permissions) {
+    return idBased(ownerType, ownerId, resourceType, AuthorizationScope.WILDCARD_CHAR, permissions);
   }
 
   public static ConfiguredAuthorization propertyBased(

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -17,4 +17,34 @@ public record ConfiguredAuthorization(
     String ownerId,
     AuthorizationResourceType resourceType,
     String resourceId,
-    Set<PermissionType> permissions) {}
+    String resourcePropertyName,
+    Set<PermissionType> permissions) {
+
+  public static ConfiguredAuthorization idBased(
+      final AuthorizationOwnerType ownerType,
+      final String ownerId,
+      final AuthorizationResourceType resourceType,
+      final String resourceId,
+      final Set<PermissionType> permissions) {
+    return new ConfiguredAuthorization(
+        ownerType, ownerId, resourceType, resourceId, null, permissions);
+  }
+
+  public static ConfiguredAuthorization propertyBased(
+      final AuthorizationOwnerType ownerType,
+      final String ownerId,
+      final AuthorizationResourceType resourceType,
+      final String resourcePropertyName,
+      final Set<PermissionType> permissions) {
+    return new ConfiguredAuthorization(
+        ownerType, ownerId, resourceType, null, resourcePropertyName, permissions);
+  }
+
+  public boolean isIdBased() {
+    return resourceId != null && !resourceId.isBlank();
+  }
+
+  public boolean isPropertyBased() {
+    return resourcePropertyName != null && !resourcePropertyName.isBlank();
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -49,11 +49,11 @@ public record ConfiguredAuthorization(
         ownerType, ownerId, resourceType, null, resourcePropertyName, permissions);
   }
 
-  public boolean isIdBased() {
+  public boolean hasResourceId() {
     return resourceId != null && !resourceId.isBlank();
   }
 
-  public boolean isPropertyBased() {
+  public boolean hasResourcePropertyName() {
     return resourcePropertyName != null && !resourcePropertyName.isBlank();
   }
 }

--- a/security/security-validation/pom.xml
+++ b/security/security-validation/pom.xml
@@ -32,6 +32,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/security/security-validation/src/test/java/io/camunda/security/validation/AuthorizationValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/AuthorizationValidatorTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,6 +50,25 @@ class AuthorizationValidatorTest {
 
     // then
     assertThat(violations).containsExactly(expectedViolation);
+  }
+
+  @Test
+  void shouldAggregateMultipleViolations() {
+    // given
+    final var authWithMultipleViolations =
+        new TestAuthorization(null, null, null, null, null, null);
+
+    // when
+    final var violations = validateAuthorization(authWithMultipleViolations);
+
+    // then
+    assertThat(violations)
+        .containsExactlyInAnyOrder(
+            "No ownerId provided",
+            "No ownerType provided",
+            "No resourceType provided",
+            "No permissionTypes provided",
+            "Either resourceId or resourcePropertyName must be provided");
   }
 
   static Stream<Arguments> validAuthorizationCases() {

--- a/security/security-validation/src/test/java/io/camunda/security/validation/AuthorizationValidatorTest.java
+++ b/security/security-validation/src/test/java/io/camunda/security/validation/AuthorizationValidatorTest.java
@@ -9,6 +9,8 @@ package io.camunda.security.validation;
 
 import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -16,7 +18,10 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AuthorizationValidatorTest {
 
@@ -25,52 +30,219 @@ class AuthorizationValidatorTest {
           new IdentifierValidator(
               Pattern.compile("^[a-zA-Z0-9_~@.+-]+$"), Pattern.compile("^[a-zA-Z0-9_~@.+-]+$")));
 
-  @Test
-  public void shouldValidateOwnerType() {
-    // when:
-    final List<String> violations =
-        VALIDATOR.validateIdBased(
-            "foo",
-            null,
-            AuthorizationResourceType.RESOURCE,
-            WILDCARD_CHAR,
-            Set.of(PermissionType.READ));
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("validAuthorizationCases")
+  void shouldSuccessfullyValidate(final TestAuthorization authorizationTestCase) {
+    // when
+    final var violations = validateAuthorization(authorizationTestCase);
 
-    // then:
-    assertThat(violations).hasSize(1);
-    assertThat(violations).contains("No ownerType provided");
-  }
-
-  @Test
-  public void shouldSuccessfullyValidateIdBased() {
-    // when:
-    final List<String> violations =
-        VALIDATOR.validateIdBased(
-            "foo",
-            AuthorizationOwnerType.USER,
-            AuthorizationResourceType.RESOURCE,
-            WILDCARD_CHAR,
-            Set.of(PermissionType.READ));
-
-    // then:
+    // then
     assertThat(violations).isEmpty();
   }
 
-  @Test
-  void shouldNotAllowWildcardAsPropertyName() {
-    // when:
-    final List<String> violations =
-        VALIDATOR.validatePropertyBased(
-            "foo",
-            AuthorizationOwnerType.USER,
-            AuthorizationResourceType.RESOURCE,
-            WILDCARD_CHAR,
-            Set.of(PermissionType.READ));
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("invalidAuthorizationCases")
+  void shouldFailValidation(
+      final TestAuthorization authorizationTestCase, final String expectedViolation) {
+    // when
+    final var violations = validateAuthorization(authorizationTestCase);
 
-    // then:
-    assertThat(violations).hasSize(1);
-    assertThat(violations)
-        .anyMatch(
-            s -> s.contains("The provided resourcePropertyName contains illegal characters."));
+    // then
+    assertThat(violations).containsExactly(expectedViolation);
   }
+
+  static Stream<Arguments> validAuthorizationCases() {
+    final var permissions = Set.of(PermissionType.READ);
+    return Stream.of(
+        arguments(
+            named(
+                "ID-based with wildcard",
+                new IdBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    WILDCARD_CHAR,
+                    permissions))),
+        arguments(
+            named(
+                "ID-based with specific resource",
+                new IdBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "resource-123",
+                    permissions))),
+        arguments(
+            named(
+                "Property-based with valid property name",
+                new PropertyBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "propertyName",
+                    permissions))));
+  }
+
+  static Stream<Arguments> invalidAuthorizationCases() {
+    final var permissions = Set.of(PermissionType.READ);
+    return Stream.of(
+        // Missing ownerId cases
+        arguments(
+            named(
+                "ID-based without ownerId",
+                new IdBasedAuthorization(
+                    null,
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "1",
+                    permissions)),
+            "No ownerId provided"),
+        arguments(
+            named(
+                "Property-based without ownerId",
+                new PropertyBasedAuthorization(
+                    "",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "propertyName",
+                    permissions)),
+            "No ownerId provided"),
+        // Missing ownerType cases
+        arguments(
+            named(
+                "ID-based without ownerType",
+                new IdBasedAuthorization(
+                    "foo", null, AuthorizationResourceType.RESOURCE, "2", permissions)),
+            "No ownerType provided"),
+        arguments(
+            named(
+                "Property-based without ownerType",
+                new PropertyBasedAuthorization(
+                    "foo", null, AuthorizationResourceType.RESOURCE, "propertyName", permissions)),
+            "No ownerType provided"),
+        // Missing resourceType cases
+        arguments(
+            named(
+                "ID-based without resourceType",
+                new IdBasedAuthorization(
+                    "foo", AuthorizationOwnerType.USER, null, "3", permissions)),
+            "No resourceType provided"),
+        arguments(
+            named(
+                "Property-based without resourceType",
+                new PropertyBasedAuthorization(
+                    "foo", AuthorizationOwnerType.USER, null, "propertyName", permissions)),
+            "No resourceType provided"),
+        // Missing permissions cases
+        arguments(
+            named(
+                "ID-based without permissions",
+                new IdBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "4",
+                    Set.of())),
+            "No permissionTypes provided"),
+        arguments(
+            named(
+                "Property-based without permissions",
+                new PropertyBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "propertyName",
+                    null)),
+            "No permissionTypes provided"),
+        // Missing resourceId/resourcePropertyName cases
+        arguments(
+            named(
+                "ID-based without resourceId",
+                new IdBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "",
+                    permissions)),
+            "No resourceId provided"),
+        arguments(
+            named(
+                "Property-based without resourcePropertyName",
+                new PropertyBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    null,
+                    permissions)),
+            "No resourcePropertyName provided"),
+        // Invalid resourceId/resourcePropertyName cases
+        arguments(
+            named(
+                "ID-based with invalid characters",
+                new IdBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "invalid$id",
+                    permissions)),
+            "The provided resourceId contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'"),
+        arguments(
+            named(
+                "Property-based with invalid characters",
+                new PropertyBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    "invalid$property",
+                    permissions)),
+            "The provided resourcePropertyName contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'"),
+        arguments(
+            named(
+                "Property-based with wildcard as property name",
+                new PropertyBasedAuthorization(
+                    "foo",
+                    AuthorizationOwnerType.USER,
+                    AuthorizationResourceType.RESOURCE,
+                    WILDCARD_CHAR,
+                    permissions)),
+            "The provided resourcePropertyName contains illegal characters. It must match the pattern '^[a-zA-Z0-9_~@.+-]+$'"));
+  }
+
+  private static List<String> validateAuthorization(final TestAuthorization authorization) {
+    return switch (authorization) {
+      case IdBasedAuthorization idBased ->
+          VALIDATOR.validateIdBased(
+              idBased.ownerId(),
+              idBased.ownerType(),
+              idBased.resourceType(),
+              idBased.resourceId(),
+              idBased.permissions());
+      case PropertyBasedAuthorization propertyBased ->
+          VALIDATOR.validatePropertyBased(
+              propertyBased.ownerId(),
+              propertyBased.ownerType(),
+              propertyBased.resourceType(),
+              propertyBased.resourcePropertyName(),
+              propertyBased.permissions());
+    };
+  }
+
+  private sealed interface TestAuthorization
+      permits IdBasedAuthorization, PropertyBasedAuthorization {}
+
+  private record IdBasedAuthorization(
+      String ownerId,
+      AuthorizationOwnerType ownerType,
+      AuthorizationResourceType resourceType,
+      String resourceId,
+      Set<PermissionType> permissions)
+      implements TestAuthorization {}
+
+  private record PropertyBasedAuthorization(
+      String ownerId,
+      AuthorizationOwnerType ownerType,
+      AuthorizationResourceType resourceType,
+      String resourcePropertyName,
+      Set<PermissionType> permissions)
+      implements TestAuthorization {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurer.java
@@ -31,8 +31,8 @@ public class AuthorizationConfigurer
 
   @Override
   public Either<List<String>, AuthorizationRecord> configure(final ConfiguredAuthorization auth) {
-    final boolean hasResourceId = auth.isIdBased();
-    final boolean hasPropertyName = auth.isPropertyBased();
+    final boolean hasResourceId = auth.hasResourceId();
+    final boolean hasPropertyName = auth.hasResourcePropertyName();
 
     if (hasResourceId && hasPropertyName) {
       return Either.left(List.of(ERROR_MUTUALLY_EXCLUSIVE_IDENTIFIERS));
@@ -72,7 +72,7 @@ public class AuthorizationConfigurer
             .setResourceType(auth.resourceType())
             .setPermissionTypes(auth.permissions());
 
-    if (auth.isIdBased()) {
+    if (auth.hasResourceId()) {
       record
           .setResourceMatcher(AuthorizationScope.of(auth.resourceId()).getMatcher())
           .setResourceId(auth.resourceId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurer.java
@@ -18,11 +18,6 @@ import java.util.List;
 public class AuthorizationConfigurer
     implements EntityInitializationConfigurer<ConfiguredAuthorization, AuthorizationRecord> {
 
-  private static final String ERROR_MUTUALLY_EXCLUSIVE_IDENTIFIERS =
-      "resourceId and resourcePropertyName are mutually exclusive. Provide only one of them.";
-  private static final String ERROR_MISSING_IDENTIFIER =
-      "Either resourceId or resourcePropertyName must be provided.";
-
   private final AuthorizationValidator validator;
 
   public AuthorizationConfigurer(final AuthorizationValidator validator) {
@@ -31,31 +26,14 @@ public class AuthorizationConfigurer
 
   @Override
   public Either<List<String>, AuthorizationRecord> configure(final ConfiguredAuthorization auth) {
-    final boolean hasResourceId = auth.hasResourceId();
-    final boolean hasPropertyName = auth.hasResourcePropertyName();
-
-    if (hasResourceId && hasPropertyName) {
-      return Either.left(List.of(ERROR_MUTUALLY_EXCLUSIVE_IDENTIFIERS));
-    }
-
-    if (!hasResourceId && !hasPropertyName) {
-      return Either.left(List.of(ERROR_MISSING_IDENTIFIER));
-    }
-
     final var violations =
-        hasResourceId
-            ? validator.validateIdBased(
-                auth.ownerId(),
-                auth.ownerType(),
-                auth.resourceType(),
-                auth.resourceId(),
-                auth.permissions())
-            : validator.validatePropertyBased(
-                auth.ownerId(),
-                auth.ownerType(),
-                auth.resourceType(),
-                auth.resourcePropertyName(),
-                auth.permissions());
+        validator.validate(
+            auth.ownerId(),
+            auth.ownerType(),
+            auth.resourceType(),
+            auth.resourceId(),
+            auth.resourcePropertyName(),
+            auth.permissions());
 
     if (!violations.isEmpty()) {
       return Either.left(violations);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Test;
 class AuthorizationConfigurerTest {
 
   private static final ConfiguredAuthorization INVALID_OWNER_TYPE =
-      new ConfiguredAuthorization(
+      ConfiguredAuthorization.idBased(
           null,
           "foo",
           AuthorizationResourceType.RESOURCE,
           WILDCARD_CHAR,
           Set.of(PermissionType.READ));
   private static final ConfiguredAuthorization VALID_AUTH =
-      new ConfiguredAuthorization(
+      ConfiguredAuthorization.idBased(
           AuthorizationOwnerType.USER,
           "foo",
           AuthorizationResourceType.RESOURCE,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.identity.initialize;
 
-import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD_CHAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.ConfiguredAuthorization;
@@ -26,18 +25,13 @@ import org.junit.jupiter.api.Test;
 class AuthorizationConfigurerTest {
 
   private static final ConfiguredAuthorization INVALID_OWNER_TYPE =
-      ConfiguredAuthorization.idBased(
-          null,
-          "foo",
-          AuthorizationResourceType.RESOURCE,
-          WILDCARD_CHAR,
-          Set.of(PermissionType.READ));
+      ConfiguredAuthorization.wildcard(
+          null, "foo", AuthorizationResourceType.RESOURCE, Set.of(PermissionType.READ));
   private static final ConfiguredAuthorization VALID_AUTH =
-      ConfiguredAuthorization.idBased(
+      ConfiguredAuthorization.wildcard(
           AuthorizationOwnerType.USER,
           "foo",
           AuthorizationResourceType.RESOURCE,
-          WILDCARD_CHAR,
           Set.of(PermissionType.READ));
   private static final AuthorizationValidator VALIDATOR =
       new AuthorizationValidator(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
@@ -8,6 +8,9 @@
 package io.camunda.zeebe.engine.processing.identity.initialize;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.camunda.security.configuration.ConfiguredAuthorization;
 import io.camunda.security.validation.AuthorizationValidator;
@@ -20,18 +23,36 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AuthorizationConfigurerTest {
 
-  private static final ConfiguredAuthorization INVALID_OWNER_TYPE =
+  private static final ConfiguredAuthorization INVALID_WILDCARD_AUTH_MISSING_OWNER_TYPE =
       ConfiguredAuthorization.wildcard(
           null, "foo", AuthorizationResourceType.RESOURCE, Set.of(PermissionType.READ));
-  private static final ConfiguredAuthorization VALID_AUTH =
+  private static final ConfiguredAuthorization VALID_WILDCARD_AUTH =
       ConfiguredAuthorization.wildcard(
           AuthorizationOwnerType.USER,
           "foo",
           AuthorizationResourceType.RESOURCE,
+          Set.of(PermissionType.READ));
+  private static final ConfiguredAuthorization VALID_ID_BASED_AUTH =
+      ConfiguredAuthorization.idBased(
+          AuthorizationOwnerType.USER,
+          "bar",
+          AuthorizationResourceType.RESOURCE,
+          "123",
+          Set.of(PermissionType.READ));
+  private static final ConfiguredAuthorization VALID_PROPERTY_BASED_AUTH =
+      ConfiguredAuthorization.propertyBased(
+          AuthorizationOwnerType.USER,
+          "baz",
+          AuthorizationResourceType.USER,
+          "propertyName",
           Set.of(PermissionType.READ));
   private static final AuthorizationValidator VALIDATOR =
       new AuthorizationValidator(
@@ -41,28 +62,92 @@ class AuthorizationConfigurerTest {
   void shouldReturnViolationOnValidationFailure() {
     // when:
     final Either<List<String>, AuthorizationRecord> result =
-        new AuthorizationConfigurer(VALIDATOR).configure(INVALID_OWNER_TYPE);
+        new AuthorizationConfigurer(VALIDATOR).configure(INVALID_WILDCARD_AUTH_MISSING_OWNER_TYPE);
 
     // then:
     assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).contains("No ownerType provided");
+    assertThat(result.getLeft()).containsExactly("No ownerType provided");
   }
 
   @Test
-  void shouldSuccessfullyConfigure() {
+  void shouldReturnViolationWhenBothResourceIdAndPropertyNameProvided() {
+    // given: an authorization with both resourceId and resourcePropertyName
+    final var authWithBoth =
+        new ConfiguredAuthorization(
+            AuthorizationOwnerType.USER,
+            "foo",
+            AuthorizationResourceType.RESOURCE,
+            "resource-123",
+            "propertyName",
+            Set.of(PermissionType.READ));
+
+    // when:
+    final var result = new AuthorizationConfigurer(VALIDATOR).configure(authWithBoth);
+
+    // then:
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .containsExactly(
+            "resourceId and resourcePropertyName are mutually exclusive. Provide only one of them.");
+  }
+
+  @ParameterizedTest
+  @MethodSource("missingResourceIdentifierCases")
+  void shouldReturnViolationWhenBothResourceIdAndPropertyNameMissing(
+      final String missingResourceId, final String missingPropertyName) {
+    // given: an authorization with neither resourceId nor resourcePropertyName
+    final var authWithNeither =
+        new ConfiguredAuthorization(
+            AuthorizationOwnerType.USER,
+            "foo",
+            AuthorizationResourceType.RESOURCE,
+            missingResourceId,
+            missingPropertyName,
+            Set.of(PermissionType.READ));
+
+    // when:
+    final var result = new AuthorizationConfigurer(VALIDATOR).configure(authWithNeither);
+
+    // then:
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .containsExactly("Either resourceId or resourcePropertyName must be provided.");
+  }
+
+  private static Stream<Arguments> missingResourceIdentifierCases() {
+    return Stream.of(
+        argumentSet("Both null", null, null),
+        argumentSet("Both empty strings", "", ""),
+        argumentSet("Both blank strings", "  ", "  "),
+        argumentSet("Null resourceId and empty propertyName", null, ""));
+  }
+
+  @ParameterizedTest(name = "[{index}]: {0}")
+  @MethodSource("validAuthorizations")
+  void shouldSuccessfullyConfigure(final ConfiguredAuthorization authorization) {
     // when:
     final Either<List<String>, AuthorizationRecord> result =
-        new AuthorizationConfigurer(VALIDATOR).configure(VALID_AUTH);
+        new AuthorizationConfigurer(VALIDATOR).configure(authorization);
 
     // then:
     assertThat(result.isRight()).isTrue();
+  }
+
+  private static Stream<Arguments> validAuthorizations() {
+    return Stream.of(
+        arguments(named("Valid wildcard authorization", VALID_WILDCARD_AUTH)),
+        arguments(named("Valid ID-based authorization", VALID_ID_BASED_AUTH)),
+        arguments(named("Valid PROPERTY-based authorization", VALID_PROPERTY_BASED_AUTH)));
   }
 
   @Test
   void shouldAggregateToViolations() {
     // given:
     final List<ConfiguredAuthorization> auths =
-        List.of(VALID_AUTH, INVALID_OWNER_TYPE, INVALID_OWNER_TYPE);
+        List.of(
+            VALID_WILDCARD_AUTH,
+            INVALID_WILDCARD_AUTH_MISSING_OWNER_TYPE,
+            INVALID_WILDCARD_AUTH_MISSING_OWNER_TYPE);
 
     // when:
     final Either<List<String>, List<AuthorizationRecord>> result =
@@ -77,7 +162,8 @@ class AuthorizationConfigurerTest {
   @Test
   void shouldAggregateToAuthorizationRecords() {
     // given:
-    final List<ConfiguredAuthorization> auths = List.of(VALID_AUTH, VALID_AUTH);
+    final List<ConfiguredAuthorization> auths =
+        List.of(VALID_WILDCARD_AUTH, VALID_ID_BASED_AUTH, VALID_PROPERTY_BASED_AUTH);
 
     // when:
     final Either<List<String>, List<AuthorizationRecord>> result =
@@ -85,6 +171,6 @@ class AuthorizationConfigurerTest {
 
     // then:
     assertThat(result.isRight()).isTrue();
-    assertThat(result.get()).hasSize(2);
+    assertThat(result.get()).hasSize(3);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/initialize/AuthorizationConfigurerTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.identity.initialize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
-import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.camunda.security.configuration.ConfiguredAuthorization;
@@ -69,59 +68,6 @@ class AuthorizationConfigurerTest {
     // then:
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft()).containsExactly("No ownerType provided");
-  }
-
-  @Test
-  void shouldReturnViolationWhenBothResourceIdAndPropertyNameProvided() {
-    // given: an authorization with both resourceId and resourcePropertyName
-    final var authWithBoth =
-        new ConfiguredAuthorization(
-            AuthorizationOwnerType.USER,
-            "foo",
-            AuthorizationResourceType.RESOURCE,
-            "resource-123",
-            "propertyName",
-            Set.of(PermissionType.READ));
-
-    // when:
-    final var result = new AuthorizationConfigurer(VALIDATOR).configure(authWithBoth);
-
-    // then:
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft())
-        .containsExactly(
-            "resourceId and resourcePropertyName are mutually exclusive. Provide only one of them.");
-  }
-
-  @ParameterizedTest
-  @MethodSource("missingResourceIdentifierCases")
-  void shouldReturnViolationWhenBothResourceIdAndPropertyNameMissing(
-      final String missingResourceId, final String missingPropertyName) {
-    // given: an authorization with neither resourceId nor resourcePropertyName
-    final var authWithNeither =
-        new ConfiguredAuthorization(
-            AuthorizationOwnerType.USER,
-            "foo",
-            AuthorizationResourceType.RESOURCE,
-            missingResourceId,
-            missingPropertyName,
-            Set.of(PermissionType.READ));
-
-    // when:
-    final var result = new AuthorizationConfigurer(VALIDATOR).configure(authWithNeither);
-
-    // then:
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft())
-        .containsExactly("Either resourceId or resourcePropertyName must be provided.");
-  }
-
-  private static Stream<Arguments> missingResourceIdentifierCases() {
-    return Stream.of(
-        argumentSet("Both null", null, null),
-        argumentSet("Both empty strings", "", ""),
-        argumentSet("Both blank strings", "  ", "  "),
-        argumentSet("Null resourceId and empty propertyName", null, ""));
   }
 
   @ParameterizedTest(name = "[{index}]: {0}")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -463,7 +463,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .resourceId("")
                 .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissionTypes(permissions),
-            "No resourceId provided."),
+            "Either resourceId or resourcePropertyName must be provided."),
         Arguments.of(
             new AuthorizationIdBasedRequest()
                 .ownerId("ownerId")
@@ -565,7 +565,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .resourcePropertyName("")
                 .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissionTypes(permissions),
-            "No resourcePropertyName provided."),
+            "Either resourceId or resourcePropertyName must be provided."),
         Arguments.of(
             new AuthorizationPropertyBasedRequest()
                 .ownerId("ownerId")


### PR DESCRIPTION
## Description

This PR provides support for creating PROPERTY-based authorizations from configuration, in addition to the existing ID-based (including wildcard `*`) authorizations.

### Background
Issue #39581 introduced the ability to configure ID-based authorizations via application properties. The configuration structure supports authorizations with a `resourceId` field that can be either a specific ID or a wildcard (`*`).

This PR extends that functionality to also support PROPERTY-based authorizations, which allow authorization to be defined based on resource property names rather than specific resource IDs.

### Configuration structure

The updated configuration now supports two mutually exclusive authorization types:

<details><summary><b>1. ID-based authorization (existing)</b></summary>

```yaml
camunda:
  security:
    initialization:
      authorizations:
        # Wildcard - grants access to ALL process definitions
        - ownerType: USER
          ownerId: john.doe
          resourceType: PROCESS_DEFINITION
          resourceId: "*"
          permissions:
            - READ_PROCESS_INSTANCE
            - CREATE_PROCESS_INSTANCE
        # Specific ID - grants access to a single process definition
        - ownerType: ROLE
          ownerId: developers
          resourceType: PROCESS_DEFINITION
          resourceId: "order-process"
          permissions:
            - UPDATE_USER_TASK
```
</details>

<details><summary><b>2. PROPERTY-based authorization (new)</b></summary>

```yaml
camunda:
  security:
    initialization:
      authorizations:
        - ownerType: USER
          ownerId: jane.doe
          resourceType: USER_TASK
          resourcePropertyName: "assignee"
          permissions:
            - READ
            - UPDATE
```
</details>

### New validations

- **Required**: At least one of `resourceId` or `resourcePropertyName` must be provided
- **Mutually exclusive**: `resourceId` and `resourcePropertyName` cannot both be provided

## Related issues

closes #44478
