### PR TITLE
feat: introduce uncommitted reader and write listener support in log …

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -188,6 +188,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.getContext().getLog().openCommittedReader();
   }
 
+  public RaftLogReader openUncommittedReader() {
+    return server.getContext().getLog().openUncommittedReader();
+  }
+
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
     server.addRoleChangeListener(listener);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -87,6 +87,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final PartitionMessagingService partitionMessagingService;
   private final String exporterPositionsTopic;
   private final ExporterMode exporterMode;
+  private final boolean uncommittedReader;
   private final Duration distributionInterval;
   private ExporterStateDistributionService exporterDistributionService;
   private ScheduledTimer exporterDistributionTimer;
@@ -134,6 +135,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     partitionMessagingService = context.getPartitionMessagingService();
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
+    uncommittedReader = context.isUncommittedReader();
     distributionInterval = context.getDistributionInterval();
     positionsToSkipFilter = context.getPositionsToSkipFilter();
 
@@ -370,7 +372,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   @Override
   protected void onActorStarting() {
     if (exporterMode == ExporterMode.ACTIVE) {
-      logStreamReader = logStream.newLogStreamReader();
+      logStreamReader = logStream.newLogStreamReader(uncommittedReader);
     }
   }
 
@@ -589,7 +591,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private void restartActiveExportingMode() {
-    logStreamReader = logStream.newLogStreamReader();
+    logStreamReader = logStream.newLogStreamReader(uncommittedReader);
     startActiveExportingFrom(-1);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -29,6 +29,7 @@ public final class ExporterDirectorContext {
   private ZeebeDb zeebeDb;
   private PartitionMessagingService partitionMessagingService;
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
+  private boolean uncommittedReader = true;
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
@@ -60,6 +61,10 @@ public final class ExporterDirectorContext {
 
   public ExporterMode getExporterMode() {
     return exporterMode;
+  }
+
+  public boolean isUncommittedReader() {
+    return uncommittedReader;
   }
 
   public Duration getDistributionInterval() {
@@ -117,6 +122,11 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext exporterMode(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;
+    return this;
+  }
+
+  public ExporterDirectorContext uncommittedReader(final boolean uncommittedReader) {
+    this.uncommittedReader = uncommittedReader;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -92,6 +92,7 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
     return right(
         new AtomixLogStorage(
             server::openReader,
+            server::openUncommittedReader,
             // Prevent followers from writing new events
             new LogAppenderForReadOnlyStorage()));
   }
@@ -123,7 +124,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
           new NotLeaderException(
               String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
     } else {
-      final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
+      final var logStorage =
+          AtomixLogStorage.ofPartition(
+              server::openReader, server::openUncommittedReader, logAppender);
       return right(logStorage);
     }
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -47,6 +47,14 @@ public interface LogStream extends AutoCloseable {
   LogStreamReader newLogStreamReader();
 
   /**
+   * @param uncommitted whether the reader should read uncommitted data
+   * @return a future, when successfully completed it returns a newly created log stream reader
+   */
+  default LogStreamReader newLogStreamReader(final boolean uncommitted) {
+    return newLogStreamReader();
+  }
+
+  /**
    * @return a future, when successfully completed it returns a newly created log stream record
    *     writer
    */

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -33,6 +33,15 @@ public interface LogStorage {
   LogStorageReader newReader();
 
   /**
+   * Creates a new reader initialized at the given address, which can read uncommitted data.
+   *
+   * @return a new stateful storage reader
+   */
+  default LogStorageReader newUncommittedReader() {
+    return newReader();
+  }
+
+  /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at
    * which the block has been written.
    *
@@ -93,6 +102,20 @@ public interface LogStorage {
   void removeCommitListener(CommitListener listener);
 
   /**
+   * Register a write listener
+   *
+   * @param listener the listener which will be notified when a new record is written.
+   */
+  void addWriteListener(WriteListener listener);
+
+  /**
+   * Remove a write listener
+   *
+   * @param listener the listener to remove
+   */
+  void removeWriteListener(WriteListener listener);
+
+  /**
    * An append listener can be added to an append call to be notified of different events that can
    * occur during the append operation.
    */
@@ -126,5 +149,13 @@ public interface LogStorage {
 
     /** Called when a new record is committed in the storage */
     void onCommit();
+  }
+
+  /**
+   * Consumers of LogStorage can use this listener to get notified when new records are written.
+   */
+  interface WriteListener {
+    /** Called when a new record is written in the storage */
+    void onWrite();
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -31,6 +31,7 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentSkipListMap<Integer, Entry> entries;
   private LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
+  private final Set<WriteListener> writeListeners = new HashSet<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
 
@@ -73,6 +74,7 @@ public class ListLogStorage implements LogStorage {
     entries.put(index, entry);
     positionIndexMapping.put(lowestPosition, index);
     listener.onWrite(index, highestPosition);
+    writeListeners.forEach(WriteListener::onWrite);
 
     if (positionListener != null) {
       positionListener.accept(highestPosition);
@@ -89,6 +91,16 @@ public class ListLogStorage implements LogStorage {
   @Override
   public void removeCommitListener(final CommitListener listener) {
     commitListeners.remove(listener);
+  }
+
+  @Override
+  public void addWriteListener(final WriteListener listener) {
+    writeListeners.add(listener);
+  }
+
+  @Override
+  public void removeWriteListener(final WriteListener listener) {
+    writeListeners.remove(listener);
   }
 
   public void reset() {


### PR DESCRIPTION
…storage

Add `newUncommittedReader` method to enable reading uncommitted data from log storage. Introduce `WriteListener` interface for notifying consumers on new writes. Update relevant implementations and tests to support the new functionality.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
