### PR TITLE
[Backport stable/8.6] fix: Add `JobIntent.YIELD` to the whitelisted commands

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
@@ -24,6 +24,7 @@ public final class RequestLimiter extends AbstractLimiter<Intent> {
       Set.of(
           JobIntent.COMPLETE,
           JobIntent.FAIL,
+          JobIntent.YIELD,
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,


### PR DESCRIPTION
# Description
Backport of #41924 to `stable/8.6`.

relates to #35074