### PR TITLE
Enhance BatchItemsTable with links to process instances

### DIFF
--- a/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
@@ -117,7 +117,11 @@ describe('<BatchItemsTable />', () => {
     );
 
     expect(screen.getByText('3 Items')).toBeInTheDocument();
-    expect(screen.getByText('2251799813685250')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: /view process instance 2251799813685250/i,
+      }),
+    ).toHaveAttribute('href', '/processes/2251799813685250');
     expect(screen.getByText('2251799813685251')).toBeInTheDocument();
     expect(screen.getByText('2251799813685252')).toBeInTheDocument();
   });

--- a/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
@@ -8,9 +8,11 @@
 
 import {useMemo, useCallback} from 'react';
 import {PaginatedSortableTable} from 'modules/components/PaginatedSortableTable';
+import {Link} from 'react-router-dom';
 import {useBatchOperationItems} from 'modules/queries/batch-operations/useBatchOperationItems';
 import {BatchStateIndicator} from 'App/BatchOperations/BatchStateIndicator';
 import {formatDate} from 'modules/utils/date';
+import {Paths} from 'modules/Routes';
 
 const TABLE_HEADERS = [
   {key: 'processInstanceKey', header: 'Process Instance Key', isDisabled: true},
@@ -52,11 +54,19 @@ export const BatchItemsTable: React.FC<Props> = ({
 
   const rows = useMemo(
     () =>
-      items.map((item) => ({
-        id: item.itemKey.toString(),
-        processInstanceKey: item.processInstanceKey,
-        state: <BatchStateIndicator status={item.state} />,
-        processedDate: formatDate(item.processedDate ?? ''),
+      items.map(({itemKey, processInstanceKey, state, processedDate}) => ({
+        id: itemKey.toString(),
+        processInstanceKey: (
+          <Link
+            to={Paths.processInstance(processInstanceKey)}
+            title={`View process instance ${processInstanceKey}`}
+            aria-label={`View process instance ${processInstanceKey}`}
+          >
+            {processInstanceKey}
+          </Link>
+        ),
+        state: <BatchStateIndicator status={state} />,
+        processedDate: formatDate(processedDate ?? ''),
       })),
     [items],
   );


### PR DESCRIPTION
## Description
The processInstanceKey cell in the batch operation details page is rendered as a link to the correct process instance details route.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44854
