### PR TITLE
Delete Authorization API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
@@ -1,0 +1,388 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect, APIRequestContext} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertBadRequest,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  encode,
+  assertForbiddenRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  createUser,
+  createComponentAuthorization,
+  createRole,
+  createGroup,
+  createMappingRule,
+  expectAuthorizationCanBeFound,
+  expectAuthorizationCanNotBeFound,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
+import {cleanupRoles} from 'utils/rolesCleanup';
+import {cleanupGroups} from 'utils/groupsCleanup';
+import {cleanupMappingRules} from 'utils/mappingRuleCleanup';
+
+test.describe.parallel('Delete Authorization API', () => {
+  const cleanups: ((request: APIRequestContext) => Promise<void>)[] = [];
+
+  test.afterAll(async ({request}) => {
+    for (const cleanup of cleanups) {
+      await cleanup(request);
+    }
+  });
+
+  test('Delete User Authorization - Success 204', async ({request}) => {
+    let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let userAuthorizationKey: string;
+    await test.step('Setup - Create user for authorization tests', async () => {
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+    });
+
+    await test.step('Setup - Grant user necessary authorizations', async () => {
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        user.username,
+        'USER',
+        '*',
+        'ROLE',
+        ['READ'],
+      );
+      userAuthorizationKey = await createComponentAuthorization(
+        request,
+        authorizationBody,
+      );
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, userAuthorizationKey);
+    });
+
+    await test.step('Delete authorization', async () => {
+      const deleteRes = await request.delete(
+        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(deleteRes.status()).toBe(204);
+    });
+
+    await test.step('Verify authorization is deleted', async () => {
+      await expectAuthorizationCanNotBeFound(request, userAuthorizationKey);
+    });
+  });
+
+  test('Delete Role Authorization - Success 204', async ({request}) => {
+    let originalRole: {
+      roleId: string;
+      name: string;
+      description: string;
+    };
+    let roleAuthorizationKey: string;
+    let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    await test.step('Setup - Create role for Authorization tests', async () => {
+      originalRole = await createRole(request);
+      cleanups.push(async (request) => {
+        await cleanupRoles(request, [originalRole.roleId]);
+      });
+    });
+
+    await test.step('Setup - Create user for authorization tests', async () => {
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+    });
+
+    await test.step('Setup - Grant created role authorization', async () => {
+      const roleAuthorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        originalRole.roleId,
+        'ROLE',
+        '*',
+        'USER',
+        ['DELETE'],
+      );
+      roleAuthorizationKey = await createComponentAuthorization(
+        request,
+        roleAuthorizationBody,
+      );
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, roleAuthorizationKey);
+    });
+
+    await test.step('Delete authorization', async () => {
+      const deleteRes = await request.delete(
+        buildUrl(`/authorizations/${roleAuthorizationKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(deleteRes.status()).toBe(204);
+    });
+
+    await test.step('Verify authorization is deleted', async () => {
+      await expectAuthorizationCanNotBeFound(request, roleAuthorizationKey);
+    });
+  });
+
+  test('Delete Mapping Rule Authorization - Success 204', async ({request}) => {
+    let originalMappingRule: {
+      mappingRuleId: string;
+      claimName: string;
+      claimValue: string;
+      name: string;
+    };
+    let originalGroup: {
+      groupId: string;
+      name: string;
+      description: string;
+    } = {} as {
+      groupId: string;
+      name: string;
+      description: string;
+    };
+    let mappingRuleAuthorizationKey: string;
+
+    await test.step('Setup - Create group for Authorization tests', async () => {
+      originalGroup = await createGroup(request);
+      cleanups.push(async (request) => {
+        await cleanupGroups(request, [originalGroup.groupId]);
+      });
+    });
+
+    await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
+      originalMappingRule = await createMappingRule(request);
+      cleanups.push(async (request) => {
+        await cleanupMappingRules(request, [originalMappingRule.mappingRuleId]);
+      });
+    });
+
+    await test.step('Setup - Grant created mapping rule authorization', async () => {
+      const mappingRuleAuthorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        originalMappingRule.mappingRuleId,
+        'MAPPING_RULE',
+        '*',
+        'GROUP',
+        ['CREATE'],
+      );
+      mappingRuleAuthorizationKey = await createComponentAuthorization(
+        request,
+        mappingRuleAuthorizationBody,
+      );
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, mappingRuleAuthorizationKey);
+    });
+
+    await test.step('Delete authorization', async () => {
+      const deleteRes = await request.delete(
+        buildUrl(`/authorizations/${mappingRuleAuthorizationKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(deleteRes.status()).toBe(204);
+    });
+
+    await test.step('Verify authorization is deleted', async () => {
+      await expectAuthorizationCanNotBeFound(request, mappingRuleAuthorizationKey);
+    });
+  });
+
+  test('Delete Authorization - second delete attempt - Not Found 404', async ({
+    request,
+  }) => {
+    let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let userAuthorizationKey: string;
+    await test.step('Setup - Create user for authorization tests', async () => {
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+    });
+
+    await test.step('Setup - Grant user necessary authorizations', async () => {
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        user.username,
+        'USER',
+        '*',
+        'ROLE',
+        ['READ'],
+      );
+      userAuthorizationKey = await createComponentAuthorization(
+        request,
+        authorizationBody,
+      );
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, userAuthorizationKey);
+    });
+
+    await test.step('Delete authorization', async () => {
+      const deleteRes = await request.delete(
+        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      expect(deleteRes.status()).toBe(204);
+    });
+
+    await test.step('Verify authorization is deleted', async () => {
+      await expectAuthorizationCanNotBeFound(request, userAuthorizationKey);
+    });
+
+    await test.step('Attempt to delete already deleted authorization', async () => {
+      const deleteRes = await request.delete(
+        buildUrl(`/authorizations/${userAuthorizationKey}`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertNotFoundRequest(
+        deleteRes,
+        `Command 'DELETE' rejected with code 'NOT_FOUND': Expected to delete authorization with key ${userAuthorizationKey}, but an authorization with this key does not exist`,
+      );
+    });
+  });
+
+  test('Delete Authorization - Unauthorized Request - 401', async ({
+    request,
+  }) => {
+    const deleteRes = await request.delete(
+      buildUrl(`/authorizations/anyAuthorizationKey`),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    await assertUnauthorizedRequest(deleteRes);
+  });
+
+  test('Delete Authorization - Invalid Authorization Key - Bad Request 400', async ({
+    request,
+  }) => {
+    const invalidAuthorizationKey = 'meow';
+    const deleteRes = await request.delete(
+      buildUrl(`/authorizations/${invalidAuthorizationKey}`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertBadRequest(
+      deleteRes,
+      `Failed to convert 'authorizationKey' with value: '${invalidAuthorizationKey}'`,
+    );
+  });
+
+  test('Delete Authorization - 403 Forbidden', async ({request}) => {
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let userAuthorizationKey: string = '';
+
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [
+          userWithResourcesAuthorizationToSendRequest.username,
+        ]);
+      });
+
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+    });
+
+    await test.step('Setup - Grant user necessary authorizations', async () => {
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        user.username,
+        'USER',
+        '*',
+        'ROLE',
+        ['READ'],
+      );
+      userAuthorizationKey = await createComponentAuthorization(
+        request,
+        authorizationBody,
+      );
+    });
+
+    await test.step('Delete Authorization and assert results', async () => {
+      const token = encode(
+        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+      );
+
+      await expect(async () => {
+        const deleteRes = await request.delete(
+          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+          },
+        );
+        await assertForbiddenRequest(
+          deleteRes,
+          "Command 'DELETE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'DELETE' on resource 'AUTHORIZATION'",
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
@@ -156,7 +156,7 @@ test.describe.parallel('Get Authorization API', () => {
     });
   });
 
-  test('Get existing Authorization - forbidden', async ({request}) => {
+  test('Get existing Authorization - 403 Forbidden', async ({request}) => {
     let userWithResourcesAuthorizationToSendRequest: {
       username: string;
       name: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
@@ -15,6 +15,7 @@ import {
   assertUnauthorizedRequest,
   assertNotFoundRequest,
   encode,
+  assertForbiddenRequest,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
@@ -27,6 +28,7 @@ import {
   expectAuthorizationCanBeFound,
   verifyAuthorizationFields,
   type Authorization,
+  grantUserResourceAuthorization,
 } from '@requestHelpers';
 import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
 import {waitForAssertion} from 'utils/waitForAssertion';
@@ -908,6 +910,90 @@ test.describe.parallel('Update Authorization API', () => {
         },
       );
       await assertInvalidArgument(authRes, 400, 'No permissionTypes provided.');
+    });
+  });
+
+  test('Update User Authorization - 403 Forbidden', async ({request}) => {
+    let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let userAuthorizationKey: string;
+    let originalUserAuthorization: Authorization = {} as Authorization;
+    await test.step('Setup - Create user for authorization tests', async () => {
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [
+          userWithResourcesAuthorizationToSendRequest.username,
+        ]);
+      });
+    });
+
+    await test.step('Setup - Grant user necessary authorizations', async () => {
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        user.username,
+        'USER',
+        '*',
+        'ROLE',
+        ['READ'],
+      );
+      userAuthorizationKey = await createComponentAuthorization(
+        request,
+        authorizationBody,
+      );
+      originalUserAuthorization = authorizationBody;
+    });
+
+    const updatedUserAuthorization = {
+      ...originalUserAuthorization,
+      permissionTypes: ['READ', 'UPDATE'],
+    };
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, userAuthorizationKey);
+    });
+
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    await test.step('Update user authorization to add UPDATE permission', async () => {
+      await expect(async () => {
+        const authRes = await request.put(
+          buildUrl(`/authorizations/${userAuthorizationKey}`),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {
+              ...updatedUserAuthorization,
+            },
+          },
+        );
+        await assertForbiddenRequest(
+          authRes,
+          "Command 'UPDATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'",
+        );
+      }).toPass(defaultAssertionOptions);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -28,7 +28,7 @@ export interface Authorization {
   resourceType: string;
   permissionTypes: string[];
   authorizationKey?: string;
-};
+}
 
 export async function createComponentAuthorization(
   request: APIRequestContext,
@@ -149,4 +149,22 @@ export function verifyAuthorizationFields(
     authorizationRequiredFieldsWithoutPermissionTypes,
   );
   expect(obj.permissionTypes.sort()).toEqual(expected.permissionTypes.sort());
+}
+
+export async function expectAuthorizationCanNotBeFound(
+  request: APIRequestContext,
+  authorizationKey: string,
+) {
+  await expect(async () => {
+    const statusRes = await request.get(
+      buildUrl(`/authorizations/${authorizationKey}`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(statusRes, 404);
+  }).toPass({
+    intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+    timeout: 120_000,
+  });
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -46,6 +46,7 @@ export {
   expectAuthorizationCanBeFound,
   verifyAuthorizationFields,
   type Authorization,
+  expectAuthorizationCanNotBeFound,
 } from './authorization-requestHelpers';
 export {assertRoleInResponse} from './role-requestHelpers';
 export {assertClientsInResponse} from './clients-requestHelpers';


### PR DESCRIPTION
## Description

This PR covers Delete Authorization API test with happy path:

- Delete User Authorization - Success 204
- Delete Role Authorization - Success 204
- Delete Mapping Rule Authorization - Success 204
- Delete Authorization - second delete attempt - Not Found 404

and unhappy path:

- Delete Authorization - Unauthorized Request - 401
- Delete Authorization - Invalid Authorization Key - Bad Request 400
- Delete Authorization - 403 Forbidden

Also this PR present Forbidden 403 test for Update Authorization API

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21472606285)
