### PR TITLE
Backup retention

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -23612,6 +23612,184 @@
           ],
           "title": "Current Checkpoint ID",
           "type": "stat"
+        },
+        {
+          "id": 707,
+          "type": "stat",
+          "title": "Retention last execution",
+          "description": "The amount of backups and ranges deleted by the retention mechanism during it's last execution.",
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 12,
+            "y": 1011
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "green"
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "camunda_backup_retention_backups_deleted_round",
+              "interval": "",
+              "legendFormat": "Backups deleted",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            },
+            {
+              "refId": "B",
+              "expr": "camunda_backup_retention_ranges_deleted_round",
+              "range": true,
+              "instant": false,
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}",
+                "type": "prometheus"
+              },
+              "hide": false,
+              "editorMode": "builder",
+              "legendFormat": "Ranges deleted"
+            },
+            {
+              "refId": "C",
+              "expr": "camunda_backup_retention_earliest_backup_id",
+              "range": true,
+              "instant": false,
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}",
+                "type": "prometheus"
+              },
+              "hide": false,
+              "editorMode": "builder",
+              "legendFormat": "Earliest backup"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "last"
+              ],
+              "fields": ""
+            },
+            "orientation": "auto",
+            "textMode": "value_and_name",
+            "wideLayout": true,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
+        },
+        {
+          "id": 708,
+          "type": "stat",
+          "title": "Retention schedule",
+          "description": "Retention mechanism scheduled execution information",
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 18,
+            "y": 1011
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "color": {
+                "mode": "fixed",
+                "fixedColor": "green"
+              },
+              "unit": "dateTimeAsIsoNoDateIfToday",
+              "fieldMinMax": false
+            },
+            "overrides": []
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "camunda_backup_retention_last_execution_millis",
+              "interval": "",
+              "legendFormat": "Last retention execution",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true,
+              "instant": false,
+              "exemplar": false
+            },
+            {
+              "refId": "B",
+              "expr": "camunda_backup_retention_next_execution_millis",
+              "range": true,
+              "instant": false,
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}",
+                "type": "prometheus"
+              },
+              "hide": false,
+              "editorMode": "builder",
+              "legendFormat": "Next retention execution"
+            }
+          ],
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "value_and_name",
+            "wideLayout": false,
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          }
         }
       ],
       "title": "Backups",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -23651,16 +23651,16 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "camunda_backup_retention_backups_deleted_round",
+              "expr": "camunda_backup_retention_backups_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}",
               "interval": "",
-              "legendFormat": "Backups deleted",
+              "legendFormat": "Backups deleted - {{partition}}",
               "refId": "A",
               "editorMode": "code",
               "range": true
             },
             {
               "refId": "B",
-              "expr": "camunda_backup_retention_ranges_deleted_round",
+              "expr": "camunda_backup_retention_ranges_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}",
               "range": true,
               "instant": false,
               "datasource": {
@@ -23669,11 +23669,11 @@
               },
               "hide": false,
               "editorMode": "builder",
-              "legendFormat": "Ranges deleted"
+              "legendFormat": "Ranges deleted - p{{partition}}"
             },
             {
               "refId": "C",
-              "expr": "camunda_backup_retention_earliest_backup_id",
+              "expr": "camunda_backup_retention_earliest_backup_id{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}",
               "range": true,
               "instant": false,
               "datasource": {
@@ -23682,7 +23682,7 @@
               },
               "hide": false,
               "editorMode": "builder",
-              "legendFormat": "Earliest backup"
+              "legendFormat": "Earliest backup - p{{partition}}"
             }
           ],
           "datasource": {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -306,7 +306,7 @@ public class BackupRetention extends Actor {
             .toArray(CompletableFuture[]::new);
 
     CompletableFuture.allOf(futures)
-        .thenAccept(ignore -> metrics.incrementRangesDeleted(context.deletableRangeMarkers.size()))
+        .thenAccept(ignore -> metrics.recordRangesDeleted(context.deletableRangeMarkers.size()))
         .thenApply(v -> context)
         .thenAccept(future::complete);
     return future;
@@ -327,7 +327,7 @@ public class BackupRetention extends Actor {
             .toArray(CompletableFuture[]::new);
 
     CompletableFuture.allOf(futures)
-        .thenAccept(ignore -> metrics.incrementBackupsDeleted(context.deletableRangeMarkers.size()))
+        .thenAccept(ignore -> metrics.recordBackupsDeleted(context.deletableBackups().size()))
         .thenAccept(future::complete);
     return future;
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.retention;
+
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
+import io.camunda.zeebe.backup.api.BackupRangeMarker;
+import io.camunda.zeebe.backup.api.BackupRanges;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.schedule.Schedule;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the retention of backups by periodically deleting old backups and their associated range
+ * markers based on a configurable retention window.
+ *
+ * <h2>Retention Process</h2>
+ *
+ * The retention process is executed on a configurable schedule and performs the following steps for
+ * each partition:
+ *
+ * <ol>
+ *   <li><b>Retrieve Backups:</b> Fetches all existing backups for the partition from the backup
+ *       store, sorted by creation time and checkpoint ID.
+ *   <li><b>Filter Backups:</b> Identifies backups that fall outside the retention window (i.e.,
+ *       backups older than {@code currentTime - retentionWindow}) and marks them for deletion.
+ *       Determines the earliest backup checkpoint ID that should be retained.
+ *   <li><b>Retrieve Range Markers:</b> Fetches all range markers for the partition and enriches the
+ *       retention context. Range markers with checkpoint IDs less than the earliest retained backup
+ *       are marked for deletion.
+ *   <li><b>Reset Range Start:</b> If a previous start marker exists and its associated end marker
+ *       has a lower checkpoint ID, the start marker is deleted and a new one is created pointing to
+ *       the earliest retained backup.
+ *   <li><b>Delete Markers:</b> Removes all range markers that are no longer needed (those
+ *       associated with deleted backups).
+ *   <li><b>Delete Backups:</b> Removes all backups identified for deletion from the backup store.
+ * </ol>
+ *
+ * <h2>Scheduling</h2>
+ *
+ * The retention task is scheduled according to the provided {@link Schedule}. After each execution
+ * (successful or failed), the next execution time is calculated and the task is rescheduled.
+ *
+ * <h2>Metrics</h2>
+ *
+ * The following metrics are recorded during retention:
+ *
+ * <ul>
+ *   <li>Next scheduled execution time
+ *   <li>Last execution time
+ *   <li>Earliest retained backup ID
+ *   <li>Number of range markers deleted
+ *   <li>Number of backups deleted
+ * </ul>
+ *
+ * @see BackupStore
+ * @see Schedule
+ * @see BackupRangeMarker
+ */
+public class BackupRetention extends Actor {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupRetention.class);
+  private static final Comparator<BackupStatus> BACKUP_STATUS_COMPARATOR =
+      Comparator.comparing(
+          (BackupStatus s) ->
+              s.descriptor()
+                  .map(BackupDescriptor::checkpointTimestamp)
+                  .orElse(Instant.ofEpochMilli(s.id().checkpointId())),
+          Comparator.nullsLast(Comparator.naturalOrder()));
+
+  private final BackupStore backupStore;
+  private final Schedule retentionSchedule;
+  private final Duration retentionWindow;
+  private final long checkpointOffset;
+  private final Supplier<Integer> partitionsSupplier;
+  private final RetentionMetrics metrics;
+
+  public BackupRetention(
+      final BackupStore backupStore,
+      final Schedule retentionSchedule,
+      final Duration retentionWindow,
+      final long checkpointOffset,
+      final Supplier<Integer> partitionsSupplier,
+      final MeterRegistry meterRegistry) {
+    metrics = new RetentionMetrics(meterRegistry);
+    this.backupStore = backupStore;
+    this.retentionSchedule = retentionSchedule;
+    this.retentionWindow = retentionWindow;
+    this.checkpointOffset = checkpointOffset;
+    this.partitionsSupplier = partitionsSupplier;
+  }
+
+  @Override
+  protected void onActorStarted() {
+    LOG.debug("Retention scheduler started");
+    metrics.register();
+    final var next =
+        retentionSchedule.nextExecution(Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
+    LOG.debug("Scheduling next retention task in {} ", next);
+    metrics.recordNextExecution(next.get());
+    actor.runAt(next.get().toEpochMilli(), this::reschedulingTask);
+  }
+
+  @Override
+  protected void onActorClosed() {
+    LOG.debug("Retention scheduler stopped");
+    metrics.close();
+  }
+
+  private void reschedulingTask() {
+    performRetention()
+        .onComplete(
+            (v, err) -> {
+              metrics.recordLastExecution(Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
+              if (err != null) {
+                LOG.error("Unexpected error occurred during backup retention task", err);
+              } else {
+                LOG.debug("Backup retention task completed successfully");
+              }
+              final var next =
+                  retentionSchedule.nextExecution(
+                      Instant.ofEpochMilli(ActorClock.currentTimeMillis()));
+              LOG.debug("Scheduling next retention task in {} ", next);
+              metrics.recordNextExecution(next.get());
+              actor.runAt(next.get().toEpochMilli(), this::reschedulingTask);
+            });
+  }
+
+  private ActorFuture<Void> performRetention() {
+    final var now = ActorClock.currentTimeMillis();
+    final var window = now - retentionWindow.toMillis();
+    final ActorFuture<Void> retentionFuture = createFuture();
+    final var partitionFutures =
+        IntStream.rangeClosed(1, partitionsSupplier.get())
+            .parallel()
+            .mapToObj(partitionId -> createRetentionContext(partitionId, window))
+            .map(
+                future ->
+                    future
+                        .andThen(this::logContext, this)
+                        .andThen(this::resetRangeStart, this)
+                        .andThen(this::deleteMarkers, this)
+                        .thenApply(this::deleteBackups, this)
+                        .toCompletableFuture())
+            .toArray(CompletableFuture[]::new);
+
+    CompletableFuture.allOf(partitionFutures).thenAccept(v -> retentionFuture.complete(null));
+
+    return retentionFuture;
+  }
+
+  private ActorFuture<RetentionContext> logContext(final RetentionContext ctx) {
+    LOG.atDebug()
+        .addKeyValue("deletableBackups", ctx.deletableBackups)
+        .addKeyValue("earliestBackupInNewRange", ctx.earliestBackupInNewRange)
+        .addKeyValue("previousStartMarker", ctx.previousStartMarker)
+        .addKeyValue("deletableRangeMarkers", ctx.deletableRangeMarkers)
+        .setMessage("Retention context for partition " + ctx.partitionId)
+        .log();
+    return CompletableActorFuture.completed(ctx);
+  }
+
+  private ActorFuture<RetentionContext> createRetentionContext(
+      final int partitionId, final long window) {
+    return retrieveBackups(partitionId)
+        .thenApply((statuses) -> filterBackups(statuses, window, partitionId), this)
+        .andThen(
+            (context) ->
+                retrieveRangeMarkers(partitionId)
+                    .thenApply((markers) -> enrichContextWithMarkers(context, markers), this),
+            this);
+  }
+
+  private ActorFuture<Collection<BackupStatus>> retrieveBackups(final int partitionId) {
+    final var identifier =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.of(partitionId), CheckpointPattern.any());
+    final ActorFuture<Collection<BackupStatus>> requestFuture = createFuture();
+    backupStore
+        .list(identifier)
+        .thenApply(backups -> backups.stream().sorted(BACKUP_STATUS_COMPARATOR).toList())
+        .thenAccept(requestFuture::complete);
+    return requestFuture;
+  }
+
+  private ActorFuture<Collection<BackupRangeMarker>> retrieveRangeMarkers(final int partitionId) {
+    final ActorFuture<Collection<BackupRangeMarker>> requestFuture = createFuture();
+    backupStore
+        .rangeMarkers(partitionId)
+        .thenApply(markers -> markers.stream().sorted(BackupRanges.MARKER_ORDERING).toList())
+        .thenAccept(requestFuture::complete);
+    return requestFuture;
+  }
+
+  private RetentionContext enrichContextWithMarkers(
+      final RetentionContext retentionContext, final Collection<BackupRangeMarker> markers) {
+    BackupRangeMarker rangeStart = null;
+
+    for (final BackupRangeMarker marker : markers) {
+      if (marker instanceof BackupRangeMarker.Start
+          && marker.checkpointId() <= retentionContext.earliestBackupInNewRange) {
+        rangeStart = marker;
+      }
+
+      if (marker.checkpointId() < retentionContext.earliestBackupInNewRange) {
+        retentionContext.deletableRangeMarkers.add(marker);
+      } else {
+        break;
+      }
+    }
+    if (rangeStart != null) {
+      return retentionContext.withPreviousStartMarker(rangeStart);
+    }
+    return retentionContext;
+  }
+
+  private RetentionContext filterBackups(
+      final Collection<BackupStatus> backups, final long window, final int partitionId) {
+    final var context = RetentionContext.init(partitionId);
+    long firstAvailableBackupInNewRange = -1L;
+
+    for (final var backup : backups) {
+      final var backupTimestamp =
+          backup
+              .descriptor()
+              .map(BackupDescriptor::checkpointTimestamp)
+              .orElse(Instant.ofEpochMilli(backup.id().checkpointId() - checkpointOffset))
+              .toEpochMilli();
+      if (backupTimestamp < window) {
+        context.deletableBackups.add(backup.id());
+      } else {
+        firstAvailableBackupInNewRange = backup.id().checkpointId();
+        break;
+      }
+    }
+    return context.withEarliestBackupInNewRange(firstAvailableBackupInNewRange);
+  }
+
+  private CompletableActorFuture<RetentionContext> resetRangeStart(final RetentionContext context) {
+    final CompletableActorFuture<RetentionContext> future = new CompletableActorFuture<>();
+    metrics.recordEarliestBackupId(context.earliestBackupInNewRange);
+    if (shouldResetMarker(context)) {
+      final var marker = context.previousStartMarker.get();
+      LOG.debug(
+          "Resetting range start marker {} for partition {} to checkpoint id {}",
+          context.previousStartMarker.get(),
+          context.partitionId,
+          context.earliestBackupInNewRange);
+      backupStore
+          .storeRangeMarker(
+              context.partitionId, new BackupRangeMarker.Start(context.earliestBackupInNewRange))
+          .thenCompose(ignore -> backupStore.deleteRangeMarker(context.partitionId, marker))
+          .thenAccept(ignore -> metrics.recordEarliestBackupId(context.earliestBackupInNewRange))
+          .thenApply(v -> context)
+          .thenAccept(future::complete);
+    } else {
+      future.complete(context);
+    }
+    return future;
+  }
+
+  private boolean shouldResetMarker(final RetentionContext context) {
+    return context.previousStartMarker.isPresent()
+        && !context.deletableBackups.isEmpty()
+        && context.previousStartMarker.get().checkpointId() != context.earliestBackupInNewRange;
+  }
+
+  private CompletableActorFuture<RetentionContext> deleteMarkers(final RetentionContext context) {
+    final CompletableActorFuture<RetentionContext> future = new CompletableActorFuture<>();
+    if (context.deletableRangeMarkers.isEmpty() || context.deletableBackups.isEmpty()) {
+      future.complete(context);
+      return future;
+    }
+    LOG.debug(
+        "Deleting range markers {} for partition {}",
+        context.deletableRangeMarkers,
+        context.partitionId);
+
+    final var futures =
+        context.deletableRangeMarkers.stream()
+            .map(marker -> backupStore.deleteRangeMarker(context.partitionId, marker))
+            .toList()
+            .toArray(CompletableFuture[]::new);
+
+    CompletableFuture.allOf(futures)
+        .thenAccept(ignore -> metrics.incrementRangesDeleted(context.deletableRangeMarkers.size()))
+        .thenApply(v -> context)
+        .thenAccept(future::complete);
+    return future;
+  }
+
+  private CompletableActorFuture<Void> deleteBackups(final RetentionContext context) {
+    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
+    if (context.deletableBackups.isEmpty()) {
+      future.complete(null);
+      return future;
+    }
+    LOG.debug(
+        "Deleting {} backups for partition {}", context.deletableBackups, context.partitionId);
+    final var futures =
+        context.deletableBackups.stream()
+            .map(backupStore::delete)
+            .toList()
+            .toArray(CompletableFuture[]::new);
+
+    CompletableFuture.allOf(futures)
+        .thenAccept(ignore -> metrics.incrementBackupsDeleted(context.deletableRangeMarkers.size()))
+        .thenAccept(future::complete);
+    return future;
+  }
+
+  record RetentionContext(
+      List<BackupIdentifier> deletableBackups,
+      long earliestBackupInNewRange,
+      Optional<BackupRangeMarker> previousStartMarker,
+      List<BackupRangeMarker> deletableRangeMarkers,
+      int partitionId) {
+
+    static RetentionContext init(final int partitionId) {
+      return new RetentionContext(
+          new ArrayList<>(), -1L, Optional.empty(), new ArrayList<>(), partitionId);
+    }
+
+    RetentionContext withPreviousStartMarker(final BackupRangeMarker rangeMarker) {
+      return new RetentionContext(
+          deletableBackups,
+          earliestBackupInNewRange,
+          Optional.of(rangeMarker),
+          deletableRangeMarkers,
+          partitionId);
+    }
+
+    RetentionContext withEarliestBackupInNewRange(final long checkpointId) {
+      return new RetentionContext(
+          deletableBackups, checkpointId, previousStartMarker, deletableRangeMarkers, partitionId);
+    }
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -79,22 +79,9 @@ public class RetentionMetrics implements CloseableSilently {
   public void close() {
     meterRegistry.remove(lastExecutionGauge);
     meterRegistry.remove(nextExecutionGauge);
-    partitionMetrics.keySet().forEach(this::removePartition);
-  }
-
-  public void removePartition(final int partitionId) {
-    partitionMetrics.remove(partitionId);
-    final String partition = String.valueOf(partitionId);
-    safeRemoveGauge(EARLIEST_BACKUP_ID, partition);
-    safeRemoveGauge(BACKUPS_DELETED_ROUND, partition);
-    safeRemoveGauge(RANGES_DELETED_ROUND, partition);
-  }
-
-  private void safeRemoveGauge(final String metricName, final String partition) {
-    final var gauge = meterRegistry.find(metricName).tag(PARTITION_TAG, partition).gauge();
-    if (gauge != null) {
-      meterRegistry.remove(gauge);
-    }
+    meterRegistry.find(EARLIEST_BACKUP_ID).gauges().forEach(meterRegistry::remove);
+    meterRegistry.find(BACKUPS_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
+    meterRegistry.find(RANGES_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
   }
 
   public void recordLastExecution(final Instant lastExecution) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -82,6 +82,7 @@ public class RetentionMetrics implements CloseableSilently {
     meterRegistry.find(EARLIEST_BACKUP_ID).gauges().forEach(meterRegistry::remove);
     meterRegistry.find(BACKUPS_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
     meterRegistry.find(RANGES_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
+    partitionMetrics.clear();
   }
 
   public void recordLastExecution(final Instant lastExecution) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -34,7 +34,7 @@ public class RetentionMetrics implements CloseableSilently {
     this.meterRegistry = meterRegistry;
   }
 
-  public PartitionMetrics forPartition(final int partitionId) {
+  PartitionMetrics forPartition(final int partitionId) {
     return partitionMetrics.computeIfAbsent(
         partitionId,
         id -> {
@@ -105,20 +105,20 @@ public class RetentionMetrics implements CloseableSilently {
     this.nextExecution = nextExecution.toEpochMilli();
   }
 
-  public static class PartitionMetrics {
+  static class PartitionMetrics {
     private long earliestBackupId = 0L;
     private long backupsDeleted = 0L;
     private long rangesDeleted = 0L;
 
-    public void setEarliestBackupId(final long id) {
+    void setEarliestBackupId(final long id) {
       earliestBackupId = id;
     }
 
-    public void setBackupsDeleted(final long count) {
+    void setBackupsDeleted(final long count) {
       backupsDeleted = count;
     }
 
-    public void setRangesDeleted(final long count) {
+    void setRangesDeleted(final long count) {
       rangesDeleted = count;
     }
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.retention;
+
+import io.camunda.zeebe.util.CloseableSilently;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Instant;
+
+public class RetentionMetrics implements CloseableSilently {
+  static final String NAMESPACE = "camunda.backup.retention";
+  static final String RETENTION_LAST_EXECUTION = NAMESPACE + ".last.execution.millis";
+  static final String RETENTION_NEXT_EXECUTION = NAMESPACE + ".next.execution.millis";
+  static final String BACKUPS_DELETED_ROUND = NAMESPACE + ".backups.deleted.round";
+  static final String RANGES_DELETED_ROUND = NAMESPACE + ".ranges.deleted.round";
+  static final String EARLIEST_BACKUP_ID = NAMESPACE + ".earliest.backup.id";
+
+  private final MeterRegistry meterRegistry;
+  private Counter backupsDeletedCounter;
+  private Counter rangesDeletedCounter;
+  private Gauge lastExecutionGauge;
+  private Gauge nextExecutionGauge;
+  private Gauge earliestBackupGauge;
+  private long lastExecutionTimestamp = 0L;
+  private long nextExecutionTimestamp = 0L;
+  private long earliestBackupId = 0L;
+
+  public RetentionMetrics(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void register() {
+    lastExecutionGauge =
+        Gauge.builder(RETENTION_LAST_EXECUTION, () -> lastExecutionTimestamp)
+            .description("Timestamp in milliseconds of the last retention execution")
+            .register(meterRegistry);
+
+    nextExecutionGauge =
+        Gauge.builder(RETENTION_NEXT_EXECUTION, () -> nextExecutionTimestamp)
+            .description("Timestamp in milliseconds of the next retention execution")
+            .register(meterRegistry);
+
+    earliestBackupGauge =
+        Gauge.builder(EARLIEST_BACKUP_ID, () -> earliestBackupId)
+            .description("The ID of the earliest backup retained")
+            .register(meterRegistry);
+
+    backupsDeletedCounter =
+        Counter.builder(BACKUPS_DELETED_ROUND)
+            .description("Number of backups deleted in the last retention round")
+            .register(meterRegistry);
+
+    rangesDeletedCounter =
+        Counter.builder(RANGES_DELETED_ROUND)
+            .description("Number of ranges deleted in the last retention round")
+            .register(meterRegistry);
+  }
+
+  public void recordLastExecution(final Instant timestamp) {
+    lastExecutionTimestamp = timestamp.toEpochMilli();
+  }
+
+  public void recordNextExecution(final Instant timestamp) {
+    nextExecutionTimestamp = timestamp.toEpochMilli();
+  }
+
+  public void recordEarliestBackupId(final long backupId) {
+    earliestBackupId = backupId;
+  }
+
+  public void incrementBackupsDeleted(final long count) {
+    backupsDeletedCounter.increment(count);
+  }
+
+  public void incrementRangesDeleted(final long count) {
+    rangesDeletedCounter.increment(count);
+  }
+
+  @Override
+  public void close() {
+    meterRegistry.remove(lastExecutionGauge);
+    meterRegistry.remove(nextExecutionGauge);
+    meterRegistry.remove(earliestBackupGauge);
+    meterRegistry.remove(backupsDeletedCounter);
+    meterRegistry.remove(rangesDeletedCounter);
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -256,12 +256,6 @@ public class RetentionTest {
                 .subList(0, 4)
                 .forEach(
                     backup -> verify(backupStore).delete(argThat(id -> id.equals(backup.id())))));
-    /*    verify(backupStore)
-        .delete(backupsPerPartition.get(1).subList(0, 4).stream().map(BackupStatus::id).toList());
-    verify(backupStore)
-        .delete(backupsPerPartition.get(2).subList(0, 4).stream().map(BackupStatus::id).toList());
-    verify(backupStore)
-        .delete(backupsPerPartition.get(3).subList(0, 4).stream().map(BackupStatus::id).toList());*/
 
     verify(backupStore)
         .storeRangeMarker(
@@ -318,15 +312,6 @@ public class RetentionTest {
                 marker ->
                     marker.checkpointId() == backupsPerPartition.get(1).get(3).id().checkpointId()
                         && marker instanceof Start));
-
-    /*    verify(backupStore)
-        .deleteRangeMarker(eq(1), argThat(c -> c.containsAll(ranges.subList(0, 2))));
-
-    verify(backupStore)
-        .deleteRangeMarkers(eq(2), argThat(c -> c.containsAll(ranges.subList(0, 2))));
-
-    verify(backupStore)
-        .deleteRangeMarkers(eq(3), argThat(c -> c.containsAll(ranges.subList(0, 2))));*/
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.retention;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.api.BackupRangeMarker;
+import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
+import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.util.VersionUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RetentionTest {
+
+  @RegisterExtension
+  public final ControlledActorSchedulerExtension actorScheduler =
+      new ControlledActorSchedulerExtension();
+
+  @Mock private BackupStore backupStore;
+  private BackupRetention backupRetention;
+
+  @BeforeEach
+  void setUp() {
+    backupRetention =
+        new BackupRetention(
+            backupStore,
+            new IntervalSchedule(Duration.ofSeconds(10)),
+            Duration.ofMinutes(2),
+            0,
+            () -> 1,
+            new SimpleMeterRegistry());
+
+    doReturn(CompletableFuture.completedFuture(null)).when(backupStore).delete(any());
+    doReturn(CompletableFuture.completedFuture(null))
+        .when(backupStore)
+        .storeRangeMarker(anyInt(), any());
+    lenient()
+        .doReturn(CompletableFuture.completedFuture(null))
+        .when(backupStore)
+        .deleteRangeMarker(anyInt(), any());
+    doReturn(CompletableFuture.completedFuture(null))
+        .when(backupStore)
+        .deleteRangeMarker(anyInt(), any());
+    actorScheduler.getClock().pinCurrentTime();
+  }
+
+  @Test
+  void shouldPerformAllActionsSinglePartition() {
+    // given
+    final var now = actorScheduler.getClock().instant();
+    final BackupStatus backup1 = backup(now.minusSeconds(360));
+    final BackupStatus backup2 = backup(now.minusSeconds(300));
+    final BackupStatus backup3 = backup(now.minusSeconds(290));
+    final BackupStatus backup4 = backup(now.minusSeconds(130));
+    final BackupStatus backup5 = backup(now.minusSeconds(110));
+    final BackupStatus backup6 = backup(now.minusSeconds(20));
+    final BackupStatus backup7 = backup(now.minusSeconds(10));
+
+    final List<BackupRangeMarker> ranges =
+        List.of(
+            new Start(now.minusSeconds(360).toEpochMilli()),
+            new End(now.minusSeconds(290).toEpochMilli()),
+            new Start(now.minusSeconds(130).toEpochMilli()),
+            new End(now.minusSeconds(20).toEpochMilli()),
+            new Start(now.minusSeconds(10).toEpochMilli()),
+            new End(now.minusSeconds(10).toEpochMilli()));
+
+    when(backupStore.list(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(backup1, backup2, backup3, backup4, backup5, backup6, backup7)));
+
+    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupStore).delete(backup1.id());
+    verify(backupStore).delete(backup2.id());
+    verify(backupStore).delete(backup3.id());
+    verify(backupStore).delete(backup4.id());
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backup5.id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backup4.id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+  }
+
+  @Test
+  void shouldPerformAllActionsSinglePartitionWithoutCreatedDate() {
+    // given
+    final var now = actorScheduler.getClock().instant();
+    final BackupStatus backup1 = backupNoCreatedDate(1, 1, now.minusSeconds(360));
+    final BackupStatus backup2 = backupNoCreatedDate(1, 1, now.minusSeconds(300));
+    final BackupStatus backup3 = backupNoCreatedDate(1, 1, now.minusSeconds(290));
+    final BackupStatus backup4 = backupNoCreatedDate(1, 1, now.minusSeconds(130));
+    final BackupStatus backup5 = backupNoCreatedDate(1, 1, now.minusSeconds(110));
+    final BackupStatus backup6 = backupNoCreatedDate(1, 1, now.minusSeconds(20));
+    final BackupStatus backup7 = backupNoCreatedDate(1, 1, now.minusSeconds(10));
+
+    final List<BackupRangeMarker> ranges =
+        List.of(
+            new Start(now.minusSeconds(360).toEpochMilli()),
+            new End(now.minusSeconds(290).toEpochMilli()),
+            new Start(now.minusSeconds(130).toEpochMilli()),
+            new End(now.minusSeconds(20).toEpochMilli()),
+            new Start(now.minusSeconds(10).toEpochMilli()),
+            new End(now.minusSeconds(10).toEpochMilli()));
+
+    when(backupStore.list(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(backup1, backup2, backup3, backup4, backup5, backup6, backup7)));
+
+    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupStore).delete(backup1.id());
+    verify(backupStore).delete(backup2.id());
+    verify(backupStore).delete(backup3.id());
+    verify(backupStore).delete(backup4.id());
+
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backup5.id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backup4.id().checkpointId()
+                        && marker instanceof Start));
+  }
+
+  @Test
+  void shouldPerformAllActionsMultiPartition() {
+    // given
+    backupRetention =
+        new BackupRetention(
+            backupStore,
+            new IntervalSchedule(Duration.ofSeconds(10)),
+            Duration.ofMinutes(2),
+            0,
+            () -> 3,
+            new SimpleMeterRegistry());
+    final var now = actorScheduler.getClock().instant();
+    final Map<Integer, List<BackupStatus>> backupsPerPartition = new HashMap<>();
+    for (int i = 1; i <= 3; i++) {
+      final BackupStatus backup1 = backup(i, 1, now.minusSeconds(360));
+      final BackupStatus backup2 = backup(i, 1, now.minusSeconds(300));
+      final BackupStatus backup3 = backup(i, 1, now.minusSeconds(290));
+      final BackupStatus backup4 = backup(i, 1, now.minusSeconds(130));
+      final BackupStatus backup5 = backup(i, 1, now.minusSeconds(110));
+      final BackupStatus backup6 = backup(i, 1, now.minusSeconds(20));
+      final BackupStatus backup7 = backup(i, 1, now.minusSeconds(10));
+      backupsPerPartition.put(
+          i, List.of(backup1, backup2, backup3, backup4, backup5, backup6, backup7));
+    }
+
+    final List<BackupRangeMarker> ranges =
+        List.of(
+            new Start(now.minusSeconds(360).toEpochMilli()),
+            new End(now.minusSeconds(290).toEpochMilli()),
+            new Start(now.minusSeconds(130).toEpochMilli()),
+            new End(now.minusSeconds(20).toEpochMilli()),
+            new Start(now.minusSeconds(10).toEpochMilli()),
+            new End(now.minusSeconds(10).toEpochMilli()));
+
+    doReturn(CompletableFuture.completedFuture(backupsPerPartition.get(1)))
+        .when(backupStore)
+        .list(argThat(id -> id.partitionId().get() == 1));
+    doReturn(CompletableFuture.completedFuture(backupsPerPartition.get(2)))
+        .when(backupStore)
+        .list(argThat(id -> id.partitionId().get() == 2));
+    doReturn(CompletableFuture.completedFuture(backupsPerPartition.get(3)))
+        .when(backupStore)
+        .list(argThat(id -> id.partitionId().get() == 3));
+
+    when(backupStore.rangeMarkers(anyInt())).thenReturn(CompletableFuture.completedFuture(ranges));
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    backupsPerPartition.forEach(
+        (key, value) ->
+            value
+                .subList(0, 4)
+                .forEach(
+                    backup -> verify(backupStore).delete(argThat(id -> id.equals(backup.id())))));
+    /*    verify(backupStore)
+        .delete(backupsPerPartition.get(1).subList(0, 4).stream().map(BackupStatus::id).toList());
+    verify(backupStore)
+        .delete(backupsPerPartition.get(2).subList(0, 4).stream().map(BackupStatus::id).toList());
+    verify(backupStore)
+        .delete(backupsPerPartition.get(3).subList(0, 4).stream().map(BackupStatus::id).toList());*/
+
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(1).get(4).id().checkpointId()
+                        && marker instanceof Start));
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(2),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(2).get(4).id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(3),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(3).get(4).id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+
+    verify(backupStore).deleteRangeMarker(eq(2), argThat(c -> c.equals(ranges.getFirst())));
+    verify(backupStore).deleteRangeMarker(eq(2), argThat(c -> c.equals(ranges.get(1))));
+
+    verify(backupStore).deleteRangeMarker(eq(3), argThat(c -> c.equals(ranges.getFirst())));
+    verify(backupStore).deleteRangeMarker(eq(3), argThat(c -> c.equals(ranges.get(1))));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(1).get(3).id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            eq(2),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(1).get(3).id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            eq(3),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backupsPerPartition.get(1).get(3).id().checkpointId()
+                        && marker instanceof Start));
+
+    /*    verify(backupStore)
+        .deleteRangeMarker(eq(1), argThat(c -> c.containsAll(ranges.subList(0, 2))));
+
+    verify(backupStore)
+        .deleteRangeMarkers(eq(2), argThat(c -> c.containsAll(ranges.subList(0, 2))));
+
+    verify(backupStore)
+        .deleteRangeMarkers(eq(3), argThat(c -> c.containsAll(ranges.subList(0, 2))));*/
+  }
+
+  @Test
+  void shouldHandleNoEndMarker() {
+    // given
+    final var now = actorScheduler.getClock().instant();
+    final BackupStatus backup1 = backup(now.minusSeconds(200));
+    final BackupStatus backup2 = backup(now.minusSeconds(150));
+    final BackupStatus backup3 = backup(now.minusSeconds(110));
+
+    when(backupStore.list(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
+
+    when(backupStore.rangeMarkers(1))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                List.of(
+                    new Start(now.minusSeconds(360).toEpochMilli()),
+                    new End(now.minusSeconds(290).toEpochMilli()),
+                    new Start(now.minusSeconds(130).toEpochMilli()))));
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupStore).delete(backup1.id());
+    verify(backupStore).delete(backup2.id());
+    verify(backupStore)
+        .storeRangeMarker(
+            eq(1),
+            argThat(
+                marker ->
+                    marker.checkpointId() == backup3.id().checkpointId()
+                        && marker instanceof Start));
+
+    verify(backupStore, atLeast(1))
+        .deleteRangeMarker(
+            anyInt(),
+            argThat(
+                marker ->
+                    marker instanceof Start
+                        && marker.checkpointId() == now.minusSeconds(130).toEpochMilli()));
+  }
+
+  @Test
+  void shouldNotDeleteMarkerIfSameAsLastBackup() {
+    // given
+    reset(backupStore);
+    final var now = actorScheduler.getClock().instant();
+    final BackupStatus backup1 = backup(now.minusSeconds(200));
+    final BackupStatus backup2 = backup(now.minusSeconds(150));
+    final BackupStatus backup3 = backup(now.minusSeconds(110));
+
+    final List<BackupRangeMarker> ranges =
+        List.of(
+            new Start(now.minusSeconds(360).toEpochMilli()),
+            new End(now.minusSeconds(290).toEpochMilli()),
+            new Start(now.minusSeconds(110).toEpochMilli()),
+            new End(now.minusSeconds(110).toEpochMilli()));
+
+    when(backupStore.list(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
+
+    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
+    doReturn(CompletableFuture.completedFuture(null))
+        .when(backupStore)
+        .deleteRangeMarker(anyInt(), any());
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupStore).delete(backup1.id());
+    verify(backupStore).delete(backup2.id());
+    verify(backupStore, times(0)).storeRangeMarker(eq(1), any());
+
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
+    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+  }
+
+  @Test
+  void shouldHandleNoBackups() {
+    // given
+    reset(backupStore);
+    when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when
+    actorScheduler.submitActor(backupRetention);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofSeconds(10));
+    actorScheduler.workUntilDone();
+
+    // then
+    verify(backupStore).list(any());
+    verify(backupStore, times(0)).deleteRangeMarker(anyInt(), any());
+    verify(backupStore, times(0)).delete(any());
+    verify(backupStore, times(0)).storeRangeMarker(anyInt(), any());
+    verify(backupStore, times(0)).deleteRangeMarker(anyInt(), any());
+  }
+
+  private BackupStatus backup(final Instant timestamp) {
+    return backup(1, 1, timestamp);
+  }
+
+  private BackupStatus backup(final int partition, final int nodeId, final Instant timestamp) {
+    return new BackupStatusImpl(
+        new BackupIdentifierImpl(nodeId, partition, timestamp.toEpochMilli()),
+        Optional.of(
+            new BackupDescriptorImpl(
+                10L, 3, VersionUtil.getVersion(), timestamp, CheckpointType.SCHEDULED_BACKUP)),
+        null,
+        null,
+        Optional.of(timestamp),
+        null);
+  }
+
+  private BackupStatus backupNoCreatedDate(
+      final int partition, final int nodeId, final Instant timestamp) {
+    return new BackupStatusImpl(
+        new BackupIdentifierImpl(nodeId, partition, timestamp.toEpochMilli()),
+        Optional.empty(),
+        null,
+        null,
+        Optional.empty(),
+        null);
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -242,7 +242,6 @@ public class RetentionTest {
         backupStore,
         new IntervalSchedule(Duration.ofSeconds(10)),
         Duration.ofMinutes(2),
-        0,
         topologyManager,
         new SimpleMeterRegistry());
   }
@@ -270,7 +269,7 @@ public class RetentionTest {
   private List<BackupStatus> createDefaultBackupsNoCreatedDate(
       final int partition, final int nodeId, final Instant now) {
     return java.util.Arrays.stream(DEFAULT_BACKUP_OFFSETS)
-        .mapToObj(offset -> backupNoCreatedDate(partition, nodeId, now.minusSeconds(offset)))
+        .mapToObj(offset -> backupNoDescriptor(partition, nodeId, now.minusSeconds(offset)))
         .toList();
   }
 
@@ -348,7 +347,7 @@ public class RetentionTest {
         null);
   }
 
-  private BackupStatus backupNoCreatedDate(
+  private BackupStatus backupNoDescriptor(
       final int partition, final int nodeId, final Instant timestamp) {
     return new BackupStatusImpl(
         new BackupIdentifierImpl(nodeId, partition, timestamp.toEpochMilli()),
@@ -356,7 +355,7 @@ public class RetentionTest {
         null,
         null,
         Optional.empty(),
-        null);
+        Optional.of(timestamp));
   }
 
   @Nested

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
@@ -22,6 +22,7 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
     final var backupCfg = brokerStartupContext.getBrokerConfiguration().getData().getBackup();
     final var scheduler = brokerStartupContext.getActorSchedulingService();
     final var meterRegistry = brokerStartupContext.getMeterRegistry();
+    final var partitionManager = brokerStartupContext.getPartitionManager();
 
     if (backupCfg.isContinuous()) {
       concurrencyControl.run(
@@ -32,7 +33,8 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
                     scheduler,
                     backupCfg,
                     brokerStartupContext.getBrokerClient(),
-                    meterRegistry);
+                    meterRegistry,
+                    partitionManager);
 
             concurrencyControl.runOnCompletion(
                 scheduler.submitActor(schedulingService),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
@@ -33,8 +33,7 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
                     scheduler,
                     backupCfg,
                     brokerStartupContext.getBrokerClient(),
-                    meterRegistry,
-                    partitionManager);
+                    meterRegistry);
 
             concurrencyControl.runOnCompletion(
                 scheduler.submitActor(schedulingService),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.backup.schedule.Schedule;
 import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
@@ -60,8 +59,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       final ActorSchedulingService actorScheduler,
       final BackupCfg backupCfg,
       final BrokerClient brokerClient,
-      final MeterRegistry meterRegistry,
-      final PartitionManager partitionManager) {
+      final MeterRegistry meterRegistry) {
     this.membershipService = membershipService;
     this.actorScheduler = actorScheduler;
     this.backupCfg = backupCfg;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -92,7 +92,6 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
               backupStore,
               retentionCfg.getCleanupSchedule(),
               retentionCfg.getWindow(),
-              backupCfg.getOffset(),
               brokerClient.getTopologyManager(),
               meterRegistry);
       LOG.info(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -50,7 +50,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   private final BackupCfg backupCfg;
   private final ActorSchedulingService actorScheduler;
   private final MeterRegistry meterRegistry;
-  private final PartitionManager partitionManager;
+  private final BrokerClient brokerClient;
   private CheckpointScheduler checkpointScheduler;
   private final BackupRequestHandler backupRequestHandler;
   private BackupRetention backupRetentionJob;
@@ -66,9 +66,9 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
     this.actorScheduler = actorScheduler;
     this.backupCfg = backupCfg;
     this.meterRegistry = meterRegistry;
+    this.brokerClient = brokerClient;
     backupRequestHandler =
         new BackupRequestHandler(brokerClient, new CheckpointIdGenerator(backupCfg.getOffset()));
-    this.partitionManager = partitionManager;
   }
 
   @Override
@@ -95,7 +95,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
               retentionCfg.getCleanupSchedule(),
               retentionCfg.getWindow(),
               backupCfg.getOffset(),
-              () -> partitionManager.getZeebePartitions().size(),
+              brokerClient.getTopologyManager(),
               meterRegistry);
       LOG.info(
           "Backup retention initialized with cleanup schedule {}",

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -13,18 +13,32 @@ import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.azure.AzureBackupStore;
 import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
 import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
+import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.backup.retention.BackupRetention;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.backup.schedule.CheckpointScheduler;
 import io.camunda.zeebe.backup.schedule.Schedule;
 import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.partitioning.PartitionManager;
+import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,21 +50,25 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   private final BackupCfg backupCfg;
   private final ActorSchedulingService actorScheduler;
   private final MeterRegistry meterRegistry;
+  private final PartitionManager partitionManager;
   private CheckpointScheduler checkpointScheduler;
   private final BackupRequestHandler backupRequestHandler;
+  private BackupRetention backupRetentionJob;
 
   public CheckpointSchedulingService(
       final ClusterMembershipService membershipService,
       final ActorSchedulingService actorScheduler,
       final BackupCfg backupCfg,
       final BrokerClient brokerClient,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final PartitionManager partitionManager) {
     this.membershipService = membershipService;
     this.actorScheduler = actorScheduler;
     this.backupCfg = backupCfg;
     this.meterRegistry = meterRegistry;
     backupRequestHandler =
         new BackupRequestHandler(brokerClient, new CheckpointIdGenerator(backupCfg.getOffset()));
+    this.partitionManager = partitionManager;
   }
 
   @Override
@@ -67,6 +85,23 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       LOG.info("Backup scheduler initialized with interval {}", backupSchedule);
     }
 
+    final var retentionCfg = backupCfg.getRetention();
+    if (retentionCfg.getCleanupSchedule() != null
+        && !(retentionCfg.getCleanupSchedule() instanceof NoneSchedule)) {
+      final var backupStore = buildBackupStore(backupCfg);
+      backupRetentionJob =
+          new BackupRetention(
+              backupStore,
+              retentionCfg.getCleanupSchedule(),
+              retentionCfg.getWindow(),
+              backupCfg.getOffset(),
+              () -> partitionManager.getZeebePartitions().size(),
+              meterRegistry);
+      LOG.info(
+          "Backup retention initialized with cleanup schedule {}",
+          retentionCfg.getCleanupSchedule());
+    }
+
     if (checkpointSchedule != null || backupSchedule != null) {
       checkpointScheduler =
           new CheckpointScheduler(
@@ -78,6 +113,9 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   protected void onActorStarted() {
     if (checkpointScheduler != null && shouldStartSchedulers()) {
       actorScheduler.submitActor(checkpointScheduler);
+      if (backupRetentionJob != null) {
+        actorScheduler.submitActor(backupRetentionJob);
+      }
     }
   }
 
@@ -85,9 +123,14 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   protected void onActorCloseRequested() {
     membershipService.removeListener(this);
     if (isSchedulerActive()) {
+      final List<ActorFuture<Void>> shutdownFutures = new ArrayList<>();
+      shutdownFutures.add(checkpointScheduler.closeAsync());
+      if (backupRetentionJob != null) {
+        shutdownFutures.add(backupRetentionJob.closeAsync());
+      }
       actor.runOnCompletion(
-          checkpointScheduler.closeAsync(),
-          (ok, error) -> {
+          shutdownFutures,
+          (error) -> {
             if (error != null) {
               LOG.error("Failed to close checkpoint creator actor", error);
             }
@@ -115,12 +158,18 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   private void checkedStopScheduler() {
     if (shouldStopSchedulers() && isSchedulerActive()) {
       checkpointScheduler.close();
+      if (backupRetentionJob != null) {
+        backupRetentionJob.close();
+      }
     }
   }
 
   private void checkedStartScheduler() {
     if (shouldStartSchedulers() && isSchedulerInactive()) {
       actorScheduler.submitActor(checkpointScheduler);
+      if (backupRetentionJob != null) {
+        actorScheduler.submitActor(backupRetentionJob);
+      }
     }
   }
 
@@ -146,5 +195,38 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
         .min(Comparator.comparing(Member::id, MemberId::compareTo))
         .map(lowestMember -> !lowestMember.id().equals(localMemberId))
         .orElse(false);
+  }
+
+  private BackupStore buildBackupStore(final BackupCfg backupCfg) {
+    final var store = backupCfg.getStore();
+    return switch (store) {
+      case S3 -> buildS3BackupStore(backupCfg);
+      case GCS -> buildGcsBackupStore(backupCfg);
+      case AZURE -> buildAzureBackupStore(backupCfg);
+      case FILESYSTEM -> buildFilesystemBackupStore(backupCfg);
+      case NONE ->
+          throw new IllegalArgumentException(
+              "No backup store configured, cannot restore from backup.");
+    };
+  }
+
+  private static BackupStore buildS3BackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
+    return S3BackupStore.of(storeConfig);
+  }
+
+  private static BackupStore buildGcsBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupCfg.getGcs());
+    return GcsBackupStore.of(storeConfig);
+  }
+
+  private static BackupStore buildAzureBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = AzureBackupStoreConfig.toStoreConfig(backupCfg.getAzure());
+    return AzureBackupStore.of(storeConfig);
+  }
+
+  private static BackupStore buildFilesystemBackupStore(final BackupCfg backupCfg) {
+    final var storeConfig = FilesystemBackupStoreConfig.toStoreConfig(backupCfg.getFilesystem());
+    return FilesystemBackupStore.of(storeConfig);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
@@ -100,8 +100,7 @@ public class CheckpointSchedulerServiceTest {
             scheduler,
             brokerConfig.getData().getBackup(),
             brokerClient,
-            new SimpleMeterRegistry(),
-            mockPartitionManager);
+            new SimpleMeterRegistry());
   }
 
   @Test
@@ -267,8 +266,7 @@ public class CheckpointSchedulerServiceTest {
             scheduler,
             brokerConfig.getData().getBackup(),
             brokerClient,
-            new SimpleMeterRegistry(),
-            mockPartitionManager);
+            new SimpleMeterRegistry());
 
     final var member = mock(Member.class);
     doReturn(Set.of(member)).when(membershipService).getMembers();

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -611,25 +611,6 @@
       <artifactId>zeebe-backup-store-filesystem</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-storage-blob</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -605,6 +605,31 @@
       <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-filesystem</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/AzureBackupRetentionAcceptanceIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.azure.AzureBackupConfig;
+import io.camunda.zeebe.backup.azure.AzureBackupStore;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class AzureBackupRetentionAcceptanceIT implements BackupRetentionAcceptance {
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+  private static final String CONTAINER_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> Map.of("azurite", AZURITE_CONTAINER));
+
+  private BackupStore backupStore;
+  private BlobServiceClient blobServiceClient;
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(BROKER_COUNT)
+          .withGatewaysCount(1)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withEmbeddedGateway(false)
+          .withGatewayConfig(
+              g -> {
+                final var membership = g.unifiedConfig().getCluster().getMembership();
+                membership.setProbeInterval(Duration.ofMillis(100));
+                membership.setFailureTimeout(Duration.ofSeconds(2));
+              })
+          .withNodeConfig(
+              node ->
+                  node.withProperty("zeebe.clock.controlled", true)
+                      .withProperty("management.endpoints.web.exposure.include", "*"))
+          .build();
+
+  @BeforeEach
+  void configureBrokersAndStartCluster() {
+    final AzureBackupConfig config =
+        new AzureBackupConfig.Builder()
+            .withConnectionString(AZURITE_CONTAINER.getConnectString())
+            .withContainerName(CONTAINER_NAME)
+            .build();
+    backupStore = AzureBackupStore.of(config);
+  }
+
+  @Override
+  public TestCluster getTestCluster() {
+    return cluster;
+  }
+
+  @Override
+  public BackupStore getBackupStore() {
+    return backupStore;
+  }
+
+  @Override
+  public void assertManifestDoesNotExist(final long backupId) {
+    final var containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var client =
+                              containerClient.getBlobClient(
+                                  "manifests/%d/%d/%d/manifest.json"
+                                      .formatted(partitionId, backupId, brokerId));
+                          assertThat(client.getBlockBlobClient().exists()).isFalse();
+                        }));
+  }
+
+  @Override
+  public void assertContentsDoNotExist(final long backupId) {
+    final var containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var prefix =
+                              "contents/%d/%d/%d".formatted(partitionId, backupId, brokerId);
+                          final var blobs =
+                              containerClient.listBlobs(
+                                  new ListBlobsOptions().setPrefix(prefix), null);
+                          assertThat(blobs.stream().count()).isZero();
+                        }));
+  }
+
+  @Override
+  public Consumer<Camunda> backupConfig() {
+    return cfg -> {
+      final var backup = cfg.getData().getPrimaryStorage().getBackup();
+      final var azure = backup.getAzure();
+
+      backup.setStore(PrimaryStorageBackup.BackupStoreType.AZURE);
+      azure.setBasePath(CONTAINER_NAME);
+      azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
+      final var config =
+          new AzureBackupConfig.Builder()
+              .withConnectionString(AZURITE_CONTAINER.getConnectString())
+              .withContainerName(CONTAINER_NAME)
+              .build();
+      blobServiceClient = AzureBackupStore.buildClient(config);
+    };
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -150,7 +150,7 @@ public interface BackupRetentionAcceptance {
                   .as("End range marker for partition %d should be present", partitionId)
                   .isPresent();
               AssertionsForClassTypes.assertThat(endMarker.get().checkpointId())
-                  .as("Start range marker for partition %d should be updated", partitionId)
+                  .as("End range marker for partition %d should be greater than start", partitionId)
                   .isGreaterThan(newStartBackupId);
             });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -67,21 +67,6 @@ public interface BackupRetentionAcceptance {
     final List<Long> backupIds = new ArrayList<>();
 
     // Wait for 3 completed backups
-    /*    Awaitility.await("Initial backups are created")
-    .atMost(Duration.ofSeconds(30))
-    .pollInterval(Duration.ofSeconds(1))
-    .until(
-        () -> {
-          final var backups = actuator.list();
-          if (backups.stream().filter(f -> f.getState() == StateCode.COMPLETED).count() < 3) {
-            progressClock(BACKUP_INTERVAL.toMillis());
-            return false;
-          }
-          backups.sort(Comparator.comparingLong(BackupInfo::getBackupId));
-          nextBackupId.set(backups.get(2).getBackupId());
-          backups.subList(0, 2).forEach(backup -> backupIds.add(backup.getBackupId()));
-          return true;
-        });*/
     final var firstBackup = awaitNewBackup(0);
     final var secondBackup = awaitNewBackup(firstBackup);
     final var thirdBackup = awaitNewBackup(secondBackup);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
+import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.PinTimeRequest;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Acceptance tests for the BackupRetention mechanism combined with the CheckpointScheduler. These
+ * tests verify that backups follow a rolling window pattern and that old backups and range markers
+ * are properly deleted.
+ */
+public interface BackupRetentionAcceptance {
+  int PARTITION_COUNT = 3;
+  int BROKER_COUNT = 3;
+  int REPLICATION_FACTOR = 3;
+  Duration BACKUP_INTERVAL = Duration.ofSeconds(5);
+  Duration CLEANUP_INTERVAL = Duration.ofSeconds(5);
+  Duration RETENTION_WINDOW = Duration.ofSeconds(15);
+
+  TestCluster getTestCluster();
+
+  BackupStore getBackupStore();
+
+  default void containerSetup() {}
+
+  void assertManifestDoesNotExist(long checkpointId);
+
+  void assertContentsDoNotExist(long checkpointId);
+
+  @BeforeEach
+  default void setup() {
+    applyBackupConfig();
+    containerSetup();
+    getTestCluster().start().awaitCompleteTopology();
+  }
+
+  @Test
+  default void shouldMaintainRollingWindowAndDeleteOldBackupsWithRangeMarkers() {
+
+    pinClock();
+    final var actuator = BackupActuator.of(getTestCluster().availableGateway());
+    final List<Long> backupIds = new ArrayList<>();
+    final AtomicLong nextBackupId = new AtomicLong();
+
+    // Wait for 3 completed backups
+    Awaitility.await("Initial backups are created")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              final var backups = actuator.list();
+              if (backups.stream().filter(f -> f.getState() == StateCode.COMPLETED).count() < 3) {
+                progressClock(BACKUP_INTERVAL.toMillis());
+                return false;
+              }
+              backups.sort(Comparator.comparingLong(BackupInfo::getBackupId));
+              nextBackupId.set(backups.get(2).getBackupId());
+              backups.subList(0, 2).forEach(backup -> backupIds.add(backup.getBackupId()));
+              return true;
+            });
+
+    resetTime();
+
+    Awaitility.await("Retention deletes old backups")
+        .atMost(Duration.ofSeconds(90))
+        .pollInterval(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final var currentBackups = actuator.list();
+              final var currentBackupIds =
+                  currentBackups.stream().map(BackupInfo::getBackupId).toList();
+
+              // Initial backups should have been deleted
+              assertThat(currentBackupIds)
+                  .as("Initial backup %s should have been deleted by retention", backupIds)
+                  .doesNotContainAnyElementsOf(backupIds);
+            });
+
+    backupIds.forEach(
+        backupId -> {
+          assertManifestNotFoundFromStore(backupId);
+          assertManifestDoesNotExist(backupId);
+          assertContentsDoNotExist(backupId);
+        });
+    assertRangeMarkerHasBeenUpdated(nextBackupId.get());
+  }
+
+  default void assertManifestNotFoundFromStore(final Long backupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var identifier =
+                              new BackupIdentifierImpl(brokerId, partitionId, backupId);
+                          assertThat(getBackupStore().getStatus(identifier).join())
+                              .extracting(BackupStatus::statusCode)
+                              .isEqualTo(BackupStatusCode.DOES_NOT_EXIST);
+                        }));
+  }
+
+  default void assertRangeMarkerHasBeenUpdated(final long newStartBackupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId -> {
+              final var markers = getBackupStore().rangeMarkers(partitionId).join();
+              AssertionsForClassTypes.assertThat(markers.size()).isEqualTo(2);
+              final var startMarker = markers.stream().filter(Start.class::isInstance).findFirst();
+              AssertionsForClassTypes.assertThat(startMarker)
+                  .as("Start range marker for partition %d should be present", partitionId)
+                  .isPresent();
+              AssertionsForClassTypes.assertThat(startMarker.get().checkpointId())
+                  .as("Start range marker for partition %d should be updated", partitionId)
+                  .isEqualTo(newStartBackupId);
+
+              final var endMarker = markers.stream().filter(End.class::isInstance).findFirst();
+              AssertionsForClassTypes.assertThat(endMarker)
+                  .as("End range marker for partition %d should be present", partitionId)
+                  .isPresent();
+              AssertionsForClassTypes.assertThat(endMarker.get().checkpointId())
+                  .as("Start range marker for partition %d should be updated", partitionId)
+                  .isGreaterThan(newStartBackupId);
+            });
+  }
+
+  private void progressClock(final long millis) {
+    getTestCluster()
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var clockActuator = ActorClockActuator.of(broker);
+              clockActuator.addTime(new AddTimeRequest(millis));
+            });
+  }
+
+  private void resetTime() {
+    getTestCluster()
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var clockActuator = ActorClockActuator.of(broker);
+              clockActuator.resetTime();
+            });
+  }
+
+  private void pinClock() {
+    getTestCluster()
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var clock = ActorClockActuator.of(broker);
+              clock.pinClock(new PinTimeRequest(clock.getCurrentClock().epochMilli()));
+            });
+  }
+
+  Consumer<Camunda> backupConfig();
+
+  default void applyBackupConfig() {
+    getTestCluster()
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              broker.withUnifiedConfig(backupConfig());
+              broker.withDataConfig(
+                  data -> {
+                    data.getPrimaryStorage().getBackup().setContinuous(true);
+                    data.getPrimaryStorage()
+                        .getBackup()
+                        .setSchedule("PT" + BACKUP_INTERVAL.getSeconds() + "S");
+                    data.getPrimaryStorage()
+                        .getBackup()
+                        .getRetention()
+                        .setCleanupSchedule("PT" + CLEANUP_INTERVAL.getSeconds() + "S");
+                    data.getPrimaryStorage().getBackup().getRetention().setWindow(RETENTION_WINDOW);
+                  });
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupRetentionAcceptanceIT.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Filesystem;
 import io.camunda.configuration.PrimaryStorageBackup;
@@ -18,11 +16,9 @@ import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.io.TempDir;
 
 @ZeebeIntegration
@@ -53,30 +49,6 @@ public class FilesystemBackupRetentionAcceptanceIT implements BackupRetentionAcc
   @Override
   public BackupStore getBackupStore() {
     return backupStore;
-  }
-
-  @Override
-  public void assertManifestDoesNotExist(final long backupId) {
-    final Path manifestsDir = basePath.resolve("manifests");
-    IntStream.rangeClosed(1, PARTITION_COUNT)
-        .forEach(
-            partitionId -> {
-              final Path partitionDir = manifestsDir.resolve(String.valueOf(partitionId));
-              final Path checkpointDir = partitionDir.resolve(String.valueOf(backupId));
-              assertThat(Files.exists(checkpointDir)).isFalse();
-            });
-  }
-
-  @Override
-  public void assertContentsDoNotExist(final long backupId) {
-    final Path contentsDir = basePath.resolve("contents");
-    IntStream.rangeClosed(1, PARTITION_COUNT)
-        .forEach(
-            partitionId -> {
-              final Path partitionDir = contentsDir.resolve(String.valueOf(partitionId));
-              final Path checkpointDir = partitionDir.resolve(String.valueOf(backupId));
-              assertThat(Files.exists(checkpointDir)).isFalse();
-            });
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/FilesystemBackupRetentionAcceptanceIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Filesystem;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.filesystem.FilesystemBackupConfig;
+import io.camunda.zeebe.backup.filesystem.FilesystemBackupStore;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.io.TempDir;
+
+@ZeebeIntegration
+public class FilesystemBackupRetentionAcceptanceIT implements BackupRetentionAcceptance {
+  private static @TempDir Path tempDir;
+  private final Path basePath = tempDir.resolve(UUID.randomUUID().toString());
+  private BackupStore backupStore;
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(BROKER_COUNT)
+          .withGatewaysCount(1)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withEmbeddedGateway(false)
+          .withNodeConfig(
+              node ->
+                  node.withProperty("zeebe.clock.controlled", true)
+                      .withProperty("management.endpoints.web.exposure.include", "*"))
+          .build();
+
+  @Override
+  public TestCluster getTestCluster() {
+    return cluster;
+  }
+
+  @Override
+  public BackupStore getBackupStore() {
+    return backupStore;
+  }
+
+  @Override
+  public void assertManifestDoesNotExist(final long backupId) {
+    final Path manifestsDir = basePath.resolve("manifests");
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId -> {
+              final Path partitionDir = manifestsDir.resolve(String.valueOf(partitionId));
+              final Path checkpointDir = partitionDir.resolve(String.valueOf(backupId));
+              assertThat(Files.exists(checkpointDir)).isFalse();
+            });
+  }
+
+  @Override
+  public void assertContentsDoNotExist(final long backupId) {
+    final Path contentsDir = basePath.resolve("contents");
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId -> {
+              final Path partitionDir = contentsDir.resolve(String.valueOf(partitionId));
+              final Path checkpointDir = partitionDir.resolve(String.valueOf(backupId));
+              assertThat(Files.exists(checkpointDir)).isFalse();
+            });
+  }
+
+  @Override
+  public Consumer<Camunda> backupConfig() {
+    return cfg -> {
+      cfg.getData()
+          .getPrimaryStorage()
+          .getBackup()
+          .setStore(PrimaryStorageBackup.BackupStoreType.FILESYSTEM);
+
+      final var config = new Filesystem();
+      config.setBasePath(basePath.toAbsolutePath().toString());
+      cfg.getData().getPrimaryStorage().getBackup().setFilesystem(config);
+
+      backupStore =
+          FilesystemBackupStore.of(
+              new FilesystemBackupConfig(basePath.toAbsolutePath().toString()));
+    };
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupRetentionAcceptanceIT.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.exception.UncheckedException;
+import org.junit.jupiter.api.AfterEach;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -59,6 +60,13 @@ public class GcsBackupRetentionAcceptanceIT implements BackupRetentionAcceptance
                   node.withProperty("zeebe.clock.controlled", true)
                       .withProperty("management.endpoints.web.exposure.include", "*"))
           .build();
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+  }
 
   @Override
   public TestCluster getTestCluster() {
@@ -114,9 +122,7 @@ public class GcsBackupRetentionAcceptanceIT implements BackupRetentionAcceptance
                           final var prefix =
                               "%s/contents/%d/%d/%d"
                                   .formatted(basePath, partitionId, backupId, brokerId);
-                          final var blobs =
-                              client.list(
-                                  BUCKET_NAME, BlobListOption.prefix(basePath + "/" + prefix));
+                          final var blobs = client.list(BUCKET_NAME, BlobListOption.prefix(prefix));
                           assertThat(blobs.streamAll().count()).isZero();
                         }));
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/GcsBackupRetentionAcceptanceIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Gcs;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.GcsContainer;
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.exception.UncheckedException;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class GcsBackupRetentionAcceptanceIT implements BackupRetentionAcceptance {
+
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+  @Container private static final GcsContainer GCS = new GcsContainer();
+  private final String basePath = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+  private BackupStore backupStore;
+  private Storage client;
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(BROKER_COUNT)
+          .withGatewaysCount(1)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withEmbeddedGateway(false)
+          .withGatewayConfig(
+              g -> {
+                final var membership = g.unifiedConfig().getCluster().getMembership();
+                membership.setProbeInterval(Duration.ofMillis(100));
+                membership.setFailureTimeout(Duration.ofSeconds(2));
+              })
+          .withNodeConfig(
+              node ->
+                  node.withProperty("zeebe.clock.controlled", true)
+                      .withProperty("management.endpoints.web.exposure.include", "*"))
+          .build();
+
+  @Override
+  public TestCluster getTestCluster() {
+    return cluster;
+  }
+
+  @Override
+  public BackupStore getBackupStore() {
+    return backupStore;
+  }
+
+  @Override
+  public void containerSetup() {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withoutAuthentication()
+            .withHost(GCS.externalEndpoint())
+            .withBucketName(BUCKET_NAME)
+            .build();
+
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_NAME));
+    } catch (final Exception e) {
+      throw new UncheckedException(e);
+    }
+  }
+
+  @Override
+  public void assertManifestDoesNotExist(final long backupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var manifest =
+                              client.get(
+                                  BUCKET_NAME,
+                                  "%s/manifests/%d/%d/%d/manifest.json"
+                                      .formatted(basePath, partitionId, backupId, brokerId));
+                          assertThat(manifest).isNull();
+                        }));
+  }
+
+  @Override
+  public void assertContentsDoNotExist(final long backupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var prefix =
+                              "%s/contents/%d/%d/%d"
+                                  .formatted(basePath, partitionId, backupId, brokerId);
+                          final var blobs =
+                              client.list(
+                                  BUCKET_NAME, BlobListOption.prefix(basePath + "/" + prefix));
+                          assertThat(blobs.streamAll().count()).isZero();
+                        }));
+  }
+
+  @Override
+  public Consumer<Camunda> backupConfig() {
+    return cfg -> {
+      cfg.getData()
+          .getPrimaryStorage()
+          .getBackup()
+          .setStore(PrimaryStorageBackup.BackupStoreType.GCS);
+
+      final var gcs = cfg.getData().getPrimaryStorage().getBackup().getGcs();
+      gcs.setAuth(Gcs.GcsBackupStoreAuth.NONE);
+      gcs.setBasePath(basePath);
+      gcs.setBucketName(BUCKET_NAME);
+      gcs.setHost(GCS.externalEndpoint());
+
+      final var brokerCfg =
+          new GcsBackupConfig.Builder()
+              .withoutAuthentication()
+              .withHost(GCS.externalEndpoint())
+              .withBucketName(BUCKET_NAME)
+              .withBasePath(basePath)
+              .build();
+
+      backupStore = GcsBackupStore.of(brokerCfg);
+
+      client = GcsBackupStore.buildClient(brokerCfg);
+    };
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.MinioContainer;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@Testcontainers
+@ZeebeIntegration
+public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance {
+
+  private final String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Container
+  private final MinioContainer minio = new MinioContainer().withDomain("minio.local", bucketName);
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(() -> Map.of("minio", minio));
+
+  private BackupStore backupStore;
+  private S3AsyncClient client;
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(BROKER_COUNT)
+          .withGatewaysCount(1)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withEmbeddedGateway(false)
+          .withNodeConfig(
+              node ->
+                  node.withProperty("zeebe.clock.controlled", true)
+                      .withProperty("management.endpoints.web.exposure.include", "*"))
+          .build();
+
+  @Override
+  public TestCluster getTestCluster() {
+    return cluster;
+  }
+
+  @Override
+  public BackupStore getBackupStore() {
+    return backupStore;
+  }
+
+  @Override
+  public void containerSetup() {
+    final var config =
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(minio.externalEndpoint())
+            .withRegion(minio.region())
+            .withCredentials(minio.accessKey(), minio.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(25))
+            .forcePathStyleAccess(true)
+            .build();
+
+    try (final var client = S3BackupStore.buildClient(config)) {
+      // it's possible to query to fast and get a 503 from the server here, so simply retry after
+      Awaitility.await("until bucket is created")
+          .untilAsserted(
+              () -> client.createBucket(builder -> builder.bucket(bucketName).build()).join());
+    }
+  }
+
+  @Override
+  public void assertManifestDoesNotExist(final long backupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId ->
+                            assertThatThrownBy(
+                                    () ->
+                                        client
+                                            .headObject(
+                                                req ->
+                                                    req.bucket(bucketName)
+                                                        .key(
+                                                            "manifests/%d/%d/%d/manifest.json"
+                                                                .formatted(
+                                                                    partitionId,
+                                                                    backupId,
+                                                                    brokerId)))
+                                            .join())
+                                .hasCauseInstanceOf(NoSuchKeyException.class)));
+  }
+
+  @Override
+  public void assertContentsDoNotExist(final long backupId) {
+    IntStream.rangeClosed(1, PARTITION_COUNT)
+        .forEach(
+            partitionId ->
+                IntStream.rangeClosed(0, BROKER_COUNT - 1)
+                    .forEach(
+                        brokerId -> {
+                          final var response =
+                              client
+                                  .listObjectsV2(
+                                      req ->
+                                          req.bucket(bucketName)
+                                              .prefix(
+                                                  "contents/%d/%d/%d"
+                                                      .formatted(partitionId, backupId, brokerId)))
+                                  .join();
+
+                          assertThat(response.contents().isEmpty()).isTrue();
+                        }));
+  }
+
+  @Override
+  public Consumer<Camunda> backupConfig() {
+    return cfg -> {
+      final var backup = cfg.getData().getPrimaryStorage().getBackup();
+      final var s3 = backup.getS3();
+
+      backup.setStore(PrimaryStorageBackup.BackupStoreType.S3);
+      s3.setBucketName(bucketName);
+      s3.setEndpoint(minio.externalEndpoint());
+      s3.setRegion(minio.region());
+      s3.setAccessKey(minio.accessKey());
+      s3.setSecretKey(minio.secretKey());
+      s3.setForcePathStyleAccess(true);
+
+      final var brokerCfg =
+          new S3BackupConfig.Builder()
+              .withBucketName(bucketName)
+              .withEndpoint(minio.externalEndpoint())
+              .withRegion(minio.region())
+              .withCredentials(minio.accessKey(), minio.secretKey())
+              .forcePathStyleAccess(true)
+              .build();
+
+      backupStore = S3BackupStore.of(brokerCfg);
+      client = S3BackupStore.buildClient(brokerCfg);
+    };
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
@@ -49,6 +49,7 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
 
   private BackupStore backupStore;
   private S3AsyncClient client;
+
   @TestZeebe(autoStart = false)
   private final TestCluster cluster =
       TestCluster.builder()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
@@ -7,9 +7,6 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.PrimaryStorageBackup;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -24,15 +21,11 @@ import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 @Testcontainers
 @ZeebeIntegration
@@ -48,7 +41,6 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
   final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(() -> Map.of("minio", minio));
 
   private BackupStore backupStore;
-  private S3AsyncClient client;
 
   @TestZeebe(autoStart = false)
   private final TestCluster cluster =
@@ -63,13 +55,6 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
                   node.withProperty("zeebe.clock.controlled", true)
                       .withProperty("management.endpoints.web.exposure.include", "*"))
           .build();
-
-  @AfterEach
-  public void tearDown() {
-    if (client != null) {
-      client.close();
-    }
-  }
 
   @Override
   public TestCluster getTestCluster() {
@@ -102,52 +87,6 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
   }
 
   @Override
-  public void assertManifestDoesNotExist(final long backupId) {
-    IntStream.rangeClosed(1, PARTITION_COUNT)
-        .forEach(
-            partitionId ->
-                IntStream.rangeClosed(0, BROKER_COUNT - 1)
-                    .forEach(
-                        brokerId ->
-                            assertThatThrownBy(
-                                    () ->
-                                        client
-                                            .headObject(
-                                                req ->
-                                                    req.bucket(bucketName)
-                                                        .key(
-                                                            "manifests/%d/%d/%d/manifest.json"
-                                                                .formatted(
-                                                                    partitionId,
-                                                                    backupId,
-                                                                    brokerId)))
-                                            .join())
-                                .hasCauseInstanceOf(NoSuchKeyException.class)));
-  }
-
-  @Override
-  public void assertContentsDoNotExist(final long backupId) {
-    IntStream.rangeClosed(1, PARTITION_COUNT)
-        .forEach(
-            partitionId ->
-                IntStream.rangeClosed(0, BROKER_COUNT - 1)
-                    .forEach(
-                        brokerId -> {
-                          final var response =
-                              client
-                                  .listObjectsV2(
-                                      req ->
-                                          req.bucket(bucketName)
-                                              .prefix(
-                                                  "contents/%d/%d/%d"
-                                                      .formatted(partitionId, backupId, brokerId)))
-                                  .join();
-
-                          assertThat(response.contents().isEmpty()).isTrue();
-                        }));
-  }
-
-  @Override
   public Consumer<Camunda> backupConfig() {
     return cfg -> {
       final var backup = cfg.getData().getPrimaryStorage().getBackup();
@@ -171,7 +110,6 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
               .build();
 
       backupStore = S3BackupStore.of(brokerCfg);
-      client = S3BackupStore.buildClient(brokerCfg);
     };
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/S3BackupRetentionAcceptanceIT.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -48,7 +49,6 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
 
   private BackupStore backupStore;
   private S3AsyncClient client;
-
   @TestZeebe(autoStart = false)
   private final TestCluster cluster =
       TestCluster.builder()
@@ -62,6 +62,13 @@ public class S3BackupRetentionAcceptanceIT implements BackupRetentionAcceptance 
                   node.withProperty("zeebe.clock.controlled", true)
                       .withProperty("management.endpoints.web.exposure.include", "*"))
           .build();
+
+  @AfterEach
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+  }
 
   @Override
   public TestCluster getTestCluster() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
@@ -95,10 +95,16 @@ public interface ActorClockActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Response addTime(@RequestBody AddTimeRequest request);
 
+  @RequestLine("POST /pin")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Response pinClock(@RequestBody PinTimeRequest request);
+
   @RequestLine("DELETE")
   Response resetTime();
 
   record Response(long epochMilli, Instant instant) {}
 
   record AddTimeRequest(Long offsetMilli) {}
+
+  record PinTimeRequest(Long epochMilli) {}
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Mechanism to perform the automated retention of primary storage backups. This scheduled task's job is to maintain a _rolling window_ of Primary Storage (Zeebe) backups based on a configurable window timeframe.

Backup retention involves the following parts:
- Identifying which backups need to be deleted from listing the manifests - based on the time window
- Identifying whether the range index needs to be modified when deleting backups within an existing range
- Perform the deletion of backup manifest & contents
- Perform the deletion of outdated ranges

_Pending Grafana dashboards for new metrics_

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #40470
