### PR TITLE
Search Authorizaton API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -1,0 +1,447 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect, APIRequestContext} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertBadRequest,
+  assertInvalidArgument,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  encode,
+  assertForbiddenRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  createUser,
+  createComponentAuthorization,
+  createRole,
+  createGroup,
+  createMappingRule,
+  expectAuthorizationCanBeFound,
+  verifyAuthorizationFields,
+  type Authorization,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {cleanupRoles} from 'utils/rolesCleanup';
+import {cleanupGroups} from 'utils/groupsCleanup';
+import {cleanupMappingRules} from 'utils/mappingRuleCleanup';
+import {sleep} from 'utils/sleep';
+import { validateResponse } from 'json-body-assertions';
+
+const AUTHORIZATION_SEARCH_ENDPOINT = '/authorizations/search';
+
+test.describe.parallel('Search Authorization API', () => {
+  const cleanups: ((request: APIRequestContext) => Promise<void>)[] = [];
+  let user: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+  let userAuthorizationKey: string;
+  let originalUserAuthorization: Authorization = {} as Authorization;
+  let originalRole: {
+      roleId: string;
+      name: string;
+      description: string;
+    };
+    let roleAuthorizationKey: string;
+    let userForRoleAuthorization: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    let originalMappingRule: {
+      mappingRuleId: string;
+      claimName: string;
+      claimValue: string;
+      name: string;
+    };
+    let originalGroup: {
+      groupId: string;
+      name: string;
+      description: string;
+    } = {} as {
+      groupId: string;
+      name: string;
+      description: string;
+    };
+    let mappingRuleAuthorizationKey: string;
+    let expectedUserAuthorization: Authorization = {} as Authorization;
+
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create user for authorization tests', async () => {
+      user = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [user.username]);
+      });
+
+      userForRoleAuthorization = await createUser(request);
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [userForRoleAuthorization.username]);
+      });
+    });
+
+    await test.step('Setup - Grant user necessary authorizations', async () => {
+      const authorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        user.username,
+        'USER',
+        '*',
+        'ROLE',
+        ['READ'],
+      );
+      userAuthorizationKey = await createComponentAuthorization(
+        request,
+        authorizationBody,
+      );
+      originalUserAuthorization = authorizationBody;
+    });
+
+    expectedUserAuthorization = {
+        ...originalUserAuthorization,
+        authorizationKey: userAuthorizationKey,
+      };
+
+    await test.step('Setup - Create role for Authorization tests', async () => {
+      originalRole = await createRole(request);
+      cleanups.push(async (request) => {
+        await cleanupRoles(request, [originalRole.roleId]);
+      });
+    });
+
+    await test.step('Setup - Grant created role authorization', async () => {
+      const roleAuthorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        originalRole.roleId,
+        'ROLE',
+        '*',
+        'USER',
+        ['DELETE'],
+      );
+      roleAuthorizationKey = await createComponentAuthorization(
+        request,
+        roleAuthorizationBody,
+      );
+    });
+
+    await test.step('Setup - Create group for Authorization tests', async () => {
+      originalGroup = await createGroup(request);
+      cleanups.push(async (request) => {
+        await cleanupGroups(request, [originalGroup.groupId]);
+      });
+    });
+
+    await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
+      originalMappingRule = await createMappingRule(request);
+      cleanups.push(async (request) => {
+        await cleanupMappingRules(request, [originalMappingRule.mappingRuleId]);
+      });
+    });
+
+    await test.step('Setup - Grant created mapping rule authorization', async () => {
+      const mappingRuleAuthorizationBody = CREATE_CUSTOM_AUTHORIZATION_BODY(
+        originalMappingRule.mappingRuleId,
+        'MAPPING_RULE',
+        '*',
+        'GROUP',
+        ['CREATE'],
+      );
+      mappingRuleAuthorizationKey = await createComponentAuthorization(
+        request,
+        mappingRuleAuthorizationBody,
+      );
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, userAuthorizationKey);
+      await expectAuthorizationCanBeFound(request, roleAuthorizationKey);
+      await expectAuthorizationCanBeFound(request, mappingRuleAuthorizationKey);
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    for (const cleanup of cleanups) {
+      await cleanup(request);
+    }
+  });
+
+  test('Search Authorization - no filter, multiple results - 200 Success', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(35);
+      expect(body.items.length).toBeGreaterThanOrEqual(35);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - results sorted by resourceType and filtered by ownerId - 200 Success', async ({request}) => {
+    const ownerIdToSearch = user.username;
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: "resourceType",
+              order: "ASC"
+            }
+          ],
+          filter: {
+            ownerId: ownerIdToSearch,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(2);
+      expect(body.items.length).toBe(2);
+      const authorization: Authorization = body.items[0];
+      verifyAuthorizationFields(authorization, expectedUserAuthorization);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - filtered by ownerId, ownerType, and resourceType - single result - 200 Success', async ({request}) => {
+    const ownerTypeToSearch = 'USER';
+    const ownerIdToSearch = user.username;
+    const resourceTypeToSearch = 'ROLE';
+    
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            ownerId: ownerIdToSearch,
+            ownerType: ownerTypeToSearch,
+            resourceType: resourceTypeToSearch,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(1);
+      expect(body.items.length).toEqual(1);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - filtered by ownerId and resourceIds - multiple results - 200 Success', async ({request}) => {
+    const ownerIdToSearch = 'admin';
+    const resourceIdsToSearch = '*';
+    
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            ownerId: ownerIdToSearch,
+            resourceIds: [resourceIdsToSearch],
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body = await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(15);
+      expect(body.items.length).toBeGreaterThanOrEqual(15);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - no results - 200 Success', async ({request}) => {
+    const ownerIdToSearch = 'non.existent.user';
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            ownerId: ownerIdToSearch,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(0);
+      expect(body.items.length).toEqual(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - invalid sort field - 400 Bad Request', async ({request}) => {
+    const invalidSortField = 'invalidField';
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: invalidSortField,
+              order: 'ASC',
+            },
+          ],
+        },
+      });
+      await assertBadRequest(res, 'Unexpected value \'invalidField\' for enum field \'field\'. Use any of the following values: [ownerId, ownerType, resourceId, resourceType]');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - invalid filter field - 400 Bad Request', async ({request}) => {
+    const invalidFilterField = 'meow';
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            [invalidFilterField]: 'someValue',
+          },
+        },
+      });
+      await assertBadRequest(res, `Request property [filter.${invalidFilterField}] cannot be parsed`);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - Unauthorized - 401 Unauthorized', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        // No auth headers
+        data: {},
+      });
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Authorization - Forbidden for user without permission - 403 Forbidden', async ({request}) => {
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    let resourceAuthorizationKey: {authorizationKey: string};
+
+    await test.step('Setup - Create user for authorization tests', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      resourceAuthorizationKey = await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [
+          userWithResourcesAuthorizationToSendRequest.username,
+        ]);
+      });
+    });
+
+    await test.step('Poll authorization', async () => {
+      await expectAuthorizationCanBeFound(request, resourceAuthorizationKey.authorizationKey);
+    });
+
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+
+    await test.step('Attempt to search authorizations without proper permission', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+          headers: jsonHeaders(token), // overrides default demo:demo
+          data: {},
+        });
+        await assertStatusCode(res, 200);
+        await validateResponse({
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        }, res);
+        const body = await res.json();
+        console.log(body);
+        expect(body.page.totalItems).toEqual(0);
+        expect(body.items.length).toEqual(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  // Has status 200 due to bug 39372: https://github.com/camunda/camunda/issues/39372
+  test('Search Authorization - Invalid pagination', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          page: {from: -1, limit: -1},
+        },
+      });
+      await assertStatusCode(res, 200);
+    }).toPass(defaultAssertionOptions);
+  });
+
+    test('Search Authorization - Pagination 0', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          page: {from: 0, limit: 0},
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: AUTHORIZATION_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      }, res);
+
+      const body =  await res.json();
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(35);
+      expect(body.items.length).toEqual(0);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -441,7 +441,7 @@ test.describe.parallel('Search Authorization API', () => {
     });
   });
 
-  // Search Authorization: negative pagination values return 200 instead of 400 due to bug 39372: https://github.com/camunda/camunda/issues/39372
+  // Skiped due to bug 39372: https://github.com/camunda/camunda/issues/39372
   test.skip('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -11,11 +11,8 @@ import {
   jsonHeaders,
   buildUrl,
   assertBadRequest,
-  assertInvalidArgument,
   assertUnauthorizedRequest,
-  assertNotFoundRequest,
   encode,
-  assertForbiddenRequest,
   assertStatusCode,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
@@ -32,11 +29,9 @@ import {
   grantUserResourceAuthorization,
 } from '@requestHelpers';
 import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
-import {waitForAssertion} from 'utils/waitForAssertion';
 import {cleanupRoles} from 'utils/rolesCleanup';
 import {cleanupGroups} from 'utils/groupsCleanup';
 import {cleanupMappingRules} from 'utils/mappingRuleCleanup';
-import {sleep} from 'utils/sleep';
 import {validateResponse} from 'json-body-assertions';
 
 const AUTHORIZATION_SEARCH_ENDPOINT = '/authorizations/search';
@@ -57,16 +52,11 @@ test.describe.parallel('Search Authorization API', () => {
     description: string;
   };
   let roleAuthorizationKey: string;
-  let userForRoleAuthorization: {
+  let userForRoleAuthorization: { 
     username: string;
-    name: string;
+    name: string; 
     email: string;
-    password: string;
-  } = {} as {
-    username: string;
-    name: string;
-    email: string;
-    password: string;
+    password: string; 
   };
 
   let originalMappingRule: {
@@ -76,10 +66,6 @@ test.describe.parallel('Search Authorization API', () => {
     name: string;
   };
   let originalGroup: {
-    groupId: string;
-    name: string;
-    description: string;
-  } = {} as {
     groupId: string;
     name: string;
     description: string;
@@ -200,8 +186,8 @@ test.describe.parallel('Search Authorization API', () => {
       );
 
       const body = await res.json();
-      expect(body.page.totalItems).toBeGreaterThanOrEqual(35);
-      expect(body.items.length).toBeGreaterThanOrEqual(35);
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(3);
+      expect(body.items.length).toBeGreaterThanOrEqual(3);
     }).toPass(defaultAssertionOptions);
   });
 
@@ -390,7 +376,7 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - Forbidden for user without permission - 403 Forbidden', async ({
+  test('Search Authorization - Returns empty results for user without permission - 200 Success', async ({
     request,
   }) => {
     let userWithResourcesAuthorizationToSendRequest: {
@@ -449,15 +435,14 @@ test.describe.parallel('Search Authorization API', () => {
           res,
         );
         const body = await res.json();
-        console.log(body);
         expect(body.page.totalItems).toEqual(0);
         expect(body.items.length).toEqual(0);
       }).toPass(defaultAssertionOptions);
     });
   });
 
-  // Has status 200 due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test('Search Authorization - Invalid pagination', async ({request}) => {
+  // Search Authorization: negative pagination values return 200 instead of 400 due to bug 39372: https://github.com/camunda/camunda/issues/39372
+  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -442,7 +442,7 @@ test.describe.parallel('Search Authorization API', () => {
   });
 
   // Search Authorization: negative pagination values return 200 instead of 400 due to bug 39372: https://github.com/camunda/camunda/issues/39372
-  test('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
+  test.skip('Search Authorization - Negative pagination values (known bug) - 200 instead of 400', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
@@ -450,7 +450,7 @@ test.describe.parallel('Search Authorization API', () => {
           page: {from: -1, limit: -1},
         },
       });
-      await assertStatusCode(res, 200);
+      await assertBadRequest(res, /page\.(from|limit)/i);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/search-authorization-api.spec.ts
@@ -37,56 +37,55 @@ import {cleanupRoles} from 'utils/rolesCleanup';
 import {cleanupGroups} from 'utils/groupsCleanup';
 import {cleanupMappingRules} from 'utils/mappingRuleCleanup';
 import {sleep} from 'utils/sleep';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 const AUTHORIZATION_SEARCH_ENDPOINT = '/authorizations/search';
 
 test.describe.parallel('Search Authorization API', () => {
   const cleanups: ((request: APIRequestContext) => Promise<void>)[] = [];
   let user: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
   let userAuthorizationKey: string;
   let originalUserAuthorization: Authorization = {} as Authorization;
   let originalRole: {
-      roleId: string;
-      name: string;
-      description: string;
-    };
-    let roleAuthorizationKey: string;
-    let userForRoleAuthorization: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+    roleId: string;
+    name: string;
+    description: string;
+  };
+  let roleAuthorizationKey: string;
+  let userForRoleAuthorization: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
-    let originalMappingRule: {
-      mappingRuleId: string;
-      claimName: string;
-      claimValue: string;
-      name: string;
-    };
-    let originalGroup: {
-      groupId: string;
-      name: string;
-      description: string;
-    } = {} as {
-      groupId: string;
-      name: string;
-      description: string;
-    };
-    let mappingRuleAuthorizationKey: string;
-    let expectedUserAuthorization: Authorization = {} as Authorization;
-
+  let originalMappingRule: {
+    mappingRuleId: string;
+    claimName: string;
+    claimValue: string;
+    name: string;
+  };
+  let originalGroup: {
+    groupId: string;
+    name: string;
+    description: string;
+  } = {} as {
+    groupId: string;
+    name: string;
+    description: string;
+  };
+  let mappingRuleAuthorizationKey: string;
+  let expectedUserAuthorization: Authorization = {} as Authorization;
 
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create user for authorization tests', async () => {
@@ -117,9 +116,9 @@ test.describe.parallel('Search Authorization API', () => {
     });
 
     expectedUserAuthorization = {
-        ...originalUserAuthorization,
-        authorizationKey: userAuthorizationKey,
-      };
+      ...originalUserAuthorization,
+      authorizationKey: userAuthorizationKey,
+    };
 
     await test.step('Setup - Create role for Authorization tests', async () => {
       originalRole = await createRole(request);
@@ -183,17 +182,22 @@ test.describe.parallel('Search Authorization API', () => {
     }
   });
 
-  test('Search Authorization - no filter, multiple results - 200 Success', async ({request}) => {
+  test('Search Authorization - no filter, multiple results - 200 Success', async ({
+    request,
+  }) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
       const body = await res.json();
       expect(body.page.totalItems).toBeGreaterThanOrEqual(35);
@@ -201,7 +205,9 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - results sorted by resourceType and filtered by ownerId - 200 Success', async ({request}) => {
+  test('Search Authorization - results sorted by resourceType and filtered by ownerId - 200 Success', async ({
+    request,
+  }) => {
     const ownerIdToSearch = user.username;
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
@@ -209,9 +215,9 @@ test.describe.parallel('Search Authorization API', () => {
         data: {
           sort: [
             {
-              field: "resourceType",
-              order: "ASC"
-            }
+              field: 'resourceType',
+              order: 'ASC',
+            },
           ],
           filter: {
             ownerId: ownerIdToSearch,
@@ -219,11 +225,14 @@ test.describe.parallel('Search Authorization API', () => {
         },
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
       const body = await res.json();
       expect(body.page.totalItems).toBe(2);
@@ -233,11 +242,13 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - filtered by ownerId, ownerType, and resourceType - single result - 200 Success', async ({request}) => {
+  test('Search Authorization - filtered by ownerId, ownerType, and resourceType - single result - 200 Success', async ({
+    request,
+  }) => {
     const ownerTypeToSearch = 'USER';
     const ownerIdToSearch = user.username;
     const resourceTypeToSearch = 'ROLE';
-    
+
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
@@ -250,11 +261,14 @@ test.describe.parallel('Search Authorization API', () => {
         },
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
       const body = await res.json();
       expect(body.page.totalItems).toEqual(1);
@@ -262,10 +276,12 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - filtered by ownerId and resourceIds - multiple results - 200 Success', async ({request}) => {
+  test('Search Authorization - filtered by ownerId and resourceIds - multiple results - 200 Success', async ({
+    request,
+  }) => {
     const ownerIdToSearch = 'admin';
     const resourceIdsToSearch = '*';
-    
+
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
@@ -277,11 +293,14 @@ test.describe.parallel('Search Authorization API', () => {
         },
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
       const body = await res.json();
       expect(body.page.totalItems).toBeGreaterThanOrEqual(15);
@@ -301,11 +320,14 @@ test.describe.parallel('Search Authorization API', () => {
         },
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
       const body = await res.json();
       expect(body.page.totalItems).toEqual(0);
@@ -313,7 +335,9 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - invalid sort field - 400 Bad Request', async ({request}) => {
+  test('Search Authorization - invalid sort field - 400 Bad Request', async ({
+    request,
+  }) => {
     const invalidSortField = 'invalidField';
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
@@ -327,11 +351,16 @@ test.describe.parallel('Search Authorization API', () => {
           ],
         },
       });
-      await assertBadRequest(res, 'Unexpected value \'invalidField\' for enum field \'field\'. Use any of the following values: [ownerId, ownerType, resourceId, resourceType]');
+      await assertBadRequest(
+        res,
+        "Unexpected value 'invalidField' for enum field 'field'. Use any of the following values: [ownerId, ownerType, resourceId, resourceType]",
+      );
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - invalid filter field - 400 Bad Request', async ({request}) => {
+  test('Search Authorization - invalid filter field - 400 Bad Request', async ({
+    request,
+  }) => {
     const invalidFilterField = 'meow';
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
@@ -342,11 +371,16 @@ test.describe.parallel('Search Authorization API', () => {
           },
         },
       });
-      await assertBadRequest(res, `Request property [filter.${invalidFilterField}] cannot be parsed`);
+      await assertBadRequest(
+        res,
+        `Request property [filter.${invalidFilterField}] cannot be parsed`,
+      );
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - Unauthorized - 401 Unauthorized', async ({request}) => {
+  test('Search Authorization - Unauthorized - 401 Unauthorized', async ({
+    request,
+  }) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         // No auth headers
@@ -356,7 +390,9 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Authorization - Forbidden for user without permission - 403 Forbidden', async ({request}) => {
+  test('Search Authorization - Forbidden for user without permission - 403 Forbidden', async ({
+    request,
+  }) => {
     let userWithResourcesAuthorizationToSendRequest: {
       username: string;
       name: string;
@@ -384,7 +420,10 @@ test.describe.parallel('Search Authorization API', () => {
     });
 
     await test.step('Poll authorization', async () => {
-      await expectAuthorizationCanBeFound(request, resourceAuthorizationKey.authorizationKey);
+      await expectAuthorizationCanBeFound(
+        request,
+        resourceAuthorizationKey.authorizationKey,
+      );
     });
 
     const token = encode(
@@ -393,16 +432,22 @@ test.describe.parallel('Search Authorization API', () => {
 
     await test.step('Attempt to search authorizations without proper permission', async () => {
       await expect(async () => {
-        const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
-          headers: jsonHeaders(token), // overrides default demo:demo
-          data: {},
-        });
+        const res = await request.post(
+          buildUrl(AUTHORIZATION_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {},
+          },
+        );
         await assertStatusCode(res, 200);
-        await validateResponse({
-          path: AUTHORIZATION_SEARCH_ENDPOINT,
-          method: 'POST',
-          status: '200',
-        }, res);
+        await validateResponse(
+          {
+            path: AUTHORIZATION_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
         const body = await res.json();
         console.log(body);
         expect(body.page.totalItems).toEqual(0);
@@ -424,7 +469,7 @@ test.describe.parallel('Search Authorization API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-    test('Search Authorization - Pagination 0', async ({request}) => {
+  test('Search Authorization - Pagination 0', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUTHORIZATION_SEARCH_ENDPOINT), {
         headers: jsonHeaders(),
@@ -433,13 +478,16 @@ test.describe.parallel('Search Authorization API', () => {
         },
       });
       await assertStatusCode(res, 200);
-      await validateResponse({
-        path: AUTHORIZATION_SEARCH_ENDPOINT,
-        method: 'POST',
-        status: '200',
-      }, res);
+      await validateResponse(
+        {
+          path: AUTHORIZATION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
 
-      const body =  await res.json();
+      const body = await res.json();
       expect(body.page.totalItems).toBeGreaterThanOrEqual(35);
       expect(body.items.length).toEqual(0);
     }).toPass(defaultAssertionOptions);


### PR DESCRIPTION
## Description

This PR covers Search Authorization API test with happy path:

- Search Authorization - no filter, multiple results - 200 Success
- Search Authorization - results sorted by resourceType and filtered by ownerId - 200 Success
- Search Authorization - filtered by ownerId, ownerType, and resourceType - single result - 200 Success
- Search Authorization - filtered by ownerId and resourceIds - multiple results - 200 Success
- Search Authorization - no results - 200 Success

and unhappy path tests:

- Search Authorization - invalid sort field - 400 Bad Request
- Search Authorization - invalid filter field - 400 Bad Request
- Search Authorization - Unauthorized - 401 Unauthorized
- Search Authorization - Returns empty results for user without permission - 200 Success

It also covers pagination limit test, which isn't working as expected (reported in [this issue](https://github.com/camunda/camunda/issues/39372)).

- Search Authorization - Negative pagination values (known bug) - 200 instead of 400
- Search Authorization - Pagination 0

During work on Authorization API tests inconsistency between API docs and reality was found. Reported it [in this issue](https://github.com/camunda/camunda/issues/44872).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21622800433)
