### PR TITLE
POC: process instance introspection

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -108,6 +108,7 @@ import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedOutputValue;
 import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceIntrospectRecordValue.ProcessInstanceIntrospectActionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.util.Either;
 import java.time.OffsetDateTime;
@@ -798,10 +799,12 @@ public final class ResponseMapper {
 
   public static ProcessInstanceIntrospectResult toIntrospectProcessInstanceResponse(
       final ProcessInstanceIntrospectRecord brokerResponse) {
-    return new ProcessInstanceIntrospectResult(brokerResponse.getProcessInstanceKey());
+    return new ProcessInstanceIntrospectResult(
+        brokerResponse.getProcessInstanceKey(), brokerResponse.getActions());
   }
 
-  public record ProcessInstanceIntrospectResult(long processInstanceKey) {}
+  public record ProcessInstanceIntrospectResult(
+      long processInstanceKey, List<ProcessInstanceIntrospectActionRecordValue> actions) {}
 
   static class RestJobActivationResult
       implements JobActivationResult<io.camunda.gateway.protocol.model.JobActivationResult> {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -99,6 +99,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -794,6 +795,13 @@ public final class ResponseMapper {
           brokerInfo.addPartitionsItem(partitionDto);
         });
   }
+
+  public static ProcessInstanceIntrospectResult toIntrospectProcessInstanceResponse(
+      final ProcessInstanceIntrospectRecord brokerResponse) {
+    return new ProcessInstanceIntrospectResult(brokerResponse.getProcessInstanceKey());
+  }
+
+  public record ProcessInstanceIntrospectResult(long processInstanceKey) {}
 
   static class RestJobActivationResult
       implements JobActivationResult<io.camunda.gateway.protocol.model.JobActivationResult> {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceR
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerIntrospectProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMigrateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerModifyProcessInstanceRequest;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
@@ -419,6 +421,13 @@ public final class ProcessInstanceServices
                                 .build())
                         .page(query.page())
                         .sort(query.sort())));
+  }
+
+  public CompletableFuture<ProcessInstanceIntrospectRecord> introspectProcessInstance(
+      final Long processInstanceKey) {
+    final var brokerRequest =
+        new BrokerIntrospectProcessInstanceRequest().setProcessInstanceKey(processInstanceKey);
+    return sendBrokerRequest(brokerRequest);
   }
 
   public record ProcessInstanceCreateRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelP
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithAwaitingResultProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceIntrospectProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -51,6 +52,7 @@ import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -137,6 +139,11 @@ public final class BpmnProcessors {
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
     addAdHocSubProcessActivityStreamProcessors(
         typedRecordProcessors, processingState, writers, authCheckBehavior, bpmnBehaviors);
+
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE_INTROSPECT,
+        ProcessInstanceIntrospectIntent.INTROSPECT,
+        new ProcessInstanceIntrospectProcessor(writers, keyGenerator));
 
     return bpmnStreamProcessor;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -143,7 +143,7 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_INTROSPECT,
         ProcessInstanceIntrospectIntent.INTROSPECT,
-        new ProcessInstanceIntrospectProcessor(writers, keyGenerator));
+        new ProcessInstanceIntrospectProcessor(writers, keyGenerator, processingState));
 
     return bpmnStreamProcessor;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceIntrospectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceIntrospectProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class ProcessInstanceIntrospectProcessor
+    implements TypedRecordProcessor<ProcessInstanceIntrospectRecord> {
+
+  private final TypedEventWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final KeyGenerator keyGenerator;
+
+  public ProcessInstanceIntrospectProcessor(
+      final Writers writers, final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceIntrospectRecord> record) {
+    final var key = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(
+        key, ProcessInstanceIntrospectIntent.INTROSPECTED, record.getValue());
+    responseWriter.writeEventOnCommand(
+        key, ProcessInstanceIntrospectIntent.INTROSPECTED, record.getValue(), record);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceIntrospectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceIntrospectProcessor.java
@@ -7,14 +7,21 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectActionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.Map;
 
 public class ProcessInstanceIntrospectProcessor
     implements TypedRecordProcessor<ProcessInstanceIntrospectRecord> {
@@ -22,20 +29,84 @@ public class ProcessInstanceIntrospectProcessor
   private final TypedEventWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final KeyGenerator keyGenerator;
+  private final ProcessingState processingState;
 
   public ProcessInstanceIntrospectProcessor(
-      final Writers writers, final KeyGenerator keyGenerator) {
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     this.keyGenerator = keyGenerator;
+    this.processingState = processingState;
   }
 
   @Override
   public void processRecord(final TypedRecord<ProcessInstanceIntrospectRecord> record) {
     final var key = keyGenerator.nextKey();
+
+    // TODO enrich the record with actual introspection data
+    final var processInstanceKey = record.getValue().getProcessInstanceKey();
+    final var processInstance =
+        processingState.getElementInstanceState().getInstance(processInstanceKey);
+    // TODO fix tenant
+    final var processDef =
+        processingState
+            .getProcessState()
+            .getProcessByKeyAndTenant(
+                processInstance.getValue().getProcessDefinitionKey(),
+                TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    final var children = processingState.getElementInstanceState().getChildren(processInstanceKey);
+    children.stream()
+        .map(child -> getAction(child, processDef))
+        .forEach(
+            action ->
+                record
+                    .getValue()
+                    .addAction(
+                        new ProcessInstanceIntrospectActionRecord()
+                            .setAction(action.type.name())
+                            .setElementInstanceKey(action.elementInstanceKey)
+                            .setParameters(action.parameters)));
+
     stateWriter.appendFollowUpEvent(
         key, ProcessInstanceIntrospectIntent.INTROSPECTED, record.getValue());
     responseWriter.writeEventOnCommand(
         key, ProcessInstanceIntrospectIntent.INTROSPECTED, record.getValue(), record);
+  }
+
+  private Action getAction(
+      final ElementInstance elementInstance, final DeployedProcess deployedProcess) {
+    return switch (elementInstance.getValue().getBpmnElementType()) {
+      case USER_TASK -> getUserTaskAction(elementInstance, deployedProcess);
+      default -> new Action(ActionType.UNKNOWN, -1L, Map.of());
+    };
+  }
+
+  private Action getUserTaskAction(
+      final ElementInstance elementInstance, final DeployedProcess deployedProcess) {
+    final var element =
+        deployedProcess
+            .getProcess()
+            .getElementById(elementInstance.getValue().getElementId(), ExecutableUserTask.class);
+
+    // Check if the element has a job type definition (indicating a job worker user task)
+    // vs. being a native Camunda user task
+    if (element != null && element.getJobWorkerProperties() != null) {
+      final var job = processingState.getJobState().getJob(elementInstance.getJobKey());
+      return new Action(
+          ActionType.JOB_WORKER, elementInstance.getKey(), Map.of("jobType", job.getType()));
+    }
+
+    return new Action(ActionType.USER_TASK, elementInstance.getKey(), Map.of());
+  }
+
+  public record Action(ActionType type, Long elementInstanceKey, Map<String, String> parameters) {}
+
+  enum ActionType {
+    USER_TASK,
+    JOB_WORKER,
+    UNKNOWN;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
@@ -103,6 +104,7 @@ public final class EventAppliers implements EventApplier {
     register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.ACTIVATED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.TERMINATED, NOOP_EVENT_APPLIER);
+    register(ProcessInstanceIntrospectIntent.INTROSPECTED, NOOP_EVENT_APPLIER);
 
     registerProcessAppliers(state);
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -138,6 +138,19 @@ public class ProcessInstanceController {
   }
 
   @RequiresSecondaryStorage
+  @CamundaGetMapping(path = "/{processInstanceKey}/introspect")
+  public CompletableFuture<ResponseEntity<Object>> introspectProcessInstance(
+      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            processInstanceServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .introspectProcessInstance(processInstanceKey),
+        ResponseMapper::toIntrospectProcessInstanceResponse,
+        HttpStatus.OK);
+  }
+
+  @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{processInstanceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstance(
       @PathVariable("processInstanceKey") final Long processInstanceKey,

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerIntrospectProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerIntrospectProcessInstanceRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerIntrospectProcessInstanceRequest
+    extends BrokerExecuteCommand<ProcessInstanceIntrospectRecord> {
+  private final ProcessInstanceIntrospectRecord requestDto = new ProcessInstanceIntrospectRecord();
+
+  public BrokerIntrospectProcessInstanceRequest() {
+    super(ValueType.PROCESS_INSTANCE_INTROSPECT, ProcessInstanceIntrospectIntent.INTROSPECT);
+  }
+
+  public BrokerIntrospectProcessInstanceRequest setProcessInstanceKey(
+      final long processInstanceKey) {
+    requestDto.setProcessInstanceKey(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ProcessInstanceIntrospectRecord toResponseDto(final DirectBuffer buffer) {
+    final ProcessInstanceIntrospectRecord responseDto = new ProcessInstanceIntrospectRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRe
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceIntrospectRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -213,6 +214,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.GLOBAL_LISTENER_BATCH -> new GlobalListenerBatchRecord();
       case ValueType.JOB_METRICS_BATCH -> new JobMetricsBatchRecord();
       case ValueType.GLOBAL_LISTENER -> new GlobalListenerRecord();
+      case PROCESS_INSTANCE_INTROSPECT -> new ProcessInstanceIntrospectRecord();
       case ValueType.SBE_UNKNOWN -> null;
       case ValueType.NULL_VAL -> null;
     };

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectActionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectActionRecord.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceIntrospectRecordValue.ProcessInstanceIntrospectActionRecordValue;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public class ProcessInstanceIntrospectActionRecord extends ObjectValue
+    implements ProcessInstanceIntrospectActionRecordValue {
+
+  private final StringProperty actionProperty = new StringProperty("action");
+  private final LongProperty elementInstanceKey = new LongProperty("elementInstanceKey");
+  private final DocumentProperty parametersProperty = new DocumentProperty("parameters");
+
+  public ProcessInstanceIntrospectActionRecord() {
+    super(3);
+    declareProperty(actionProperty)
+        .declareProperty(elementInstanceKey)
+        .declareProperty(parametersProperty);
+  }
+
+  public void copy(final ProcessInstanceIntrospectActionRecordValue object) {
+    actionProperty.setValue(object.getAction());
+    elementInstanceKey.setValue(object.getElementInstanceKey());
+    setParameters(object.getParameters());
+  }
+
+  @Override
+  public String getAction() {
+    return bufferAsString(actionProperty.getValue());
+  }
+
+  @Override
+  public Long getElementInstanceKey() {
+    return elementInstanceKey.getValue();
+  }
+
+  public ProcessInstanceIntrospectActionRecord setElementInstanceKey(final Long key) {
+    elementInstanceKey.setValue(key);
+    return this;
+  }
+
+  @Override
+  public Map<String, String> getParameters() {
+    return MsgPackConverter.convertToStringMap(parametersProperty.getValue());
+  }
+
+  public ProcessInstanceIntrospectActionRecord setParameters(final Map<String, String> parameters) {
+    parametersProperty.setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(parameters)));
+    return this;
+  }
+
+  public ProcessInstanceIntrospectActionRecord setAction(final String action) {
+    actionProperty.setValue(action);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceIntrospectRecordValue;
+
+public class ProcessInstanceIntrospectRecord extends UnifiedRecordValue
+    implements ProcessInstanceIntrospectRecordValue {
+
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+
+  public ProcessInstanceIntrospectRecord() {
+    super(1);
+    declareProperty(processInstanceKeyProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceIntrospectRecord setProcessInstanceKey(final long key) {
+    processInstanceKeyProperty.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return -1L;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceIntrospectRecord.java
@@ -7,21 +7,26 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceIntrospectRecordValue;
+import java.util.List;
 
 public class ProcessInstanceIntrospectRecord extends UnifiedRecordValue
     implements ProcessInstanceIntrospectRecordValue {
 
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ACTIONS_KEY = new StringValue("actions");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+  private final ArrayProperty<ProcessInstanceIntrospectActionRecord> actionsProperty =
+      new ArrayProperty<>(ACTIONS_KEY, ProcessInstanceIntrospectActionRecord::new);
 
   public ProcessInstanceIntrospectRecord() {
-    super(1);
-    declareProperty(processInstanceKeyProperty);
+    super(2);
+    declareProperty(processInstanceKeyProperty).declareProperty(actionsProperty);
   }
 
   @Override
@@ -37,5 +42,23 @@ public class ProcessInstanceIntrospectRecord extends UnifiedRecordValue
   @Override
   public long getProcessDefinitionKey() {
     return -1L;
+  }
+
+  public ProcessInstanceIntrospectRecord addAction(
+      final ProcessInstanceIntrospectActionRecordValue action) {
+    actionsProperty.add().copy(action);
+    return this;
+  }
+
+  @Override
+  public List<ProcessInstanceIntrospectActionRecordValue> getActions() {
+    return actionsProperty.stream()
+        .map(
+            action -> {
+              final var copy = new ProcessInstanceIntrospectActionRecord();
+              copy.copy(action);
+              return (ProcessInstanceIntrospectActionRecordValue) copy;
+            })
+        .toList();
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -57,6 +57,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntrospectIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
@@ -117,6 +118,7 @@ import io.camunda.zeebe.protocol.record.value.MultiInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceIntrospectRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -360,6 +362,10 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.GLOBAL_LISTENER,
         new Mapping<>(GlobalListenerRecordValue.class, GlobalListenerIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_INTROSPECT,
+        new Mapping<>(
+            ProcessInstanceIntrospectRecordValue.class, ProcessInstanceIntrospectIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -59,7 +59,8 @@ public final class ValueTypes {
           ValueType.HISTORY_DELETION,
           ValueType.CONDITIONAL_SUBSCRIPTION,
           ValueType.CONDITIONAL_EVALUATION,
-          ValueType.EXPRESSION);
+          ValueType.EXPRESSION,
+          ValueType.PROCESS_INSTANCE_INTROSPECT);
 
   private ValueTypes() {}
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -98,6 +98,7 @@ public interface Intent {
     map.put(ValueType.USER_TASK, UserTaskIntent.class);
     map.put(ValueType.VARIABLE, VariableIntent.class);
     map.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentIntent.class);
+    map.put(ValueType.PROCESS_INSTANCE_INTROSPECT, ProcessInstanceIntrospectIntent.class);
     return map;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntrospectIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntrospectIntent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceIntrospectIntent implements Intent {
+  INTROSPECT(0),
+  INTROSPECTED(1);
+
+  private final short value;
+
+  ProcessInstanceIntrospectIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return INTROSPECT;
+      case 1:
+        return INTROSPECTED;
+      default:
+        throw new IllegalArgumentException(
+            "Unknown ProcessInstanceIntrospectIntent value: " + value);
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return this == INTROSPECTED;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceIntrospectRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceIntrospectRecordValue.java
@@ -17,8 +17,24 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationCreationRecordValue.Builder.class)
-public interface ProcessInstanceIntrospectRecordValue extends ProcessInstanceRelated, RecordValue {}
+public interface ProcessInstanceIntrospectRecordValue extends ProcessInstanceRelated, RecordValue {
+
+  List<ProcessInstanceIntrospectActionRecordValue> getActions();
+
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableProcessInstanceIntrospectActionRecordValue.Builder.class)
+  public interface ProcessInstanceIntrospectActionRecordValue {
+
+    String getAction();
+
+    Long getElementInstanceKey();
+
+    Map<String, String> getParameters();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceIntrospectRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceIntrospectRecordValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationCreationRecordValue.Builder.class)
+public interface ProcessInstanceIntrospectRecordValue extends ProcessInstanceRelated, RecordValue {}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -84,6 +84,7 @@
       <validValue name="EXPRESSION">66</validValue>
       <validValue name="JOB_METRICS_BATCH">67</validValue>
       <validValue name="GLOBAL_LISTENER">68</validValue>
+      <validValue name="PROCESS_INSTANCE_INTROSPECT">69</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Very rough (and incomplete) implementation of an endpoint to introspect a process instance. It will return which element instances are actives and some metadata on what action need to be performed to continue the process instance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
