### PR TITLE
fix: populate startDate for batch operations in ES/OS

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -459,6 +459,7 @@ public class BatchOperationSearchIT {
 
   private static void assertCancelBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
+    assertThat(batch.getStartDate()).isNotNull();
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey1);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
@@ -471,6 +472,7 @@ public class BatchOperationSearchIT {
 
   private static void assertMigrateBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
+    assertThat(batch.getStartDate()).isNotNull();
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey2);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CHUNK;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_EXECUTION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_INITIALIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.CLUSTER_VARIABLE;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
@@ -372,6 +373,7 @@ public class CamundaExporter implements Exporter {
             RESOURCE,
             USER_TASK,
             BATCH_OPERATION_CREATION,
+            BATCH_OPERATION_INITIALIZATION,
             BATCH_OPERATION_EXECUTION,
             BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BATCH_OPERATION_CHUNK,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
@@ -33,7 +33,7 @@ public class BatchOperationInitializedHandler
 
   @Override
   public ValueType getHandledValueType() {
-    return ValueType.BATCH_OPERATION_CREATION;
+    return ValueType.BATCH_OPERATION_INITIALIZATION;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
@@ -35,7 +35,7 @@ class BatchOperationInitializedHandlerTest {
 
   @Test
   void testGetHandledValueType() {
-    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CREATION);
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_INITIALIZATION);
   }
 
   @Test


### PR DESCRIPTION
## Description

The V2 API endpoint `POST: /v2/batch-operations/search` was not returning the `startDate` field for batch operations when using ES/OS as the secondary database.
The `startDate` was not populated because `BatchOperationInitializedHandler` was never invoked.

### Root cause

Two issues prevented the `BatchOperationInitializedHandler` from being invoked:
1. **Incorrect `ValueType` in handler:** `BatchOperationInitializedHandler.getHandledValueType()` incorrectly returned `ValueType.BATCH_OPERATION_CREATION` instead of `ValueType.BATCH_OPERATION_INITIALIZATION`. This caused a type mismatch since the handler expects `BatchOperationInitializationRecordValue` records but was registered for the wrong value type (see [ValueTypeMapping](https://github.com/camunda/camunda/blob/57b0dd55f8f907a8150ddd410472780c9d0369f8/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java#L324-L326)).

2. **Missing value type in exporter filter:** `CamundaExporter.VALUE_TYPES_2_EXPORT` did not include `BATCH_OPERATION_INITIALIZATION`, causing records with this value type to be filtered out before reaching any handler.

As a result, the `INITIALIZED` event was never processed by the ES/OS exporter, so `startDate` and the `ACTIVE` state were never set on batch operation documents in Elasticsearch/OpenSearch.

### Changes

| File | Change |
|------|--------|
| `BatchOperationInitializedHandler` | Changed `getHandledValueType()` to return `ValueType.BATCH_OPERATION_INITIALIZATION` |
| `CamundaExporter` | Added `BATCH_OPERATION_INITIALIZATION` to the `VALUE_TYPES_2_EXPORT` set |
| `BatchOperationInitializedHandlerTest` | Updated test to verify correct value type |
| `BatchOperationSearchIT` | Added assertions to verify `startDate` field is populated in batch operation search responses |

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #42165
