### PR TITLE
refactor: move query keys into keys factory

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
@@ -76,7 +76,7 @@ const VariablePanel: React.FC<Props> = observer(function VariablePanel({
         kind: listenerTypeFilter,
       },
     },
-    disabled: !shouldFetchListeners,
+    enabled: !!shouldFetchListeners,
     select: (data) => data.pages?.flatMap((page) => page.items),
   });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -50,7 +50,7 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
         listenerEventType: 'UNSPECIFIED',
       },
     },
-    disabled: !elementInstanceKey,
+    enabled: !!elementInstanceKey,
     select: (data) => data.pages?.flatMap((page) => page.items),
   });
 

--- a/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/react-query';
 import {cancelProcessInstance} from 'modules/api/v2/processInstances/cancelProcessInstance';
 import {fetchProcessInstance} from 'modules/api/v2/processInstances/fetchProcessInstance';
-import {getProcessInstanceQueryKey} from 'modules/queries/processInstance/useProcessInstance';
+import {queryKeys} from 'modules/queries/queryKeys';
 
 function useCancelProcessInstance(
   processInstanceKey: string,
@@ -36,7 +36,7 @@ function useCancelProcessInstance(
       }
 
       await queryClient.fetchQuery({
-        queryKey: getProcessInstanceQueryKey(processInstanceKey),
+        queryKey: queryKeys.processInstance.get(processInstanceKey),
         queryFn: async () => {
           const {response: processInstance, error} =
             await fetchProcessInstance(processInstanceKey);

--- a/operate/client/src/modules/mutations/processInstance/useDeleteProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useDeleteProcessInstance.tsx
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/react-query';
 import {deleteProcessInstance} from 'modules/api/v2/processInstances/deleteProcessInstance';
 import {fetchProcessInstance} from 'modules/api/v2/processInstances/fetchProcessInstance';
-import {getProcessInstanceQueryKey} from 'modules/queries/processInstance/useProcessInstance';
+import {queryKeys} from 'modules/queries/queryKeys';
 
 function useDeleteProcessInstance(
   processInstanceKey: string,
@@ -39,11 +39,11 @@ function useDeleteProcessInstance(
       }
 
       queryClient.removeQueries({
-        queryKey: getProcessInstanceQueryKey(processInstanceKey),
+        queryKey: queryKeys.processInstance.get(processInstanceKey),
       });
 
       await queryClient.fetchQuery({
-        queryKey: getProcessInstanceQueryKey(processInstanceKey),
+        queryKey: queryKeys.processInstance.get(processInstanceKey),
         queryFn: async () => {
           const {response: processInstance, error} =
             await fetchProcessInstance(processInstanceKey);

--- a/operate/client/src/modules/queries/callHierarchy/useCallHierarchy.ts
+++ b/operate/client/src/modules/queries/callHierarchy/useCallHierarchy.ts
@@ -9,19 +9,14 @@
 import {useQuery} from '@tanstack/react-query';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {fetchCallHierarchy} from 'modules/api/v2/processInstances/fetchCallHierarchy';
-
-const CALL_HIERARCHY_QUERY_KEY = 'callHierarchy';
-
-function getQueryKey(processInstanceKey?: string) {
-  return [CALL_HIERARCHY_QUERY_KEY, processInstanceKey];
-}
+import {queryKeys} from '../queryKeys';
 
 const useCallHierarchy = (
   {processInstanceKey}: Pick<ProcessInstance, 'processInstanceKey'>,
   {enabled}: {enabled: boolean},
 ) => {
   return useQuery({
-    queryKey: getQueryKey(processInstanceKey),
+    queryKey: queryKeys.callHierarchy.get(processInstanceKey),
     queryFn: async () => {
       const {response, error} = await fetchCallHierarchy(processInstanceKey);
 

--- a/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
@@ -9,8 +9,7 @@
 import {skipToken, useQuery} from '@tanstack/react-query';
 import {fetchElementInstance} from '../../api/v2/elementInstances/fetchElementInstance';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
-
-const ELEMENT_INSTANCE_QUERY_KEY = 'elementInstance';
+import {queryKeys} from '../queryKeys';
 
 const useElementInstance = <T = ElementInstance>(
   elementInstanceKey: string,
@@ -20,7 +19,7 @@ const useElementInstance = <T = ElementInstance>(
   },
 ) => {
   return useQuery({
-    queryKey: [ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey],
+    queryKey: queryKeys.elementInstance.get(elementInstanceKey),
     queryFn: elementInstanceKey
       ? async () => {
           const {response, error} = await fetchElementInstance({

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
@@ -14,12 +14,7 @@ import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstan
 import isEmpty from 'lodash/isEmpty';
 import {useBusinessObjects} from '../processDefinitions/useBusinessObjects';
 import {useIsProcessInstanceRunning} from '../processInstance/useIsProcessInstanceRunning';
-
-const FLOWNODE_INSTANCES_STATISTICS_QUERY_KEY = 'flownodeInstancesStatistics';
-
-function getQueryKey(processInstanceKey?: string) {
-  return [FLOWNODE_INSTANCES_STATISTICS_QUERY_KEY, processInstanceKey];
-}
+import {queryKeys} from '../queryKeys';
 
 const useFlownodeInstancesStatistics = <
   T = GetProcessInstanceStatisticsResponseBody,
@@ -32,7 +27,9 @@ const useFlownodeInstancesStatistics = <
   const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
 
   return useQuery({
-    queryKey: getQueryKey(processInstanceId),
+    queryKey: queryKeys.flowNodeInstancesStatistics.get(
+      processInstanceId ?? '',
+    ),
     queryFn:
       enabled && !!processInstanceId && !isEmpty(businessObjects)
         ? async () => {

--- a/operate/client/src/modules/queries/jobs/useJobs.ts
+++ b/operate/client/src/modules/queries/jobs/useJobs.ts
@@ -16,20 +16,16 @@ import {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import type {RequestError} from 'modules/request';
 import {searchJobs} from 'modules/api/v2/jobs/searchJobs';
+import {queryKeys} from '../queryKeys';
 
 const MAX_JOBS_PER_REQUEST = 50;
-const JOBS_SEARCH_QUERY_KEY = 'jobsSearch';
-
-function getQueryKey(payload: QueryJobsRequestBody) {
-  return [JOBS_SEARCH_QUERY_KEY, ...Object.values(payload)];
-}
 
 function useJobs<T = QueryJobsResponseBody>(options: {
   payload: QueryJobsRequestBody;
   select?: (data: {pages: QueryJobsResponseBody[]; pageParams: unknown[]}) => T;
-  disabled?: boolean;
+  enabled?: boolean;
 }): UseInfiniteQueryResult<T, RequestError> {
-  const {payload, select, disabled} = options;
+  const {payload, select, enabled} = options;
   return useInfiniteQuery<
     QueryJobsResponseBody,
     RequestError,
@@ -37,7 +33,7 @@ function useJobs<T = QueryJobsResponseBody>(options: {
     (string | unknown)[],
     number
   >({
-    queryKey: getQueryKey(payload),
+    queryKey: queryKeys.jobs.search(payload),
     queryFn: async ({pageParam}) => {
       const {response, error} = await searchJobs({
         ...payload,
@@ -76,7 +72,7 @@ function useJobs<T = QueryJobsResponseBody>(options: {
       return previousPage;
     },
     select,
-    enabled: !disabled,
+    enabled: enabled,
   });
 }
 

--- a/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
+++ b/operate/client/src/modules/queries/messageSubscriptions/useSearchMessageSubscriptions.ts
@@ -7,17 +7,28 @@
  */
 
 import {useQuery} from '@tanstack/react-query';
-import {type QueryMessageSubscriptionsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
+import {
+  type QueryMessageSubscriptionsRequestBody,
+  type QueryMessageSubscriptionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 import {searchMessageSubscriptions} from 'modules/api/v2/messageSubscriptions/searchMessageSubscriptions';
+import {queryKeys} from '../queryKeys';
 
-const useSearchMessageSubscriptions = (
+type QueryOptions<T> = {
+  select?: (result: QueryMessageSubscriptionsResponseBody) => T;
+  enabled?: boolean;
+};
+
+const useSearchMessageSubscriptions = <
+  T = QueryMessageSubscriptionsResponseBody,
+>(
   payload: QueryMessageSubscriptionsRequestBody,
-  options?: {enabled?: boolean},
+  options?: QueryOptions<T>,
 ) => {
-  const {enabled = true} = options ?? {};
+  const {enabled = true, select} = options ?? {};
 
   return useQuery({
-    queryKey: ['incidentsSearch', payload],
+    queryKey: queryKeys.messageSubscriptions.search(payload),
     queryFn: async () => {
       const {response, error} = await searchMessageSubscriptions(payload);
       if (response !== null) {
@@ -26,6 +37,7 @@ const useSearchMessageSubscriptions = (
       throw error;
     },
     enabled,
+    select,
   });
 };
 

--- a/operate/client/src/modules/queries/processInstance/useProcessInstance.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessInstance.ts
@@ -12,12 +12,7 @@ import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {fetchProcessInstance} from 'modules/api/v2/processInstances/fetchProcessInstance';
 import {isInstanceRunning} from 'modules/utils/instance';
-
-const PROCESS_INSTANCE_QUERY_KEY = 'processInstance';
-
-function getProcessInstanceQueryKey(processInstanceKey?: string) {
-  return [PROCESS_INSTANCE_QUERY_KEY, processInstanceKey];
-}
+import {queryKeys} from '../queryKeys';
 
 const useProcessInstance = <T = ProcessInstance>(
   select?: (data: ProcessInstance) => T,
@@ -25,7 +20,7 @@ const useProcessInstance = <T = ProcessInstance>(
   const {processInstanceId} = useProcessInstancePageParams();
 
   return useQuery({
-    queryKey: getProcessInstanceQueryKey(processInstanceId),
+    queryKey: queryKeys.processInstance.get(processInstanceId ?? ''),
     queryFn: processInstanceId
       ? async () => {
           const {response, error} =
@@ -49,4 +44,4 @@ const useProcessInstance = <T = ProcessInstance>(
   });
 };
 
-export {useProcessInstance, getProcessInstanceQueryKey};
+export {useProcessInstance};

--- a/operate/client/src/modules/queries/processInstance/useProcessInstancesSearch.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessInstancesSearch.ts
@@ -12,8 +12,7 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {useQuery} from '@tanstack/react-query';
 import {searchProcessInstances} from 'modules/api/v2/processInstances/searchProcessInstances';
-
-const PROCESS_INSTANCES_SEARCH_QUERY_KEY = 'processInstancesSearch';
+import {queryKeys} from '../queryKeys';
 
 type QueryOptions<T> = {
   enabled?: boolean;
@@ -25,7 +24,7 @@ const useProcessInstancesSearch = <T = QueryProcessInstancesResponseBody>(
   options?: QueryOptions<T>,
 ) => {
   return useQuery({
-    queryKey: [PROCESS_INSTANCES_SEARCH_QUERY_KEY, payload],
+    queryKey: queryKeys.processInstances.search(payload),
     queryFn: async () => {
       const {response, error} = await searchProcessInstances(payload);
       if (response !== null) {

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -16,6 +16,8 @@ import type {
   QueryDecisionInstancesRequestBody,
   QueryElementInstanceIncidentsRequestBody,
   QueryElementInstancesRequestBody,
+  QueryJobsRequestBody,
+  QueryMessageSubscriptionsRequestBody,
   QueryProcessInstanceIncidentsRequestBody,
   QueryProcessInstancesRequestBody,
   Variable,
@@ -161,6 +163,10 @@ const queryKeys = {
   },
   processInstances: {
     base: () => ['processInstances'],
+    search: (payload: QueryProcessInstancesRequestBody) => [
+      'processInstancesSearch',
+      payload,
+    ],
     searchPaginated: (payload: QueryProcessInstancesRequestBody) => [
       'processInstances',
       'search',
@@ -206,6 +212,51 @@ const queryKeys = {
     get: (
       payload?: GetIncidentProcessInstanceStatisticsByDefinitionRequestBody,
     ) => ['incidentProcessInstanceStatisticsByDefinition', payload],
+  },
+  messageSubscriptions: {
+    search: (payload: QueryMessageSubscriptionsRequestBody) => [
+      'messageSubscriptionsSearch',
+      payload,
+    ],
+  },
+  currentUser: {
+    get: () => ['currentUser'],
+  },
+  userTasks: {
+    getByElementInstance: (elementInstanceKey: string) => [
+      'userTasksByElementInstance',
+      elementInstanceKey,
+    ],
+  },
+  variable: {
+    get: (variableKey: string) => ['variable', variableKey],
+  },
+  elementInstance: {
+    get: (elementInstanceKey: string) => [
+      'elementInstance',
+      elementInstanceKey,
+    ],
+  },
+  flowNodeInstancesStatistics: {
+    get: (processInstanceKey: string) => [
+      'flowNodeInstancesStatistics',
+      processInstanceKey,
+    ],
+  },
+  callHierarchy: {
+    get: (processInstanceKey: string) => ['callHierarchy', processInstanceKey],
+  },
+  sequenceFlows: {
+    get: (processInstanceKey: string) => ['sequenceFlows', processInstanceKey],
+  },
+  jobs: {
+    search: (payload: QueryJobsRequestBody) => ['jobsSearch', payload],
+  },
+  processInstance: {
+    get: (processInstanceKey: string) => [
+      'processInstance',
+      processInstanceKey,
+    ],
   },
 };
 

--- a/operate/client/src/modules/queries/sequenceFlows/useProcessSequenceFlows.ts
+++ b/operate/client/src/modules/queries/sequenceFlows/useProcessSequenceFlows.ts
@@ -10,12 +10,7 @@ import {fetchProcessSequenceFlows} from 'modules/api/v2/processInstances/sequenc
 import {skipToken, useQuery, type UseQueryResult} from '@tanstack/react-query';
 import type {GetProcessInstanceSequenceFlowsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import type {RequestError} from 'modules/request';
-
-const SEQUENCE_FLOWS_QUERY_KEY = 'processSequenceFlows';
-
-function getQueryKey(processInstanceKey?: string) {
-  return [SEQUENCE_FLOWS_QUERY_KEY, processInstanceKey];
-}
+import {queryKeys} from '../queryKeys';
 
 const processedSequenceFlowsParser = (
   sequenceFlowsResponse: GetProcessInstanceSequenceFlowsResponseBody,
@@ -29,7 +24,7 @@ function useProcessSequenceFlows(
   processInstanceKey?: string,
 ): UseQueryResult<string[], RequestError> {
   return useQuery({
-    queryKey: getQueryKey(processInstanceKey),
+    queryKey: queryKeys.sequenceFlows.get(processInstanceKey ?? ''),
     queryFn: processInstanceKey
       ? async () => {
           const {response, error} =

--- a/operate/client/src/modules/queries/useCurrentUser.ts
+++ b/operate/client/src/modules/queries/useCurrentUser.ts
@@ -8,9 +8,10 @@
 
 import {useQuery, queryOptions} from '@tanstack/react-query';
 import {getMe} from 'modules/api/v2/authentication/me';
+import {queryKeys} from './queryKeys';
 
 const currentUserQueryOptions = queryOptions({
-  queryKey: ['currentUser'],
+  queryKey: queryKeys.currentUser.get(),
   queryFn: async () => {
     const {response, error} = await getMe();
 

--- a/operate/client/src/modules/queries/userTasks/useGetUserTaskByElementInstance.ts
+++ b/operate/client/src/modules/queries/userTasks/useGetUserTaskByElementInstance.ts
@@ -9,16 +9,14 @@
 import {useQuery} from '@tanstack/react-query';
 import {searchUserTasks} from 'modules/api/v2/userTasks/searchUserTasks';
 import type {QueryUserTasksRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
-
-const USER_TASKS_BY_ELEMENT_INSTANCE_QUERY_KEY =
-  'useGetUserTaskByElementInstance';
+import {queryKeys} from '../queryKeys';
 
 const useGetUserTaskByElementInstance = (
   elementInstanceKey: string,
   options: {enabled: boolean} = {enabled: true},
 ) => {
   return useQuery({
-    queryKey: [USER_TASKS_BY_ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey],
+    queryKey: queryKeys.userTasks.getByElementInstance(elementInstanceKey),
     queryFn: async () => {
       const payload: QueryUserTasksRequestBody = {
         filter: {elementInstanceKey},

--- a/operate/client/src/modules/queries/variables/useVariable.ts
+++ b/operate/client/src/modules/queries/variables/useVariable.ts
@@ -8,11 +8,12 @@
 
 import {useQuery} from '@tanstack/react-query';
 import {getVariable} from 'modules/api/v2/variables/getVariable';
+import {queryKeys} from '../queryKeys';
 
 function useVariable(variableKey: string, options?: {enabled?: boolean}) {
   const {enabled} = options ?? {};
   return useQuery({
-    queryKey: ['variable', variableKey],
+    queryKey: queryKeys.variable.get(variableKey),
     queryFn: async () => {
       const {response, error} = await getVariable(variableKey);
 


### PR DESCRIPTION
## Description

- Move all existing query keys to the query key factory
- Update `disabled` with `enabled` for jobs query for consistency 

## Related issues

closes #37111 
