### PR TITLE
Increase bulk size of Camunda Exporter

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Bulk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Bulk.java
@@ -15,7 +15,7 @@ import org.springframework.util.unit.DataSize;
 public class Bulk {
 
   private static final Duration DEFAULT_DELAY = Duration.ofSeconds(1);
-  private static final int DEFAULT_SIZE = 1_000;
+  private static final int DEFAULT_SIZE = 5_000;
   private static final DataSize DEFAULT_MEMORY_LIMIT = DataSize.ofMegabytes(20);
 
   private final String prefix;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -178,7 +178,7 @@ public class ExporterConfiguration {
     // delay before forced flush
     private int delay = 1;
     // bulk size before flush
-    private int size = 1_000;
+    private int size = 5_000;
     // bulk memory utilisation before flush (in Mb)
     private int memoryLimit = 20;
 


### PR DESCRIPTION
## Description

It showed in profiling and load test that the bulk size was too small. We were reaching rather quickly such bulk size (especially when we write 3-4k records per second). This means we reach this 3-4 times in a second. This has an impact on the throughput as we have to wait for the flush before we continue. 

Increasing to 5k should be a more appropriate size.


## Related issues

Was found via https://github.com/camunda/camunda/pull/44770