### PR TITLE
fix: use spring @NonNull annotation instead of jspecify

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
@@ -8,9 +8,9 @@
 package io.camunda.authentication.config;
 
 import io.micrometer.common.KeyValues;
-import org.jspecify.annotations.NonNull;
 import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.client.observation.DefaultClientRequestObservationConvention;
+import org.springframework.lang.NonNull;
 
 /**
  * Custom implementation of DefaultClientRequestObservationConvention that allows adding common tags


### PR DESCRIPTION
## Description

jspecify is not part of the declared dependencies yet and it's currently a transitive dependency.
For the time being it's best to just use spring's annotation before we migrate

This import is causing this PR #43739 to fail to build due to changes in micrometer (it started using jspecify as well)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
