### PR TITLE
Faster and transparent feedback on CI failures for better UX

### DIFF
--- a/.github/actions/post-ci-failure-reasons/README.md
+++ b/.github/actions/post-ci-failure-reasons/README.md
@@ -1,0 +1,101 @@
+# Post CI Failure Reasons
+
+A composite GitHub Action that collects job annotations from unsuccessful GitHub Actions jobs in the current Unified CI workflow run and posts them as a self-updating PR comment.
+
+## Purpose
+
+This action helps developers quickly understand CI failures at a glance by:
+
+- Collecting all annotations (errors, warnings, notices) from failed or cancelled jobs
+- Formatting them in a readable markdown format
+- Posting them as a comment on pull requests (automatically on `pull_request` events)
+- Automatically updating the comment on subsequent runs to avoid clutter (and deleting it on pass)
+
+The goal is to improve transparency and shorten the feedback cycle!
+
+## Inputs
+
+|     Input      |                                                     Description                                                     | Required |  Default  |
+|----------------|---------------------------------------------------------------------------------------------------------------------|----------|-----------|
+| `github_token` | GitHub token for API access. Needs `actions:read`, `checks:read` and `pull-requests:write` permissions.             | Yes      | -         |
+| `has_failures` | Whether there are any failures or cancellations in the workflow. When `'false'`, deletes outdated failure comments. | No       | `'false'` |
+
+## Usage
+
+### Basic Usage (in a Unified CI `check-results` job)
+
+```yaml
+jobs:
+  check-results:
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      checks: read
+      pull-requests: write
+    needs: [job1, job2, job3]  # All jobs to check
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Collect failure annotations or clean up on success
+        continue-on-error: true
+        uses: ./.github/actions/post-ci-failure-reasons
+        with:
+          github_token: ${{ github.token }}
+          has_failures: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+
+      - name: Fail if any job failed
+        run: |
+          exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+```
+
+## Features
+
+- **Automatic comment updates**: Uses a hidden HTML marker to identify and update existing comments instead of creating duplicates
+- **Automatic cleanup on success**: Deletes outdated failure comments when all checks pass, keeping PRs clean
+- **Cross-event support**: Works on pull requests, merge queue, push to `main` branch, etc. (PR comments only on GH `pull_request` events)
+- **Graceful degradation**: Won't fail the workflow if it encounters errors
+- **Rich formatting**: Includes job names, status, links, and structured annotation display
+
+## Output Format
+
+The action generates a markdown file with the following structure:
+
+```markdown
+<!-- ci-failure-analysis -->
+## 🔍 CI Failure Analysis
+
+GHA workflow run: [#123](https://github.com/org/repo/actions/runs/456)
+
+Found **2** unsuccessful job(s)
+
+### 📋 GHA job: `test-job` (failure)
+🔗 [View job logs](https://github.com/org/repo/actions/runs/456/job/789)
+
+Found 3 GHA annotation(s):
+
+- **ERROR**: Test failed: expected 5 but got 3
+- **WARNING**: Deprecated API usage detected
+- **NOTICE**: Code coverage below threshold
+
+---
+
+_Last updated: 2026-01-30 12:34:56 UTC_
+```
+
+## Requirements
+
+- GitHub CLI (`gh`) must be available in the runner
+- `jq` must be available in the runner
+
+Both are pre-installed on GitHub-hosted runners.
+
+## Permissions
+
+The action requires the following token permissions:
+
+- `actions: read` - To query workflow run and jobs data
+- `checks: read` - To read check run annotations
+- `pull-requests: write` - To post/update PR comments
+

--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -1,0 +1,128 @@
+# This action collects annotations from unsuccessful GitHub Actions jobs and posts them as a PR comment
+#
+# owner: @camunda/monorepo-devops-team
+---
+name: Post CI Failure Reasons
+
+description: Collects job annotations from unsuccessful GitHub Actions jobs in the current Unified CI workflow run and posts them as a self-updating PR comment (on pull requests)
+
+inputs:
+  github_token:
+    description: 'GitHub token for API access (needs actions:read, checks:read, and pull-requests:write)'
+    required: true
+  has_failures:
+    description: 'Whether there are any failures or cancellations in the workflow'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Find existing CI failure analysis PR comment
+      if: github.event_name == 'pull_request'
+      id: find-comment
+      uses: peter-evans/find-comment@v3
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: "<!-- ci-failure-analysis -->"
+
+    - name: Delete outdated CI failure analysis comment on success
+      if: github.event_name == 'pull_request' && inputs.has_failures == 'false' && steps.find-comment.outputs.comment-id != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "✅ All CI checks passed - deleting outdated failure analysis comment"
+        gh api \
+          --method DELETE \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/repos/${{ github.repository }}/issues/comments/${{ steps.find-comment.outputs.comment-id }}"
+
+    - name: Collect job annotations from unsuccessful jobs
+      if: inputs.has_failures == 'true'
+      id: collect-annotations
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        set +e  # Don't fail the script on errors
+
+        # Create output file for PR comment
+        COMMENT_FILE="annotations-comment.md"
+
+        echo "<!-- ci-failure-analysis -->" > "$COMMENT_FILE"
+        echo -e "## 🔍 CI Failure Analysis\n\n" | tee -a "$COMMENT_FILE"
+        echo -e "GHA workflow run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n" | tee -a "$COMMENT_FILE"
+
+        # Get all jobs from the current workflow run
+        JOBS_JSON=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100")
+
+        # Filter unsuccessful jobs (failure, cancelled)
+        UNSUCCESSFUL_JOBS=$(echo "$JOBS_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .id')
+
+        if [ -z "$UNSUCCESSFUL_JOBS" ]; then
+          echo "ℹ️ No unsuccessful jobs found." | tee -a "$COMMENT_FILE"
+          echo "comment-file=$COMMENT_FILE" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        JOB_COUNT=$(echo "$UNSUCCESSFUL_JOBS" | wc -l)
+        echo "Found **${JOB_COUNT}** unsuccessful job(s)" | tee -a "$COMMENT_FILE"
+        echo "" | tee -a "$COMMENT_FILE"
+
+        # Collect annotations for each unsuccessful job
+        for JOB_ID in $UNSUCCESSFUL_JOBS; do
+          JOB_INFO=$(echo "$JOBS_JSON" | jq -r ".jobs[] | select(.id == $JOB_ID)")
+          JOB_NAME=$(echo "$JOB_INFO" | jq -r '.name')
+          JOB_CONCLUSION=$(echo "$JOB_INFO" | jq -r '.conclusion')
+          JOB_URL=$(echo "$JOB_INFO" | jq -r '.html_url')
+
+          echo "### 📋 GHA job: \`$JOB_NAME\` (${JOB_CONCLUSION})" | tee -a "$COMMENT_FILE"
+          echo "🔗 [View job logs]($JOB_URL)" | tee -a "$COMMENT_FILE"
+          echo "" | tee -a "$COMMENT_FILE"
+
+          # Get annotations for this job
+          ANNOTATIONS=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/check-runs/$JOB_ID/annotations?per_page=100")
+
+          ANNOTATION_COUNT=$(echo "$ANNOTATIONS" | jq '. | length')
+
+          if [ "$ANNOTATION_COUNT" -eq 0 ]; then
+            echo "No GHA annotations found for this job." | tee -a "$COMMENT_FILE"
+            echo "" | tee -a "$COMMENT_FILE"
+          else
+            echo "Found $ANNOTATION_COUNT GHA annotation(s):" | tee -a "$COMMENT_FILE"
+            echo "" | tee -a "$COMMENT_FILE"
+
+            # Format annotations for display
+            echo "$ANNOTATIONS" | jq -r '.[] | "- **\(.annotation_level | ascii_upcase)**: \(.message)"' | tee -a "$COMMENT_FILE"
+
+            echo "" | tee -a "$COMMENT_FILE"
+          fi
+
+          echo "---" | tee -a "$COMMENT_FILE"
+          echo "" | tee -a "$COMMENT_FILE"
+        done
+
+        echo "" | tee -a "$COMMENT_FILE"
+        echo "_Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')_" | tee -a "$COMMENT_FILE"
+
+        # Set output for next step
+        echo "comment-file=$COMMENT_FILE" >> "$GITHUB_OUTPUT"
+
+        exit 0  # Don't fail the step
+
+    - name: Upsert CI failure analysis PR comment
+      if: github.event_name == 'pull_request' && inputs.has_failures == 'true' && steps.collect-annotations.outputs.comment-file != ''
+      uses: peter-evans/create-or-update-comment@v5
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-path: ${{ steps.collect-annotations.outputs.comment-file }}
+        edit-mode: replace

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -162,6 +162,9 @@ runs:
     with:
       distribution: ${{ inputs.java-distribution }}
       java-version: ${{ inputs.java-version }}
+  - name: Register Maven problem matcher
+    shell: bash
+    run: echo "::add-matcher::.github/maven-matcher.json"
   - name: Setup Maven
     if: inputs.maven-version != ''
     uses: ./.github/actions/setup-maven-dist

--- a/.github/maven-matcher.json
+++ b/.github/maven-matcher.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "maven-goal-failure",
+      "pattern": [
+        {
+          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>Failed to execute goal\\s+.+)$",
+          "message": 1
+        }
+      ]
+    },
+    {
+      "owner": "maven-surefire-test",
+      "pattern": [
+        {
+          "regexp": "^\\s*\\[ERROR\\]\\s+(?<message>[A-Za-z0-9_$.]+\\s+--\\s+Time elapsed:.*)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1333,7 +1333,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
+      actions: read
       checks: read
+      pull-requests: write
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - archunit-tests
@@ -1372,6 +1374,12 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - name: Post CI Failure Reasons
+        continue-on-error: true
+        uses: ./.github/actions/post-ci-failure-reasons
+        with:
+          github_token: ${{ github.token }}
+          has_failures: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
       - run: |
           echo "The \`check-results\` job has the function to fail if any previous job was unsuccessful!"
           echo "If you're reading this and wondering what the is the problem, please check other GHA jobs of this workflow run to for errors/cancellation and see their logs."


### PR DESCRIPTION
## Description

This PR adds automated failure analysis to the CI workflow by collecting and posting GitHub Actions job annotations from unsuccessful jobs. When CI jobs fail or are cancelled, the `check-results` job now automatically collects error annotations and posts them as a self-updating comment on pull requests, making it much easier for developers to understand what went wrong without having to dig through multiple job logs.

In addition to annotations created by GitHub Actions itself (timeouts, process exited with error), this PR also contributes a GHA problem matcher as an easy way to capture most relevant errors from Maven.

ℹ️ See https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md for how GHA problem matchers work. See below for limitations

See https://github.com/camunda/camunda/pull/44836#issuecomment-3823939955 for a demonstration of how the output looks like for real problems.

<img width="1101" height="938" alt="image" src="https://github.com/user-attachments/assets/f2fc518d-b5fb-4f04-9c61-6bbed45ce587" />

## What's Changed

### 1. New Composite Action: `post-ci-failure-reasons`

Created a reusable composite action at `.github/actions/post-ci-failure-reasons/` that:

- Collects annotations (errors, warnings, notices) from all failed/cancelled jobs in the workflow run
- Formats them in a readable markdown format with job names, status, and links
- Posts them as a PR comment on pull request events
- Automatically updates the same comment on subsequent runs to avoid clutter

**Key Features:**
- 🔍 **Automatic detection**: Uses GitHub REST API to query all unsuccessful jobs for annotations from any source
- 📋 **Rich formatting**: Includes job names, conclusion status, direct links to logs, and structured annotation display
- 🔄 **Self-updating**: Uses a hidden HTML marker to identify and update existing comments
- 🌐 **Universal compatibility**: Works on PRs, merge queue, main branch, scheduled runs, etc. (comments only on PRs)
- 🛡️ **Graceful degradation**: Never fails the workflow, handles errors silently

### 2. Updated CI Workflow

Modified the Unified CI `check-results` job to use the new composite action:

- Added `actions: read` permission (to query workflow run data)
- Added `pull-requests: write` permission (to post/update PR comments)
- Integrated the action with minimal configuration

### 3. Complete Documentation

Added comprehensive README for the composite action including:
- Purpose and benefits
- Input/output specifications
- Usage examples for different scenarios
- Permissions requirements
- Output format specification

## Example Output

The action generates comments like this on pull requests:

```markdown
## 🔍 CI Failure Analysis

GHA workflow run: [#123](https://github.com/camunda/camunda/actions/runs/456)

Found **2** unsuccessful job(s)

### 📋 GHA job: `test-suite` (failure)
🔗 [View job logs](https://github.com/camunda/camunda/actions/runs/456/job/789)

Found 3 GHA annotation(s):

- **ERROR**: Test failed: AssertionError expected 5 but got 3
- **WARNING**: Deprecated API usage detected in module X
- **NOTICE**: Code coverage below 80% threshold

---

_Last updated: 2026-01-30 12:34:56 UTC_
```

## Known Limitations

- Maximum 100 jobs per workflow run + 100 annotations per job (uses `per_page=100`)
    - Workflows with more jobs or annotations will have truncated results but we should be below that
- GHA problem matchers can only find singular lines, annotations will lack stack traces etc
    - Should be fine for a first overview, links to job logs are available
- PR comments only work on `pull_request` events
   - Other events (merge queue, main branch, scheduled) only show output in job logs

## Benefits

✅ **Improved Developer Experience**: Errors visible directly in PR comments, no need to hunt through logs  
✅ **Faster Debugging**: Quick overview of all failures in one place  
✅ **Reduced Context Switching**: Developers stay in the PR conversation  
✅ **Reusable**: Composite action can be used in other workflows  
✅ **Maintainable**: Centralized logic with comprehensive documentation  
✅ **Non-intrusive**: Doesn't change existing workflow behavior, only adds visibility  

## Technical Details

- Uses GitHub CLI (`gh`) for API interactions
- Uses `peter-evans/find-comment@v3` and `peter-evans/create-or-update-comment@v5` for PR comment management
- Follows all GitHub Actions best practices from AGENTS.md
- Passes `actionlint` validation without errors

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)) - makes sense but first lets wait for feedback on `main`

## Related issues

None, outcome of hackathon