### PR TITLE
feat: use original message size to estimate memory usage

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -114,6 +114,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public int getSerializedLength() {
+    return 0;
+  }
+
+  @Override
   public long getKey() {
     return 0;
   }
@@ -121,6 +126,11 @@ record MockTypedCheckpointRecord(
   @Override
   public CheckpointRecord getValue() {
     return value;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 
   @Override
@@ -136,10 +146,5 @@ record MockTypedCheckpointRecord(
   @Override
   public int getLength() {
     return 0;
-  }
-
-  @Override
-  public AuthInfo getAuthInfo() {
-    return null;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -242,7 +241,7 @@ final class ExporterContainer implements Controller {
     updateExporterState(lastAcknowledgedPosition, lastExportedMetadata);
   }
 
-  private void export(final Record<?> record) {
+  private void export(final TypedRecord<?> record) {
     ThreadContextUtil.runWithClassLoader(
         () -> exporter.export(record), exporter.getClass().getClassLoader());
     lastUnacknowledgedPosition = record.getPosition();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -123,6 +123,11 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   }
 
   @Override
+  public int getSerializedLength() {
+    return 0;
+  }
+
+  @Override
   public long getKey() {
     return key;
   }
@@ -130,6 +135,11 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   @Override
   public T getValue() {
     return record;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return null;
   }
 
   @Override
@@ -145,10 +155,5 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   @Override
   public int getLength() {
     return 0;
-  }
-
-  @Override
-  public AuthInfo getAuthInfo() {
-    return null;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -47,6 +47,15 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
     return value;
   }
 
+  public void setValue(final T value) {
+    this.value = value;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
+  }
+
   @Override
   public int getRequestStreamId() {
     return metadata.getRequestStreamId();
@@ -60,10 +69,6 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public int getLength() {
     return metadata.getLength() + value.getLength();
-  }
-
-  public void setValue(final T value) {
-    this.value = value;
   }
 
   public void setMetadata(final RecordMetadata metadata) {
@@ -146,12 +151,12 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
-  public String toJson() {
-    throw new UnsupportedOperationException("not yet implemented");
+  public int getSerializedLength() {
+    return 0;
   }
 
   @Override
-  public AuthInfo getAuthInfo() {
-    return metadata.getAuthorization();
+  public String toJson() {
+    throw new UnsupportedOperationException("not yet implemented");
   }
 }

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -259,5 +259,10 @@ public final class ExporterTest {
     public long getBatchOperationReference() {
       return 0;
     }
+
+    @Override
+    public int getSerializedLength() {
+      return 0;
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -15,7 +15,6 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.util.ObjectSizeEstimator;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
@@ -30,12 +29,12 @@ import java.util.function.BiConsumer;
 public final class ExporterBatchWriter {
   private final Map<EntityIdAndEntityType, ExporterEntity> cachedEntities = new HashMap<>();
   private final List<EntityAndHandler> cachedEntitiesToFlush = new ArrayList<>();
-  private final Map<EntityIdAndEntityType, Long> cachedEntitySizes = new HashMap<>();
   private final Map<Long, Long> cachedRecordTimestamps = new HashMap<>();
 
   private final Map<ValueType, List<ExportHandler>> handlers;
   private final BiConsumer<String, Error> customErrorHandler;
   private final CamundaExporterMetrics metrics;
+  private int memoryEstimation = 0;
 
   private ExporterBatchWriter(
       final Map<ValueType, List<ExportHandler>> handlers,
@@ -48,6 +47,7 @@ public final class ExporterBatchWriter {
 
   public void addRecord(final Record<?> record) {
     final ValueType valueType = record.getValueType();
+    final var length = record.getSerializedLength();
 
     handlers
         .getOrDefault(valueType, Collections.emptyList())
@@ -55,22 +55,26 @@ public final class ExporterBatchWriter {
             handler -> {
               if (handler.handlesRecord(record)) {
                 final List<String> entityIds = handler.generateIds(record);
-                entityIds.forEach(id -> updateAndCacheEntity(record, handler, id));
+                entityIds.forEach(
+                    id -> {
+                      updateAndCacheEntity(record, handler, id, length);
+                    });
               }
             });
   }
 
   private void updateAndCacheEntity(
-      final Record<?> record, final ExportHandler handler, final String id) {
+      final Record<?> record, final ExportHandler handler, final String id, final int length) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
+    if (!cachedEntities.containsKey(cacheKey)) {
+      memoryEstimation += length;
+    }
     final ExporterEntity entity =
         cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
 
     handler.updateEntity(record, entity);
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
-
-    cachedEntitySizes.put(cacheKey, ObjectSizeEstimator.estimateSize(entity));
 
     // we store all handlers for an entity to make sure not to miss any flushes.
     // we flush them in the same order as they were originally run.
@@ -99,8 +103,7 @@ public final class ExporterBatchWriter {
   }
 
   public int getBatchMemoryEstimateInMb() {
-    return (int) cachedEntitySizes.values().stream().mapToLong(Long::longValue).sum()
-        / (1024 * 1024);
+    return memoryEstimation / (1024 * 1024);
   }
 
   private void observeRecordTimestamps() {
@@ -121,7 +124,7 @@ public final class ExporterBatchWriter {
   private void reset() {
     cachedEntities.clear();
     cachedEntitiesToFlush.clear();
-    cachedEntitySizes.clear();
+    memoryEstimation = 0;
   }
 
   public static final class Builder {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.protocol;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -99,6 +100,12 @@ public record TestRecord(long position, ValueType valueType) implements Record<T
   @Override
   public Record<TestValue> copyOf() {
     return this;
+  }
+
+  @JsonIgnore
+  @Override
+  public int getSerializedLength() {
+    return 0;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
@@ -15,7 +15,12 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Map;
 
-public record TestRecord(long position, ValueType valueType) implements Record<TestValue> {
+public record TestRecord(long position, ValueType valueType, int serializedLength)
+    implements Record<TestValue> {
+
+  public TestRecord(final long position, final ValueType valueType) {
+    this(position, valueType, 0);
+  }
 
   @Override
   public long getPosition() {
@@ -105,7 +110,7 @@ public record TestRecord(long position, ValueType valueType) implements Record<T
   @JsonIgnore
   @Override
   public int getSerializedLength() {
-    return 0;
+    return serializedLength;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
@@ -20,6 +21,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
 
+  public final int serializedLength;
   private final ValueType valueType;
   private final T recordValue;
   private final long key;
@@ -50,6 +52,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     this.position = position;
     this.sourcePosition = sourcePosition;
     this.timestamp = timestamp;
+    serializedLength = metadata.getSerializedLength();
 
     intent = metadata.getIntent();
     recordType = metadata.getRecordType();
@@ -86,6 +89,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     position = copiedRecord.position;
     sourcePosition = copiedRecord.sourcePosition;
     timestamp = copiedRecord.timestamp;
+    serializedLength = copiedRecord.serializedLength;
 
     intent = copiedRecord.intent;
     recordType = copiedRecord.recordType;
@@ -183,6 +187,12 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public Record<T> copyOf() {
     return new CopiedRecord<>(this);
+  }
+
+  @JsonIgnore
+  @Override
+  public int getSerializedLength() {
+    return serializedLength;
   }
 
   /**

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -50,6 +50,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final AuthInfo authorization = new AuthInfo();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
+  private int serializedLength = 0;
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -65,6 +66,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   @Override
   public void wrap(final DirectBuffer buffer, int offset, final int length) {
     reset();
+    serializedLength = length;
 
     headerDecoder.wrap(buffer, offset);
 
@@ -295,6 +297,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata reset() {
+    serializedLength = 0;
     recordType = RecordType.NULL_VAL;
     requestId = RecordMetadataEncoder.requestIdNullValue();
     requestStreamId = RecordMetadataEncoder.requestStreamIdNullValue();
@@ -388,5 +391,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     builder.append('}');
     return builder.toString();
+  }
+
+  public int getSerializedLength() {
+    return serializedLength;
   }
 }

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -56,6 +56,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
     <!--
       adding SpotBugs annotations to the classpath will cause Immutables to generate the proper
       annotations and suppress false positives

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -160,4 +161,7 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
         "Failed to create a deep copy of this record; this implementation does not support this out"
             + " of the box");
   }
+
+  @JsonIgnore
+  int getSerializedLength();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -95,11 +95,6 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
-  public AuthInfo getAuthInfo() {
-    return metadata.getAuthorization();
-  }
-
-  @Override
   public int getRecordVersion() {
     return metadata.getRecordVersion();
   }
@@ -132,6 +127,17 @@ public final class TypedRecordImpl implements TypedRecord {
   @Override
   public UnifiedRecordValue getValue() {
     return value;
+  }
+
+  @JsonIgnore
+  @Override
+  public int getSerializedLength() {
+    return metadata.getSerializedLength() + value.getLength();
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl.records;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -103,6 +104,12 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public long getBatchOperationReference() {
     return metadata.getBatchOperationReference();
+  }
+
+  @JsonIgnore
+  @Override
+  public int getSerializedLength() {
+    return metadata.getSerializedLength();
   }
 
   @Override

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -141,6 +141,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public int getSerializedLength() {
+      return 0;
+    }
+
+    @Override
     public String toJson() {
       return null;
     }


### PR DESCRIPTION
## Description
Compared to #44775 in the hackaton, there's no change in the public interface `Exporter`, instead `getSerializedLength` has been added to the `Record` interface. 
Every implementation of `Record` has a reference to the RecordMetadata, so it's easy to implement.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44131
