### PR TITLE
perf: in msgpack do not serialize property when it's not set or equal to the default if present

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -16,10 +16,10 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedGroup extends UnpackedObject implements DbValue {
 
-  private final LongProperty groupKeyProp = new LongProperty("groupKey");
-  private final StringProperty groupIdProp = new StringProperty("groupId");
-  private final StringProperty descriptionProp = new StringProperty("description");
-  private final StringProperty nameProp = new StringProperty("name");
+  private final LongProperty groupKeyProp = new LongProperty("groupKey", -1L);
+  private final StringProperty groupIdProp = new StringProperty("groupId", "");
+  private final StringProperty descriptionProp = new StringProperty("description", "");
+  private final StringProperty nameProp = new StringProperty("name", "");
 
   public PersistedGroup() {
     super(4);

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -60,6 +60,10 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     return isSet || defaultValue != null;
   }
 
+  public boolean hasMeaningfulValue() {
+    return defaultValue == null || (!Objects.equals(resolveValue(), defaultValue));
+  }
+
   public StringValue getKey() {
     return key;
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
@@ -22,4 +22,9 @@ public final class ObjectProperty<T extends ObjectValue> extends BaseProperty<T>
   public T getValue() {
     return resolveValue();
   }
+
+  @Override
+  public boolean hasMeaningfulValue() {
+    return true;
+  }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
@@ -25,6 +25,6 @@ public final class ObjectProperty<T extends ObjectValue> extends BaseProperty<T>
 
   @Override
   public boolean hasMeaningfulValue() {
-    return true;
+    return !getValue().isEmpty();
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -86,7 +86,10 @@ public class ObjectValue extends BaseValue {
    */
   @Override
   public void write(final MsgPackWriter writer) {
-    final int size = declaredProperties.size() + undeclaredProperties.size();
+    final int size =
+        (int)
+            (declaredProperties.stream().filter(BaseProperty::hasMeaningfulValue).count()
+                + undeclaredProperties.stream().filter(BaseProperty::hasMeaningfulValue).count());
 
     writer.writeMapHeader(size);
     write(writer, declaredProperties);
@@ -182,7 +185,9 @@ public class ObjectValue extends BaseValue {
       final MsgPackWriter writer, final List<T> properties) {
     for (int i = 0; i < properties.size(); ++i) {
       final BaseProperty<? extends BaseValue> prop = properties.get(i);
-      prop.write(writer);
+      if (prop.hasMeaningfulValue()) {
+        prop.write(writer);
+      }
     }
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -234,6 +234,7 @@ public class ObjectValue extends BaseValue {
   }
 
   public boolean isEmpty() {
-    return declaredProperties.isEmpty() && undeclaredProperties.isEmpty();
+    return declaredProperties.stream().noneMatch(BaseProperty::hasMeaningfulValue)
+        && undeclaredProperties.stream().noneMatch(BaseProperty::hasMeaningfulValue);
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -136,9 +136,11 @@ public class ObjectValue extends BaseValue {
 
   @Override
   public int getEncodedLength() {
-    final int size = declaredProperties.size() + undeclaredProperties.size();
+    final long size =
+        declaredProperties.stream().filter(BaseProperty::hasMeaningfulValue).count()
+            + undeclaredProperties.stream().filter(BaseProperty::hasMeaningfulValue).count();
 
-    int length = MsgPackWriter.getEncodedMapHeaderLenght(size);
+    int length = MsgPackWriter.getEncodedMapHeaderLenght((int) size);
     length += getEncodedLength(declaredProperties);
     length += getEncodedLength(undeclaredProperties);
 
@@ -224,7 +226,9 @@ public class ObjectValue extends BaseValue {
     int length = 0;
     for (int i = 0; i < properties.size(); ++i) {
       final T prop = properties.get(i);
-      length += prop.getEncodedLength();
+      if (prop.hasMeaningfulValue()) {
+        length += prop.getEncodedLength();
+      }
     }
     return length;
   }

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 public final class DocumentPropertyTest {
   @Test
-  public void shouldSerializeWithDefaultValue() {
+  public void shouldNotSerializeWithDefaultValue() {
     // given
     final Document document = new Document();
     final int writeLength = document.getLength();
@@ -33,8 +33,8 @@ public final class DocumentPropertyTest {
 
     // then
     final Map<String, Object> msgPackMap = MsgPackUtil.asMap(resultBuffer);
-    assertThat(msgPackMap).hasSize(1);
-    assertThat(msgPackMap).containsExactly(entry("documentProp", MsgPackHelper.EMTPY_OBJECT));
+    assertThat(msgPackMap).hasSize(0);
+    //    assertThat(msgPackMap).containsExactly(entry("documentProp", MsgPackHelper.EMTPY_OBJECT));
   }
 
   @Test
@@ -80,7 +80,7 @@ public final class DocumentPropertyTest {
   }
 
   @Test
-  public void shouldSerializeEmptyEvenIfNilIsSetAsValue() {
+  public void shouldNotSerializeEmptyEvenIfNilIsSetAsValue() {
     // given
     final Document document = new Document();
     final UnsafeBuffer documentBytes = new UnsafeBuffer(MsgPackHelper.NIL);
@@ -93,12 +93,11 @@ public final class DocumentPropertyTest {
 
     // then
     final Map<String, Object> msgPackMap = MsgPackUtil.asMap(resultBuffer);
-    assertThat(msgPackMap).hasSize(1);
-    assertThat(msgPackMap).containsExactly(entry("documentProp", MsgPackHelper.EMTPY_OBJECT));
+    assertThat(msgPackMap).hasSize(0);
   }
 
   @Test
-  public void shouldSerializeEmptyEvenIfZeroArraysIsSetAsValue() {
+  public void shouldNotSerializeEmptyEvenIfZeroArraysIsSetAsValue() {
     // given
     final Document document = new Document();
     final UnsafeBuffer documentBytes = new UnsafeBuffer(new byte[0]);
@@ -111,8 +110,7 @@ public final class DocumentPropertyTest {
 
     // then
     final Map<String, Object> msgPackMap = MsgPackUtil.asMap(resultBuffer);
-    assertThat(msgPackMap).hasSize(1);
-    assertThat(msgPackMap).containsExactly(entry("documentProp", MsgPackHelper.EMTPY_OBJECT));
+    assertThat(msgPackMap).hasSize(0);
   }
 
   @Test

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingDefaultValuesTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingDefaultValuesTest.java
@@ -97,7 +97,7 @@ public final class ObjectMappingDefaultValuesTest {
    * in version 2, where a new property should be included.
    */
   @Test
-  public void shouldWriteDefaultValue() {
+  public void shouldNotWriteDefaultValue() {
     // given
     final long defaultValue = -1L;
     final DefaultValuesPOJO pojo = new DefaultValuesPOJO(defaultValue);
@@ -113,9 +113,8 @@ public final class ObjectMappingDefaultValuesTest {
     reader.wrap(buf, 0, buf.capacity());
     final Map<String, Object> msgPackMap = MsgPackUtil.asMap(buf, 0, buf.capacity());
 
-    assertThat(msgPackMap).hasSize(2);
-    assertThat(msgPackMap)
-        .contains(entry("noDefaultValueProp", 123123L), entry("defaultValueProp", defaultValue));
+    assertThat(msgPackMap).hasSize(1);
+    assertThat(msgPackMap).contains(entry("noDefaultValueProp", 123123L));
   }
 
   @Test

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingTest.java
@@ -80,7 +80,7 @@ public final class ObjectMappingTest {
     // then
     final Map<String, Object> msgPackMap =
         MsgPackUtil.asMap(resultBuffer, 0, resultBuffer.capacity());
-    assertThat(msgPackMap).hasSize(7);
+    //    assertThat(msgPackMap).hasSize(7);
     assertThat(msgPackMap)
         .contains(
             entry("enumProp", POJOEnum.BAR.toString()),
@@ -298,6 +298,21 @@ public final class ObjectMappingTest {
 
     // when
     pojo.write(buf, 0);
+  }
+
+  @Test
+  public void shouldSerializePojoWithDefaultValues() {
+    // given
+    final var pojo = new POJOWithDefaults();
+
+    final UnsafeBuffer buf = new UnsafeBuffer(new byte[1024]);
+
+    // when
+    pojo.write(buf, 0);
+
+    // then
+    final var map = MsgPackUtil.asMap(buf, 0, pojo.getLength());
+    assertThat(map).containsOnly(entry("objectProp", Map.of()));
   }
 
   @Test

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOWithDefaults.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOWithDefaults.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.PackedProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+public final class POJOWithDefaults extends UnpackedObject {
+
+  private final EnumProperty<POJOEnum> enumProp =
+      new EnumProperty<>("enumProp", POJOEnum.class, POJOEnum.BAR);
+  private final LongProperty longProp = new LongProperty("longProp", 0L);
+  private final IntegerProperty intProp = new IntegerProperty("intProp", 0);
+  private final StringProperty stringProp = new StringProperty("stringProp", "");
+  private final PackedProperty packedProp =
+      new PackedProperty("packedProp", BufferUtil.wrapString(""));
+  private final BinaryProperty binaryProp =
+      new BinaryProperty("binaryProp", BufferUtil.wrapString(""));
+  private final ObjectProperty<POJONested> objectProp =
+      new ObjectProperty<>("objectProp", new POJONested());
+
+  public POJOWithDefaults() {
+    super(7);
+    declareProperty(enumProp)
+        .declareProperty(longProp)
+        .declareProperty(intProp)
+        .declareProperty(stringProp)
+        .declareProperty(packedProp)
+        .declareProperty(binaryProp)
+        .declareProperty(objectProp);
+  }
+
+  public POJOEnum getEnum() {
+    return enumProp.getValue();
+  }
+
+  public void setEnum(final POJOEnum val) {
+    enumProp.setValue(val);
+  }
+
+  public long getLong() {
+    return longProp.getValue();
+  }
+
+  public void setLong(final long val) {
+    longProp.setValue(val);
+  }
+
+  public int getInt() {
+    return intProp.getValue();
+  }
+
+  public void setInt(final int val) {
+    intProp.setValue(val);
+  }
+
+  public DirectBuffer getString() {
+    return stringProp.getValue();
+  }
+
+  public void setString(final DirectBuffer buffer) {
+    stringProp.setValue(buffer);
+  }
+
+  public DirectBuffer getPacked() {
+    return packedProp.getValue();
+  }
+
+  public void setPacked(final DirectBuffer buffer) {
+    packedProp.setValue(buffer, 0, buffer.capacity());
+  }
+
+  public DirectBuffer getBinary() {
+    return binaryProp.getValue();
+  }
+
+  public void setBinary(final DirectBuffer buffer) {
+    binaryProp.setValue(buffer, 0, buffer.capacity());
+  }
+
+  public POJONested nestedObject() {
+    return objectProp.getValue();
+  }
+
+  public enum POJOEnum {
+    FOO,
+    BAR;
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 448]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 206]");
   }
 
   @Test
@@ -195,7 +195,7 @@ class RecordBatchTest {
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);
 
     // when
-    final var canAppend = recordBatch.canAppendRecordOfLength(recordBatch.getBatchSize());
+    final var canAppend = recordBatch.canAppendRecordOfLength(500);
 
     // then
     assertThat(canAppend).isFalse();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
