### PR TITLE
feat: very rough change to make archiver split batches by doc count (WIP)

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -7,7 +7,12 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
 /**
  * Represents a batch of documents to be archived. This interface serves as a common contract for
@@ -22,6 +27,10 @@ public interface ArchiveBatch {
   String finishDate();
 
   int size();
+
+  List<Long> processInstanceKeys();
+
+  List<Long> rootProcessInstanceKeys();
 
   default boolean isEmpty() {
     return size() == 0;
@@ -42,6 +51,108 @@ public interface ArchiveBatch {
     @Override
     public int size() {
       return ids.size();
+    }
+
+    @Override
+    public List<Long> processInstanceKeys() {
+      return ids.stream().map(Long::parseLong).toList();
+    }
+
+    @Override
+    public List<Long> rootProcessInstanceKeys() {
+      return List.of();
+    }
+  }
+
+  record ProcessInstanceBatchSizes(
+      Map<Long, Long> docCountByProcessInstanceKey,
+      Map<Long, Long> docCountByRootProcessInstanceKey) {
+    List<ProcessInstanceArchiveBatch> splitBatch(
+        final ProcessInstanceArchiveBatch batch, final long maxDocumentsPerBatch) {
+      final List<Long> processInstanceKeys = new ArrayList<>(batch.processInstanceKeys());
+      final List<Long> rootProcessInstanceKeys = new ArrayList<>(batch.rootProcessInstanceKeys());
+      final List<ProcessInstanceArchiveBatch> batches = new ArrayList<>();
+
+      final CurrentBatch currentBatch =
+          new CurrentBatch(
+              batch.finishDate(), new ArrayList<>(), new ArrayList<>(), new AtomicLong(0L));
+      splitBatchByKeys(
+          currentBatch,
+          processInstanceKeys,
+          docCountByProcessInstanceKey,
+          currentBatch::addProcessInstanceKey,
+          maxDocumentsPerBatch,
+          batches);
+      splitBatchByKeys(
+          currentBatch,
+          rootProcessInstanceKeys,
+          docCountByRootProcessInstanceKey,
+          currentBatch::addRootProcessInstanceKey,
+          maxDocumentsPerBatch,
+          batches);
+
+      if (!currentBatch.isEmpty()) {
+        batches.add(currentBatch.newBatch());
+      }
+
+      return batches;
+    }
+
+    private void splitBatchByKeys(
+        final CurrentBatch currentBatch,
+        final List<Long> keys,
+        final Map<Long, Long> docCountByKey,
+        final BiConsumer<Long, Long> addKeyFunction,
+        final long maxDocumentsPerBatch,
+        final List<ProcessInstanceArchiveBatch> batches) {
+      final Iterator<Long> it = keys.iterator();
+      while (it.hasNext()) {
+        final Long processInstanceKey = it.next();
+        final long docCount = docCountByKey.getOrDefault(processInstanceKey, 0L);
+        final long currentBatchDocs = currentBatch.currentDocCount();
+        if (!currentBatch.isEmpty() && (currentBatchDocs + docCount) > maxDocumentsPerBatch) {
+          batches.add(currentBatch.newBatch());
+        }
+        addKeyFunction.accept(processInstanceKey, docCount);
+        it.remove();
+      }
+    }
+
+    private record CurrentBatch(
+        String finishDate,
+        List<Long> processInstanceKeys,
+        List<Long> rootProcessInstanceKeys,
+        AtomicLong docCount) {
+
+      boolean isEmpty() {
+        return processInstanceKeys.isEmpty() && rootProcessInstanceKeys().isEmpty();
+      }
+
+      long currentDocCount() {
+        return docCount.get();
+      }
+
+      void addProcessInstanceKey(final long key, final long count) {
+        processInstanceKeys.add(key);
+        docCount.addAndGet(count);
+      }
+
+      void addRootProcessInstanceKey(final long key, final long count) {
+        rootProcessInstanceKeys.add(key);
+        docCount.addAndGet(count);
+      }
+
+      ProcessInstanceArchiveBatch newBatch() {
+        docCount.set(0L);
+        return new ProcessInstanceArchiveBatch(
+            finishDate, consumeKeys(processInstanceKeys), consumeKeys(rootProcessInstanceKeys));
+      }
+
+      private List<Long> consumeKeys(final List<Long> keys) {
+        final List<Long> consumedKeys = new ArrayList<>(keys);
+        keys.clear();
+        return consumedKeys;
+      }
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -9,8 +9,10 @@ package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceBatchSizes;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import java.util.List;
@@ -30,6 +32,9 @@ public interface ArchiverRepository extends AutoCloseable {
           UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
 
   CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch();
+
+  CompletableFuture<ProcessInstanceBatchSizes> getProcessInstancesBatchSizes(
+      ProcessInstanceArchiveBatch batch, final List<ProcessInstanceDependant> dependentIndexes);
 
   CompletableFuture<BasicArchiveBatch> getBatchOperationsNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -19,10 +19,12 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.Pro
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceBatchSizes;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -143,6 +145,13 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                 createProcessInstanceBatch(
                     response, ListViewTemplate.END_DATE, listViewTemplateDescriptor),
             executor);
+  }
+
+  @Override
+  public CompletableFuture<ProcessInstanceBatchSizes> getProcessInstancesBatchSizes(
+      final ProcessInstanceArchiveBatch batch,
+      final List<ProcessInstanceDependant> dependentIndexes) {
+    return null;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveBatchTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceBatchSizes;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ArchiveBatchTest {
+  @Test
+  void testSplitWhenAllDocCountsZero() {
+    final var sizes = new ProcessInstanceBatchSizes(Map.of(), Map.of());
+
+    final ProcessInstanceArchiveBatch batch =
+        new ProcessInstanceArchiveBatch("date", List.of(1L, 2L), List.of(10L));
+
+    assertThat(sizes.splitBatch(batch, 30L))
+        .isEqualTo(List.of(new ProcessInstanceArchiveBatch("date", List.of(1L, 2L), List.of(10L))));
+  }
+
+  @Test
+  void test() {
+    final var sizes =
+        new ProcessInstanceBatchSizes(
+            Map.ofEntries(
+                Map.entry(1L, 10L), Map.entry(2L, 10L), Map.entry(3L, 10L), Map.entry(4L, 10L)),
+            Map.ofEntries(
+                Map.entry(10L, 10L),
+                Map.entry(20L, 100L),
+                Map.entry(30L, 10L),
+                Map.entry(40L, 10L)));
+
+    final ProcessInstanceArchiveBatch batch =
+        new ProcessInstanceArchiveBatch(
+            "date", List.of(1L, 2L, 3L, 4L, 5L, 6L), List.of(10L, 20L, 30L, 40L));
+
+    assertThat(sizes.splitBatch(batch, 30L))
+        .isEqualTo(
+            List.of(
+                new ProcessInstanceArchiveBatch("date", List.of(1L, 2L, 3L), List.of()),
+                new ProcessInstanceArchiveBatch("date", List.of(4L, 5L, 6L), List.of(10L)),
+                new ProcessInstanceArchiveBatch("date", List.of(), List.of(20L)),
+                new ProcessInstanceArchiveBatch("date", List.of(), List.of(30L, 40L))));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -8,6 +8,8 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceBatchSizes;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -18,6 +20,13 @@ public class NoopArchiverRepository implements ArchiverRepository {
   public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.ProcessInstanceArchiveBatch("2024-01-01", List.of(), List.of()));
+  }
+
+  @Override
+  public CompletableFuture<ProcessInstanceBatchSizes> getProcessInstancesBatchSizes(
+      final ProcessInstanceArchiveBatch batch,
+      final List<ProcessInstanceDependant> dependentIndexes) {
+    return null;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceBatchSizes;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +28,13 @@ final class TestRepository extends NoopArchiverRepository {
   @Override
   public CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch() {
     return CompletableFuture.completedFuture((ProcessInstanceArchiveBatch) batch);
+  }
+
+  @Override
+  public CompletableFuture<ProcessInstanceBatchSizes> getProcessInstancesBatchSizes(
+      final ProcessInstanceArchiveBatch batch,
+      final List<ProcessInstanceDependant> dependentIndexes) {
+    return CompletableFuture.completedFuture(new ProcessInstanceBatchSizes(Map.of(), Map.of()));
   }
 
   @Override


### PR DESCRIPTION
Basically doing a query across all the dependent indexes to find out how many docs we would delete per process instance/root process instance, then using that to decide if the current batch of process instances is too many or not.

Pretty horrible hacky code ATM + not implemented for opensearch

This is a slight variation on "Solution 5" from here:

https://docs.google.com/document/d/1JKB5X2Doe_xnhr1e7T8jE0nWRy0WgPuSQ912lWNnsFE/edit?tab=t.0

It only uses the overall number of docs to be deleted and does not doing any splitting on a per-index level.  So it would mean sometimes we're going slower than we'd need to (for indexes with fewer docs)

Query looks like (it's a bit more complicated due to dealing with root process instances):
```
{
  "aggregations": {
    "rootProcessInstanceKey": {
      "terms": {
        "field": "rootProcessInstanceKey",
        "size": 1
      }
    },
    "processInstanceKey": {
      "aggregations": {
        "processInstances": {
          "terms": {
            "field": "processInstanceKey",
            "size": 2
          }
        }
      },
      "filter": {
        "terms": {
          "processInstanceKey": [1, 2]
        }
      }
    }
  },
  "query": {
    "bool": {
      "should": [
        {
          "terms": {
            "processInstanceKey": [1, 2]
          }
        },
        {
          "terms": {
            "rootProcessInstanceKey": [3]
          }
        }
      ]
    }
  },
  "size": 0
}
```