### PR TITLE
deps: revert breaking bpmn-js major upgrade for CPT coverage frontend

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -254,6 +254,19 @@
       "additionalBranchPrefix": "fe-"
     },
     {
+      "description": "Exclude bpmn-js usage in CPT testing that is not covered by CI to prevent breaking auto updates.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "testing/camunda-process-test-coverage-frontend/package.json"
+      ],
+      "matchPackageNames": [
+        "/bpmn-js/"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Exclude frontend deps until Optimize migrates to react-router v6 & remove enzyme",
       "matchManagers": [
         "npm",

--- a/testing/camunda-process-test-coverage-frontend/package-lock.json
+++ b/testing/camunda-process-test-coverage-frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "bootstrap": "^5.3.7",
         "bootstrap-icons": "^1.13.1",
-        "bpmn-js": "^18.0.0",
+        "bpmn-js": "^8.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -2290,16 +2290,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@bpmn-io/diagram-js-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
-      "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "license": "MIT",
-      "dependencies": {
-        "htm": "^3.1.1",
-        "preact": "^10.11.2"
-      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -5462,36 +5452,32 @@
       "license": "MIT"
     },
     "node_modules/bpmn-js": {
-      "version": "18.10.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.10.1.tgz",
-      "integrity": "sha512-4AdTtn2V3YqyYGbNeHiUBm3sl9vkZkhDaLyXRkhKo9bSepKe94EqFn6AIaXcKijMX2tj1qxz5ZcobmrxymU/SA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-8.10.0.tgz",
+      "integrity": "sha512-NozeOi01qL0ZdVq8+5hWZcikyEvgrP1yzCBqlhSufJdHFsnEMBCwn2bJJ0B/6JgX+IBwy1sk/Uw+Ds8rQ8vfrw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^9.0.4",
-        "diagram-js": "^15.5.0",
-        "diagram-js-direct-editing": "^3.2.0",
-        "ids": "^1.0.5",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.2.3",
-        "min-dom": "^4.2.1",
-        "tiny-svg": "^3.1.3"
-      },
-      "engines": {
-        "node": "*"
+        "bpmn-moddle": "^7.1.2",
+        "css.escape": "^1.5.1",
+        "diagram-js": "^7.8.2",
+        "diagram-js-direct-editing": "^1.6.3",
+        "ids": "^1.0.0",
+        "inherits": "^2.0.4",
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3",
+        "object-refs": "^0.3.0",
+        "tiny-svg": "^2.2.2"
       }
     },
     "node_modules/bpmn-moddle": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.4.tgz",
-      "integrity": "sha512-dr5s3vtOG8NkVSwa8CC55XBIKKwajomSZRb0RiMOOOF6TpqZBZvtbDjpzWICvdd/plDF6uOtaRfSgblPQLAioQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
+      "integrity": "sha512-ZcBfw0NSOdYTSXFKEn7MOXHItz7VfLZTrFYKO8cK6V8ZzGjCcdiLIOiw7Lctw1PJsihhLiZQS8Htj2xKf+NwCg==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.2.1",
-        "moddle": "^7.0.0",
-        "moddle-xml": "^11.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
+        "min-dash": "^3.5.2",
+        "moddle": "^5.0.2",
+        "moddle-xml": "^9.0.6"
       }
     },
     "node_modules/brace-expansion": {
@@ -6180,15 +6166,6 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6424,10 +6401,9 @@
       }
     },
     "node_modules/component-event": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "license": "MIT"
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
+      "integrity": "sha512-GMwOG8MnUHP1l8DZx1ztFO0SJTFnIzZnBDkXAj8RM2ntV2A6ALlDxgbMY1Fvxlg6WPQ+5IM/a6vg4PEYbjg/Rw=="
     },
     "node_modules/compose-function": {
       "version": "3.0.3",
@@ -6990,6 +6966,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "license": "MIT"
     },
     "node_modules/cssdb": {
       "version": "4.4.0",
@@ -7784,114 +7766,41 @@
       "license": "MIT"
     },
     "node_modules/diagram-js": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.6.0.tgz",
-      "integrity": "sha512-wDCJQE3deGwdT3PAV4f3SFxMGaEw6/6SknTwEu3nJYVi9pJMoGDfi6WQA2PIGZQGrBvLkHAevMf7Ae+bA1UF/A==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
+      "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
-        "clsx": "^2.1.1",
-        "didi": "^11.0.0",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
-        "object-refs": "^0.4.0",
-        "path-intersection": "^4.1.0",
-        "tiny-svg": "^4.1.4"
-      },
-      "engines": {
-        "node": "*"
+        "css.escape": "^1.5.1",
+        "didi": "^5.2.1",
+        "hammerjs": "^2.0.1",
+        "inherits": "^2.0.4",
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3",
+        "object-refs": "^0.3.0",
+        "path-intersection": "^2.2.1",
+        "tiny-svg": "^2.2.2"
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.3.0.tgz",
-      "integrity": "sha512-EjXYb35J3qBU8lLz5U81hn7wNykVmF7U5DXZ7BvPok2IX7rmPz+ZyaI5AEMiqaC6lpSnHqPxFcPgKEiJcAiv5w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.8.0.tgz",
+      "integrity": "sha512-B4Xj+PJfgBjbPEzT3uZQEkZI5xHFB0Izc+7BhDFuHidzrEMzQKZrFGdA3PqfWhReHf3dp+iB6Tt11G9eGNjKMw==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
-      },
-      "engines": {
-        "node": "*"
+        "min-dash": "^3.5.2",
+        "min-dom": "^3.1.3"
       },
       "peerDependencies": {
         "diagram-js": "*"
       }
     },
-    "node_modules/diagram-js-direct-editing/node_modules/domify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-      "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diagram-js-direct-editing/node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
-      "license": "MIT"
-    },
-    "node_modules/diagram-js-direct-editing/node_modules/min-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.2.0.tgz",
-      "integrity": "sha512-shfMH1tFbZCVSx3ECaQV1aGu8fYmGnXEWuItudWRd31DpVJzmVKXFH/Aqgf7YjOmZRgRH5BJafk16oeSbohJDg==",
-      "license": "MIT",
-      "dependencies": {
-        "domify": "^2.0.0",
-        "min-dash": "^5.0.0"
-      }
-    },
-    "node_modules/diagram-js/node_modules/domify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-      "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diagram-js/node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
-      "license": "MIT"
-    },
-    "node_modules/diagram-js/node_modules/min-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.2.0.tgz",
-      "integrity": "sha512-shfMH1tFbZCVSx3ECaQV1aGu8fYmGnXEWuItudWRd31DpVJzmVKXFH/Aqgf7YjOmZRgRH5BJafk16oeSbohJDg==",
-      "license": "MIT",
-      "dependencies": {
-        "domify": "^2.0.0",
-        "min-dash": "^5.0.0"
-      }
-    },
-    "node_modules/diagram-js/node_modules/tiny-svg": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-4.1.4.tgz",
-      "integrity": "sha512-cBaEACCbouYrQc9RG+eTXnPYosX1Ijqty/I6DdXovwDd89Pwu4jcmpOR7BuFEF9YCcd7/AWwasE0207WMK7hdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/didi": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-11.0.0.tgz",
-      "integrity": "sha512-PzCfRzQttvFpVcYMbSF7h8EsWjeJpVjWH4qDhB5LkMi1ILvHq4Ob0vhM2wLFziPkbUBi+PAo7ODbe2sacR7nJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.12"
-      }
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-5.2.1.tgz",
+      "integrity": "sha512-IKNnajUlD4lWMy/Q9Emkk7H1qnzREgY4UyE3IhmOi/9IKua0JYtYldk928bOdt1yNxN8EiOy1sqtSozEYsmjCg==",
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
@@ -10840,6 +10749,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11123,12 +11041,6 @@
       "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/htm": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11715,6 +11627,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
+    },
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -11738,13 +11655,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inherits-browser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -13961,6 +13871,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/matches-selector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -14137,20 +14053,22 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.3.tgz",
-      "integrity": "sha512-VLMYQI5+FcD9Ad24VcB08uA83B07OhueAlZ88jBK6PyupTvEJwllTMUqMy0wPGYs7pZUEtEEMWdHB63m3LtEcg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg==",
       "license": "MIT"
     },
     "node_modules/min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "license": "MIT",
       "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
+        "component-event": "^0.1.4",
+        "domify": "^1.3.1",
+        "indexof": "0.0.1",
+        "matches-selector": "^1.2.0",
+        "min-dash": "^3.8.1"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -14386,29 +14304,23 @@
       }
     },
     "node_modules/moddle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
-      "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.4.tgz",
+      "integrity": "sha512-Kjb+hjuzO+YlojNGxEUXvdhLYTHTtAABDlDcJTtTcn5MbJF9Zkv4I1Fyvp3Ypmfgg1EfHDZ3PsCQTuML9JD6wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "min-dash": "^4.2.1"
+        "min-dash": "^3.0.0"
       }
     },
     "node_modules/moddle-xml": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
-      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.6.tgz",
+      "integrity": "sha512-tl0reHpsY/aKlLGhXeFlQWlYAQHFxTkFqC8tq8jXRYpQSnLVw13T6swMaourLd7EXqHdWsc+5ggsB+fEep6xZQ==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.0.0",
-        "saxen": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "moddle": ">= 6.2.0"
+        "min-dash": "^3.5.2",
+        "moddle": "^5.0.2",
+        "saxen": "^8.1.2"
       }
     },
     "node_modules/move-concurrently": {
@@ -14861,13 +14773,10 @@
       }
     },
     "node_modules/object-refs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
-      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.3.0.tgz",
+      "integrity": "sha512-eP0ywuoWOaDoiake/6kTJlPJhs+k0qNm4nYRzXLNHj6vh+5M3i9R1epJTdxIPGlhWc4fNRQ7a6XJNCX+/L4FOQ==",
+      "license": "MIT"
     },
     "node_modules/object-visit": {
       "version": "1.0.1",
@@ -15394,13 +15303,10 @@
       }
     },
     "node_modules/path-intersection": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz",
-      "integrity": "sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.20"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA==",
+      "license": "MIT"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -17155,16 +17061,6 @@
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/preact": {
-      "version": "10.28.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
-      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -19359,13 +19255,10 @@
       "license": "ISC"
     },
     "node_modules/saxen": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
+      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -21497,9 +21390,9 @@
       "license": "MIT"
     },
     "node_modules/tiny-svg": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.3.tgz",
-      "integrity": "sha512-9mwnPqXInRsBmH/DO6NMxBE++9LsqpVXQSSTZGc5bomoKKvL5OX/Hlotw7XVXP6XLRcHWIzZpxfovGqWKgCypQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
+      "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
       "license": "MIT"
     },
     "node_modules/tmpl": {

--- a/testing/camunda-process-test-coverage-frontend/package.json
+++ b/testing/camunda-process-test-coverage-frontend/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "bootstrap": "^5.3.7",
     "bootstrap-icons": "^1.13.1",
-    "bpmn-js": "^18.0.0",
+    "bpmn-js": "^8.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
## Description

One part of the changes from https://github.com/camunda/camunda/pull/44708 (automatically merged since all non-Legacy CI checks were green) turned out to cause a failure in the release dry-run job: https://github.com/camunda/camunda/actions/runs/21381056089

Apparently, https://github.com/camunda/camunda/blob/main/testing/camunda-process-test-coverage-frontend/package.json still uses a 4-year-old version of BPMN.js and does not take upgrading from v8.6 to v18 well. Due to lack of CI coverage this was only detected after merge.

This PR reverts to BPMN.js v8.6 for the relevant project and prevents auto-updates from Renovate.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)) - the [same situation exists](https://github.com/camunda/camunda/blob/stable/8.8/testing/camunda-process-test-coverage-frontend/package.json) on `stable/8.8` branch where an automatic upgrade could break releases afaik

## Related issues

[Slack](https://camunda.slack.com/archives/C06UWQNCU7M/p1769479368199209)
