### PR TITLE
[Backport stable/8.7] fix: Add `JobIntent.YIELD` to the whitelisted commands

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -21,6 +21,7 @@ public class WhiteListedCommands {
       Set.of(
           JobIntent.COMPLETE,
           JobIntent.FAIL,
+          JobIntent.YIELD,
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,


### PR DESCRIPTION
# Description
Backport of #41924 to `stable/8.7`.

relates to #35074