### PR TITLE
[Backport stable/8.8] deps: revert breaking bpmn-js major upgrade for CPT coverage frontend

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -201,6 +201,19 @@
       "additionalBranchPrefix": "fe-"
     },
     {
+      "description": "Exclude bpmn-js usage in CPT testing that is not covered by CI to prevent breaking auto updates.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchFileNames": [
+        "testing/camunda-process-test-coverage-frontend/package.json"
+      ],
+      "matchPackageNames": [
+        "/bpmn-js/"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Exclude frontend deps until Optimize migrates to react-router v6 & remove enzyme",
       "matchManagers": [
         "npm",

--- a/testing/camunda-process-test-coverage-frontend/package-lock.json
+++ b/testing/camunda-process-test-coverage-frontend/package-lock.json
@@ -7763,6 +7763,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.9.0.tgz",
       "integrity": "sha512-o1yUtX5TXV1pmpevP55gxU/AEG6nCidOXGs/HLuxNXG0zMZ3jQta7kMqRxTK93rNw/XuHmP1eMOwdvdJ2RP5qA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",


### PR DESCRIPTION
# Description
Backport of #44743 to `stable/8.8`.

relates to 