### PR TITLE
[Backport stable/8.7] fix: do not enforce write limits for whitelisted commands

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -21,7 +21,10 @@ public class WhiteListedCommands {
       Set.of(
           JobIntent.COMPLETE,
           JobIntent.FAIL,
+<<<<<<< HEAD
           JobIntent.YIELD,
+=======
+>>>>>>> e395c6a6 (fix: do not enforce write limits for whitelisted commands)
           ProcessInstanceIntent.CANCEL,
           DeploymentIntent.CREATE,
           DeploymentIntent.DISTRIBUTE,


### PR DESCRIPTION
# Description
Backport of #38812 to `stable/8.7`.

relates to #38454