### PR TITLE
Increase flow control write limit for tests

### DIFF
--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -32,7 +32,7 @@ orchestration:
       zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
       # Configure a rate limit for all writes, so that we can visualize flow control metrics.
       zeebe.broker.flowControl.write.enabled: "true"
-      zeebe.broker.flowControl.write.limit: 4000
+      zeebe.broker.flowControl.write.limit: 8000
       zeebe.broker.flowControl.write.throttling.enabled: "true"
       # Disable the importers
       camunda.tasklist.importerEnabled: "false"

--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -31,8 +31,8 @@ orchestration:
       zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
       zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
       # Configure a rate limit for all writes, so that we can visualize flow control metrics.
-      zeebe.broker.flowControl.write.enabled: "false"
-      zeebe.broker.flowControl.write.limit: 8000
+      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.limit: 10000
       zeebe.broker.flowControl.write.throttling.enabled: "true"
       # Disable the importers
       camunda.tasklist.importerEnabled: "false"

--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -31,7 +31,7 @@ orchestration:
       zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
       zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
       # Configure a rate limit for all writes, so that we can visualize flow control metrics.
-      zeebe.broker.flowControl.write.enabled: "true"
+      zeebe.broker.flowControl.write.enabled: "false"
       zeebe.broker.flowControl.write.limit: 8000
       zeebe.broker.flowControl.write.throttling.enabled: "true"
       # Disable the importers


### PR DESCRIPTION
## Description

One of the major blockers we found was the write limit we have set in our tests. https://github.com/camunda/camunda/pull/44770

This limit is to prevent processing loops to overwhelm the cluster. The solution is not optimal as it is not dynamic (we will create an issue for this). 

As we have set this config in production as well, we will keep it for now, but increase it. As on higher load where we write 6-8k of records we are throttling ourselvs without an reason.

Best is to revisite the complete flow control write limiting.

## Related issues


See https://github.com/camunda/camunda/pull/44770
