### PR TITLE
deps: use node 24 in build-frontend action

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -9,7 +9,7 @@ inputs:
   node-version:
     description: The Node.js version to use
     required: false
-    default: "20"
+    default: "24"
   directory:
     description: Directory of the Yarn workspace to build
     required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1136,7 +1136,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: 'npm'
           cache-dependency-path: 'identity/client/package-lock.json'
       - name: Install dependencies


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Use Node 24 by default in build-frontend action

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
