### PR TITLE
feat: fix resource deletion request, camunda-api-zod-schemas updated

### DIFF
--- a/operate/client/src/App/Processes/ListView/v2/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/v2/ProcessOperations/index.tsx
@@ -38,7 +38,7 @@ const ProcessOperations: React.FC<Props> = observer(
 
     const deleteResourceMutation = useDeleteResource(
       processDefinitionKey,
-      {operationReference: Date.now(), deleteHistory: true},
+      {deleteHistory: true},
       {
         onSuccess: () => {
           notificationsStore.displayNotification({


### PR DESCRIPTION
## Description

### Reason of this PR 
feat: update camunda-api-zod-schemas #44397
Schema updated making `operationReference` mandatory if `DeleteResourceRequest` is present.

###  Workaround
use `Date.now()` in `operationReference` field until schema is updated

### Fix
- feat: fix resource deletion request body schema #44416
- this PR

## Related issues

relates #31690
