### PR TITLE
[Backport stable/8.8] perf: use struct of array pattern for LogAppendEntryMetadata

### DIFF
--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -138,6 +138,13 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -49,7 +49,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class LogStreamMetrics {
@@ -150,7 +149,7 @@ public final class LogStreamMetrics {
   }
 
   public void flowControlAccepted(
-      final WriteContext context, final List<LogAppendEntryMetadata> batchMetadata) {
+      final WriteContext context, final LogAppendEntryMetadata batchMetadata) {
     triedAppends.increment();
 
     if (context instanceof UserCommand) {
@@ -167,7 +166,7 @@ public final class LogStreamMetrics {
 
   public void flowControlRejected(
       final WriteContext context,
-      final List<LogAppendEntryMetadata> batchMetadata,
+      final LogAppendEntryMetadata batchMetadata,
       final Rejection reason) {
     triedAppends.increment();
     deferredAppends.increment();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
@@ -39,8 +38,8 @@ import java.util.TreeMap;
  * Access patterns:
  *
  * <ol>
- *   <li>Calls to {@link #tryAcquire(WriteContext, List)} from the sequencer, serialized through the
- *       sequencers write lock.
+ *   <li>Calls to {@link #tryAcquire(WriteContext, LogAppendEntryMetadata)} from the sequencer,
+ *       serialized through the sequencers write lock.
  *   <li>Calls to {@link #onAppend(InFlightEntry, long)} from the sequencer, serialized through the
  *       sequencers write lock.
  *   <li>Calls to {@link #onWrite(long, long)} from the log storage, serialized through the single
@@ -54,8 +53,9 @@ import java.util.TreeMap;
  * The order in which these methods are called is weakly constrained:
  *
  * <ul>
- *   <li>{@link #tryAcquire(WriteContext, List)} and {@link #onAppend(InFlightEntry, long)} are
- *       always called in that order and before any other methods.
+ *   <li>{@link #tryAcquire(WriteContext, LogAppendEntryMetadata)} and {@link
+ *       #onAppend(InFlightEntry, long)} are always called in that order and before any other
+ *       methods.
  *   <li>{@link #onWrite(long, long)} and {@link #onCommit(long, long)} and {@link
  *       #onProcessed(long)} can be called in any order.
  * </ul>
@@ -114,7 +114,7 @@ public final class FlowControl implements AppendListener {
   // False positive: https://github.com/checkstyle/checkstyle/issues/14891
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   public Either<Rejection, InFlightEntry> tryAcquire(
-      final WriteContext context, final List<LogAppendEntryMetadata> batchMetadata) {
+      final WriteContext context, final LogAppendEntryMetadata batchMetadata) {
     final var result = tryAcquireInternal(context, batchMetadata);
     switch (result) {
       case Either.Left<Rejection, InFlightEntry>(final var reason) ->
@@ -127,7 +127,7 @@ public final class FlowControl implements AppendListener {
   }
 
   private Either<Rejection, InFlightEntry> tryAcquireInternal(
-      final WriteContext context, final List<LogAppendEntryMetadata> batchMetadata) {
+      final WriteContext context, final LogAppendEntryMetadata batchMetadata) {
     Listener requestListener = null;
     var alwaysAllowed = false;
     switch (context) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -11,18 +11,17 @@ import com.netflix.concurrency.limits.Limiter.Listener;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.util.CloseableSilently;
-import java.util.List;
 
 public final class InFlightEntry {
   final LogStreamMetrics metrics;
-  List<LogAppendEntryMetadata> entryMetadata;
+  LogAppendEntryMetadata entryMetadata;
   Listener requestListener;
   CloseableSilently writeTimer;
   CloseableSilently commitTimer;
 
   public InFlightEntry(
       final LogStreamMetrics metrics,
-      final List<LogAppendEntryMetadata> entryMetadata,
+      final LogAppendEntryMetadata entryMetadata,
       final Listener requestListener) {
     this.metrics = metrics;
     this.entryMetadata = entryMetadata;
@@ -42,10 +41,10 @@ public final class InFlightEntry {
   public void onWrite() {
     final var entryMetadata = this.entryMetadata;
     if (entryMetadata != null) {
-      entryMetadata.forEach(
-          metadata ->
-              metrics.recordAppendedEntry(
-                  1, metadata.recordType(), metadata.valueType(), metadata.intent()));
+      for (int i = 0; i < entryMetadata.size(); i++) {
+        metrics.recordAppendedEntry(
+            1, entryMetadata.recordType(i), entryMetadata.valueType(i), entryMetadata.intent(i));
+      }
       this.entryMetadata = null;
     }
     final var writeTimer = this.writeTimer;

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -13,8 +13,11 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit.Throttling;
 import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -104,7 +107,14 @@ public class FlowControlTest {
             i ->
                 flowControl.tryAcquire(
                     writeContext,
-                    List.of(new LogAppendEntryMetadata(RecordType.COMMAND, valueType, intent))))
+                    LogAppendEntryMetadata.copyMetadata(
+                        List.of(
+                            LogAppendEntry.of(
+                                new RecordMetadata()
+                                    .recordType(RecordType.COMMAND)
+                                    .valueType(valueType)
+                                    .intent(intent),
+                                new UnifiedRecordValue(0))))))
         .toList();
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadataTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadataTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Arrays;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+final class LogAppendEntryMetadataTest {
+
+  @Property
+  void shouldCopyMetadata(
+      @ForAll("recordTypes") final RecordType recordType,
+      @ForAll("valueTypes") final ValueType valueType,
+      @ForAll("intents") final Intent intent) {
+    // given
+    final var compatibleIntent = Intent.fromProtocolValue(valueType, intent.value());
+    final var entries = List.of(createEntry(recordType, valueType, compatibleIntent));
+
+    // when
+    final var metadata = LogAppendEntryMetadata.copyMetadata(entries);
+
+    // then
+    assertThat(metadata.size()).isEqualTo(1);
+    assertThat(metadata.recordType(0)).isEqualTo(recordType);
+    assertThat(metadata.valueType(0)).isEqualTo(valueType);
+    assertThat(metadata.intent(0)).isEqualTo(compatibleIntent);
+  }
+
+  private LogAppendEntry createEntry(
+      final RecordType recordType, final ValueType valueType, final Intent intent) {
+    final var metadata =
+        new RecordMetadata().recordType(recordType).valueType(valueType).intent(intent);
+    return LogAppendEntry.of(metadata, new UnifiedRecordValue(0));
+  }
+
+  @Provide
+  Arbitrary<RecordType> recordTypes() {
+    return Arbitraries.of(
+        Arrays.stream(RecordType.values()).filter(v -> v != RecordType.SBE_UNKNOWN).toList());
+  }
+
+  @Provide
+  Arbitrary<ValueType> valueTypes() {
+    return Arbitraries.of(
+        Arrays.stream(ValueType.values()).filter(v -> v != ValueType.SBE_UNKNOWN).toList());
+  }
+
+  @Provide
+  Arbitrary<Intent> intents() {
+    return Arbitraries.of(
+        Intent.INTENT_CLASSES.stream()
+            .flatMap(clazz -> Arrays.stream(clazz.getEnumConstants()))
+            .distinct()
+            .toList());
+  }
+}


### PR DESCRIPTION
# Description
Backport of #44840 to `stable/8.8`.

relates to #39881