### PR TITLE
[Backport stable/8.8] fix: populate startDate for batch operations in ES/OS

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
@@ -383,6 +383,7 @@ public class BatchOperationSearchTest {
 
   private static void assertCancelBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
+    assertThat(batch.getStartDate()).isNotNull();
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey1);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
@@ -393,6 +394,7 @@ public class BatchOperationSearchTest {
 
   private static void assertMigrateBatchOperation(final BatchOperation batch) {
     assertThat(batch).isNotNull();
+    assertThat(batch.getStartDate()).isNotNull();
     assertThat(batch.getBatchOperationKey()).isEqualTo(batchOperationKey2);
     assertThat(batch.getType()).isEqualTo(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CHUNK;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_EXECUTION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_INITIALIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
@@ -482,6 +483,7 @@ public class CamundaExporter implements Exporter {
             FORM,
             USER_TASK,
             BATCH_OPERATION_CREATION,
+            BATCH_OPERATION_INITIALIZATION,
             BATCH_OPERATION_EXECUTION,
             BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BATCH_OPERATION_CHUNK,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
@@ -33,7 +33,7 @@ public class BatchOperationInitializedHandler
 
   @Override
   public ValueType getHandledValueType() {
-    return ValueType.BATCH_OPERATION_CREATION;
+    return ValueType.BATCH_OPERATION_INITIALIZATION;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
@@ -35,7 +35,7 @@ class BatchOperationInitializedHandlerTest {
 
   @Test
   void testGetHandledValueType() {
-    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CREATION);
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_INITIALIZATION);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #44780 to `stable/8.8`.

relates to #42165