### PR TITLE
fix: update Java base images to address CVEs

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -101,7 +101,7 @@ jobs:
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
           vault-url: ${{ secrets.VAULT_ADDR }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           # Overriding the default GITHUB_TOKEN with a GitHub App token in order to workaround
@@ -290,7 +290,7 @@ jobs:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/zeebe
       DOCKER_IMAGE: camunda/zeebe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Import Secrets
@@ -304,11 +304,18 @@ jobs:
           secrets: |
             secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Logs on to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -388,7 +395,7 @@ jobs:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/operate
       DOCKER_IMAGE: camunda/operate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Import Secrets
@@ -402,11 +409,18 @@ jobs:
           secrets: |
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -460,7 +474,7 @@ jobs:
           command: |
             docker -D buildx imagetools create \
               --tag ${{ env.DOCKER_IMAGE }}:latest \
-              ${{ steps.build-operate-docker.outputs.image }} 
+              ${{ steps.build-operate-docker.outputs.image }}
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -489,7 +503,7 @@ jobs:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/tasklist
       DOCKER_IMAGE: camunda/tasklist
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Import Secrets
@@ -503,11 +517,18 @@ jobs:
           secrets: |
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -590,7 +611,7 @@ jobs:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
       DOCKER_IMAGE: camunda/camunda
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Import Secrets
@@ -714,7 +735,7 @@ jobs:
     # Minor releases take more time since a lot of issues are included in the changelog
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -53,8 +53,8 @@ jobs:
           - 5000:5000
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+        uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.3.0
         with:
           ignore: DL3018 # redundant when pinning the base image
           dockerfile: operate.Dockerfile
@@ -69,8 +69,15 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+      - name: Login to Minimus
+        uses: docker/login-action@v3
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "adopt"
           java-version: "21"

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,10 +1,24 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="alpine:3.23.3"
-ARG BASE_DIGEST="sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+ARG BASE_DIGEST="sha256:cc7175593660c343b265defdfaaa9b01789b711135323d3546a48c20fdf48a00"
 
-# Prepare tasklist Distribution
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS prepare
+# If you don't have access to Minimus hardened base images, you can use public
+# base images like this instead on your own risk.
+# Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.9_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:d3eb69add1874bc785382d6282db53a67841f602a1139dee6c4a1221d8c56568"
+ARG BASE="hardened"
 
+### Base Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
+
+### Base Public Application Image ###
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
+
+# Prepare Tasklist Distribution
+FROM base-${BASE} AS prepare
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 WORKDIR /tmp/tasklist
 
@@ -12,18 +26,13 @@ WORKDIR /tmp/tasklist
 COPY ${DISTBALL} tasklist.tar.gz
 RUN tar xzvf tasklist.tar.gz --strip 1 && \
     rm tasklist.tar.gz
-
-### Base image ###
-# hadolint ignore=DL3006
-FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base
-
-# Install Tini
-RUN apk update && apk add --no-cache tini
+COPY docker-notice.txt notice.txt
+RUN sed -i '/^exec /i cat /usr/local/tasklist/notice.txt' bin/tasklist
 
 ### Application Image ###
 # hadolint ignore=DL3006
+FROM base-${BASE} AS app
 
-FROM base AS app
 # leave unset to use the default value at the top of the file
 ARG BASE_IMAGE
 ARG BASE_DIGEST
@@ -32,7 +41,7 @@ ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.name="docker.io/library/${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="hto@camunda.com"
@@ -56,15 +65,14 @@ LABEL io.k8s.description="Tasklist is a ready-to-use application to rapidly impl
 
 EXPOSE 8080
 
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
-
 ENV TASKLIST_HOME=/usr/local/tasklist
 
 WORKDIR ${TASKLIST_HOME}
 VOLUME /tmp
 VOLUME ${TASKLIST_HOME}/logs
 
+# Switch to root to allow setting up our own user
+USER root
 RUN addgroup --gid 1001 camunda && \
     adduser -D -h ${TASKLIST_HOME} -G camunda -u 1001 camunda && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
@@ -80,4 +88,4 @@ RUN mv ${TASKLIST_HOME}/bin/tasklist-migrate ${TASKLIST_HOME}/bin/migrate
 
 USER 1001:1001
 
-ENTRYPOINT ["/sbin/tini", "--", "/usr/local/tasklist/bin/tasklist"]
+ENTRYPOINT ["/usr/local/tasklist/bin/tasklist"]


### PR DESCRIPTION
## Description

Update Java base images to address the following Oracle Java SE / GraalVM CVEs that are currently flagged on our Docker images:

- CVE-2026-21945 – Security component (DoS, availability-only impact in our context)
- CVE-2026-21925 – RMI component (C/I impact in generic Java deployments)

In our deployment these CVEs are only present at the runtime level (JDK version) and are not practically exploitable because we run server-side applications with trusted, administrator-provided code and do not expose Java sandbox or RMI surfaces to untrusted input. Nevertheless, we align with vendor fixes and remove the vulnerable JDK versions from all affected images.

## Changes

- Bump Java / GraalVM versions in all affected Dockerfiles to releases that include the upstream fixes for CVE-2026-21945 and CVE-2026-21925.

## Testing

- Built all updated images locally.
- Smoke-tested startup for the affected services using the new base images.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates #44868
