### PR TITLE
feat: BufferWriter.write returns the written length

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/SbeBufferWriterReader.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/SbeBufferWriterReader.java
@@ -40,7 +40,7 @@ public abstract class SbeBufferWriterReader<
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(getBodyEncoder().sbeBlockLength())
@@ -49,6 +49,8 @@ public abstract class SbeBufferWriterReader<
         .version(getBodyEncoder().sbeSchemaVersion());
 
     getBodyEncoder().wrap(buffer, offset + headerEncoder.encodedLength());
+
+    return getLength();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -85,8 +85,8 @@ public final class SnapshotChunkImpl
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    super.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    final var len = super.write(buffer, offset);
 
     // The snapshot checksum is 0 for backwards compatibility reasons, when sending chunk data to
     // brokers on older versions which checks on the snapshot checksum.
@@ -99,6 +99,7 @@ public final class SnapshotChunkImpl
         .checksum(checksum)
         .snapshotChecksum(0)
         .putContent(content, 0, content.capacity());
+    return len + encoder.encodedLength();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
@@ -105,8 +105,8 @@ public interface RaftEntrySerializer {
     }
 
     @Override
-    public void write(final MutableDirectBuffer writeBuffer, final int offset) {
-      writeFunction.apply(writeBuffer, offset);
+    public int write(final MutableDirectBuffer writeBuffer, final int offset) {
+      return writeFunction.apply(writeBuffer, offset);
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupDeleteRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupDeleteRequest.java
@@ -96,7 +96,7 @@ public class BackupDeleteRequest extends BrokerRequest<BackupStatusResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupListRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupListRequest.java
@@ -105,7 +105,7 @@ public class BackupListRequest extends BrokerRequest<BackupListResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupStatusRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupStatusRequest.java
@@ -97,7 +97,7 @@ public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
@@ -89,7 +89,7 @@ public class BrokerBackupRangesRequest extends BrokerRequest<BackupRangesRespons
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRequest.java
@@ -140,7 +140,7 @@ public final class BrokerBackupRequest extends BrokerRequest<BackupResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerCheckpointStateRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerCheckpointStateRequest.java
@@ -98,7 +98,7 @@ public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateR
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
@@ -120,8 +120,8 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 
   protected boolean isValidResponse() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -149,7 +149,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
+    public int write(final MutableDirectBuffer buffer, final int offset) {
       throw new UnsupportedOperationException();
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributeMessage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributeMessage.java
@@ -44,7 +44,6 @@ public class ExporterStateDistributeMessage
 
   @Override
   public int getLength() {
-
     final var length = new MutableInteger();
     exporterState.forEach(
         (id, state) ->
@@ -63,7 +62,6 @@ public class ExporterStateDistributeMessage
     super.write(buffer, offset);
 
     final var stateEncoder = encoder.stateCount(exporterState.size());
-
     exporterState.forEach(
         (id, state) -> {
           final var idBuffer = BufferUtil.wrapString(id);
@@ -75,7 +73,7 @@ public class ExporterStateDistributeMessage
               .putExporterId(idBuffer, 0, idBuffer.capacity())
               .putMetadata(metadata, 0, metadata.capacity());
         });
-    return getLength();
+    return headerEncoder.encodedLength() + encoder.encodedLength();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributeMessage.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributeMessage.java
@@ -59,7 +59,7 @@ public class ExporterStateDistributeMessage
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     super.write(buffer, offset);
 
     final var stateEncoder = encoder.stateCount(exporterState.size());
@@ -75,6 +75,7 @@ public class ExporterStateDistributeMessage
               .putExporterId(idBuffer, 0, idBuffer.capacity())
               .putMetadata(metadata, 0, metadata.capacity());
         });
+    return getLength();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -224,7 +224,8 @@ public final class ErrorResponseWriter implements BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
+    final int initialOffset = offset;
     // protocol header
     messageHeaderEncoder.wrap(buffer, offset);
 
@@ -240,6 +241,8 @@ public final class ErrorResponseWriter implements BufferWriter {
     errorResponseEncoder.wrap(buffer, offset);
 
     errorResponseEncoder.errorCode(errorCode).putErrorData(errorMessage, 0, errorMessage.length);
+
+    return errorResponseEncoder.limit() - initialOffset;
   }
 
   public void reset() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -225,24 +225,10 @@ public final class ErrorResponseWriter implements BufferWriter {
 
   @Override
   public int write(final MutableDirectBuffer buffer, int offset) {
-    final int initialOffset = offset;
-    // protocol header
-    messageHeaderEncoder.wrap(buffer, offset);
-
-    messageHeaderEncoder
-        .blockLength(errorResponseEncoder.sbeBlockLength())
-        .templateId(errorResponseEncoder.sbeTemplateId())
-        .schemaId(errorResponseEncoder.sbeSchemaId())
-        .version(errorResponseEncoder.sbeSchemaVersion());
-
-    offset += messageHeaderEncoder.encodedLength();
-
-    // error message
-    errorResponseEncoder.wrap(buffer, offset);
-
+    errorResponseEncoder.wrapAndApplyHeader(buffer, offset, messageHeaderEncoder);
     errorResponseEncoder.errorCode(errorCode).putErrorData(errorMessage, 0, errorMessage.length);
 
-    return errorResponseEncoder.limit() - initialOffset;
+    return messageHeaderEncoder.encodedLength() + errorResponseEncoder.encodedLength();
   }
 
   public void reset() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
@@ -53,7 +53,7 @@ public final class ApiResponseWriter implements ResponseWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
     headerEncoder.wrap(buffer, offset);
 
     headerEncoder
@@ -68,5 +68,6 @@ public final class ApiResponseWriter implements ResponseWriter {
     if (hasPayload) {
       responseEncoder.putPayload(payload, 0, payload.length);
     }
+    return getLength();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -81,7 +81,8 @@ public final class BackupApiResponseWriter implements ResponseWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     responseWriter.accept(buffer, offset);
+    return getLength();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
@@ -30,5 +30,7 @@ public class CommandApiResponseWriter implements ResponseWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {}
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return 0;
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -118,7 +118,7 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
     // protocol header
     messageHeaderEncoder
         .wrap(buffer, offset)
@@ -151,6 +151,8 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
 
     responseEncoder.limit(offset);
     responseEncoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
+
+    return getLength();
   }
 
   private void reset() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
@@ -49,7 +49,7 @@ public final class QueryResponseWriter implements ResponseWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
     // protocol header
     headerEncoder.wrap(buffer, offset);
 
@@ -64,6 +64,8 @@ public final class QueryResponseWriter implements ResponseWriter {
     responseEncoder.wrap(buffer, offset);
 
     responseEncoder.putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
+
+    return getLength();
   }
 
   public QueryResponseWriter bpmnProcessId(final DirectBuffer bpmnProcessId) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
@@ -49,7 +49,6 @@ public class SnapshotApiResponseWriter implements ResponseWriter {
 
   @Override
   public int write(final MutableDirectBuffer buffer, final int offset) {
-    serializer.serialize(snapshotChunk, buffer, offset);
-    return getLength();
+    return serializer.serialize(snapshotChunk, buffer, offset);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
@@ -48,7 +48,8 @@ public class SnapshotApiResponseWriter implements ResponseWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     serializer.serialize(snapshotChunk, buffer, offset);
+    return getLength();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
@@ -124,7 +124,6 @@ public class SnapshotBrokerRequest extends BrokerRequest<SnapshotResponse> {
 
   @Override
   public int write(final MutableDirectBuffer buffer, final int offset) {
-    serializer.serialize(request, buffer, offset);
-    return getLength();
+    return serializer.serialize(request, buffer, offset);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
@@ -123,7 +123,8 @@ public class SnapshotBrokerRequest extends BrokerRequest<SnapshotResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     serializer.serialize(request, buffer, offset);
+    return getLength();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -107,7 +107,9 @@ final class RemoteJobStreamErrorHandlerTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {}
+    public int write(final MutableDirectBuffer buffer, final int offset) {
+      return 0;
+    }
   }
 
   private record TestErrorHandler(List<TestErrorHandler.Error> errors)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
@@ -226,8 +226,8 @@ public final class QueryApiIT {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
-      request.write(buffer, offset);
+    public int write(final MutableDirectBuffer buffer, final int offset) {
+      return request.write(buffer, offset);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableScopeKey.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clustervariable/DbClusterVariableScopeKey.java
@@ -47,12 +47,12 @@ public class DbClusterVariableScopeKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    scope.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    int written = scope.write(buffer, offset);
 
     if (scope.getValue() != ClusterVariableScope.GLOBAL) {
-      final var scopeLength = scope.getLength();
-      scopeKey.write(buffer, offset + scopeLength);
+      written += scopeKey.write(buffer, offset + written);
     } // else don't write scopeKey as part of the key
+    return written;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/MetricsKey.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/MetricsKey.java
@@ -79,10 +79,11 @@ public final class MetricsKey implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     buffer.putInt(offset, jobTypeIndex, Protocol.ENDIANNESS);
     buffer.putInt(offset + Integer.BYTES, tenantIdIndex, Protocol.ENDIANNESS);
     buffer.putInt(offset + 2 * Integer.BYTES, workerNameIndex, Protocol.ENDIANNESS);
+    return getLength();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/MetricsValue.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/jobmetrics/MetricsValue.java
@@ -71,7 +71,7 @@ public final class MetricsValue implements DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     int currentOffset = offset;
     for (final StatusMetrics metric : metrics) {
       buffer.putInt(currentOffset, metric.getCount(), Protocol.ENDIANNESS);
@@ -79,6 +79,7 @@ public final class MetricsValue implements DbValue {
       buffer.putLong(currentOffset, metric.getLastUpdatedAt(), Protocol.ENDIANNESS);
       currentOffset += Long.BYTES;
     }
+    return getLength();
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -775,8 +775,9 @@ public final class EngineRule extends ExternalResource {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
+    public int write(final MutableDirectBuffer buffer, final int offset) {
       buffer.putBytes(offset, genericBuffer, 0, genericBuffer.capacity());
+      return buffer.capacity();
     }
 
     public DirectBuffer getDirectBuffer() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -777,7 +777,7 @@ public final class EngineRule extends ExternalResource {
     @Override
     public int write(final MutableDirectBuffer buffer, final int offset) {
       buffer.putBytes(offset, genericBuffer, 0, genericBuffer.capacity());
-      return buffer.capacity();
+      return genericBuffer.capacity();
     }
 
     public DirectBuffer getDirectBuffer() {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -139,7 +139,7 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/BrokerExecuteQuery.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/BrokerExecuteQuery.java
@@ -99,7 +99,7 @@ public final class BrokerExecuteQuery extends BrokerRequest<String> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    request.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return request.write(buffer, offset);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -130,8 +130,9 @@ public final class LoggedEventImpl implements LoggedEvent {
   }
 
   @Override
-  public void write(final MutableDirectBuffer destination, final int offset) {
+  public int write(final MutableDirectBuffer destination, final int offset) {
     destination.putBytes(offset, buffer, fragmentOffset, getLength());
+    return getLength();
   }
 
   private int getMessageLength() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -131,8 +131,9 @@ public final class LoggedEventImpl implements LoggedEvent {
 
   @Override
   public int write(final MutableDirectBuffer destination, final int offset) {
-    destination.putBytes(offset, buffer, fragmentOffset, getLength());
-    return getLength();
+    final var length = getLength();
+    destination.putBytes(offset, buffer, fragmentOffset, length);
+    return length;
   }
 
   private int getMessageLength() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -41,7 +41,8 @@ public record SequencedBatch(
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     SequencedBatchSerializer.serializeBatch(buffer, offset, this);
+    return length;
   }
 }

--- a/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackUtil.java
+++ b/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackUtil.java
@@ -49,4 +49,9 @@ public final class MsgPackUtil {
   public interface CheckedConsumer<T> {
     void accept(T t) throws Exception;
   }
+
+  @FunctionalInterface
+  public interface CheckedToIntFunction<T> {
+    int apply(T t) throws Exception;
+  }
 }

--- a/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackWriterMiscTest.java
+++ b/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackWriterMiscTest.java
@@ -15,16 +15,16 @@ public final class MsgPackWriterMiscTest {
 
   @Test
   public void testEncodedMapHeaderLength() {
-    assertThat(MsgPackWriter.getEncodedMapHeaderLenght(0x0f)).isEqualTo(1);
-    assertThat(MsgPackWriter.getEncodedMapHeaderLenght(0xffff)).isEqualTo(3);
-    assertThat(MsgPackWriter.getEncodedMapHeaderLenght(0x7fff_ffff)).isEqualTo(5);
+    assertThat(MsgPackWriter.getEncodedMapHeaderLength(0x0f)).isEqualTo(1);
+    assertThat(MsgPackWriter.getEncodedMapHeaderLength(0xffff)).isEqualTo(3);
+    assertThat(MsgPackWriter.getEncodedMapHeaderLength(0x7fff_ffff)).isEqualTo(5);
   }
 
   @Test
   public void testEncodedArayHeaderLength() {
-    assertThat(MsgPackWriter.getEncodedArrayHeaderLenght(0x0f)).isEqualTo(1);
-    assertThat(MsgPackWriter.getEncodedArrayHeaderLenght(0xffff)).isEqualTo(3);
-    assertThat(MsgPackWriter.getEncodedArrayHeaderLenght(0x7fff_ffff)).isEqualTo(5);
+    assertThat(MsgPackWriter.getEncodedArrayHeaderLength(0x0f)).isEqualTo(1);
+    assertThat(MsgPackWriter.getEncodedArrayHeaderLength(0xffff)).isEqualTo(3);
+    assertThat(MsgPackWriter.getEncodedArrayHeaderLength(0x7fff_ffff)).isEqualTo(5);
   }
 
   @Test

--- a/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackWriterTest.java
+++ b/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackWriterTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.test.util.BufferAssert.assertThatBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackUtil.CheckedConsumer;
+import io.camunda.zeebe.msgpack.spec.MsgPackUtil.CheckedToIntFunction;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.agrona.DirectBuffer;
@@ -38,7 +39,7 @@ public final class MsgPackWriterTest {
   public String name;
 
   @Parameter(1)
-  public CheckedConsumer<MsgPackWriter> actualValueWriter;
+  public CheckedToIntFunction<MsgPackWriter> actualValueWriter;
 
   @Parameter(2)
   public CheckedConsumer<ByteArrayBuilder> expectedValueWriter;
@@ -183,11 +184,12 @@ public final class MsgPackWriterTest {
     final byte[] expectedValue = builder.value;
 
     // when
-    actualValueWriter.accept(writer);
+    final var len = actualValueWriter.apply(writer);
 
     // then
     assertThat(writer.getOffset()).isEqualTo(WRITE_OFFSET + expectedValue.length);
     assertThatBuffer(actualValueBuffer).hasBytes(expectedValue, WRITE_OFFSET);
+    assertThat(len).isEqualTo(expectedValue.length);
   }
 
   // helping the compiler with recognizing lamdas
@@ -196,7 +198,8 @@ public final class MsgPackWriterTest {
     return arg;
   }
 
-  protected static CheckedConsumer<MsgPackWriter> actual(final CheckedConsumer<MsgPackWriter> arg) {
+  protected static CheckedToIntFunction<MsgPackWriter> actual(
+      final CheckedToIntFunction<MsgPackWriter> arg) {
     return arg;
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -61,11 +61,11 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     if (writer == null) {
       writer = new MsgPackWriter();
     }
     writer.wrap(buffer, offset);
-    write(writer);
+    return write(writer);
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -84,7 +84,7 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     set();
   }
 
-  public void write(final MsgPackWriter writer) {
+  public int write(final MsgPackWriter writer) {
     T valueToWrite = value;
     if (!isSet) {
       valueToWrite = defaultValue;
@@ -95,8 +95,9 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
           key, "Expected a value or default value to be set before writing, but has nothing");
     }
 
-    key.write(writer);
-    valueToWrite.write(writer);
+    int written = key.write(writer);
+    written += valueToWrite.write(writer);
+    return written;
   }
 
   public void writeJSON(final StringBuilder sb, final boolean maskSanitized) {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -55,11 +55,13 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeArrayHeader(items.size());
+  public int write(final MsgPackWriter writer) {
+    int length = 0;
+    length += writer.writeArrayHeader(items.size());
     for (int i = 0; i < items.size(); i++) {
-      items.get(i).write(writer);
+      length += items.get(i).write(writer);
     }
+    return length;
   }
 
   @Override
@@ -76,7 +78,7 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue
 
   @Override
   public int getEncodedLength() {
-    return MsgPackWriter.getEncodedArrayHeaderLenght(items.size())
+    return MsgPackWriter.getEncodedArrayHeaderLength(items.size())
         + CollectionUtil.sum(items, BaseValue::getEncodedLength);
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BaseValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BaseValue.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 public abstract class BaseValue implements Recyclable {
   public abstract void writeJSON(StringBuilder builder);
 
-  public abstract void write(MsgPackWriter writer);
+  public abstract int write(MsgPackWriter writer);
 
   public abstract void read(MsgPackReader reader);
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BinaryValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BinaryValue.java
@@ -64,8 +64,8 @@ public class BinaryValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeBinary(data);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeBinary(data);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BooleanValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/BooleanValue.java
@@ -41,8 +41,8 @@ public final class BooleanValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeBoolean(val);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeBoolean(val);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/DeltaEncodedLongArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/DeltaEncodedLongArrayValue.java
@@ -62,16 +62,17 @@ public final class DeltaEncodedLongArrayValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeArrayHeader(values.length);
+  public int write(final MsgPackWriter writer) {
+    int written = writer.writeArrayHeader(values.length);
 
     for (int i = 0; i < values.length; i++) {
       if (i == 0) {
-        writer.writeInteger(values[i]);
+        written += writer.writeInteger(values[i]);
       } else {
-        writer.writeInteger(values[i] - values[i - 1]);
+        written += writer.writeInteger(values[i] - values[i - 1]);
       }
     }
+    return written;
   }
 
   @Override
@@ -91,7 +92,7 @@ public final class DeltaEncodedLongArrayValue extends BaseValue {
 
   @Override
   public int getEncodedLength() {
-    final int header = MsgPackWriter.getEncodedArrayHeaderLenght(values.length);
+    final int header = MsgPackWriter.getEncodedArrayHeaderLength(values.length);
     int data = 0;
     for (int i = 0; i < values.length; i++) {
       if (i == 0) {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/EnumValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/EnumValue.java
@@ -50,8 +50,8 @@ public final class EnumValue<E extends Enum<E>> extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    decodedValue.write(writer);
+  public int write(final MsgPackWriter writer) {
+    return decodedValue.write(writer);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/IntegerValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/IntegerValue.java
@@ -41,8 +41,8 @@ public final class IntegerValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeInteger(value);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeInteger(value);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/LongValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/LongValue.java
@@ -41,8 +41,8 @@ public final class LongValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeInteger(value);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeInteger(value);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -85,12 +85,13 @@ public class ObjectValue extends BaseValue {
    * write all the values.
    */
   @Override
-  public void write(final MsgPackWriter writer) {
+  public int write(final MsgPackWriter writer) {
     final int size = declaredProperties.size() + undeclaredProperties.size();
 
-    writer.writeMapHeader(size);
-    write(writer, declaredProperties);
-    write(writer, undeclaredProperties);
+    int written = writer.writeMapHeader(size);
+    written += write(writer, declaredProperties);
+    written += write(writer, undeclaredProperties);
+    return written;
   }
 
   @Override
@@ -135,7 +136,7 @@ public class ObjectValue extends BaseValue {
   public int getEncodedLength() {
     final int size = declaredProperties.size() + undeclaredProperties.size();
 
-    int length = MsgPackWriter.getEncodedMapHeaderLenght(size);
+    int length = MsgPackWriter.getEncodedMapHeaderLength(size);
     length += getEncodedLength(declaredProperties);
     length += getEncodedLength(undeclaredProperties);
 
@@ -178,12 +179,14 @@ public class ObjectValue extends BaseValue {
     }
   }
 
-  private <T extends BaseProperty<?>> void write(
+  private <T extends BaseProperty<?>> int write(
       final MsgPackWriter writer, final List<T> properties) {
+    int written = 0;
     for (int i = 0; i < properties.size(); ++i) {
       final BaseProperty<? extends BaseValue> prop = properties.get(i);
-      prop.write(writer);
+      written += prop.write(writer);
     }
+    return written;
   }
 
   /**

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/PackedValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/PackedValue.java
@@ -46,8 +46,8 @@ public class PackedValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeRaw(buffer);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeRaw(buffer);
   }
 
   @Override

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
@@ -87,8 +87,8 @@ public final class StringValue extends BaseValue {
   }
 
   @Override
-  public void write(final MsgPackWriter writer) {
-    writer.writeString(bytes);
+  public int write(final MsgPackWriter writer) {
+    return writer.writeString(bytes);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -47,7 +47,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .brokerId(brokerId)
@@ -58,6 +58,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
     if (hasPayload) {
       bodyEncoder.putPayload(payload, 0, payload.length);
     }
+    return getLength();
   }
 
   public int getBrokerId() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -58,7 +58,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
     if (hasPayload) {
       bodyEncoder.putPayload(payload, 0, payload.length);
     }
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
   public int getBrokerId() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminResponse.java
@@ -33,8 +33,9 @@ public class AdminResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    return getLength();
   }
 
   public byte[] getPayload() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
@@ -95,7 +95,7 @@ public class BackupListResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
     final var backupsEncoder = bodyEncoder.backupsCount(internalBackups.size());
     internalBackups.forEach(
@@ -110,6 +110,7 @@ public class BackupListResponse implements BufferReader, BufferWriter {
                 .putCreatedAt(backup.encodedCreatedAt, 0, backup.encodedCreatedAt.length)
                 .putBrokerVersion(
                     backup.encodedBrokerVersion, 0, backup.encodedBrokerVersion.length));
+    return getLength();
   }
 
   public List<BackupStatus> getBackups() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
@@ -110,7 +110,7 @@ public class BackupListResponse implements BufferReader, BufferWriter {
                 .putCreatedAt(backup.encodedCreatedAt, 0, backup.encodedCreatedAt.length)
                 .putBrokerVersion(
                     backup.encodedBrokerVersion, 0, backup.encodedBrokerVersion.length));
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
   public List<BackupStatus> getBackups() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRangesResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRangesResponse.java
@@ -52,7 +52,7 @@ public final class BackupRangesResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     final var rangesEncoder = bodyEncoder.rangesCount(ranges.size());
@@ -67,6 +67,7 @@ public final class BackupRangesResponse implements BufferReader, BufferWriter {
         missingCheckpointsEncoder.next().checkpointId(checkpointId);
       }
     }
+    return bodyEncoder.encodedLength() + headerEncoder.encodedLength();
   }
 
   private static void writeCheckpointInfo(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -104,7 +104,7 @@ public class BackupRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
@@ -115,5 +115,6 @@ public class BackupRequest implements BufferReader, BufferWriter {
     if (checkpointType != null) {
       bodyEncoder.checkpointType(checkpointType.getValue());
     }
+    return getLength();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -115,6 +115,6 @@ public class BackupRequest implements BufferReader, BufferWriter {
     if (checkpointType != null) {
       bodyEncoder.checkpointType(checkpointType.getValue());
     }
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -248,7 +248,6 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
 
   @Override
   public int write(final MutableDirectBuffer buffer, final int offset) {
-
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
     bodyEncoder
         .backupId(backupId)
@@ -263,7 +262,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         .putBrokerVersion(encodedBrokerVersion, 0, encodedBrokerVersion.length)
         .putCreatedAt(encodedCreatedAt, 0, encodedCreatedAt.length)
         .putLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length);
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
   private byte[] encodeString(final String value, final String charsetName) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -247,7 +247,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
 
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
     bodyEncoder
@@ -263,6 +263,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         .putBrokerVersion(encodedBrokerVersion, 0, encodedBrokerVersion.length)
         .putCreatedAt(encodedCreatedAt, 0, encodedCreatedAt.length)
         .putLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length);
+    return getLength();
   }
 
   private byte[] encodeString(final String value, final String charsetName) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -357,7 +357,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(bodyEncoder.sbeBlockLength())
@@ -419,6 +419,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         partitionHealthEncoder.next().partitionId(entry.getKey()).healthStatus(entry.getValue());
       }
     }
+    return getLength();
   }
 
   public static BrokerInfo fromProperties(final Properties properties) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -357,18 +357,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
   @Override
-  public int write(final MutableDirectBuffer buffer, int offset) {
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .nodeId(nodeId)
         .partitionsCount(partitionsCount)
         .clusterSize(clusterSize)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -419,7 +419,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         partitionHealthEncoder.next().partitionId(entry.getKey()).healthStatus(entry.getValue());
       }
     }
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
   public static BrokerInfo fromProperties(final Properties properties) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
@@ -89,7 +89,7 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
           .checkpointPosition(partitionState.checkpointPosition)
           .firstLogPosition(partitionState.firstLogPosition);
     }
-    return getLength();
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/CheckpointStateResponse.java
@@ -64,7 +64,7 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     final var checkpointStateEncoder = bodyEncoder.checkpointStatesCount(checkpointStates.size());
@@ -89,6 +89,7 @@ public class CheckpointStateResponse implements BufferReader, BufferWriter {
           .checkpointPosition(partitionState.checkpointPosition)
           .firstLogPosition(partitionState.firstLogPosition);
     }
+    return getLength();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
@@ -111,7 +111,8 @@ public final class ErrorResponse implements BufferWriter, BufferReader {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
+    final int initialOffset = offset;
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(bodyEncoder.sbeBlockLength())
@@ -125,6 +126,8 @@ public final class ErrorResponse implements BufferWriter, BufferReader {
         .wrap(buffer, offset)
         .errorCode(errorCode)
         .putErrorData(errorData, 0, errorData.capacity());
+
+    return bodyEncoder.limit() - initialOffset;
   }
 
   public byte[] toBytes() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
@@ -111,23 +111,13 @@ public final class ErrorResponse implements BufferWriter, BufferReader {
   }
 
   @Override
-  public int write(final MutableDirectBuffer buffer, int offset) {
-    final int initialOffset = offset;
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .errorCode(errorCode)
         .putErrorData(errorData, 0, errorData.capacity());
 
-    return bodyEncoder.limit() - initialOffset;
+    return bodyEncoder.encodedLength() + headerEncoder.encodedLength();
   }
 
   public byte[] toBytes() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -195,19 +195,9 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public int write(final MutableDirectBuffer buffer, int offset) {
-    final int initialOffset = offset;
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
         .key(key)
         .operationReference(operationReference)
@@ -216,6 +206,6 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .putValue(value, 0, value.capacity())
         .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
 
-    return bodyEncoder.limit() - initialOffset;
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -85,7 +85,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     final int decodedPartitionId = Protocol.decodePartitionId(key);
     if (decodedPartitionId >= Protocol.START_PARTITION_ID
         && decodedPartitionId <= Protocol.MAXIMUM_PARTITIONS) {
-      this.partitionId = decodedPartitionId;
+      partitionId = decodedPartitionId;
     }
 
     return this;
@@ -195,7 +195,8 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
+    final int initialOffset = offset;
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(bodyEncoder.sbeBlockLength())
@@ -214,5 +215,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .intent(intent.value())
         .putValue(value, 0, value.capacity())
         .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+
+    return bodyEncoder.limit() - initialOffset;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandResponse.java
@@ -189,19 +189,9 @@ public final class ExecuteCommandResponse implements BufferReader, BufferWriter 
   }
 
   @Override
-  public int write(final MutableDirectBuffer buffer, int offset) {
-    final int initialOffset = offset;
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
         .key(key)
         .recordType(recordType)
@@ -211,6 +201,6 @@ public final class ExecuteCommandResponse implements BufferReader, BufferWriter 
         .putValue(value, 0, value.capacity())
         .putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
 
-    return bodyEncoder.limit() - initialOffset;
+    return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandResponse.java
@@ -189,7 +189,8 @@ public final class ExecuteCommandResponse implements BufferReader, BufferWriter 
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
+    final int initialOffset = offset;
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(bodyEncoder.sbeBlockLength())
@@ -209,5 +210,7 @@ public final class ExecuteCommandResponse implements BufferReader, BufferWriter 
         .rejectionType(rejectionType)
         .putValue(value, 0, value.capacity())
         .putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
+
+    return bodyEncoder.limit() - initialOffset;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteQueryRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteQueryRequest.java
@@ -73,12 +73,13 @@ public final class ExecuteQueryRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
         .key(key)
         .valueType(valueType);
+    return getLength();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteQueryResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteQueryResponse.java
@@ -41,7 +41,7 @@ public final class ExecuteQueryResponse implements BufferReader, BufferWriter {
   }
 
   public ExecuteQueryResponse setBpmnProcessId(final DirectBuffer bpmnProcessId) {
-    this.rawBpmnProcessId.wrap(bpmnProcessId);
+    rawBpmnProcessId.wrap(bpmnProcessId);
     return this;
   }
 
@@ -51,10 +51,11 @@ public final class ExecuteQueryResponse implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .putBpmnProcessId(rawBpmnProcessId, 0, rawBpmnProcessId.capacity());
+    return getLength();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/SbeBufferWriterReader.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/SbeBufferWriterReader.java
@@ -40,7 +40,7 @@ public abstract class SbeBufferWriterReader<
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
         .wrap(buffer, offset)
         .blockLength(getBodyEncoder().sbeBlockLength())
@@ -49,6 +49,8 @@ public abstract class SbeBufferWriterReader<
         .version(getBodyEncoder().sbeSchemaVersion());
 
     getBodyEncoder().wrap(buffer, offset + headerEncoder.encodedLength());
+
+    return getLength();
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -144,17 +144,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
   @Override
   public int write(final MutableDirectBuffer buffer, int offset) {
-    final int initialOffset = offset;
-    headerEncoder.wrap(buffer, offset);
-
-    headerEncoder
-        .blockLength(encoder.sbeBlockLength())
-        .templateId(encoder.sbeTemplateId())
-        .schemaId(encoder.sbeSchemaId())
-        .version(encoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-    encoder.wrap(buffer, offset);
+    encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     // working with fixed-length fields
     encoder

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -143,7 +143,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   @Override
-  public int write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     // working with fixed-length fields
@@ -171,10 +171,12 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     encoder.putAuthorization(authorizationBuffer, 0, authorizationBuffer.capacity());
 
     if (agent != null) {
-      encoder.putAgent(agent.toDirectBuffer(), 0, agent.getLength());
+      final var bb = agent.toDirectBuffer();
+      encoder.putAgent(bb, 0, bb.capacity());
     } else {
       encoder.agent("");
     }
+    return headerEncoder.encodedLength() + encoder.encodedLength();
   }
 
   public long getRequestId() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -143,7 +143,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, int offset) {
+    final int initialOffset = offset;
     headerEncoder.wrap(buffer, offset);
 
     headerEncoder

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -167,7 +167,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    encoder.putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+    final var authorizationBuffer = authorization.toDirectBuffer();
+    encoder.putAuthorization(authorizationBuffer, 0, authorizationBuffer.capacity());
 
     if (agent != null) {
       encoder.putAgent(agent.toDirectBuffer(), 0, agent.getLength());

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/ErrorResponseWriter.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/ErrorResponseWriter.java
@@ -35,22 +35,13 @@ public final class ErrorResponseWriter<R> extends AbstractMessageBuilder<R> {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
-    // protocol header
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     // protocol message
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .errorCode(errorCode)
         .putErrorData(errorData, 0, errorData.length);
+    return bodyEncoder.encodedLength() + headerEncoder.encodedLength();
   }
 
   @Override

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/ExecuteCommandResponseWriter.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/ExecuteCommandResponseWriter.java
@@ -96,24 +96,14 @@ public final class ExecuteCommandResponseWriter
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     EnsureUtil.ensureNotNull("recordType", recordType);
     EnsureUtil.ensureNotNull("valueType", valueType);
     EnsureUtil.ensureNotNull("intent", intent);
 
-    // protocol header
-    headerEncoder
-        .wrap(buffer, offset)
-        .blockLength(bodyEncoder.sbeBlockLength())
-        .templateId(bodyEncoder.sbeTemplateId())
-        .schemaId(bodyEncoder.sbeSchemaId())
-        .version(bodyEncoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-
     // protocol message
     bodyEncoder
-        .wrap(buffer, offset)
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .recordType(recordType)
         .valueType(valueType)
         .intent(intent.value())
@@ -122,5 +112,6 @@ public final class ExecuteCommandResponseWriter
         .rejectionType(rejectionType)
         .putValue(value, 0, value.length)
         .putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
+    return bodyEncoder.encodedLength() + headerEncoder.encodedLength();
   }
 }

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -130,20 +130,14 @@ public final class ExecuteCommandRequest implements ClientRequest {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    messageHeaderEncoder
-        .wrap(buffer, offset)
-        .schemaId(requestEncoder.sbeSchemaId())
-        .templateId(requestEncoder.sbeTemplateId())
-        .blockLength(requestEncoder.sbeBlockLength())
-        .version(requestEncoder.sbeSchemaVersion());
-
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     requestEncoder
-        .wrap(buffer, offset + messageHeaderEncoder.encodedLength())
+        .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
         .partitionId(partitionId)
         .key(key)
         .valueType(valueType)
         .intent(intent.value())
         .putValue(encodedCmd, 0, encodedCmd.length);
+    return requestEncoder.encodedLength() + messageHeaderEncoder.encodedLength();
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/ServerResponseImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/ServerResponseImpl.java
@@ -46,8 +46,8 @@ public final class ServerResponseImpl implements ServerResponse {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    writer.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return writer.write(buffer, offset);
   }
 
   public BufferWriter getWriter() {
@@ -59,6 +59,7 @@ public final class ServerResponseImpl implements ServerResponse {
     return requestId;
   }
 
+  @Override
   public int getPartitionId() {
     return partitionId;
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamRequest.java
@@ -50,7 +50,7 @@ public final class AddStreamRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .putStreamType(streamType, 0, streamType.capacity());
@@ -67,6 +67,7 @@ public final class AddStreamRequest implements BufferReader, BufferWriter {
           .high(streamId.getMostSignificantBits())
           .low(streamId.getLeastSignificantBits());
     }
+    return getLength();
   }
 
   public DirectBuffer streamType() {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamResponse.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamResponse.java
@@ -28,8 +28,9 @@ public final class AddStreamResponse implements StreamResponse {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    return getLength();
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
@@ -69,7 +69,7 @@ public final class ErrorResponse implements StreamResponse {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .code(code)
@@ -81,6 +81,7 @@ public final class ErrorResponse implements StreamResponse {
                 .next()
                 .code(detail.code())
                 .putMessage(detail.messageBuffer(), 0, detail.messageBuffer().capacity()));
+    return getLength();
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamRequest.java
@@ -45,7 +45,7 @@ public final class PushStreamRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     if (streamId != null) {
@@ -60,6 +60,7 @@ public final class PushStreamRequest implements BufferReader, BufferWriter {
         PushStreamRequestEncoder.payloadHeaderLength(),
         messageEncoder,
         PushStreamRequestEncoder.BYTE_ORDER);
+    return getLength();
   }
 
   /** May return null if it was never read or set. */

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamResponse.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamResponse.java
@@ -29,8 +29,9 @@ public final class PushStreamResponse implements BufferReader, StreamResponse {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    return getLength();
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamRequest.java
@@ -35,7 +35,7 @@ public final class RemoveStreamRequest implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     if (streamId != null) {
@@ -44,6 +44,7 @@ public final class RemoveStreamRequest implements BufferReader, BufferWriter {
           .high(streamId.getMostSignificantBits())
           .low(streamId.getLeastSignificantBits());
     }
+    return getLength();
   }
 
   public UUID streamId() {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamResponse.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/RemoveStreamResponse.java
@@ -28,8 +28,9 @@ public final class RemoveStreamResponse implements StreamResponse {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     messageEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    return getLength();
   }
 
   @Override

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -461,8 +461,10 @@ public class AtomixTransportTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
-      buffer.putBytes(offset, msg.getBytes());
+    public int write(final MutableDirectBuffer buffer, final int offset) {
+      final var bytes = msg.getBytes();
+      buffer.putBytes(offset, bytes);
+      return bytes.length;
     }
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -335,8 +335,9 @@ class ClientStreamManagerTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
+    public int write(final MutableDirectBuffer buffer, final int offset) {
       buffer.putInt(offset, data);
+      return getLength();
     }
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -443,8 +443,9 @@ final class ClientStreamRequestManagerTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
+    public int write(final MutableDirectBuffer buffer, final int offset) {
       buffer.putInt(offset, 0);
+      return getLength();
     }
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -157,8 +157,9 @@ final class RemoteStreamPusherTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {
+    public int write(final MutableDirectBuffer buffer, final int offset) {
       buffer.putInt(offset, version);
+      return getLength();
     }
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -131,7 +131,9 @@ final class RemoteStreamerTest {
     }
 
     @Override
-    public void write(final MutableDirectBuffer buffer, final int offset) {}
+    public int write(final MutableDirectBuffer buffer, final int offset) {
+      return 0;
+    }
   }
 
   private record TestMetadata(int id) implements BufferReader {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestSerializableData.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestSerializableData.java
@@ -43,8 +43,9 @@ class TestSerializableData implements BufferReader, BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     buffer.putInt(offset, data);
+    return Integer.BYTES;
   }
 
   @Override

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferWriter.java
@@ -27,6 +27,7 @@ public interface BufferWriter {
    *
    * @param buffer the buffer that this writer writes to
    * @param offset the offset in the buffer that the writer begins writing at
+   * @return the number of bytes written
    */
-  void write(MutableDirectBuffer buffer, int offset);
+  int write(MutableDirectBuffer buffer, int offset);
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/DirectBufferWriter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/DirectBufferWriter.java
@@ -21,8 +21,9 @@ public final class DirectBufferWriter implements BufferWriter {
   }
 
   @Override
-  public void write(final MutableDirectBuffer writeBuffer, final int writeOffset) {
+  public int write(final MutableDirectBuffer writeBuffer, final int writeOffset) {
     writeBuffer.putBytes(writeOffset, buffer, offset, length);
+    return length;
   }
 
   public DirectBufferWriter wrap(final DirectBuffer buffer, final int offset, final int length) {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
@@ -31,8 +31,9 @@ public final class DbByte implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
+  public int write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
     mutableDirectBuffer.putByte(offset, value);
+    return getLength();
   }
 
   public byte getValue() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
@@ -35,8 +35,9 @@ public final class DbBytes implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
+  public int write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
     mutableDirectBuffer.putBytes(offset, bytes, 0, bytes.capacity());
+    return getLength();
   }
 
   public byte[] getBytes() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
@@ -54,10 +54,10 @@ public class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType extends Db
   }
 
   @Override
-  public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
-    first.write(mutableDirectBuffer, offset);
-    final int firstKeyPartLength = first.getLength();
-    second.write(mutableDirectBuffer, offset + firstKeyPartLength);
+  public int write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
+    int written = first.write(mutableDirectBuffer, offset);
+    written += second.write(mutableDirectBuffer, offset + written);
+    return written;
   }
 
   private static Collection<DbForeignKey<DbKey>> collectContainedForeignKeys(

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbEnumValue.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbEnumValue.java
@@ -60,7 +60,7 @@ public final class DbEnumValue<T extends Enum<T>> implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    value.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return value.write(buffer, offset);
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
@@ -49,8 +49,8 @@ public record DbForeignKey<K extends DbKey>(
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    inner.write(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    return inner.write(buffer, offset);
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
@@ -33,8 +33,9 @@ public final class DbInt implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     buffer.putInt(offset, intValue, ZB_DB_BYTE_ORDER);
+    return getLength();
   }
 
   public int getValue() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
@@ -33,8 +33,9 @@ public final class DbLong implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     buffer.putLong(offset, longValue, ZB_DB_BYTE_ORDER);
+    return getLength();
   }
 
   public long getValue() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbNil.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbNil.java
@@ -30,8 +30,9 @@ public final class DbNil implements DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
+  public int write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
     mutableDirectBuffer.putByte(offset, EXISTENCE_BYTE);
+    return getLength();
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbShort.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbShort.java
@@ -33,8 +33,9 @@ public final class DbShort implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     buffer.putShort(offset, shortValue, ZB_DB_BYTE_ORDER);
+    return getLength();
   }
 
   public short getValue() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbString.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbString.java
@@ -45,12 +45,13 @@ public final class DbString implements DbKey, DbValue {
   }
 
   @Override
-  public void write(final MutableDirectBuffer mutableDirectBuffer, int offset) {
+  public int write(final MutableDirectBuffer mutableDirectBuffer, int offset) {
     final int length = bytes.capacity();
     mutableDirectBuffer.putInt(offset, length, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
 
     mutableDirectBuffer.putBytes(offset, bytes, 0, bytes.capacity());
+    return getLength();
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbTenantAwareKey.java
@@ -64,17 +64,17 @@ public record DbTenantAwareKey<WrappedKey extends DbKey>(
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     switch (placementType) {
       case PREFIX -> {
-        tenantKey.write(buffer, offset);
-        final var tenantKeyLength = tenantKey.getLength();
-        wrappedKey.write(buffer, offset + tenantKeyLength);
+        int written = tenantKey.write(buffer, offset);
+        written += wrappedKey.write(buffer, offset + written);
+        return written;
       }
       case SUFFIX -> {
-        wrappedKey.write(buffer, offset);
-        final var wrappedKeyLength = wrappedKey.getLength();
-        tenantKey.write(buffer, offset + wrappedKeyLength);
+        int written = wrappedKey.write(buffer, offset);
+        written += tenantKey.write(buffer, offset + written);
+        return written;
       }
       default -> throw new IllegalStateException("Unexpected value: " + placementType);
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
@@ -29,7 +29,8 @@ public final class DbNullKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
+  public int write(final MutableDirectBuffer buffer, final int offset) {
     // do nothing
+    return 0;
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
@@ -56,8 +56,8 @@ public class ColumnFamilyContext {
     return keyBuffer.byteArray();
   }
 
-  public void writeValue(final DbValue value) {
-    value.write(valueBuffer, 0);
+  public int writeValue(final DbValue value) {
+    return value.write(valueBuffer, 0);
   }
 
   public byte[] getValueBufferArray() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -88,7 +88,7 @@ class TransactionalColumnFamily<
       ensureInOpenTransaction(
           transaction -> {
             columnFamilyContext.writeKey(key);
-            columnFamilyContext.writeValue(value);
+            final var valueLength = columnFamilyContext.writeValue(value);
 
             assertKeyDoesNotExist(transaction);
             assertForeignKeysExist(transaction, key, value);
@@ -97,7 +97,7 @@ class TransactionalColumnFamily<
                 columnFamilyContext.getKeyBufferArray(),
                 columnFamilyContext.getKeyLength(),
                 columnFamilyContext.getValueBufferArray(),
-                value.getLength());
+                valueLength);
           });
     }
   }


### PR DESCRIPTION
## Description
Modified interface `BufferWriter` to return the written length. 
In some cases, where we don't allocate the exact buffer it can reduce the calls to `getLength()` which is often expensive, as it needs to traverse the `MsgPack` model to compute the size. 
This is wasteful since we have just written those bytes, so it's straightforward to know this. 

In some places, mostly SBE encoders the method `getLength` is "fast" as it just uses the SBE encoders to get that information, so it can be used. 
Once this is in place we can identify more places where some optimizations can be applied, especially where we can write in a large preallocated buffer. 

I currently identified a couple:
-  `TransactionalColumnFamily.java`: `getLenght` was used after every update even though we just wrote into the buffer
- `RecordMetadata`: auth information was recomputing `getLength` even though the bytebuffer size was "exact".  This is not really related to this PR but I noticed while going through the files. 
 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).
