### PR TITLE
Demo for faster CI Analytics submission

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -76,26 +76,27 @@ runs:
         else
           echo "result=" >> $GITHUB_OUTPUT
         fi
-    ######################## Report test result #############################  
+    ######################## Report test result #############################
     - name: Get detailed info on JUnit tests
       id: get-detailed-junit-tests
       if: ${{ inputs.detailed_junit_tests == 'true' && steps.secrets.outputs.gcloud_sa_key != '' }}
       shell: bash
       run: |
         TEST_RESULTS_FILE=$(mktemp --suffix=.jsonl)
-        echo "test_results_file=${TEST_RESULTS_FILE}" >> $GITHUB_OUTPUT        
+        echo "test_results_file=${TEST_RESULTS_FILE}" >> $GITHUB_OUTPUT
         find . -iname 'TEST-*.xml' | python3 .ci/scripts/ci/observe-build-status/junit-test-results-to-jsonl.py > "${TEST_RESULTS_FILE}"
         echo "Generated $(wc -l < "${TEST_RESULTS_FILE}") test results"
 
     - name: Submit test results
-      uses: camunda/infra-global-github-actions/submit-test-status@main
+      uses: camunda/infra-global-github-actions/submit-test-status@speedup-bigquery-insert
       if: ${{ (inputs.detailed_junit_tests == 'true') && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         test_results_file_path: "${{ steps.get-detailed-junit-tests.outputs.test_results_file }}"
         job_name_override: "${{ inputs.job_name }}"
-        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"   
+        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+
    ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@main
+    - uses: camunda/infra-global-github-actions/submit-build-status@speedup-bigquery-insert
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"


### PR DESCRIPTION
## Description

Demo for https://github.com/camunda/infra-global-github-actions/pull/600

Build from `main` branch with old logic: https://github.com/camunda/camunda/actions/runs/21467932453/job/61833929961 (18 seconds)

Build from this PR with the new logic: https://github.com/camunda/camunda/actions/runs/21475973362/job/61867700433?pr=44809#step:5:1 (3 seconds)

Run query `SELECT * FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE ci_url = 'https://github.com/camunda/camunda' AND build_ref = 'refs/pull/44809/merge'` to check that data is still ingested correctly.

Works on Win/Mac:

* https://github.com/camunda/camunda/actions/runs/21475973362/job/61867700688?pr=44809
* https://github.com/camunda/camunda/actions/runs/21475973362/job/61867700693?pr=44809

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
