### PR TITLE
Add Connectors And AI Team To AlwaysGreen

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -98,7 +98,21 @@ jobs:
              "bmudric",
              "Ben-Sheppard",
              "ana-vinogradova-camunda",
-             "mrm1st3r"]'
+             "mrm1st3r",
+             "sbuettner",
+             "nikonovd",
+             "phoinixi",
+             "johnBgood",
+             "maff",
+             "mathias-vandaele",
+             "mathieu-stennier",
+             "mdii",
+             "chillleader",
+             "reiballa",
+             "vringar",
+             "ztefanie",
+             "yhaskell",
+             "shtishiv"]'
           ), github.actor) &&
        !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
     steps:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The Connectors and AI team need to be added to AlwaysGreen in this repo.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
