### PR TITLE
feat: add Global Job Statistics API

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -12,7 +12,6 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_NAME;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_NULL_VARIABLE_VALUE;
-import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.gateway.mapping.http.converters.AuditLogActorTypeConverter;
@@ -392,30 +391,23 @@ public class SearchQueryFilterMapper {
   }
 
   public static Either<List<String>, GlobalJobStatisticsFilter> toGlobalJobStatisticsFilter(
-      final io.camunda.gateway.protocol.model.GlobalJobStatisticsFilter filter) {
+      final OffsetDateTime from, final OffsetDateTime to, final String jobType) {
     final var builder = FilterBuilders.globalJobStatistics();
     final List<String> validationErrors = new ArrayList<>();
 
-    if (filter == null) {
-      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"));
-      return Either.left(validationErrors);
-    }
-
-    if (StringUtils.isEmpty(filter.getFrom())) {
-      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.from"));
+    if (from == null) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("from"));
     } else {
-      Optional.ofNullable(validateDate(filter.getFrom(), "filter.from", validationErrors))
-          .ifPresent(builder::from);
+      builder.from(from);
     }
 
-    if (StringUtils.isEmpty(filter.getTo())) {
-      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.to"));
+    if (to == null) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("to"));
     } else {
-      Optional.ofNullable(validateDate(filter.getTo(), "filter.to", validationErrors))
-          .ifPresent(builder::to);
+      builder.to(to);
     }
 
-    Optional.ofNullable(filter.getJobType()).ifPresent(builder::jobType);
+    Optional.ofNullable(jobType).ifPresent(builder::jobType);
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -56,6 +56,7 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.zeebe.util.Either;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -110,11 +111,9 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, io.camunda.search.query.GlobalJobStatisticsQuery>
-      toGlobalJobStatisticsQuery(final GlobalJobStatisticsQuery request) {
-    if (request == null) {
-      return Either.right(SearchQueryBuilders.globalJobStatisticsSearchQuery().build());
-    }
-    final var filter = SearchQueryFilterMapper.toGlobalJobStatisticsFilter(request.getFilter());
+      toGlobalJobStatisticsQuery(
+          final OffsetDateTime from, final OffsetDateTime to, final String jobType) {
+    final var filter = SearchQueryFilterMapper.toGlobalJobStatisticsFilter(from, to, jobType);
 
     if (filter.isLeft()) {
       final var problem = RequestValidator.createProblemDetail(filter.getLeft());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1509,7 +1509,10 @@ public final class SearchQueryResponseMapper {
                         .toList())
             .orElseGet(Collections::emptyList);
 
-    return new GlobalJobStatisticsQueryResult().items(items);
+    final var isIncomplete =
+        ofNullable(entity).map(GlobalJobStatisticsEntity::isIncomplete).orElse(false);
+
+    return new GlobalJobStatisticsQueryResult().items(items).isIncomplete(isIncomplete);
   }
 
   private static GlobalJobStatisticsItem toGlobalJobStatisticsItem(

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
 import io.camunda.search.clients.aggregator.SearchFiltersAggregator;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
 import io.camunda.search.clients.aggregator.SearchParentAggregator;
 import io.camunda.search.clients.aggregator.SearchSumAggregator;
 import io.camunda.search.clients.aggregator.SearchTermsAggregator;
@@ -52,6 +53,7 @@ import io.camunda.search.es.transformers.aggregator.SearchChildrenAggregatorTran
 import io.camunda.search.es.transformers.aggregator.SearchCompositeAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchFilterAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchFiltersAggregatorTransformer;
+import io.camunda.search.es.transformers.aggregator.SearchMaxAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchParentAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchSumAggregatorTransformer;
 import io.camunda.search.es.transformers.aggregator.SearchTermsAggregatorTransformer;
@@ -154,6 +156,7 @@ public final class ElasticsearchTransformers {
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));
+    mappers.put(SearchMaxAggregator.class, new SearchMaxAggregatorTransformer(mappers));
     mappers.put(
         SearchBucketSortAggregator.class, new SearchBucketSortAggregationTransformer(mappers));
     mappers.put(

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -199,6 +199,7 @@ public class SearchAggregationResultTransformer<T>
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
+            case Max -> res = transformSingleMetricAggregate(aggregate.max());
             case Cardinality -> res = transformCardinalityAggregate(aggregate.cardinality());
             default ->
                 throw new IllegalStateException(

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformer.java
@@ -8,7 +8,6 @@
 package io.camunda.search.es.transformers.aggregator;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
-import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
 import io.camunda.search.clients.aggregator.SearchMaxAggregator;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
 
@@ -21,9 +20,7 @@ public final class SearchMaxAggregatorTransformer
 
   @Override
   public Aggregation apply(final SearchMaxAggregator value) {
-    final var maxAggregation = AggregationBuilders.max().field(value.field()).build();
-
-    final var builder = new Aggregation.Builder().max(maxAggregation);
+    final var builder = new Aggregation.Builder().max(m -> m.field(value.field()));
     applySubAggregations(builder, value);
     return builder.build();
   }

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public final class SearchMaxAggregatorTransformer
+    extends AggregatorTransformer<SearchMaxAggregator, Aggregation> {
+
+  public SearchMaxAggregatorTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchMaxAggregator value) {
+    final var maxAggregation = AggregationBuilders.max().field(value.field()).build();
+
+    final var builder = new Aggregation.Builder().max(maxAggregation);
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/AggregationResultTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/AggregationResultTransformerTest.java
@@ -64,6 +64,34 @@ public class AggregationResultTransformerTest {
         Arguments.arguments(
             "{'filter#agg1': {'doc_count': 4, 'children#agg2': {'doc_count': 4}}}",
             "{'agg1':{'docCount':4,'aggregations':{'agg2':{'docCount':4}}}}"),
+        // sum aggregation
+        Arguments.arguments(
+            "{'sum#totalCount': {'value': 42.0}}", "{'totalCount':{'docCount':42}}"),
+        // max aggregation
+        Arguments.arguments(
+            "{'max#maxValue': {'value': 1234567890.0}}", "{'maxValue':{'docCount':1234567890}}"),
+        // filter with sum and max sub-aggregations
+        Arguments.arguments(
+            """
+            {
+              "filter#created": {
+                "doc_count": 10,
+                "sum#count": {"value": 100.0},
+                "max#lastUpdatedAt": {"value": 1706800000000.0}
+              }
+            }
+            """,
+            """
+            {
+              "created": {
+                "docCount": 10,
+                "aggregations": {
+                  "lastUpdatedAt": {"docCount": 1706800000000},
+                  "count": {"docCount": 100}
+                }
+              }
+            }
+            """),
         // multiple nested aggregations
         Arguments.arguments(
             """

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class SearchMaxAggregatorTransformerTest
+    extends AbstractSearchAggregatorTransformerTest<SearchMaxAggregator> {
+
+  private static Stream<Arguments> provideAggregations() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchAggregatorBuilders.max().name("name").field("field1").build(),
+            "{'max':{'field':'field1'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.max()
+                .name("maxAgg")
+                .field("field1")
+                .aggregations(SearchAggregatorBuilders.max("maxSubAgg", "field2"))
+                .build(),
+            "{'aggregations':{'maxSubAgg':{'max':{'field':'field2'}}},'max':{'field':'field1'}}"));
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullName() {
+    // when - then
+    assertThatThrownBy(() -> SearchAggregatorBuilders.max().build())
+        .hasMessageContaining("Expected non-null field for name.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // when/then
+    assertThatThrownBy(() -> SearchAggregatorBuilders.max().name("name").build())
+        .hasMessageContaining("Expected non-null field for field.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Override
+  protected Class<SearchMaxAggregator> getTransformerClass() {
+    return SearchMaxAggregator.class;
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
 import io.camunda.search.clients.aggregator.SearchFiltersAggregator;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
 import io.camunda.search.clients.aggregator.SearchParentAggregator;
 import io.camunda.search.clients.aggregator.SearchSumAggregator;
 import io.camunda.search.clients.aggregator.SearchTermsAggregator;
@@ -51,6 +52,7 @@ import io.camunda.search.os.transformers.aggregator.SearchChildrenAggregatorTran
 import io.camunda.search.os.transformers.aggregator.SearchCompositeAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchFilterAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchFiltersAggregatorTransformer;
+import io.camunda.search.os.transformers.aggregator.SearchMaxAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchParentAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchSumAggregatorTransformer;
 import io.camunda.search.os.transformers.aggregator.SearchTermsAggregatorTransformer;
@@ -154,6 +156,7 @@ public final class OpensearchTransformers {
     mappers.put(SearchChildrenAggregator.class, new SearchChildrenAggregatorTransformer(mappers));
     mappers.put(SearchParentAggregator.class, new SearchParentAggregatorTransformer(mappers));
     mappers.put(SearchSumAggregator.class, new SearchSumAggregatorTransformer(mappers));
+    mappers.put(SearchMaxAggregator.class, new SearchMaxAggregatorTransformer(mappers));
     mappers.put(
         SearchBucketSortAggregator.class, new SearchBucketSortAggregationTransformer(mappers));
     mappers.put(

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchAggregationResultTransformer.java
@@ -198,6 +198,7 @@ public class SearchAggregationResultTransformer<T>
             case Composite -> res = transformMultiBucketAggregate(aggregate.composite());
             case TopHits -> res = transformTopHitsAggregate(key, aggregate.topHits());
             case Sum -> res = transformSingleMetricAggregate(aggregate.sum());
+            case Max -> res = transformSingleMetricAggregate(aggregate.max());
             case Cardinality -> res = transformCardinalityAggregate(aggregate.cardinality());
             default ->
                 throw new IllegalStateException(

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformer.java
@@ -10,7 +10,6 @@ package io.camunda.search.os.transformers.aggregator;
 import io.camunda.search.clients.aggregator.SearchMaxAggregator;
 import io.camunda.search.os.transformers.OpensearchTransformers;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
 
 public class SearchMaxAggregatorTransformer
     extends AggregatorTransformer<SearchMaxAggregator, Aggregation> {
@@ -21,9 +20,7 @@ public class SearchMaxAggregatorTransformer
 
   @Override
   public Aggregation apply(final SearchMaxAggregator value) {
-    final var maxAggregation = AggregationBuilders.max().field(value.field()).build();
-
-    final var builder = new Aggregation.Builder().max(maxAggregation);
+    final var builder = new Aggregation.Builder().max(m -> m.field(value.field()));
     applySubAggregations(builder, value);
     return builder.build();
   }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
+
+public class SearchMaxAggregatorTransformer
+    extends AggregatorTransformer<SearchMaxAggregator, Aggregation> {
+
+  public SearchMaxAggregatorTransformer(final OpensearchTransformers mappers) {
+    super(mappers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchMaxAggregator value) {
+    final var maxAggregation = AggregationBuilders.max().field(value.field()).build();
+
+    final var builder = new Aggregation.Builder().max(maxAggregation);
+    applySubAggregations(builder, value);
+    return builder.build();
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/AggregationResultTransformerTest.java
@@ -64,6 +64,34 @@ public class AggregationResultTransformerTest {
         Arguments.arguments(
             "{'filter#agg1': {'doc_count': 4, 'children#agg2': {'doc_count': 4}}}",
             "{'agg1':{'docCount':4,'aggregations':{'agg2':{'docCount':4}}}}"),
+        // sum aggregation
+        Arguments.arguments(
+            "{'sum#totalCount': {'value': 42.0}}", "{'totalCount':{'docCount':42}}"),
+        // max aggregation
+        Arguments.arguments(
+            "{'max#maxValue': {'value': 1234567890.0}}", "{'maxValue':{'docCount':1234567890}}"),
+        // filter with sum and max sub-aggregations
+        Arguments.arguments(
+            """
+            {
+              "filter#created": {
+                "doc_count": 10,
+                "sum#count": {"value": 100.0},
+                "max#lastUpdatedAt": {"value": 1706800000000.0}
+              }
+            }
+            """,
+            """
+            {
+              "created": {
+                "docCount": 10,
+                "aggregations": {
+                  "lastUpdatedAt": {"docCount": 1706800000000},
+                  "count": {"docCount": 100}
+                }
+              }
+            }
+            """),
         // multiple nested aggregations
         Arguments.arguments(
             """

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.aggregator.SearchAggregatorBuilders;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class SearchMaxAggregatorTransformerTest
+    extends AbstractSearchAggregatorTransformerTest<SearchMaxAggregator> {
+
+  private static Stream<Arguments> provideAggregations() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchAggregatorBuilders.max().name("name").field("field1").build(),
+            "{'max':{'field':'field1'}}"),
+        Arguments.arguments(
+            SearchAggregatorBuilders.max()
+                .name("maxAgg")
+                .field("field1")
+                .aggregations(SearchAggregatorBuilders.max("maxSubAgg", "field2"))
+                .build(),
+            "{'aggregations':{'maxSubAgg':{'max':{'field':'field2'}}},'max':{'field':'field1'}}"));
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullName() {
+    // when - then
+    assertThatThrownBy(() -> SearchAggregatorBuilders.max().build())
+        .hasMessageContaining("Expected non-null field for name.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // when/then
+    assertThatThrownBy(() -> SearchAggregatorBuilders.max().name("name").build())
+        .hasMessageContaining("Expected non-null field for field.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Override
+  protected Class<SearchMaxAggregator> getTransformerClass() {
+    return SearchMaxAggregator.class;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java
@@ -29,6 +29,14 @@ public final class SearchAggregatorBuilders {
     return sum().name(name).field(field).build();
   }
 
+  public static SearchMaxAggregator.Builder max() {
+    return new SearchMaxAggregator.Builder();
+  }
+
+  public static SearchMaxAggregator max(final String name, final String field) {
+    return max().name(name).field(field).build();
+  }
+
   public static SearchParentAggregator.Builder parent() {
     return new SearchParentAggregator.Builder();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchMaxAggregator.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchMaxAggregator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregator;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+
+public record SearchMaxAggregator(String name, String field, List<SearchAggregator> aggregations)
+    implements SearchAggregator {
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<SearchAggregator> getAggregations() {
+    return aggregations;
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<SearchMaxAggregator> {
+
+    private String field;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    public Builder field(final String field) {
+      this.field = field;
+      return this;
+    }
+
+    @Override
+    public SearchMaxAggregator build() {
+      return new SearchMaxAggregator(
+          Objects.requireNonNull(name, "Expected non-null field for name."),
+          Objects.requireNonNull(field, "Expected non-null field for field."),
+          aggregations);
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
@@ -33,6 +34,8 @@ public class JobDocumentReader extends DocumentBasedReader implements JobReader 
   @Override
   public GlobalJobStatisticsEntity getGlobalJobStatistics(
       final GlobalJobStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return getSearchExecutor()
+        .aggregate(query, GlobalJobStatisticsAggregationResult.class, resourceAccessChecks)
+        .entity();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers;
 
 import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
+import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
@@ -21,6 +22,7 @@ import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
+import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
@@ -37,6 +39,7 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLatestVersionAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.GlobalJobStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
@@ -49,6 +52,7 @@ import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregatio
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinitionLatestVersionAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.GlobalJobStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
@@ -99,6 +103,7 @@ import io.camunda.search.clients.transformers.filter.DecisionRequirementsFilterT
 import io.camunda.search.clients.transformers.filter.FilterTransformer;
 import io.camunda.search.clients.transformers.filter.FlownodeInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.FormFilterTransformer;
+import io.camunda.search.clients.transformers.filter.GlobalJobStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupMemberFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
@@ -166,6 +171,7 @@ import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.FormFilter;
+import io.camunda.search.filter.GlobalJobStatisticsFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.filter.IncidentFilter;
@@ -199,6 +205,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -275,6 +282,7 @@ import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscript
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -412,7 +420,8 @@ public final class ServiceTransformers {
             ClusterVariableQuery.class,
             AuditLogQuery.class,
             IncidentProcessInstanceStatisticsByErrorQuery.class,
-            IncidentProcessInstanceStatisticsByDefinitionQuery.class)
+            IncidentProcessInstanceStatisticsByDefinitionQuery.class,
+            GlobalJobStatisticsQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -556,6 +565,10 @@ public final class ServiceTransformers {
         UsageMetricsTUFilter.class,
         new UsageMetricsTUFilterTransformer(indexDescriptors.get(UsageMetricTUTemplate.class)));
     mappers.put(
+        GlobalJobStatisticsFilter.class,
+        new GlobalJobStatisticsFilterTransformer(
+            indexDescriptors.get(JobMetricsBatchTemplate.class)));
+    mappers.put(
         ProcessDefinitionStatisticsFilter.class,
         new ProcessDefinitionStatisticsFilterTransformer(
             mappers, indexDescriptors.get(ListViewTemplate.class)));
@@ -624,6 +637,8 @@ public final class ServiceTransformers {
     mappers.put(
         DecisionDefinitionLatestVersionAggregation.class,
         new DecisionDefinitionLatestVersionAggregationTransformer());
+    mappers.put(
+        GlobalJobStatisticsAggregation.class, new GlobalJobStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -657,5 +672,8 @@ public final class ServiceTransformers {
     mappers.put(
         DecisionDefinitionLatestVersionAggregationResult.class,
         new DecisionDefinitionLatestVersionAggregationResultTransformer());
+    mappers.put(
+        GlobalJobStatisticsAggregationResult.class,
+        new GlobalJobStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/GlobalJobStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/GlobalJobStatisticsAggregationTransformer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_INCOMPLETE;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_INCOMPLETE_BATCH;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.max;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.sum;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+
+import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class GlobalJobStatisticsAggregationTransformer
+    implements AggregationTransformer<GlobalJobStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<GlobalJobStatisticsAggregation, ServiceTransformers> value) {
+
+    // Created filter bucket with count and lastUpdatedAt sub-aggregations
+    final var createdAgg =
+        filter()
+            .name(AGGREGATION_CREATED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_CREATED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_CREATED_AT))
+            .build();
+
+    // Completed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var completedAgg =
+        filter()
+            .name(AGGREGATION_COMPLETED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_COMPLETED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_COMPLETED_AT))
+            .build();
+
+    // Failed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var failedAgg =
+        filter()
+            .name(AGGREGATION_FAILED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_FAILED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_FAILED_AT))
+            .build();
+
+    // Max aggregation to check if any batch was incomplete
+    final var incompleteAgg = max(AGGREGATION_INCOMPLETE, FIELD_INCOMPLETE_BATCH);
+
+    return List.of(createdAgg, completedAgg, failedAgg, incompleteAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/GlobalJobStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/GlobalJobStatisticsAggregationResultTransformer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_INCOMPLETE;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+
+import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+public class GlobalJobStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<GlobalJobStatisticsAggregationResult> {
+
+  @Override
+  public GlobalJobStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+
+    // Extract metrics from nested filter bucket aggregations
+    final var createdMetric = extractStatusMetric(aggregations, AGGREGATION_CREATED);
+    final var completedMetric = extractStatusMetric(aggregations, AGGREGATION_COMPLETED);
+    final var failedMetric = extractStatusMetric(aggregations, AGGREGATION_FAILED);
+
+    // Extract incomplete flag
+    final boolean isIncomplete = extractMaxBoolean(aggregations);
+
+    final var entity =
+        new GlobalJobStatisticsEntity(createdMetric, completedMetric, failedMetric, isIncomplete);
+
+    return new GlobalJobStatisticsAggregationResult(entity);
+  }
+
+  private StatusMetric extractStatusMetric(
+      final Map<String, AggregationResult> aggregations, final String bucketName) {
+    final var bucketAgg = aggregations.get(bucketName);
+    if (bucketAgg == null || bucketAgg.aggregations() == null) {
+      return new StatusMetric(0L, null);
+    }
+
+    final var subAggregations = bucketAgg.aggregations();
+    final long count = extractDocCount(subAggregations);
+    final OffsetDateTime lastUpdatedAt = extractMaxTimestamp(subAggregations);
+
+    return new StatusMetric(count, lastUpdatedAt);
+  }
+
+  private long extractDocCount(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_COUNT);
+    if (agg != null && agg.docCount() != null) {
+      return agg.docCount();
+    }
+    return 0L;
+  }
+
+  private OffsetDateTime extractMaxTimestamp(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_LAST_UPDATED_AT);
+    if (agg != null && agg.docCount() != null) {
+      final long epochMillis = agg.docCount();
+      if (epochMillis > 0) {
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+      }
+    }
+    return null;
+  }
+
+  private boolean extractMaxBoolean(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_INCOMPLETE);
+    if (agg != null && agg.docCount() != null) {
+      // Max of boolean field: 0 = all false, 1 = at least one true
+      return agg.docCount() > 0;
+    }
+    return false;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GlobalJobStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GlobalJobStatisticsFilterTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.GlobalJobStatisticsFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GlobalJobStatisticsFilterTransformer
+    extends IndexFilterTransformer<GlobalJobStatisticsFilter> {
+
+  public GlobalJobStatisticsFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final GlobalJobStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    if (filter.from() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.START_TIME, List.of(Operation.gte(filter.from()))));
+    }
+
+    if (filter.to() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.END_TIME, List.of(Operation.lte(filter.to()))));
+    }
+
+    // Optional jobType filter
+    if (filter.jobType() != null) {
+      queries.add(term(JobMetricsBatchTemplate.JOB_TYPE, filter.jobType()));
+    }
+
+    return queries.isEmpty() ? matchAll() : and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/GlobalJobStatisticsAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/GlobalJobStatisticsAggregationTransformerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_INCOMPLETE;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_INCOMPLETE_BATCH;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchFilterAggregator;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import io.camunda.search.clients.aggregator.SearchSumAggregator;
+import io.camunda.search.clients.query.SearchMatchAllQuery;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GlobalJobStatisticsAggregationTransformerTest {
+
+  private final GlobalJobStatisticsAggregationTransformer transformer =
+      new GlobalJobStatisticsAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldBuildExpectedAggregationStructure() {
+    // given
+    final var aggregation = new GlobalJobStatisticsAggregation();
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(4);
+
+    // Verify created filter bucket
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            createdAgg -> {
+              assertThat(createdAgg.name()).isEqualTo(AGGREGATION_CREATED);
+              assertThat(createdAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  createdAgg.aggregations(), FIELD_CREATED_COUNT, FIELD_LAST_CREATED_AT);
+            });
+
+    // Verify completed filter bucket
+    assertThat(aggregations.get(1))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            completedAgg -> {
+              assertThat(completedAgg.name()).isEqualTo(AGGREGATION_COMPLETED);
+              assertThat(completedAgg.query().queryOption())
+                  .isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  completedAgg.aggregations(), FIELD_COMPLETED_COUNT, FIELD_LAST_COMPLETED_AT);
+            });
+
+    // Verify failed filter bucket
+    assertThat(aggregations.get(2))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            failedAgg -> {
+              assertThat(failedAgg.name()).isEqualTo(AGGREGATION_FAILED);
+              assertThat(failedAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  failedAgg.aggregations(), FIELD_FAILED_COUNT, FIELD_LAST_FAILED_AT);
+            });
+
+    // Verify incomplete max aggregation
+    assertThat(aggregations.get(3))
+        .isInstanceOfSatisfying(
+            SearchMaxAggregator.class,
+            incompleteAgg -> {
+              assertThat(incompleteAgg.name()).isEqualTo(AGGREGATION_INCOMPLETE);
+              assertThat(incompleteAgg.field()).isEqualTo(FIELD_INCOMPLETE_BATCH);
+            });
+  }
+
+  @Test
+  void shouldBuildFilterBucketsWithMatchAllQuery() {
+    // given
+    final var aggregation = new GlobalJobStatisticsAggregation();
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    // All filter buckets should use match_all query
+    aggregations.stream()
+        .filter(SearchFilterAggregator.class::isInstance)
+        .map(SearchFilterAggregator.class::cast)
+        .forEach(
+            filterAgg ->
+                assertThat(filterAgg.query().queryOption())
+                    .isInstanceOf(SearchMatchAllQuery.class));
+  }
+
+  @Test
+  void shouldBuildSubAggregationsWithCorrectTypes() {
+    // given
+    final var aggregation = new GlobalJobStatisticsAggregation();
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    // Verify each filter bucket has exactly 2 sub-aggregations: sum and max
+    aggregations.stream()
+        .filter(SearchFilterAggregator.class::isInstance)
+        .map(SearchFilterAggregator.class::cast)
+        .forEach(
+            filterAgg -> {
+              assertThat(filterAgg.aggregations()).hasSize(2);
+
+              // First sub-aggregation should be sum for count
+              assertThat(filterAgg.aggregations().get(0))
+                  .isInstanceOfSatisfying(
+                      SearchSumAggregator.class,
+                      sumAgg -> assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT));
+
+              // Second sub-aggregation should be max for lastUpdatedAt
+              assertThat(filterAgg.aggregations().get(1))
+                  .isInstanceOfSatisfying(
+                      SearchMaxAggregator.class,
+                      maxAgg -> assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT));
+            });
+  }
+
+  private void assertSubAggregations(
+      final List<SearchAggregator> subAggs,
+      final String expectedCountField,
+      final String expectedLastUpdatedAtField) {
+    assertThat(subAggs).hasSize(2);
+
+    // Verify count sum aggregation
+    assertThat(subAggs.get(0))
+        .isInstanceOfSatisfying(
+            SearchSumAggregator.class,
+            sumAgg -> {
+              assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT);
+              assertThat(sumAgg.field()).isEqualTo(expectedCountField);
+            });
+
+    // Verify lastUpdatedAt max aggregation
+    assertThat(subAggs.get(1))
+        .isInstanceOfSatisfying(
+            SearchMaxAggregator.class,
+            maxAgg -> {
+              assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT);
+              assertThat(maxAgg.field()).isEqualTo(expectedLastUpdatedAtField);
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/GlobalJobStatisticsAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/GlobalJobStatisticsAggregationResultTransformerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_INCOMPLETE;
+import static io.camunda.search.aggregation.GlobalJobStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class GlobalJobStatisticsAggregationResultTransformerTest {
+
+  private final GlobalJobStatisticsAggregationResultTransformer transformer =
+      new GlobalJobStatisticsAggregationResultTransformer();
+
+  @Test
+  public void shouldReturnZeroCountsWhenAggregationsEmpty() {
+    // given
+    final Map<String, AggregationResult> input = Map.of();
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+    assertThat(entity.isIncomplete()).isFalse();
+  }
+
+  @Test
+  public void shouldTransformAllStatusMetrics() {
+    // given
+    final long createdCount = 100L;
+    final long completedCount = 80L;
+    final long failedCount = 5L;
+    final long createdTimestamp = 1706800000000L;
+    final long completedTimestamp = 1706800100000L;
+    final long failedTimestamp = 1706800200000L;
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_CREATED, statusBucket(createdCount, createdTimestamp),
+            AGGREGATION_COMPLETED, statusBucket(completedCount, completedTimestamp),
+            AGGREGATION_FAILED, statusBucket(failedCount, failedTimestamp),
+            AGGREGATION_INCOMPLETE, new AggregationResult(0L, Map.of()));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+
+    assertThat(entity.created().count()).isEqualTo(createdCount);
+    assertThat(entity.created().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(createdTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.completed().count()).isEqualTo(completedCount);
+    assertThat(entity.completed().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(completedTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.failed().count()).isEqualTo(failedCount);
+    assertThat(entity.failed().lastUpdatedAt())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(failedTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.isIncomplete()).isFalse();
+  }
+
+  @Test
+  public void shouldSetIncompleteToTrueWhenMaxIncompleteGreaterThanZero() {
+    // given
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_CREATED, statusBucket(10L, 0L),
+            AGGREGATION_COMPLETED, statusBucket(5L, 0L),
+            AGGREGATION_FAILED, statusBucket(1L, 0L),
+            AGGREGATION_INCOMPLETE, new AggregationResult(1L, Map.of()));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.entity().isIncomplete()).isTrue();
+  }
+
+  @Test
+  public void shouldHandleMissingSubAggregations() {
+    // given - bucket exists but has no sub-aggregations
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_CREATED, new AggregationResult(10L, null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+  }
+
+  @Test
+  public void shouldHandleZeroTimestampAsNull() {
+    // given - timestamp is 0, should be treated as null
+    final Map<String, AggregationResult> input = Map.of(AGGREGATION_CREATED, statusBucket(50L, 0L));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+    assertThat(entity.created().count()).isEqualTo(50L);
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+  }
+
+  @Test
+  public void shouldHandleNullDocCountInSubAggregations() {
+    // given
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_COUNT, new AggregationResult(null, Map.of()),
+            AGGREGATION_LAST_UPDATED_AT, new AggregationResult(null, Map.of()));
+
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_CREATED, new AggregationResult(10L, subAggs));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+  }
+
+  @Test
+  public void shouldHandlePartialAggregations() {
+    // given - only created aggregation is present
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_CREATED, statusBucket(25L, 1706800000000L));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    final var entity = result.entity();
+    assertThat(entity.created().count()).isEqualTo(25L);
+    assertThat(entity.created().lastUpdatedAt()).isNotNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+  }
+
+  private static AggregationResult statusBucket(final long count, final long lastUpdatedAtMillis) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_COUNT, new AggregationResult(count, Map.of()),
+            AGGREGATION_LAST_UPDATED_AT, new AggregationResult(lastUpdatedAtMillis, Map.of()));
+
+    return new AggregationResult(0L, subAggs);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GlobalJobStatisticsFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GlobalJobStatisticsFilterTransformerTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchMatchNoneQuery;
+import io.camunda.search.clients.query.SearchRangeQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchTermsQuery;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.Authorization.Builder;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GlobalJobStatisticsFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldReturnNullWhenNoFilters() {
+    // given
+    final var filter = FilterBuilders.globalJobStatistics(f -> f);
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then - no filter query needed when there are no filters
+    assertThat(searchQuery).isNull();
+  }
+
+  @Test
+  void shouldQueryByFromTime() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var filter = FilterBuilders.globalJobStatistics(f -> f.from(fromTime));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            rangeQuery -> {
+              assertThat(rangeQuery.field()).isEqualTo("startTime");
+              assertThat(rangeQuery.gte()).isNotNull();
+            });
+  }
+
+  @Test
+  void shouldQueryByToTime() {
+    // given
+    final var toTime = OffsetDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+    final var filter = FilterBuilders.globalJobStatistics(f -> f.to(toTime));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            rangeQuery -> {
+              assertThat(rangeQuery.field()).isEqualTo("endTime");
+              assertThat(rangeQuery.lte()).isNotNull();
+            });
+  }
+
+  @Test
+  void shouldQueryByFromAndToTime() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var toTime = OffsetDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+    final var filter = FilterBuilders.globalJobStatistics(f -> f.from(fromTime).to(toTime));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.must()).hasSize(2);
+
+              // First clause should be range on startTime (from)
+              assertThat(boolQuery.must().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchRangeQuery.class,
+                      rangeQuery -> {
+                        assertThat(rangeQuery.field()).isEqualTo("startTime");
+                        assertThat(rangeQuery.gte()).isNotNull();
+                      });
+
+              // Second clause should be range on endTime (to)
+              assertThat(boolQuery.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchRangeQuery.class,
+                      rangeQuery -> {
+                        assertThat(rangeQuery.field()).isEqualTo("endTime");
+                        assertThat(rangeQuery.lte()).isNotNull();
+                      });
+            });
+  }
+
+  @Test
+  void shouldQueryByJobType() {
+    // given
+    final var filter = FilterBuilders.globalJobStatistics(f -> f.jobType("myJobType"));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            termQuery -> {
+              assertThat(termQuery.field()).isEqualTo("jobType");
+              assertThat(termQuery.value().stringValue()).isEqualTo("myJobType");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFilters() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var toTime = OffsetDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+    final var filter =
+        FilterBuilders.globalJobStatistics(
+            f -> f.from(fromTime).to(toTime).jobType("workerJobType"));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.must()).hasSize(3);
+
+              // First must clause should be range on startTime (from)
+              assertThat(boolQuery.must().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchRangeQuery.class,
+                      rangeQuery -> assertThat(rangeQuery.field()).isEqualTo("startTime"));
+
+              // Second must clause should be range on endTime (to)
+              assertThat(boolQuery.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchRangeQuery.class,
+                      rangeQuery -> assertThat(rangeQuery.field()).isEqualTo("endTime"));
+
+              // Third must clause should be term on jobType
+              assertThat(boolQuery.must().get(2).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      termQuery -> {
+                        assertThat(termQuery.field()).isEqualTo("jobType");
+                        assertThat(termQuery.value().stringValue()).isEqualTo("workerJobType");
+                      });
+            });
+  }
+
+  @Test
+  void shouldIgnoreAuthorizationCheckWhenEnabled() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var authorization =
+        Authorization.of(a -> a.readJobMetric().resourceIds(List.of("1", "2")));
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.globalJobStatistics(f -> f.from(fromTime)), resourceAccessChecks);
+
+    // then - authorization is ignored for job metrics, only filter query is returned
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            rangeQuery -> assertThat(rangeQuery.field()).isEqualTo("startTime"));
+  }
+
+  @Test
+  void shouldReturnNonMatchWhenNoResourceIdsProvided() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var authorization = Authorization.of(Builder::readJobMetric);
+    final var authorizationCheck = AuthorizationCheck.enabled(authorization);
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.globalJobStatistics(f -> f.from(fromTime)), resourceAccessChecks);
+
+    // then - when authorization is enabled but no resource IDs are granted, return matchNone
+    assertThat(searchQuery.queryOption()).isInstanceOf(SearchMatchNoneQuery.class);
+  }
+
+  @Test
+  void shouldIgnoreAuthorizationCheckWhenDisabled() {
+    // given
+    final var fromTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+    final var authorizationCheck = AuthorizationCheck.disabled();
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(authorizationCheck, TenantCheck.disabled());
+
+    // when
+    final var searchQuery =
+        transformQuery(
+            FilterBuilders.globalJobStatistics(f -> f.from(fromTime)), resourceAccessChecks);
+
+    // then - authorization is disabled, only filter query is returned
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            rangeQuery -> assertThat(rangeQuery.field()).isEqualTo("startTime"));
+  }
+
+  @Test
+  void shouldApplyTenantCheck() {
+    // given
+    final var tenantCheck = TenantCheck.enabled(List.of("tenant1", "tenant2"));
+    final var resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), tenantCheck);
+
+    // when
+    final var searchQuery =
+        transformQuery(FilterBuilders.globalJobStatistics(f -> f), resourceAccessChecks);
+
+    // then - tenant check should be applied
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            termsQuery -> {
+              assertThat(termsQuery.field()).isEqualTo("tenantId");
+              assertThat(termsQuery.values()).hasSize(2);
+            });
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -401,6 +401,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
-    return new GlobalJobStatisticsEntity(List.of());
+    return new GlobalJobStatisticsEntity(List.of(), false);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -401,6 +401,6 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public GlobalJobStatisticsEntity getGlobalJobStatistics(final GlobalJobStatisticsQuery query) {
-    return new GlobalJobStatisticsEntity(List.of(), false);
+    return new GlobalJobStatisticsEntity(null, null, null, false);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/GlobalJobStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/GlobalJobStatisticsAggregation.java
@@ -7,4 +7,26 @@
  */
 package io.camunda.search.aggregation;
 
-public class GlobalJobStatisticsAggregation implements AggregationBase {}
+public class GlobalJobStatisticsAggregation implements AggregationBase {
+
+  // Filter bucket names
+  public static final String AGGREGATION_CREATED = "created";
+  public static final String AGGREGATION_COMPLETED = "completed";
+  public static final String AGGREGATION_FAILED = "failed";
+
+  // Sub-aggregation names (used within each filter bucket)
+  public static final String AGGREGATION_COUNT = "count";
+  public static final String AGGREGATION_LAST_UPDATED_AT = "lastUpdatedAt";
+
+  // For tracking incomplete batches
+  public static final String AGGREGATION_INCOMPLETE = "incomplete";
+
+  // Field names for aggregations
+  public static final String FIELD_CREATED_COUNT = "createdCount";
+  public static final String FIELD_COMPLETED_COUNT = "completedCount";
+  public static final String FIELD_FAILED_COUNT = "failedCount";
+  public static final String FIELD_LAST_CREATED_AT = "lastCreatedAt";
+  public static final String FIELD_LAST_COMPLETED_AT = "lastCompletedAt";
+  public static final String FIELD_LAST_FAILED_AT = "lastFailedAt";
+  public static final String FIELD_INCOMPLETE_BATCH = "incompleteBatch";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/GlobalJobStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/GlobalJobStatisticsAggregationResult.java
@@ -5,12 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.entities;
+package io.camunda.search.aggregation.result;
 
-import java.time.OffsetDateTime;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
 
-public record GlobalJobStatisticsEntity(
-    StatusMetric created, StatusMetric completed, StatusMetric failed, boolean isIncomplete) {
-
-  public record StatusMetric(long count, OffsetDateTime lastUpdatedAt) {}
-}
+public record GlobalJobStatisticsAggregationResult(GlobalJobStatisticsEntity entity)
+    implements AggregationResultBase {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalJobStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalJobStatisticsEntity.java
@@ -10,7 +10,7 @@ package io.camunda.search.entities;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public record GlobalJobStatisticsEntity(List<StatisticsItem> items) {
+public record GlobalJobStatisticsEntity(List<StatisticsItem> items, boolean isIncomplete) {
 
   public record StatisticsItem(StatusMetric created, StatusMetric completed, StatusMetric failed) {}
 

--- a/search/search-domain/src/main/java/io/camunda/search/query/GlobalJobStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/GlobalJobStatisticsQuery.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.query;
 
+import io.camunda.search.aggregation.AggregationBase;
 import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.GlobalJobStatisticsFilter;
@@ -29,6 +30,11 @@ public record GlobalJobStatisticsQuery(GlobalJobStatisticsFilter filter)
   @Override
   public SortOption sort() {
     return NoSort.NO_SORT;
+  }
+
+  @Override
+  public AggregationBase aggregation() {
+    return new GlobalJobStatisticsAggregation();
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -2,7 +2,7 @@
 
 paths:
   /jobs/statistics/global:
-    post:
+    get:
       x-eventually-consistent: true
       tags:
         - Job
@@ -10,12 +10,32 @@ paths:
       summary: Global job statistics
       description: |
         Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GlobalJobStatisticsQuery'
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: |
+            Start of the time window to filter metrics. ISO 8601 date-time format.
+          schema:
+            type: string
+            format: date-time
+          example: "2024-07-28T15:51:28.071Z"
+        - name: to
+          in: query
+          required: true
+          description: |
+            End of the time window to filter metrics. ISO 8601 date-time format.
+          schema:
+            type: string
+            format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+        - name: jobType
+          in: query
+          required: false
+          description: Optional job type to limit the aggregation to a single job type.
+          schema:
+            type: string
+          example: "fetch-customer-data"
       responses:
         "200":
           description: Global job metrics
@@ -36,39 +56,6 @@ paths:
 
 components:
   schemas:
-    GlobalJobStatisticsQuery:
-      type: object
-      additionalProperties: false
-      required:
-        - filter
-      properties:
-        filter:
-          $ref: '#/components/schemas/GlobalJobStatisticsFilter'
-
-    GlobalJobStatisticsFilter:
-      description: Filters for global job statistics query.
-      type: object
-      additionalProperties: false
-      required:
-        - from
-        - to
-      properties:
-        from:
-          description: |
-            Start of the time window to filter metrics. ISO 8601 date-time format.
-          type: string
-          format: date-time
-          example: "2024-07-28T15:51:28.071Z"
-        to:
-          description: |
-            End of the time window to filter metrics. ISO 8601 date-time format.
-          type: string
-          format: date-time
-          example: "2024-07-29T15:51:28.071Z"
-        jobType:
-          description: Optional job type to limit the aggregation to a single job type.
-          type: string
-          example: "fetch-customer-data"
 
     GlobalJobStatisticsQueryResult:
       description: Global job statistics query result.

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -75,12 +75,17 @@ components:
       type: object
       required:
         - items
+        - isIncomplete
       properties:
         items:
           description: List of aggregated job statistics.
           type: array
           items:
             $ref: '#/components/schemas/GlobalJobStatisticsItem'
+        isIncomplete:
+          description: True if some data is missing because internal limits were reached and some metrics were not recorded.
+          type: boolean
+          example: false
 
     GlobalJobStatisticsItem:
       description: Aggregated job metrics for a time bucket.

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -5,7 +5,7 @@ paths:
     post:
       x-eventually-consistent: true
       tags:
-        - Job metrics
+        - Job
       operationId: getGlobalJobStatistics
       summary: Global job statistics
       description: |
@@ -74,26 +74,10 @@ components:
       description: Global job statistics query result.
       type: object
       required:
-        - items
-        - isIncomplete
-      properties:
-        items:
-          description: List of aggregated job statistics.
-          type: array
-          items:
-            $ref: '#/components/schemas/GlobalJobStatisticsItem'
-        isIncomplete:
-          description: True if some data is missing because internal limits were reached and some metrics were not recorded.
-          type: boolean
-          example: false
-
-    GlobalJobStatisticsItem:
-      description: Aggregated job metrics for a time bucket.
-      type: object
-      required:
         - created
         - completed
         - failed
+        - isIncomplete
       properties:
         created:
           $ref: '#/components/schemas/StatusMetric'
@@ -101,6 +85,10 @@ components:
           $ref: '#/components/schemas/StatusMetric'
         failed:
           $ref: '#/components/schemas/StatusMetric'
+        isIncomplete:
+          description: True if some data is missing because internal limits were reached and some metrics were not recorded.
+          type: boolean
+          example: false
 
     StatusMetric:
       description: Metric for a single job status.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -16,7 +16,6 @@ import io.camunda.gateway.mapping.http.RequestMapper.FailJobRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.UpdateJobRequest;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
-import io.camunda.gateway.protocol.model.GlobalJobStatisticsQuery;
 import io.camunda.gateway.protocol.model.GlobalJobStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobActivationResult;
@@ -31,16 +30,19 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import java.time.OffsetDateTime;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
 @RequestMapping("/v2/jobs")
@@ -107,10 +109,12 @@ public class JobController {
   }
 
   @RequiresSecondaryStorage
-  @CamundaPostMapping(path = "/statistics/global")
+  @CamundaGetMapping(path = "/statistics/global")
   public ResponseEntity<GlobalJobStatisticsQueryResult> getGlobalJobStatistics(
-      @RequestBody final GlobalJobStatisticsQuery request) {
-    return SearchQueryRequestMapper.toGlobalJobStatisticsQuery(request)
+      @RequestParam final OffsetDateTime from,
+      @RequestParam final OffsetDateTime to,
+      @RequestParam(required = false) final String jobType) {
+    return SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType)
         .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalStatistics);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
-import io.camunda.search.entities.GlobalJobStatisticsEntity.StatisticsItem;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -917,11 +916,9 @@ public class JobControllerTest extends RestControllerTest {
     final var lastUpdatedAt = OffsetDateTime.parse("2024-07-29T15:51:28.071Z");
     final var statisticsEntity =
         new GlobalJobStatisticsEntity(
-            List.of(
-                new StatisticsItem(
-                    new StatusMetric(100, lastUpdatedAt),
-                    new StatusMetric(80, lastUpdatedAt),
-                    new StatusMetric(5, lastUpdatedAt))),
+            new StatusMetric(100, lastUpdatedAt),
+            new StatusMetric(80, lastUpdatedAt),
+            new StatusMetric(5, lastUpdatedAt),
             false);
 
     when(jobServices.getGlobalStatistics(any())).thenReturn(statisticsEntity);
@@ -938,22 +935,18 @@ public class JobControllerTest extends RestControllerTest {
     final var expectedResponse =
         """
             {
-              "items": [
-                {
-                  "created": {
-                    "count": 100,
-                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
-                  },
-                  "completed": {
-                    "count": 80,
-                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
-                  },
-                  "failed": {
-                    "count": 5,
-                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
-                  }
-                }
-              ],
+              "created": {
+                "count": 100,
+                "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+              },
+              "completed": {
+                "count": 80,
+                "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+              },
+              "failed": {
+                "count": 5,
+                "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+              },
               "isIncomplete": false
             }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -923,15 +923,6 @@ public class JobControllerTest extends RestControllerTest {
 
     when(jobServices.getGlobalStatistics(any())).thenReturn(statisticsEntity);
 
-    final var request =
-        """
-            {
-              "filter": {
-                "from": "2024-07-28T15:51:28.071Z",
-                "to": "2024-07-29T15:51:28.071Z"
-              }
-            }""";
-
     final var expectedResponse =
         """
             {
@@ -952,11 +943,11 @@ public class JobControllerTest extends RestControllerTest {
 
     // when/then
     webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/statistics/global")
+        .get()
+        .uri(
+            JOBS_BASE_URL
+                + "/statistics/global?from=2024-07-28T15:51:28.071Z&to=2024-07-29T15:51:28.071Z")
         .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isOk()
@@ -967,13 +958,12 @@ public class JobControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectGlobalJobStatisticsWithEmptyBody() {
+  void shouldRejectGlobalJobStatisticsWithMissingParams() {
     // when/then
     webClient
-        .post()
+        .get()
         .uri(JOBS_BASE_URL + "/statistics/global")
         .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isBadRequest();
@@ -982,23 +972,12 @@ public class JobControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectGlobalJobStatisticsWithMissingFromAndTo() {
-    // given
-    final var request =
-        """
-            {
-              "filter": {
-                "jobType": "some-job-type"
-              }
-            }""";
-
+  void shouldRejectGlobalJobStatisticsWithMissingTo() {
     // when/then
     webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/statistics/global")
+        .get()
+        .uri(JOBS_BASE_URL + "/statistics/global?from=2024-07-28T15:51:28.071Z")
         .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isBadRequest();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -921,7 +921,8 @@ public class JobControllerTest extends RestControllerTest {
                 new StatisticsItem(
                     new StatusMetric(100, lastUpdatedAt),
                     new StatusMetric(80, lastUpdatedAt),
-                    new StatusMetric(5, lastUpdatedAt))));
+                    new StatusMetric(5, lastUpdatedAt))),
+            false);
 
     when(jobServices.getGlobalStatistics(any())).thenReturn(statisticsEntity);
 
@@ -952,7 +953,8 @@ public class JobControllerTest extends RestControllerTest {
                     "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
                   }
                 }
-              ]
+              ],
+              "isIncomplete": false
             }""";
 
     // when/then


### PR DESCRIPTION
## Description

This pull request adds support for the `max` aggregation to the search client, enabling both Elasticsearch and OpenSearch backends to perform maximum value aggregations on fields. It introduces the new `SearchMaxAggregator` type, updates the transformation logic and tests to cover the new aggregation, and implements the global job statistics aggregation endpoint.

### Aggregation Support

* Added the new `SearchMaxAggregator` type and builder methods to `SearchAggregatorBuilders`, allowing construction of max aggregations. (`search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchMaxAggregator.java`, `search/search-client-query-transformer/src/main/java/io/camunda/search/clients/aggregator/SearchAggregatorBuilders.java`) [[1]](diffhunk://#diff-ad4efe3858c21a7180d5fb5e4fa7a0cadc86f680dcafcc7766805099f38584a5R1-R50) [[2]](diffhunk://#diff-f453a8fe76f94b06baa3e3c1f290b5c63dea636200b2fec3c9feadcb698b5d33R32-R39)
* Implemented transformer classes for the max aggregation for both Elasticsearch and OpenSearch (`SearchMaxAggregatorTransformer`), and registered them in their respective transformer registries. (`search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java`, `search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregator/SearchMaxAggregatorTransformer.java`, `search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java`, `search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/aggregator/SearchMaxAggregatorTransformer.java`) [[1]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR17) [[2]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR56) [[3]](diffhunk://#diff-919958141c3d20edbe5ff1f61580b28675c1bc08402f2cf22e814fbf91068ddfR159) [[4]](diffhunk://#diff-0ff3748e065a0a933b9fac9d137baca2c5fc0c24f230fd7d13f6cf9c33e028e7R1-R30) [[5]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR16) [[6]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR55) [[7]](diffhunk://#diff-9d31bfdda577f8eb2c0e77817bff09f9c711903ca85d75d4f48c894af3c569ccR159) [[8]](diffhunk://#diff-af9d35a785c588d90887a1462da5e9ae172e4fd745e0a03cc01b52c70ff795feR1-R30)

### Transformation Logic

* Updated the aggregation result transformers for both Elasticsearch and OpenSearch to handle the new max aggregation type. [[1]](diffhunk://#diff-94c46f968e4dd355de4ecb06fe2856786e47cd2ba3bfc7d41a8b8df98d5de5bbR202) [[2]](diffhunk://#diff-c4991e7b556bf18f2f29858e87fd27a635491dea74c5ebb0d54d8ca7ad041062R201)


### Global Job Statistics

* Implemented the global job statistics aggregation endpoint in `JobDocumentReader`, wiring up the aggregation logic. (`search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobDocumentReader.java`) [[1]](diffhunk://#diff-566b979f8f658b823b25703b169c45a32b81c2b8212de870886c30c4a61ed401R10) [[2]](diffhunk://#diff-566b979f8f658b823b25703b169c45a32b81c2b8212de870886c30c4a61ed401L36-R39)
* Updated the mapping logic to include the `isIncomplete` property in the result. (`gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java`)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes https://github.com/camunda/camunda/issues/43072
closes https://github.com/camunda/camunda/issues/43073
