### PR TITLE
feat: increase importer serialization max buffer to 5 MB

### DIFF
--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
@@ -213,7 +213,7 @@ public abstract class ImportJobAbstract implements ImportJob {
 
   protected static class EntitySizeEstimator {
     private static final int INITIAL_BUFFER_SIZE = 1024;
-    private static final int MAX_BUFFER_SIZE = 1024 * 1024;
+    private static final int MAX_BUFFER_SIZE = 5 * 1024 * 1024; // 5 MB
     private static final ThreadLocal<Kryo> KYRO_THREAD_LOCAL =
         ThreadLocal.withInitial(
             () -> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR aims at solving a problem that happens if a variable is bigger than 1 MB.
With the current behavior, the importer stops at that variable with an error and gets stuck.
The new behavior allocates 5 MB instead of 1 MB, so that the program is much more lenient with big-size variables.

Channel of the incident:
[#inc-support-31159-tasklist-importer-stuck](https://camunda.slack.com/archives/C0AB29LG01L)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
