### PR TITLE
Hackathon/performance/exporter read uncommit

### DIFF
--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     outputs:
-      sanitized-name: ${{ steps.sanitize.outputs.branch_name }}-benchmark
+      sanitized-name: ${{ steps.sanitize.outputs.branch_name }}
     steps:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -36,6 +36,7 @@ jobs:
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       ref: ${{ github.event.pull_request.head.ref }}
+      scenario: 'max'
 
   delete-benchmark:
     name: Benchmark Cleanup

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -188,6 +188,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     return server.getContext().getLog().openCommittedReader();
   }
 
+  public RaftLogReader openUncommittedReader() {
+    return server.getContext().getLog().openUncommittedReader();
+  }
+
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
     server.addRoleChangeListener(listener);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -69,6 +69,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   // Use concrete type because it must be modifiable
   private final ArrayList<ExporterContainer> containers;
   private final LogStream logStream;
+  private final boolean uncommittedReader;
   private final RecordExporter recordExporter;
   private final ZeebeDb zeebeDb;
   private final ExporterMetrics metrics;
@@ -113,6 +114,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     partitionId = logStream.getPartitionId();
     meterRegistry = context.getMeterRegistry();
     clock = context.getClock();
+    uncommittedReader = context.isUncommittedReader();
     containers =
         context.getDescriptors().entrySet().stream()
             .map(
@@ -370,7 +372,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   @Override
   protected void onActorStarting() {
     if (exporterMode == ExporterMode.ACTIVE) {
-      logStreamReader = logStream.newLogStreamReader();
+      logStreamReader = logStream.newUncommitedLogsStreamReader();
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -69,7 +69,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   // Use concrete type because it must be modifiable
   private final ArrayList<ExporterContainer> containers;
   private final LogStream logStream;
-  private final boolean uncommittedReader;
   private final RecordExporter recordExporter;
   private final ZeebeDb zeebeDb;
   private final ExporterMetrics metrics;
@@ -114,7 +113,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     partitionId = logStream.getPartitionId();
     meterRegistry = context.getMeterRegistry();
     clock = context.getClock();
-    uncommittedReader = context.isUncommittedReader();
     containers =
         context.getDescriptors().entrySet().stream()
             .map(
@@ -591,7 +589,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private void restartActiveExportingMode() {
-    logStreamReader = logStream.newLogStreamReader();
+    logStreamReader = logStream.newUncommitedLogsStreamReader();
     startActiveExportingFrom(-1);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -33,6 +33,7 @@ public final class ExporterDirectorContext {
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
   private InstantSource clock;
+  private boolean uncommittedReader;
 
   public int getId() {
     return id;
@@ -48,6 +49,10 @@ public final class ExporterDirectorContext {
 
   public Map<ExporterDescriptor, ExporterInitializationInfo> getDescriptors() {
     return descriptors;
+  }
+
+  public boolean isUncommittedReader() {
+    return uncommittedReader;
   }
 
   public ZeebeDb getZeebeDb() {
@@ -117,6 +122,11 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext exporterMode(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;
+    return this;
+  }
+
+  public ExporterDirectorContext uncommittedReader(final boolean uncommittedReader) {
+    this.uncommittedReader = uncommittedReader;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -33,7 +33,6 @@ public final class ExporterDirectorContext {
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
   private InstantSource clock;
-  private boolean uncommittedReader;
 
   public int getId() {
     return id;
@@ -49,10 +48,6 @@ public final class ExporterDirectorContext {
 
   public Map<ExporterDescriptor, ExporterInitializationInfo> getDescriptors() {
     return descriptors;
-  }
-
-  public boolean isUncommittedReader() {
-    return uncommittedReader;
   }
 
   public ZeebeDb getZeebeDb() {
@@ -122,11 +117,6 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext exporterMode(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;
-    return this;
-  }
-
-  public ExporterDirectorContext uncommittedReader(final boolean uncommittedReader) {
-    this.uncommittedReader = uncommittedReader;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -29,14 +29,18 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
 
   public AtomixLogStorage(
-      final AtomixReaderFactory readerFactory, final AtomixReaderFactory uncommittedReaderFactory, final ZeebeLogAppender logAppender) {
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender logAppender) {
     this.readerFactory = readerFactory;
     this.uncommittedReaderFactory = uncommittedReaderFactory;
     this.logAppender = logAppender;
   }
 
   public static AtomixLogStorage ofPartition(
-      final AtomixReaderFactory readerFactory,final AtomixReaderFactory uncommittedReaderFactory, final ZeebeLogAppender appender) {
+      final AtomixReaderFactory readerFactory,
+      final AtomixReaderFactory uncommittedReaderFactory,
+      final ZeebeLogAppender appender) {
     return new AtomixLogStorage(readerFactory, uncommittedReaderFactory, appender);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorage.java
@@ -24,18 +24,20 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class AtomixLogStorage implements LogStorage, RaftCommitListener {
 
   private final AtomixReaderFactory readerFactory;
+  private final AtomixReaderFactory uncommittedReaderFactory;
   private final ZeebeLogAppender logAppender;
   private final Set<CommitListener> commitListeners = new CopyOnWriteArraySet<>();
 
   public AtomixLogStorage(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender logAppender) {
+      final AtomixReaderFactory readerFactory, final AtomixReaderFactory uncommittedReaderFactory, final ZeebeLogAppender logAppender) {
     this.readerFactory = readerFactory;
+    this.uncommittedReaderFactory = uncommittedReaderFactory;
     this.logAppender = logAppender;
   }
 
   public static AtomixLogStorage ofPartition(
-      final AtomixReaderFactory readerFactory, final ZeebeLogAppender appender) {
-    return new AtomixLogStorage(readerFactory, appender);
+      final AtomixReaderFactory readerFactory,final AtomixReaderFactory uncommittedReaderFactory, final ZeebeLogAppender appender) {
+    return new AtomixLogStorage(readerFactory, uncommittedReaderFactory, appender);
   }
 
   @Override
@@ -51,6 +53,11 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
       final AppendListener listener) {
     final var adapter = new AtomixAppendListenerAdapter(listener);
     logAppender.appendEntry(lowestPosition, highestPosition, bufferWriter, adapter);
+  }
+
+  @Override
+  public AtomixLogStorageReader newUncommittedReader() {
+    return new AtomixLogStorageReader(uncommittedReaderFactory.create());
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -91,7 +91,7 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
 
     return right(
         new AtomixLogStorage(
-            server::openReader,
+            server::openReader,server::openUncommittedReader ,
             // Prevent followers from writing new events
             new LogAppenderForReadOnlyStorage()));
   }
@@ -123,7 +123,7 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
           new NotLeaderException(
               String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
     } else {
-      final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
+      final var logStorage = AtomixLogStorage.ofPartition(server::openReader,server::openUncommittedReader, logAppender);
       return right(logStorage);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -91,7 +91,8 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
 
     return right(
         new AtomixLogStorage(
-            server::openReader,server::openUncommittedReader ,
+            server::openReader,
+            server::openUncommittedReader,
             // Prevent followers from writing new events
             new LogAppenderForReadOnlyStorage()));
   }
@@ -123,7 +124,9 @@ public final class LogStoragePartitionTransitionStep implements PartitionTransit
           new NotLeaderException(
               String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
     } else {
-      final var logStorage = AtomixLogStorage.ofPartition(server::openReader,server::openUncommittedReader, logAppender);
+      final var logStorage =
+          AtomixLogStorage.ofPartition(
+              server::openReader, server::openUncommittedReader, logAppender);
       return right(logStorage);
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -45,7 +45,7 @@ final class AtomixLogStorageReaderTest {
             .withMetaStore(mock(JournalMetaStore.class))
             .build();
     final Appender appender = new Appender();
-    logStorage = new AtomixLogStorage(log::openUncommittedReader, appender);
+    logStorage = new AtomixLogStorage(log::openUncommittedReader, log::openUncommittedReader, appender);
     reader = logStorage.newReader();
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -45,7 +45,8 @@ final class AtomixLogStorageReaderTest {
             .withMetaStore(mock(JournalMetaStore.class))
             .build();
     final Appender appender = new Appender();
-    logStorage = new AtomixLogStorage(log::openUncommittedReader, log::openUncommittedReader, appender);
+    logStorage =
+        new AtomixLogStorage(log::openUncommittedReader, log::openUncommittedReader, appender);
     reader = logStorage.newReader();
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -112,6 +112,12 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   }
 
   @Override
+  public LogStreamReader newUncommitedLogsStreamReader() {
+    ensureOpen();
+    return createNonCommitedLogStreamReader();
+  }
+
+  @Override
   public void onCommit() {
     if (closed) {
       // This can be called by the raft thread after we've already closed the log stream.
@@ -130,6 +136,12 @@ public final class LogStreamImpl implements LogStream, CommitListener {
 
   private LogStreamReader createLogStreamReader() {
     final var newReader = new LogStreamReaderImpl(logStorage.newReader());
+    readers.add(newReader);
+    return newReader;
+  }
+
+  private LogStreamReader createNonCommitedLogStreamReader(){
+    final var newReader = new LogStreamReaderImpl(logStorage.newUncommittedReader());
     readers.add(newReader);
     return newReader;
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -140,7 +140,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
     return newReader;
   }
 
-  private LogStreamReader createNonCommitedLogStreamReader(){
+  private LogStreamReader createNonCommitedLogStreamReader() {
     final var newReader = new LogStreamReaderImpl(logStorage.newUncommittedReader());
     readers.add(newReader);
     return newReader;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -71,4 +71,9 @@ public interface LogStream extends AutoCloseable {
    * @param recordAwaiter the listener to remove
    */
   void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  /**
+   * @return a future, when successfully completed it returns a newly created log stream reader
+   */
+  LogStreamReader newUncommitedLogsStreamReader();
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -37,8 +37,7 @@ public interface LogStorage {
    *
    * @return a new stateful storage reader
    */
-   LogStorageReader newUncommittedReader();
-
+  LogStorageReader newUncommittedReader();
 
   /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -33,6 +33,14 @@ public interface LogStorage {
   LogStorageReader newReader();
 
   /**
+   * Creates a new reader initialized at the given address, which can read uncommitted data.
+   *
+   * @return a new stateful storage reader
+   */
+   LogStorageReader newUncommittedReader();
+
+
+  /**
    * Writes a block containing one or multiple log entries in the storage and returns the address at
    * which the block has been written.
    *

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.ByteBuffer;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -290,6 +291,11 @@ final class SequencerTest {
     }
 
     @Override
+    public LogStorageReader newUncommittedReader() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void append(
         final long lowestPosition,
         final long highestPosition,
@@ -300,6 +306,12 @@ final class SequencerTest {
       }
       position = highestPosition;
       listener.onCommit(position, highestPosition);
+    }
+
+    @Override
+    public void append(final long lowestPosition, final long highestPosition,
+        final ByteBuffer blockBuffer, final AppendListener listener) {
+      LogStorage.super.append(lowestPosition, highestPosition, blockBuffer, listener);
     }
 
     @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -309,8 +309,11 @@ final class SequencerTest {
     }
 
     @Override
-    public void append(final long lowestPosition, final long highestPosition,
-        final ByteBuffer blockBuffer, final AppendListener listener) {
+    public void append(
+        final long lowestPosition,
+        final long highestPosition,
+        final ByteBuffer blockBuffer,
+        final AppendListener listener) {
       LogStorage.super.append(lowestPosition, highestPosition, blockBuffer, listener);
     }
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -52,6 +52,13 @@ public class ListLogStorage implements LogStorage {
   }
 
   @Override
+  public LogStorageReader newUncommittedReader() {
+    final ListLogStorageReader listLogStorageReader = new ListLogStorageReader();
+    listLogStorageReaders.add(listLogStorageReader);
+    return listLogStorageReader;
+  }
+
+  @Override
   public void append(
       final long lowestPosition,
       final long highestPosition,

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestLogStream.java
@@ -118,6 +118,11 @@ public class TestLogStream implements LogStream {
     logStream.removeRecordAvailableListener(recordAwaiter);
   }
 
+  @Override
+  public LogStreamReader newUncommitedLogsStreamReader() {
+    return logStream.newUncommitedLogsStreamReader();
+  }
+
   private Either<WriteFailure, Long> syncTryWrite(
       final Supplier<Either<WriteFailure, Long>> writeOperation) {
     final var written =


### PR DESCRIPTION
This pull request introduces support for reading uncommitted log entries in the log storage and log stream subsystems. The main changes involve adding new APIs and implementations for uncommitted log readers and updating relevant classes to use these new readers where appropriate.