### PR TITLE
Do not build AuditLog if transformer does not support record

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
@@ -74,9 +74,11 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
 
   @Override
   public boolean handlesRecord(final Record<R> record) {
-    final var info = AuditLogInfo.of(record);
+    if (!transformer.supports(record)) {
+      return false;
+    }
 
-    return transformer.supports(record) && configuration.isEnabled(info);
+    return configuration.isEnabled(AuditLogInfo.of(record));
   }
 
   @Override


### PR DESCRIPTION
## Description

Was found via profiling, that this has an impact on our exporting, as we always create audit log infos even when it was not supported

<!-- Describe the goal and purpose of this PR. -->

## Related issues

See https://github.com/camunda/camunda/pull/44770/changes/6620819372da363cd01447fb434f19c90dca3360
