### PR TITLE
hackathon: Disable Archiver

### DIFF
--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -77,7 +77,7 @@ elasticsearch:
         cpu: 3
         memory: 3Gi
       limits:
-        cpu: 3
+        cpu: 6
         memory: 6Gi
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -51,13 +51,15 @@ public abstract class ElasticsearchUtil {
 
   public static String whereToSearch(
       final IndexTemplateDescriptor template, final QueryType queryType) {
-    switch (queryType) {
-      case ONLY_RUNTIME:
-        return template.getFullQualifiedName();
-      case ALL:
-      default:
-        return template.getAlias();
-    }
+    // TODO: Sort this out
+    //    switch (queryType) {
+    //      case ONLY_RUNTIME:
+    //        return template.getFullQualifiedName();
+    //      case ALL:
+    //      default:
+    //        return template.getAlias();
+    //    }
+    return template.getAlias();
   }
 
   public static Query joinWithOr(final Query... queries) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -18,6 +18,11 @@ import java.util.Map;
 public interface SearchEngineClient extends CloseableSilently {
   void createIndex(final IndexDescriptor indexDescriptor, final IndexConfiguration settings);
 
+  void createIndex(
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final IndexConfiguration settings);
+
   /**
    * @param indexDescriptor indexDescriptor
    * @param indexConfiguration indexConfiguration
@@ -33,7 +38,9 @@ public interface SearchEngineClient extends CloseableSilently {
    * @param newProperties New properties to be appended to the index
    */
   void putMapping(
-      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties);
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final Collection<IndexMappingProperty> newProperties);
 
   Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource);

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/IndexConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.schema.config;
 
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -14,6 +16,7 @@ import java.util.Objects;
 public class IndexConfiguration {
   public static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191;
 
+  private int partitionId = START_PARTITION_ID;
   private Integer numberOfShards = 1;
   private Integer numberOfReplicas = 1;
   private Integer templatePriority;
@@ -22,6 +25,14 @@ public class IndexConfiguration {
   private Map<String, Integer> shardsByIndexName = new HashMap<>();
 
   private Integer variableSizeThreshold = DEFAULT_VARIABLE_SIZE_THRESHOLD;
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
 
   public Integer getNumberOfShards() {
     return numberOfShards;

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.schema.config;
 
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.time.Duration;
 
@@ -15,6 +17,7 @@ public class SchemaManagerConfiguration {
   private boolean isCreateSchema = true;
   private SchemaManagerRetryConfiguration retry = new SchemaManagerRetryConfiguration();
   private boolean versionCheckRestrictionEnabled = true;
+  private int partitionId = START_PARTITION_ID;
 
   public boolean isCreateSchema() {
     return isCreateSchema;
@@ -38,6 +41,14 @@ public class SchemaManagerConfiguration {
 
   public void setVersionCheckRestrictionEnabled(final boolean versionCheckRestrictionEnabled) {
     this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
   }
 
   public static class SchemaManagerRetryConfiguration extends RetryConfiguration {

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -8,6 +8,7 @@
 package io.camunda.search.schema.elasticsearch;
 
 import static io.camunda.search.schema.utils.SearchEngineClientUtils.convertValue;
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.AcknowledgedResponse;
@@ -84,13 +85,25 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   @Override
   public void createIndex(
       final IndexDescriptor indexDescriptor, final IndexConfiguration settings) {
-    final CreateIndexRequest request = createIndexRequest(indexDescriptor, settings);
+    createIndex(START_PARTITION_ID, indexDescriptor, settings);
+  }
+
+  @Override
+  public void createIndex(
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final IndexConfiguration settings) {
+    final CreateIndexRequest request = createIndexRequest(partitionId, indexDescriptor, settings);
     try {
       client.indices().create(request);
-      LOG.debug("Index [{}] was successfully created", indexDescriptor.getFullQualifiedName());
+      LOG.debug(
+          "Index [{}] was successfully created",
+          indexDescriptor.getShardedFullQualifiedName(partitionId));
     } catch (final IOException ioe) {
       final var errMsg =
-          String.format("Index [%s] was not created", indexDescriptor.getFullQualifiedName());
+          String.format(
+              "Index [%s] was not created",
+              indexDescriptor.getShardedFullQualifiedName(partitionId));
       LOG.error(errMsg, ioe);
       throw new SearchEngineException(errMsg, ioe);
     } catch (final ElasticsearchException elsEx) {
@@ -100,13 +113,15 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
         final var warnMsg =
             String.format(
                 "Expected to create index [%s], but already exist. Will continue, likely was created by a different instance.",
-                indexDescriptor.getFullQualifiedName());
+                indexDescriptor.getShardedFullQualifiedName(partitionId));
         LOG.debug(warnMsg, elsEx);
         return;
       }
 
       final var errMsg =
-          String.format("Index [%s] was not created", indexDescriptor.getFullQualifiedName());
+          String.format(
+              "Index [%s] was not created",
+              indexDescriptor.getShardedFullQualifiedName(partitionId));
       LOG.error(errMsg, elsEx);
       throw new SearchEngineException(errMsg, elsEx);
     }
@@ -147,15 +162,21 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
   @Override
   public void putMapping(
-      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final Collection<IndexMappingProperty> newProperties) {
     final PutMappingRequest request = putMappingRequest(indexDescriptor, newProperties);
 
     try {
       client.indices().putMapping(request);
-      LOG.debug("Mapping in [{}] was successfully updated", indexDescriptor.getFullQualifiedName());
+      LOG.debug(
+          "Mapping in [{}] was successfully updated",
+          indexDescriptor.getShardedFullQualifiedName(partitionId));
     } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
-          String.format("Mapping in [%s] was NOT updated", indexDescriptor.getFullQualifiedName());
+          String.format(
+              "Mapping in [%s] was NOT updated",
+              indexDescriptor.getShardedFullQualifiedName(partitionId));
       LOG.error(errMsg, e);
       throw new SearchEngineException(errMsg, e);
     }
@@ -585,7 +606,9 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   }
 
   private CreateIndexRequest createIndexRequest(
-      final IndexDescriptor indexDescriptor, final IndexConfiguration settings) {
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final IndexConfiguration settings) {
     try (final var templateFile =
         getResourceAsStream(indexDescriptor.getMappingsClasspathFilename())) {
 
@@ -598,7 +621,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                   .build());
 
       return new CreateIndexRequest.Builder()
-          .index(indexDescriptor.getFullQualifiedName())
+          .index(indexDescriptor.getShardedFullQualifiedName(partitionId))
           .aliases(indexDescriptor.getAlias(), a -> a.isWriteIndex(false))
           .mappings(templateFields.mappings())
           .settings(templateFields.settings())

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -8,6 +8,7 @@
 package io.camunda.search.schema.opensearch;
 
 import static io.camunda.search.schema.utils.SearchEngineClientUtils.convertValue;
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -94,6 +95,14 @@ public class OpensearchEngineClient implements SearchEngineClient {
   @Override
   public void createIndex(
       final IndexDescriptor indexDescriptor, final IndexConfiguration settings) {
+    createIndex(START_PARTITION_ID, indexDescriptor, settings);
+  }
+
+  @Override
+  public void createIndex(
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final IndexConfiguration settings) {
     final CreateIndexRequest request = createIndexRequest(indexDescriptor, settings);
 
     try {
@@ -159,7 +168,9 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
   @Override
   public void putMapping(
-      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {
+      final int partitionId,
+      final IndexDescriptor indexDescriptor,
+      final Collection<IndexMappingProperty> newProperties) {
     final PutMappingRequest request = putMappingRequest(indexDescriptor, newProperties);
 
     try {

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
@@ -78,7 +78,7 @@ public class ElasticsearchEngineClientIT {
     newProperties.add(new IndexMappingProperty("email", Map.of("type", "keyword")));
 
     // when
-    elsEngineClient.putMapping(descriptor, newProperties);
+    elsEngineClient.putMapping(1, descriptor, newProperties);
 
     // then
     final var index = elsClient.indices().get(req -> req.index(indexName)).get(indexName);

--- a/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/opensearch/OpensearchEngineClientIT.java
@@ -152,7 +152,7 @@ public class OpensearchEngineClientIT {
     newProperties.add(new IndexMappingProperty("age", Map.of("type", "integer")));
 
     // when
-    opensearchEngineClient.putMapping(descriptor, newProperties);
+    opensearchEngineClient.putMapping(1, descriptor, newProperties);
 
     // then
     final var indices =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
 public abstract class AbstractIndexDescriptor implements IndexDescriptor {
 
   public static final String SCHEMA_FOLDER_OPENSEARCH = "/schema/opensearch/create";
@@ -34,7 +36,13 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
         formattedIndexPrefix(),
         getComponentName(),
         getIndexName(),
-        getVersion());
+        getVersion(),
+        START_PARTITION_ID);
+  }
+
+  @Override
+  public String getShardedFullQualifiedName(final int partitionId) {
+    return String.format("%sp%s", getFullQualifiedName(), partitionId);
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
@@ -17,6 +17,8 @@ public interface IndexDescriptor {
 
   String getFullQualifiedName();
 
+  String getShardedFullQualifiedName(int partitionId);
+
   String getAlias();
 
   String getIndexName();

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/AuthorizationIndex.java
@@ -29,6 +29,16 @@ public class AuthorizationIndex extends AbstractIndexDescriptor implements Prio5
   }
 
   @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getFullQualifiedName() {
+    return super.getFullQualifiedName();
+  }
+
+  @Override
   public String getVersion() {
     return INDEX_VERSION;
   }
@@ -36,10 +46,5 @@ public class AuthorizationIndex extends AbstractIndexDescriptor implements Prio5
   @Override
   public String getComponentName() {
     return ComponentNames.CAMUNDA.toString();
-  }
-
-  @Override
-  public String getIndexName() {
-    return INDEX_NAME;
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/PersistentWebSessionIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/PersistentWebSessionIndexDescriptor.java
@@ -28,6 +28,11 @@ public class PersistentWebSessionIndexDescriptor extends AbstractIndexDescriptor
   }
 
   @Override
+  public String getShardedFullQualifiedName(final int partitionId) {
+    return super.getFullQualifiedName();
+  }
+
+  @Override
   public String getVersion() {
     return INDEX_VERSION;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -126,6 +126,7 @@ public class CamundaExporter implements Exporter {
 
       try (final var schemaManager = createSchemaManager()) {
         if (!schemaManager.isSchemaReadyForUse()) {
+          schemaManager.startup();
           throw new ExporterException("Schema is not ready for use");
         }
       }
@@ -272,6 +273,8 @@ public class CamundaExporter implements Exporter {
   private SchemaManager createSchemaManager() {
     final var schemaManagerConfiguration = new SchemaManagerConfiguration();
     schemaManagerConfiguration.setCreateSchema(configuration.isCreateSchema());
+    schemaManagerConfiguration.setPartitionId(context.getPartitionId());
+
     return new SchemaManager(
         searchEngineClient,
         provider.getIndexDescriptors(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -89,6 +89,7 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
+  private long lastFlushTimestamp = 0L;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
@@ -146,7 +147,7 @@ public class CamundaExporter implements Exporter {
       writer = createBatchWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
-      scheduleDelayedFlush();
+      scheduleDelayedFlush(System.currentTimeMillis());
 
       LOG.info("Exporter opened");
     } catch (final Exception e) {
@@ -319,19 +320,29 @@ public class CamundaExporter implements Exporter {
     return builder.build();
   }
 
-  private void scheduleDelayedFlush() {
-    controller.scheduleCancellableTask(
-        Duration.ofSeconds(configuration.getBulk().getDelay()), this::flushAndReschedule);
+  private void scheduleDelayedFlush(final long now) {
+    long delta = configuration.getBulk().getDelay();
+    if (lastFlushTimestamp > 0) {
+      delta =
+          Math.min(
+              configuration.getBulk().getDelay() * 1000L - (now - lastFlushTimestamp),
+              configuration.getBulk().getDelay() * 1000L);
+    }
+
+    controller.scheduleCancellableTask(Duration.ofMillis(delta), this::flushAndReschedule);
   }
 
   private void flushAndReschedule() {
+    final var now = System.currentTimeMillis();
     try {
-      flush();
-      updateLastExportedPosition(lastPosition);
+      if (now - lastFlushTimestamp >= configuration.getBulk().getDelay() * 1000L) {
+        flush();
+        updateLastExportedPosition(lastPosition);
+      }
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred on periodically flushing bulk, will retry later.", e);
     }
-    scheduleDelayedFlush();
+    scheduleDelayedFlush(now);
   }
 
   private void flush() {
@@ -353,6 +364,8 @@ public class CamundaExporter implements Exporter {
     // Update the record counters only after the flush was successful. If the synchronous flush
     // fails then the exporter will be invoked with the same record again.
     updateLastExportedPosition(lastPosition);
+
+    lastFlushTimestamp = System.currentTimeMillis();
   }
 
   private void updateLastExportedPosition(final long lastPosition) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -197,199 +197,302 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
         new ExporterEntityCacheImpl<>(
             configuration.getBatchOperationCache().getMaxCacheSize(),
             entityCacheProvider.getBatchOperationCacheLoader(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(BatchOperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new CaffeineCacheStatsCounter(NAMESPACE, "batchOperation", meterRegistry));
 
     processCache =
         new ExporterEntityCacheImpl<>(
             configuration.getProcessCache().getMaxCacheSize(),
             entityCacheProvider.getProcessCacheLoader(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(ProcessIndex.class).getShardedFullQualifiedName(partitionId)),
             new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry));
 
     decisionRequirementsCache =
         new ExporterEntityCacheImpl<>(
             configuration.getDecisionRequirementsCache().getMaxCacheSize(),
             entityCacheProvider.getDecisionRequirementsCacheLoader(
-                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(DecisionRequirementsIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new CaffeineCacheStatsCounter(NAMESPACE, "decisionRequirements", meterRegistry));
 
     formCache =
         new ExporterEntityCacheImpl<>(
             configuration.getFormCache().getMaxCacheSize(),
             entityCacheProvider.getFormCacheLoader(
-                indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(FormIndex.class).getShardedFullQualifiedName(partitionId)),
             new CaffeineCacheStatsCounter(NAMESPACE, "form", meterRegistry));
 
     exportHandlers = new LinkedHashSet<>();
     exportHandlers.addAll(
         ImmutableSet.of(
             new RoleCreateUpdateHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(RoleIndex.class).getShardedFullQualifiedName(partitionId)),
+            new RoleDeletedHandler(
+                indexDescriptors.get(RoleIndex.class).getShardedFullQualifiedName(partitionId)),
             new RoleMemberAddedHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(RoleIndex.class).getShardedFullQualifiedName(partitionId)),
             new RoleMemberRemovedHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(RoleIndex.class).getShardedFullQualifiedName(partitionId)),
             new UserCreatedUpdatedHandler(
-                indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
-            new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(UserIndex.class).getShardedFullQualifiedName(partitionId)),
+            new UserDeletedHandler(
+                indexDescriptors.get(UserIndex.class).getShardedFullQualifiedName(partitionId)),
             new AuthorizationCreatedUpdatedHandler(
-                indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(AuthorizationIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new AuthorizationDeletedHandler(
-                indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(AuthorizationIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new TenantCreateUpdateHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(TenantIndex.class).getShardedFullQualifiedName(partitionId)),
             new TenantDeletedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(TenantIndex.class).getShardedFullQualifiedName(partitionId)),
             new TenantEntityAddedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(TenantIndex.class).getShardedFullQualifiedName(partitionId)),
             new TenantEntityRemovedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(TenantIndex.class).getShardedFullQualifiedName(partitionId)),
             new GroupCreatedUpdatedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(GroupIndex.class).getShardedFullQualifiedName(partitionId)),
             new GroupEntityAddedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(GroupIndex.class).getShardedFullQualifiedName(partitionId)),
             new GroupEntityRemovedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new GroupDeletedHandler(indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(GroupIndex.class).getShardedFullQualifiedName(partitionId)),
+            new GroupDeletedHandler(
+                indexDescriptors.get(GroupIndex.class).getShardedFullQualifiedName(partitionId)),
             new DecisionHandler(
-                indexDescriptors.get(DecisionIndex.class).getFullQualifiedName(),
+                indexDescriptors.get(DecisionIndex.class).getShardedFullQualifiedName(partitionId),
                 decisionRequirementsCache),
             new ListViewProcessInstanceFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
+                processCache),
             new ListViewFlowNodeFromIncidentHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ListViewFlowNodeFromJobHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ListViewFlowNodeFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ListViewVariableFromVariableHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ClusterVariableCreatedHandler(
-                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(ClusterVariableIndex.class)
+                    .getShardedFullQualifiedName(partitionId),
                 configuration.getIndex().getVariableSizeThreshold()),
             new ClusterVariableDeletedHandler(
-                indexDescriptors.get(ClusterVariableIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(ClusterVariableIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new VariableHandler(
-                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(VariableTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 configuration.getIndex().getVariableSizeThreshold()),
             new DecisionRequirementsHandler(
-                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(DecisionRequirementsIndex.class)
+                    .getShardedFullQualifiedName(partitionId),
                 decisionRequirementsCache),
             new PostImporterQueueFromIncidentHandler(
-                indexDescriptors.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(PostImporterQueueTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new FlowNodeInstanceFromIncidentHandler(
-                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(FlowNodeInstanceTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new FlowNodeInstanceFromProcessInstanceHandler(
-                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(FlowNodeInstanceTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 processCache),
             new IncidentHandler(
-                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
+                indexDescriptors
+                    .get(IncidentTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
+                processCache),
             new SequenceFlowHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(SequenceFlowTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new SequenceFlowDeletedHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(SequenceFlowTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new DecisionEvaluationHandler(
-                indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(DecisionInstanceTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ProcessHandler(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(), processCache),
-            new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(ProcessIndex.class).getShardedFullQualifiedName(partitionId),
+                processCache),
+            new EmbeddedFormHandler(
+                indexDescriptors.get(FormIndex.class).getShardedFullQualifiedName(partitionId)),
             new FormHandler(
-                indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),
+                indexDescriptors.get(FormIndex.class).getShardedFullQualifiedName(partitionId),
+                formCache),
             new HistoryDeletionDeletedHandler(
-                indexDescriptors.get(HistoryDeletionIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(HistoryDeletionIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new MessageSubscriptionFromProcessMessageSubscriptionHandler(
-                indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(MessageSubscriptionTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 exporterMetadata),
             new UserTaskHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(TaskTemplate.class).getShardedFullQualifiedName(partitionId),
                 formCache,
                 processCache,
                 exporterMetadata),
             new UserTaskJobBasedHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(TaskTemplate.class).getShardedFullQualifiedName(partitionId),
                 formCache,
                 processCache,
                 exporterMetadata,
                 objectMapper),
             new UserTaskProcessInstanceHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(TaskTemplate.class).getShardedFullQualifiedName(partitionId)),
             new UserTaskVariableHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(TaskTemplate.class).getShardedFullQualifiedName(partitionId),
                 configuration.getIndex().getVariableSizeThreshold()),
             new UserTaskCompletionVariableHandler(
-                indexDescriptors.get(SnapshotTaskVariableTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(SnapshotTaskVariableTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 configuration.getIndex().getVariableSizeThreshold(),
                 objectMapper),
             new OperationFromProcessInstanceHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new OperationFromVariableDocumentHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new OperationFromIncidentHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new OperationFromHistoryDeletionHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new MappingRuleCreatedUpdatedHandler(
-                indexDescriptors.get(MappingRuleIndex.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(MappingRuleIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new MappingRuleDeletedHandler(
-                indexDescriptors.get(MappingRuleIndex.class).getFullQualifiedName()),
-            new JobHandler(indexDescriptors.get(JobTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(MappingRuleIndex.class)
+                    .getShardedFullQualifiedName(partitionId)),
+            new JobHandler(
+                indexDescriptors.get(JobTemplate.class).getShardedFullQualifiedName(partitionId)),
             new MigratedVariableHandler(
-                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(VariableTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             // Batch Operation Handler
             new BatchOperationCreatedHandler(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(BatchOperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new BatchOperationInitializedHandler(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(BatchOperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new BatchOperationLifecycleManagementHandler(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(BatchOperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new BatchOperationChunkCreatedHandler(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(BatchOperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new ProcessInstanceCancellationOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ProcessInstanceMigrationOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ProcessInstanceModificationOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ResolveIncidentOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ProcessInstanceHistoryDeletionOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ProcessDefinitionHistoryDeletionOperationHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(OperationTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ListViewFromProcessInstanceCancellationOperationHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ListViewFromProcessInstanceMigrationOperationHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ListViewFromProcessInstanceModificationOperationHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new ListViewFromIncidentResolutionOperationHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
+                indexDescriptors
+                    .get(ListViewTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
                 batchOperationCache),
             new UsageMetricExportedHandler(
-                indexDescriptors.get(UsageMetricTemplate.class).getFullQualifiedName(),
-                indexDescriptors.get(UsageMetricTUTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(UsageMetricTemplate.class)
+                    .getShardedFullQualifiedName(partitionId),
+                indexDescriptors
+                    .get(UsageMetricTUTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new JobBatchMetricsExportedHandler(
-                indexDescriptors.get(JobMetricsBatchTemplate.class).getFullQualifiedName()),
+                indexDescriptors
+                    .get(JobMetricsBatchTemplate.class)
+                    .getShardedFullQualifiedName(partitionId)),
             new CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandler(
                 indexDescriptors
                     .get(CorrelatedMessageSubscriptionTemplate.class)
-                    .getFullQualifiedName()),
+                    .getShardedFullQualifiedName(partitionId)),
             new CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler(
                 indexDescriptors
                     .get(CorrelatedMessageSubscriptionTemplate.class)
-                    .getFullQualifiedName())));
+                    .getShardedFullQualifiedName(partitionId))));
 
     if (configuration.getAuditLog().isEnabled()) {
       addAuditLogHandlers(configuration.getAuditLog(), partitionId);
@@ -399,16 +502,20 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       // only add this handler when the items are exported on creation
       exportHandlers.add(
           new BatchOperationChunkCreatedItemHandler(
-              indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+              indexDescriptors
+                  .get(OperationTemplate.class)
+                  .getShardedFullQualifiedName(partitionId),
               batchOperationCache));
       exportHandlers.add(
           new ListViewFromChunkItemHandler(
-              indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()));
+              indexDescriptors
+                  .get(ListViewTemplate.class)
+                  .getShardedFullQualifiedName(partitionId)));
     }
 
     indicesWithCustomErrorHandlers =
         Map.of(
-            indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+            indexDescriptors.get(OperationTemplate.class).getShardedFullQualifiedName(partitionId),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
   }
 
@@ -494,7 +601,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   }
 
   private void addAuditLogHandlers(final AuditLogConfiguration auditLog, final int partitionId) {
-    final var indexName = (indexDescriptors.get(AuditLogTemplate.class).getFullQualifiedName());
+    final var indexName =
+        (indexDescriptors.get(AuditLogTemplate.class).getShardedFullQualifiedName(partitionId));
     final var auditLogBuilder = AuditLogHandler.builder(indexName, auditLog);
 
     if (partitionId == PROCESS_DEFINITION_PARTITION) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.exporter.tasks;
 
-import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
-
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
@@ -240,22 +238,23 @@ public final class BackgroundTaskManagerFactory {
     final List<RunnableTask> tasks = new ArrayList<>();
 
     tasks.add(buildIncidentMarkerTask());
-    if (config.getHistory().isProcessInstanceEnabled()) {
-      tasks.add(buildProcessInstanceArchiverJob());
-      if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
-        tasks.add(buildProcessInstanceToBeArchivedCountJob());
-      }
-    }
-    tasks.add(buildUsageMetricsArchiverJob());
-    tasks.add(buildUsageMetricsTUArchiverJob());
-    tasks.add(buildStandaloneDecisionArchiverJob());
-    if (partitionId == START_PARTITION_ID) {
-      tasks.add(buildBatchOperationArchiverJob());
-      tasks.add(buildBatchOperationUpdateTask());
-      if (config.getHistory().getRetention().isEnabled()) {
-        tasks.add(buildRolloverPeriodJob());
-      }
-    }
+
+    //    if (config.getHistory().isProcessInstanceEnabled()) {
+    //      tasks.add(buildProcessInstanceArchiverJob());
+    //      if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
+    //        tasks.add(buildProcessInstanceToBeArchivedCountJob());
+    //      }
+    //    }
+    //    tasks.add(buildUsageMetricsArchiverJob());
+    //    tasks.add(buildUsageMetricsTUArchiverJob());
+    //    tasks.add(buildStandaloneDecisionArchiverJob());
+    //    if (partitionId == START_PARTITION_ID) {
+    //      tasks.add(buildBatchOperationArchiverJob());
+    //      tasks.add(buildBatchOperationUpdateTask());
+    //      if (config.getHistory().getRetention().isEnabled()) {
+    //        tasks.add(buildRolloverPeriodJob());
+    //      }
+    //    }
 
     tasks.add(buildHistoryDeletionJob());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -255,8 +255,8 @@ public final class BackgroundTaskManagerFactory {
     //        tasks.add(buildRolloverPeriodJob());
     //      }
     //    }
-
-    tasks.add(buildHistoryDeletionJob());
+    //
+    //    tasks.add(buildHistoryDeletionJob());
 
     executor.setCorePoolSize(tasks.size());
     return tasks;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -193,6 +193,11 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
     }
 
     @Override
+    public String getShardedFullQualifiedName(final int partitionId) {
+      return "foo_" + partitionId;
+    }
+
+    @Override
     public String getAlias() {
       return "foo_alias";
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -173,6 +173,11 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     }
 
     @Override
+    public String getShardedFullQualifiedName(final int partitionId) {
+      return "foo_" + partitionId;
+    }
+
+    @Override
     public String getAlias() {
       return "foo_alias";
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -696,9 +696,16 @@ abstract class IncidentUpdateRepositoryIT {
       final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
       final String suffix = date.format(formatter);
       return new IndexDescriptor() {
+
+
         @Override
         public String getFullQualifiedName() {
           return source.getFullQualifiedName() + "-" + suffix;
+        }
+
+        @Override
+        public String getShardedFullQualifiedName(final int partitionId) {
+          return "foo_" + partitionId;
         }
 
         @Override


### PR DESCRIPTION

## Description

Create a POC where we disable archiving and instead write to multiple main shards.

In this variation, we are going to "create indexes" by the partitionId. So there will be `operate-list-view-8.3.0_p1`, `operate-list-view-8.3.0_p2` etc
 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
