### PR TITLE
Improve performance of Intent lookup

### DIFF
--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -19,8 +19,10 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public interface Intent {
@@ -28,6 +30,18 @@ public interface Intent {
   Map<ValueType, Class<? extends Intent>> VALUE_TYPE_TO_INTENT_MAP = computeValueTypeToIntentMap();
   Collection<Class<? extends Intent>> INTENT_CLASSES =
       VALUE_TYPE_TO_INTENT_MAP.values().stream().distinct().collect(Collectors.toList());
+  Map<Class<? extends Intent>, Map<Short, Intent>> PROTOCOL_VALUE_TO_INTENT_MAP =
+      INTENT_CLASSES.stream()
+          .collect(
+              Collectors.toMap(
+                  Function.identity(),
+                  intentClass -> {
+                    final Map<Short, Intent> map = new HashMap<>();
+                    for (final Intent intentValue : intentClass.getEnumConstants()) {
+                      map.put(intentValue.value(), intentValue);
+                    }
+                    return map;
+                  }));
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -135,12 +149,7 @@ public interface Intent {
       return Intent.UNKNOWN;
     }
     final Class<? extends Intent> intentClass = fromValueType(valueType);
-    for (final Intent intentValue : intentClass.getEnumConstants()) {
-      if (intentValue.value() == intent) {
-        return intentValue;
-      }
-    }
-    return Intent.UNKNOWN;
+    return PROTOCOL_VALUE_TO_INTENT_MAP.get(intentClass).getOrDefault(intent, UNKNOWN);
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -19,24 +19,24 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.agrona.collections.Int2ObjectHashMap;
 
 public interface Intent {
 
   Map<ValueType, Class<? extends Intent>> VALUE_TYPE_TO_INTENT_MAP = computeValueTypeToIntentMap();
   Collection<Class<? extends Intent>> INTENT_CLASSES =
       VALUE_TYPE_TO_INTENT_MAP.values().stream().distinct().collect(Collectors.toList());
-  Map<Class<? extends Intent>, Map<Short, Intent>> PROTOCOL_VALUE_TO_INTENT_MAP =
+  Map<Class<? extends Intent>, Int2ObjectHashMap<Intent>> PROTOCOL_VALUE_TO_INTENT_MAP =
       INTENT_CLASSES.stream()
           .collect(
               Collectors.toMap(
                   Function.identity(),
                   intentClass -> {
-                    final Map<Short, Intent> map = new HashMap<>();
+                    final Int2ObjectHashMap<Intent> map = new Int2ObjectHashMap<>();
                     for (final Intent intentValue : intentClass.getEnumConstants()) {
                       map.put(intentValue.value(), intentValue);
                     }


### PR DESCRIPTION
Intents can be serialized either as string or integer values. When it is necessary to deserialize the string values it is easy to do since the standard `Enum.valueOf` method can be used, but there is no standard way to deserialize the integer values.

The previous implementation (#41694)  just looked at all the possible enumeration constants for an intent class one by one comparing them with the provided protocol value. While this linear search is not very expensive by itself, the fact that it is called very frequently in a hot path can negatively impact the performance of the whole application.

The new implementation performs this linear search in a static context, ensuring it is performed only once when the Intent class is initialized. The result of the search is then saved in a hash map so that following calls in the hot path can retrieve the correct value in constant time.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

