### PR TITLE
fix: use known appended position for the scaling position

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -196,7 +196,7 @@ public class ScaleUpTest {
     final var getStatusCommand =
         RecordToWrite.command().scale(ScaleIntent.STATUS, new ScaleRecord().status());
     // when
-    final var key = engine.writeRecords(scaleUpCommand, getStatusCommand);
+    final var highestPositionAppended = engine.writeRecords(scaleUpCommand, getStatusCommand);
 
     // then
     final var record =
@@ -205,8 +205,9 @@ public class ScaleUpTest {
             .getLast();
     assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(record.getValue().getRedistributedPartitions()).containsExactly(1, 2);
-    // SCALE_UP command is the first command
-    assertThat(record.getValue().getScalingPosition()).isEqualTo(4);
+    // SCALE_UP command is the first command we manually appended, meaning it is positioned 1 before
+    // the status command
+    assertThat(record.getValue().getScalingPosition()).isEqualTo(highestPositionAppended - 1);
     assertThat(record.getValue().getMessageCorrelationPartitions()).isEqualTo(2);
 
     // when the partitions are marked as bootstrapped


### PR DESCRIPTION
## Description

This PR fixes a flaky test relying on deterministic amount of records being pre-written to figure out the position. Since scheduled commands make this unpredictable, we use a relative position based on what we just wrote.
