### PR TITLE
ci: add copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,30 @@
+# description: Instructions for GitHub co-pilot coding agent, ensuring the agent has an environment that it can work in.
+# see_also: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment
+# test location: /
+# type: AGENT_SETUP
+# owner: @camunda/monorepo-devops-team
+---
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+    
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,9 +8,6 @@ name: "Copilot Setup Steps"
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
@@ -18,12 +15,14 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     permissions:
       contents: read
-    
+
     steps:
       - uses: actions/checkout@v6
+      # If we want to align Copilot and CI setups more in the future, consider using (parts of) .github/actions/setup-build here
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'


### PR DESCRIPTION
## Description

As part of my work I'm using GitHub co-pilot coding agent to contribute to different repositories. Rather than working locally in my environment, it works "autonomous", and requires the right environment setup to work. In the context of this repository it needs to have access to the right Java version, be able to download maven dependencies etc, just as a developer would. 

In a [recent built](https://github.com/camunda/camunda/agents/pull/44768) it failed to install maven dependencies and execute the build, likely because of environment not being setup.

This PR adds [co-pilot agent setup instructions](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment#preinstalling-tools-or-dependencies-in-copilots-environment) in an attempt to overcome the issue. I'm not fully aware what context is needed ("what is the basic developer setup?"), hence I re-used the setup action used by CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

None.