### PR TITLE
refactor: remove unused private methods

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -15,13 +15,11 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.async.NonBlockingByteBufferJsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -141,18 +139,6 @@ public interface TypedApiEntityConsumer<T> {
     @Override
     public int getBufferedBytes() {
       return bufferedBytes;
-    }
-
-    private String getJsonString() {
-      try (final ByteArrayOutputStream output = new ByteArrayOutputStream();
-          final JsonGenerator generator = json.createGenerator(output)) {
-        buffer.serialize(generator);
-        generator.flush();
-        return output.toString(StandardCharsets.UTF_8.name());
-      } catch (final Exception ex) {
-        LOGGER.warn("Failed to serialize JSON string", ex);
-        return "Original response cannot be constructed";
-      }
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
@@ -15,13 +15,11 @@
  */
 package io.camunda.client.impl.http;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.async.NonBlockingByteBufferJsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import io.camunda.client.protocol.rest.ProblemDetail;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -134,18 +132,6 @@ public interface TypedApiEntityConsumer<T> {
     @Override
     public int getBufferedBytes() {
       return bufferedBytes;
-    }
-
-    private String getJsonString() {
-      try (final ByteArrayOutputStream output = new ByteArrayOutputStream();
-          final JsonGenerator generator = json.createGenerator(output)) {
-        buffer.serialize(generator);
-        generator.flush();
-        return output.toString(StandardCharsets.UTF_8.name());
-      } catch (final Exception ex) {
-        LOGGER.warn("Failed to serialize JSON string", ex);
-        return "Original response cannot be constructed";
-      }
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -946,13 +946,6 @@ public class BrokerBasedPropertiesOverride {
     override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
   }
 
-  private void setArgIfNotNull(
-      final Map<String, Object> args, final String breadcrumb, final Object value) {
-    if (value != null) {
-      setArg(args, breadcrumb, value);
-    }
-  }
-
   @SuppressWarnings("unchecked")
   private void setArg(final Map<String, Object> args, final String breadcrumb, final Object value) {
     final String[] keys = breadcrumb.split("\\.");

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/usertest/UserTestDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/usertest/UserTestDataGenerator.java
@@ -24,7 +24,9 @@ import io.camunda.operate.util.ZeebeTestUtil;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -557,27 +559,6 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
                       .join();
                   break;
               }
-            })
-        .name("operate")
-        .timeout(Duration.ofSeconds(JOB_WORKER_TIMEOUT))
-        .open();
-  }
-
-  private JobWorker progressFlightRegistrationDetermineWeight() {
-    return client
-        .newWorker()
-        .jobType("determineLuggageWeight")
-        .handler(
-            (jobClient, job) -> {
-              if (!canProgress(job.getProcessInstanceKey())) {
-                return;
-              }
-              jobClient
-                  .newCompleteCommand(job.getKey())
-                  .variables(
-                      "{\"luggageWeight\":" + (ThreadLocalRandom.current().nextInt(10) + 20) + "}")
-                  .send()
-                  .join();
             })
         .name("operate")
         .timeout(Duration.ofSeconds(JOB_WORKER_TIMEOUT))

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/CallActivityIncidentZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/CallActivityIncidentZeebeIT.java
@@ -16,8 +16,6 @@ import static io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDt
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.camunda.operate.qa.util.RestAPITestUtil;
-import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.ProcessInstanceCoreStatisticsDto;
@@ -192,14 +190,6 @@ public class CallActivityIncidentZeebeIT extends OperateZeebeAbstractIT {
         .filteredOn(i -> i.getFlowNodeId().equals(CALL_ACTIVITY_ID))
         .extracting("state")
         .containsOnly(FlowNodeStateDto.ACTIVE);
-  }
-
-  private ListViewQueryDto createGetAllProcessInstancesQuery(final Long... processDefinitionKeys) {
-    final ListViewQueryDto q = RestAPITestUtil.createGetAllProcessInstancesQuery();
-    if (processDefinitionKeys != null && processDefinitionKeys.length > 0) {
-      q.setProcessIds(CollectionUtil.toSafeListOfStrings(processDefinitionKeys));
-    }
-    return q;
   }
 
   private ListViewResponseDto getProcessInstanceList(final ListViewRequestDto request)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/DecisionZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/DecisionZeebeIT.java
@@ -18,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.camunda.operate.data.util.DecisionDataUtil;
-import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.SearchTestRule;
 import io.camunda.operate.webapp.reader.DecisionReader;
@@ -147,9 +146,5 @@ public class DecisionZeebeIT extends OperateZeebeAbstractIT {
     assertThat(entity2.getId()).isEqualTo(entity1.getId());
     assertThat(entity2.getName()).isEqualTo(entity1.getName());
     assertThat(entity2.getDecisionId()).isEqualTo(entity1.getDecisionId());
-  }
-
-  private void createData() throws PersistenceException {
-    searchTestRule.persistOperateEntitiesNew(testDataUtil.createDecisionDefinitions());
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -7,13 +7,8 @@
  */
 package io.camunda.operate.webapp.opensearch.writer;
 
-import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ONLY_RUNTIME;
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.operate.util.CollectionUtil.getOrDefaultForNullValue;
 import static io.camunda.operate.util.ConversionUtils.toLongOrNull;
-import static io.camunda.operate.util.ExceptionHelper.withOperateRuntimeException;
 import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VARIABLE;
 import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
 
@@ -26,12 +21,10 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.ListViewStore;
 import io.camunda.operate.store.OperationStore;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import io.camunda.operate.store.opensearch.dsl.RequestDSL;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.opensearch.OpenSearchQueryHelper;
 import io.camunda.operate.webapp.reader.IncidentReader;
 import io.camunda.operate.webapp.reader.OperationReader;
-import io.camunda.operate.webapp.rest.dto.operation.CreateBatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
@@ -51,18 +44,12 @@ import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -389,73 +376,6 @@ public class OpensearchBatchOperationWriter
               ex.getMessage()),
           ex);
     }
-  }
-
-  private int addOperations(
-      final CreateBatchOperationRequestDto batchOperationRequest,
-      final BatchOperationEntity batchOperation)
-      throws IOException {
-    final int batchSize = operateProperties.getElasticsearch().getBatchSize();
-    Query query =
-        openSearchQueryHelper.createProcessInstancesQuery(batchOperationRequest.getQuery());
-    if (permissionsService.permissionsEnabled()) {
-      final PermissionType permission =
-          batchOperationRequest.getOperationType() == OperationType.DELETE_PROCESS_INSTANCE
-              ? PermissionType.DELETE_PROCESS_INSTANCE
-              : PermissionType.UPDATE_PROCESS_INSTANCE;
-      final var allowed = permissionsService.getProcessesWithPermission(permission);
-      final var permissionQuery =
-          allowed.isAll()
-              ? matchAll()
-              : stringTerms(ListViewTemplate.BPMN_PROCESS_ID, allowed.getIds());
-      query = constantScore(withTenantCheck(and(query, permissionQuery)));
-    }
-    final RequestDSL.QueryType queryType =
-        batchOperationRequest.getOperationType() == OperationType.DELETE_PROCESS_INSTANCE
-            ? ALL
-            : ONLY_RUNTIME;
-    final var searchRequestBuilder =
-        searchRequestBuilder(listViewTemplate, queryType)
-            .query(query)
-            .size(batchSize)
-            .source(
-                sourceInclude(
-                    OperationTemplate.PROCESS_INSTANCE_KEY,
-                    OperationTemplate.PROCESS_DEFINITION_KEY,
-                    OperationTemplate.BPMN_PROCESS_ID));
-
-    final AtomicInteger operationsCount = new AtomicInteger();
-
-    final Consumer<List<Hit<ProcessInstanceSource>>> hitsConsumer =
-        hits ->
-            withOperateRuntimeException(
-                () -> {
-                  final List<ProcessInstanceSource> processInstanceSources =
-                      hits.stream().map(Hit::source).toList();
-                  return operationsCount.addAndGet(
-                      persistOperationHelper.persistOperations(
-                          processInstanceSources,
-                          batchOperation.getId(),
-                          batchOperationRequest,
-                          null));
-                });
-
-    final Consumer<HitsMetadata<ProcessInstanceSource>> hitsMetadataConsumer =
-        hitsMeta -> {
-          validateTotalHits(hitsMeta);
-          batchOperation.setInstancesCount((int) hitsMeta.total().value());
-        };
-
-    richOpenSearchClient
-        .doc()
-        .unsafeScrollWith(
-            searchRequestBuilder,
-            hitsConsumer,
-            hitsMetadataConsumer,
-            ProcessInstanceSource.class,
-            false);
-
-    return operationsCount.get();
   }
 
   private void validateTotalHits(final HitsMetadata<?> hitsMeta) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/DecisionRestService.java
@@ -65,15 +65,6 @@ public class DecisionRestService extends InternalAPIErrorController {
     return batchOperationWriter.scheduleDeleteDecisionDefinition(decisionDefinitionEntity);
   }
 
-  private void checkIdentityReadPermission(final Long decisionDefinitionKey) {
-    final String decisionId = decisionReader.getDecision(decisionDefinitionKey).getDecisionId();
-    if (!permissionsService.hasPermissionForDecision(
-        decisionId, PermissionType.READ_DECISION_DEFINITION)) {
-      throw new NotAuthorizedException(
-          String.format("No read permission for decision %s", decisionId));
-    }
-  }
-
   private void checkIdentityDeletePermission(final String decisionId) {
     if (!permissionsService.hasPermissionForDecision(
         decisionId, PermissionType.DELETE_DECISION_INSTANCE)) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/AlertReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/AlertReaderES.java
@@ -178,8 +178,4 @@ public class AlertReaderES implements AlertReader {
     return ElasticsearchReaderUtil.mapHits(
         searchResponse.hits(), AlertDefinitionDto.class, objectMapper);
   }
-
-  private void logError(final String alertId) {
-    LOG.error("Was not able to retrieve alert with id [{}] from Elasticsearch.", alertId);
-  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/ProcessInstanceRepositoryES.java
@@ -8,8 +8,6 @@
 package io.camunda.optimize.service.db.repository.es;
 
 import static io.camunda.optimize.dto.optimize.DefinitionType.PROCESS;
-import static io.camunda.optimize.dto.optimize.ProcessInstanceConstants.ACTIVE_STATE;
-import static io.camunda.optimize.dto.optimize.ProcessInstanceConstants.SUSPENDED_STATE;
 import static io.camunda.optimize.service.db.DatabaseConstants.MAX_RESPONSE_SIZE_LIMIT;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.END_DATE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_INSTANCE_ID;
@@ -28,7 +26,6 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.camunda.optimize.dto.optimize.ImportRequestDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.PageResultDto;
@@ -267,12 +264,5 @@ class ProcessInstanceRepositoryES implements ProcessInstanceRepository {
     }
 
     return result;
-  }
-
-  private ImmutableMap<String, String> createUpdateStateScriptParamsMap(final String newState) {
-    return ImmutableMap.of(
-        "activeState", ACTIVE_STATE,
-        "suspendedState", SUSPENDED_STATE,
-        "newState", newState);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/RoundingUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/RoundingUtil.java
@@ -29,10 +29,6 @@ public final class RoundingUtil {
     }
   }
 
-  private static long round(final Double numberToRound) {
-    return Math.round(Math.log10(numberToRound));
-  }
-
   private static double roundUp(final Double numberToRound) {
     return Math.ceil(Math.log10(numberToRound));
   }

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -193,13 +193,6 @@
       <version>${version.guava}</version>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.opensearch.client</groupId>
-      <artifactId>opensearch-rest-client</artifactId>
-      <version>${version.opensearch}</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/UpgradeStepsIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/UpgradeStepsIT.java
@@ -406,8 +406,4 @@ public class UpgradeStepsIT extends AbstractUpgradeIT {
     return applyLookupSkip(
         new DeleteIndexIfExistsStep(indexMapping.getIndexName(), indexMapping.getVersion()));
   }
-
-  private Map<String, Set<String>> getAliasMap(final String aliasName) throws IOException {
-    return getPrefixAwareClient().getAliasesForIndexPattern(aliasName);
-  }
 }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/SchemaUpgradeClientOSReindexTest.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/os/SchemaUpgradeClientOSReindexTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.optimize.upgrade.os;
 
-import static io.camunda.optimize.service.util.mapper.ObjectMapperFactory.OPTIMIZE_MAPPER;
 import static io.camunda.optimize.upgrade.db.SchemaUpgradeClientFactory.createSchemaUpgradeClient;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -29,11 +28,9 @@ import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
 import io.camunda.optimize.upgrade.exception.UpgradeRuntimeException;
 import io.github.netmikey.logunit.api.LogCapturer;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.apache.http.HttpEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -43,7 +40,6 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.OngoingStubbing;
-import org.opensearch.client.Response;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.Retries;
 import org.opensearch.client.opensearch.core.ReindexRequest;
@@ -321,16 +317,5 @@ public class SchemaUpgradeClientOSReindexTest {
 
   private void mockCountResponseFromIndex(final String indexName, final long count) {
     when(openSearchClient.countWithoutPrefix(matches(indexName))).thenAnswer(a -> count);
-  }
-
-  private Response createOsResponse(final GetTasksResponse taskResponse) throws IOException {
-    final Response mockedReindexResponse = mock(Response.class);
-
-    final HttpEntity httpEntity = mock(HttpEntity.class);
-    when(httpEntity.getContent())
-        .thenReturn(new ByteArrayInputStream(OPTIMIZE_MAPPER.writeValueAsBytes(taskResponse)));
-    when(mockedReindexResponse.getEntity()).thenReturn(httpEntity);
-
-    return mockedReindexResponse;
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -901,13 +901,6 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     return openSearchClient.indices().rollover(rolloverRequest);
   }
 
-  private RolloverRequest applyAliasPrefixAndRolloverConditions(final RolloverRequest request) {
-    return new RolloverRequest.Builder()
-        .alias(indexNameService.getOptimizeIndexAliasForIndex(request.alias()))
-        .conditions(request.conditions())
-        .build();
-  }
-
   private String rolloverConditionsStatus(final Map<String, Boolean> conditions) {
     final String conditionsNotMet =
         conditions.entrySet().stream()

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
@@ -112,11 +112,6 @@ public class ElasticsearchClientBuilder {
   }
 
   private static RestClientBuilder.HttpClientConfigCallback createHttpClientConfigCallback(
-      final ConfigurationService configurationService) {
-    return createHttpClientConfigCallback(configurationService, null);
-  }
-
-  private static RestClientBuilder.HttpClientConfigCallback createHttpClientConfigCallback(
       final ConfigurationService configurationService,
       final SSLContext sslContext,
       final HttpRequestInterceptor... requestInterceptors) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -1463,17 +1463,4 @@ class UserTaskSearchIT {
               assertThat(resultComplete.items()).hasSize(1);
             });
   }
-
-  /**
-   * TODO: RDBMS returns the date as ISO String, there are ongoing discussion in which format the
-   * sort value should be returned for dates.
-   * https://camunda.slack.com/archives/C06UKS51QV9/p1738838925251429
-   */
-  private static String convertDateIfNeeded(final String millisOrIsoDate) {
-    if (millisOrIsoDate.contains("T")) {
-      return Long.toString(OffsetDateTime.parse(millisOrIsoDate).toInstant().toEpochMilli());
-    } else {
-      return millisOrIsoDate;
-    }
-  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -160,17 +160,6 @@ public class ProcessDefinitionTenancyIT {
         .join();
   }
 
-  private static void startProcessInstance(
-      final CamundaClient camundaClient, final String processId, final String tenant) {
-    camundaClient
-        .newCreateInstanceCommand()
-        .bpmnProcessId(processId)
-        .latestVersion()
-        .tenantId(tenant)
-        .send()
-        .join();
-  }
-
   private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
         .atMost(Duration.ofMinutes(1))

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupQueryTransformerTest.java
@@ -205,29 +205,6 @@ public class GroupQueryTransformerTest extends AbstractTransformerTest {
                                         q -> q.term(t -> t.field("join").value("group"))))))));
   }
 
-  private SearchQuery generateSearchQueryForParent(final String parentId, final String memberType) {
-    return SearchQuery.of(
-        q ->
-            q.bool(
-                b ->
-                    b.must(
-                        List.of(
-                            SearchQuery.of(
-                                q1 -> q1.term(t -> t.field("memberType").value(memberType))),
-                            SearchQuery.of(
-                                q1 ->
-                                    q1.hasParent(
-                                        p ->
-                                            p.parentType("group")
-                                                .query(
-                                                    SearchQuery.of(
-                                                        q2 ->
-                                                            q2.term(
-                                                                t ->
-                                                                    t.field("groupId")
-                                                                        .value(parentId))))))))));
-  }
-
   @Test
   public void shouldApplyAuthorizationCheck() {
     // given

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -13,7 +13,6 @@ import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchMatchPhraseQuery;
-import io.camunda.search.clients.query.SearchMatchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
 import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
@@ -680,19 +679,6 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
             (searchTermQuery) -> {
               assertThat(searchTermQuery.field()).isEqualTo(expectedField);
               assertThat(searchTermQuery.value().stringValue()).isEqualTo(expectedValue);
-            });
-  }
-
-  private void assertIsSearchMatchQuery(
-      final SearchQueryOption searchQueryOption,
-      final String expectedField,
-      final String expectedValue) {
-    assertThat(searchQueryOption)
-        .isInstanceOfSatisfying(
-            SearchMatchQuery.class,
-            (searchMatchQuery) -> {
-              assertThat(searchMatchQuery.field()).isEqualTo(expectedField);
-              assertThat(searchMatchQuery.query()).isEqualTo(expectedValue);
             });
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -58,11 +58,6 @@ public record ClusterVariableFilter(
       return this;
     }
 
-    private Builder valueUntypedOperations(final List<UntypedOperation> operations) {
-      valueOperations = addValuesToList(valueOperations, operations);
-      return this;
-    }
-
     public Builder values(final String value, final String... values) {
       return valueOperations(FilterUtil.mapDefaultToOperation(value, values));
     }

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
@@ -126,10 +126,6 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
     startProcessInstance("twoUserTasks", null);
   }
 
-  private void startMultipleVersionsProcess() {
-    startProcessInstance("multipleVersions", null);
-  }
-
   private void startOrderProcess() {
     final float price1 = Math.round(random.nextFloat() * 100000) / 100;
     final float price2 = Math.round(random.nextFloat() * 10000) / 100;

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -282,12 +282,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import javax.annotation.PostConstruct;
-import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
@@ -506,13 +505,6 @@ public class TasklistTester {
       result.add(new VariableInputDTO().setName(variables[i]).setValue(variables[i + 1]));
     }
     return result;
-  }
-
-  private String variableAsGraphqlInput(final VariableInputDTO variable) {
-    return String.format(
-        VARIABLE_INPUT_PATTERN,
-        variable.getName(),
-        StringEscapeUtils.escapeJson(variable.getValue()));
   }
 
   public TasklistTester completeUserTaskInZeebe() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -23,7 +23,6 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
 import io.camunda.client.api.command.CompleteUserTaskJobResultStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
-import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.JobKind;
@@ -664,28 +663,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         .stream()
         .filter(jobSelector::test)
         .findFirst();
-  }
-
-  private ActivatedJob getActivatedJob(final String jobType, final CamundaClient client) {
-    return awaitBehavior.until(
-        () ->
-            client
-                .newActivateJobsCommand()
-                .jobType(jobType)
-                .maxJobsToActivate(1)
-                .requestTimeout(Duration.ofSeconds(1)) // avoid long blocking call
-                .send()
-                .join()
-                .getJobs()
-                .stream()
-                .findFirst()
-                .orElse(null),
-        job ->
-            assertThat(job)
-                .withFailMessage(
-                    "Expected to complete a job with the type '%s' but no job is available.",
-                    jobType)
-                .isNotNull());
   }
 
   private void awaitIncident(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -34,8 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class CamundaProcessTestContainerRuntime
     implements AutoCloseable, CamundaProcessTestRuntime {
@@ -92,30 +90,6 @@ public class CamundaProcessTestContainerRuntime
           MultiTenancyConfiguration.MULTITENANCY_USER_USERNAME,
           MultiTenancyConfiguration.MULTITENANCY_USER_PASSWORD);
     }
-  }
-
-  /*
-   * The ES container has been removed in favor of an H2 database solution. However, the secondary
-   * storage implementation is going to become configurable in the near future so we're keeping
-   * this unused method in the code for now.
-   * {@see https://github.com/camunda/camunda/issues/29854}
-   */
-  private ElasticsearchContainer createElasticsearchContainer(
-      final Network network, final CamundaProcessTestRuntimeBuilder builder) {
-    final ElasticsearchContainer container =
-        containerFactory
-            .createElasticsearchContainer(
-                builder.getElasticsearchDockerImageName(),
-                builder.getElasticsearchDockerImageVersion())
-            .withLogConsumer(createContainerLogger(builder.getElasticsearchLoggerName()))
-            .withNetwork(network)
-            .withNetworkAliases(NETWORK_ALIAS_ELASTICSEARCH)
-            .withEnv(ContainerRuntimeEnvs.ELASTICSEARCH_ENV_XPACK_SECURITY_ENABLED, "false")
-            .withEnv(builder.getElasticsearchEnvVars());
-
-    builder.getElasticsearchExposedPorts().forEach(container::addExposedPort);
-
-    return container;
   }
 
   private CamundaContainer createCamundaContainer(
@@ -244,11 +218,6 @@ public class CamundaProcessTestContainerRuntime
     final Instant endTime = Instant.now();
     final Duration shutdownTime = Duration.between(startTime, endTime);
     LOGGER.info("Camunda container runtime stopped in {}", shutdownTime);
-  }
-
-  private static Slf4jLogConsumer createContainerLogger(final String name) {
-    final Logger logger = LoggerFactory.getLogger(name);
-    return new Slf4jLogConsumer(logger, true);
   }
 
   private static <T extends LogEntry> Slf4jJsonLogConsumer createContainerJsonLogger(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/PropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/PropertiesUtil.java
@@ -207,10 +207,6 @@ public class PropertiesUtil {
         .collect(Collectors.toList());
   }
 
-  private static String readProperty(final Properties properties, final String key) {
-    return readProperty(properties, key, Function.identity());
-  }
-
   private static <T> T readProperty(
       final Properties properties, final String key, final Function<String, T> converter) {
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -646,12 +646,6 @@ public class CamundaProcessTestContextIT {
     return deploymentEvent.getProcesses().stream().findFirst().get().getProcessDefinitionKey();
   }
 
-  private long deployProcessModel(final String resourceName) {
-    final DeploymentEvent deploymentEvent =
-        client.newDeployResourceCommand().addResourceFromClasspath(resourceName).send().join();
-    return deploymentEvent.getProcesses().stream().findFirst().get().getProcessDefinitionKey();
-  }
-
   private long deployDmnModel(final DmnModelInstance dmnModel) {
     final DeploymentEvent deploymentEvent =
         client

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
@@ -160,15 +160,6 @@ public class BackupServiceImplTest {
             "camunda_webapps_1_*_part_3_of_3");
   }
 
-  private void waitForAllTasks() {
-    try {
-      // wait for the executor to process all tasks
-      executor.submit(() -> {}).get();
-    } catch (final Exception ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
   private static class MockBackupRepository implements BackupRepository {
 
     SnapshotNameProvider snapshotNameProvider;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -71,21 +71,11 @@ import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -573,44 +563,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
     } else {
       initNioTransport();
     }
-  }
-
-  private X509Certificate[] getCertificateChain(final File keyStoreFile, final String password)
-      throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
-    final var keyStore = getKeyStore(keyStoreFile, password);
-
-    final String alias = keyStore.aliases().nextElement();
-    return Arrays.stream(keyStore.getCertificateChain(alias))
-        .map(X509Certificate.class::cast)
-        .toArray(X509Certificate[]::new);
-  }
-
-  private PrivateKey getPrivateKey(final File keyStoreFile, final String password)
-      throws CertificateException,
-          KeyStoreException,
-          IOException,
-          NoSuchAlgorithmException,
-          UnrecoverableKeyException {
-    final var keyStore = getKeyStore(keyStoreFile, password);
-
-    final String alias = keyStore.aliases().nextElement();
-    return (PrivateKey) keyStore.getKey(alias, password.toCharArray());
-  }
-
-  private KeyStore getKeyStore(final File keyStoreFile, final String password)
-      throws KeyStoreException {
-    final var keyStore = KeyStore.getInstance("PKCS12");
-    try {
-      keyStore.load(new FileInputStream(keyStoreFile), password.toCharArray());
-    } catch (final Exception e) {
-      throw new IllegalStateException(
-          String.format(
-              "Keystore failed to load file: %s, please ensure it is a valid PKCS12 keystore",
-              keyStoreFile.toPath()),
-          e);
-    }
-
-    return keyStore;
   }
 
   private void initEpollTransport() {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -345,15 +345,6 @@ public final class S3BackupStore implements BackupStore {
     return config.basePath().map(base -> base + "/").orElse("") + "ranges/" + partitionId + "/";
   }
 
-  private CompletableFuture<List<ObjectIdentifier>> listBackupObjects(final Manifest manifest) {
-    return listObjects(manifest, Directory.CONTENTS);
-  }
-
-  private CompletableFuture<List<ObjectIdentifier>> listBackupManifestObjects(
-      final Manifest manifest) {
-    return listObjects(manifest, Directory.MANIFESTS);
-  }
-
   private CompletableFuture<List<ObjectIdentifier>> listObjects(
       final Manifest manifest, final Directory directory) {
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -130,8 +130,4 @@ fixed:
     final var actualDistribution = getDistribution(partitionDistribution);
     assertThat(actualDistribution).containsExactlyInAnyOrderEntriesOf(expectedDistribution);
   }
-
-  private static MemberId member(final int id) {
-    return MemberId.from(String.valueOf(id));
-  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -630,12 +630,6 @@ public final class BrokerCfgTest {
     assertThat(networkCfg.getInternalApi().getHost()).isEqualTo(internal);
   }
 
-  private void assertAdvertisedHost(final String configFileName, final String host) {
-    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
-    final NetworkCfg networkCfg = brokerCfg.getNetwork();
-    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
-  }
-
   private void assertAdvertisedAddress(
       final String configFileName, final String host, final int port) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -386,10 +386,6 @@ class RepositoryNodeIdProviderIT {
     assertLeaseIs(true);
   }
 
-  private void assertLeaseIsNotReady() {
-    assertLeaseIs(false);
-  }
-
   private void assertLeaseIs(final boolean status) {
     Awaitility.await("Until the lease is acquired")
         .untilAsserted(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -24,13 +24,11 @@ import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
 import java.util.Optional;
-import java.util.Set;
 import org.agrona.concurrent.UnsafeBuffer;
 
 /**
@@ -180,11 +178,5 @@ public class BpmnJobActivationBehavior {
                 .tenantId(ownerTenantId)
                 .build())
         .isRight(); // we only care if the job stream is authorized, not why it isn't
-  }
-
-  private boolean isAuthorizedForJob(
-      final JobRecord jobRecord, final Set<AuthorizationScope> authorizedProcessIds) {
-    return authorizedProcessIds.contains(AuthorizationScope.WILDCARD)
-        || authorizedProcessIds.contains(AuthorizationScope.id(jobRecord.getBpmnProcessId()));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -227,17 +226,5 @@ public class UpdateAuthorizationMultipartitionTest {
         .isEqualTo(
             "Expected to create or update authorization with ownerId or resourceId '%s', but a mapping rule with this ID does not exist."
                 .formatted(nonexistentMappingRuleId));
-  }
-
-  private void interceptAuthorizationCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == AuthorizationIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerMultiInstanceActivitiesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerMultiInstanceActivitiesTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.executi
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.PROCESS_ID;
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.SERVICE_TASK_TYPE;
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.START_EL_TYPE;
-import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.SUB_PROCESS_ID;
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.createProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
@@ -66,12 +65,6 @@ public class ExecutionListenerMultiInstanceActivitiesTest {
 
     // then
     assertExecutionListenerEvents(processInstanceKey);
-  }
-
-  private static void createChildProcess() {
-    final var childProcess =
-        Bpmn.createExecutableProcess(SUB_PROCESS_ID).startEvent().manualTask().endEvent().done();
-    ENGINE.deployment().withXmlResource("child.xml", childProcess).deploy();
   }
 
   private BpmnModelInstance buildMainProcessModel(boolean sequential) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
@@ -788,12 +787,6 @@ public final class CreateDeploymentMultiplePartitionsTest {
         .isLessThan(repeated.getDecisionRequirementsVersion());
     assertThat(original.getDecisionRequirementsKey())
         .isLessThan(repeated.getDecisionRequirementsKey());
-  }
-
-  private byte[] bpmnXml(final BpmnModelInstance definition) {
-    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-    Bpmn.writeModelToStream(outStream, definition);
-    return outStream.toByteArray();
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
@@ -373,18 +373,6 @@ public final class CorrelateMessageTest {
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
-  private static void assertMessageIsNotCorrelated(
-      final Record<MessageCorrelationRecordValue> record) {
-    Assertions.assertThat(record)
-        .hasIntent(MessageCorrelationIntent.NOT_CORRELATED)
-        .hasRecordType(RecordType.EVENT)
-        .hasValueType(ValueType.MESSAGE_CORRELATION);
-    Assertions.assertThat(record.getValue())
-        .hasCorrelationKey(CORRELATION_KEY)
-        .hasName(MESSAGE_NAME)
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
   private void deployProcessWithMessageStartEvent(final String processId) {
     engine
         .deployment()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2901,20 +2901,6 @@ public class ModifyProcessInstanceTest {
         .getKey();
   }
 
-  private void assertThatElementIsTerminated(
-      final long processInstanceKey, final String elementId) {
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .onlyEvents()
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId(elementId)
-                .limit(elementId, ProcessInstanceIntent.ELEMENT_TERMINATED)
-                .toList())
-        .extracting(Record::getIntent)
-        .containsSequence(
-            ProcessInstanceIntent.ELEMENT_TERMINATING, ProcessInstanceIntent.ELEMENT_TERMINATED);
-  }
-
   @Test
   public void shouldSubscribeToConditionalBoundaryEvent() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/PendingProcessMessageSubscriptionStateTest.java
@@ -253,11 +253,6 @@ public final class PendingProcessMessageSubscriptionStateTest {
   }
 
   private ProcessMessageSubscriptionRecord subscriptionRecord(
-      final String name, final String correlationKey, final long elementInstanceKey) {
-    return subscriptionRecord("handler", name, correlationKey, elementInstanceKey);
-  }
-
-  private ProcessMessageSubscriptionRecord subscriptionRecord(
       final String handlerId,
       final String name,
       final String correlationKey,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.exporter.handlers;
 
-import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSITION;
-import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.BPMN_PROCESS_ID;
-import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.FLOW_NODE_ID;
-import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.PROCESS_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -529,30 +525,6 @@ public class IncidentHandlerTest {
     assertThat(incidentEntity.getErrorType())
         .isEqualTo(
             io.camunda.webapps.schema.entities.incident.ErrorType.AD_HOC_SUB_PROCESS_NO_RETRIES);
-  }
-
-  private String concurrencyScriptMock() {
-    return String.format(
-        "if (ctx._source.%s == null || ctx._source.%s < params.%s) { "
-            + "ctx._source.%s = params.%s; " // position
-            + "if (params.%s != null) {"
-            + "   ctx._source.%s = params.%s; " // PROCESS_DEFINITION_KEY
-            + "   ctx._source.%s = params.%s; " // BPMN_PROCESS_ID
-            + "   ctx._source.%s = params.%s; " // FLOW_NODE_ID
-            + "}"
-            + "}",
-        POSITION,
-        POSITION,
-        POSITION,
-        POSITION,
-        POSITION,
-        PROCESS_DEFINITION_KEY,
-        PROCESS_DEFINITION_KEY,
-        PROCESS_DEFINITION_KEY,
-        BPMN_PROCESS_ID,
-        BPMN_PROCESS_ID,
-        FLOW_NODE_ID,
-        FLOW_NODE_ID);
   }
 
   private static void assertEntityFields(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -525,12 +525,4 @@ final class JobHandlerTest {
   private Record<JobRecordValue> generateRecord(final JobIntent intent) {
     return factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
   }
-
-  private void assertShouldHandleRecord(final Record<JobRecordValue> record) {
-    assertThat(underTest.handlesRecord(record)).isTrue();
-  }
-
-  private void assertShouldNotHandleRecord(final Record<JobRecordValue> record) {
-    assertThat(underTest.handlesRecord(record)).isFalse();
-  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -14,7 +14,6 @@ import io.camunda.gateway.mapping.http.mapper.TenantMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mapping.http.validator.TenantRequestValidator;
-import io.camunda.gateway.protocol.model.GroupSearchQueryResult;
 import io.camunda.gateway.protocol.model.MappingRuleSearchQueryRequest;
 import io.camunda.gateway.protocol.model.MappingRuleSearchQueryResult;
 import io.camunda.gateway.protocol.model.RoleSearchQueryRequest;
@@ -30,13 +29,10 @@ import io.camunda.gateway.protocol.model.TenantSearchQueryResult;
 import io.camunda.gateway.protocol.model.TenantUpdateRequest;
 import io.camunda.gateway.protocol.model.TenantUserSearchQueryRequest;
 import io.camunda.gateway.protocol.model.TenantUserSearchResult;
-import io.camunda.gateway.protocol.model.UserSearchResult;
-import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.TenantMemberQuery;
 import io.camunda.search.query.TenantQuery;
-import io.camunda.search.query.UserQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.validation.IdentifierValidator;
 import io.camunda.security.validation.TenantValidator;
@@ -59,7 +55,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping("/v2/tenants")
@@ -369,34 +367,6 @@ public class TenantController {
     }
   }
 
-  private ResponseEntity<UserSearchResult> searchUsersInTenant(
-      final String tenantId, final UserQuery userQuery) {
-    try {
-      final var composedUserQuery = buildUserQuery(tenantId, userQuery);
-      final var result =
-          userServices
-              .withAuthentication(authenticationProvider.getCamundaAuthentication())
-              .search(composedUserQuery);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
-  }
-
-  private ResponseEntity<GroupSearchQueryResult> searchGroupsInTenant(
-      final String tenantId, final GroupQuery groupQuery) {
-    try {
-      final var composedGroupQuery = buildGroupQuery(tenantId, groupQuery);
-      final var result =
-          groupServices
-              .withAuthentication(authenticationProvider.getCamundaAuthentication())
-              .search(composedGroupQuery);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
-  }
-
   private ResponseEntity<RoleSearchQueryResult> searchRolesInTenant(
       final String tenantId, final RoleQuery roleQuery) {
     try {
@@ -422,18 +392,6 @@ public class TenantController {
       final String tenantId, final MappingRuleQuery mappingRuleQuery) {
     return mappingRuleQuery.toBuilder()
         .filter(mappingRuleQuery.filter().toBuilder().tenantId(tenantId).build())
-        .build();
-  }
-
-  private UserQuery buildUserQuery(final String tenantId, final UserQuery userQuery) {
-    return userQuery.toBuilder()
-        .filter(userQuery.filter().toBuilder().tenantId(tenantId).build())
-        .build();
-  }
-
-  private GroupQuery buildGroupQuery(final String tenantId, final GroupQuery groupQuery) {
-    return groupQuery.toBuilder()
-        .filter(groupQuery.filter().toBuilder().tenantId(tenantId).build())
         .build();
   }
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamReaderRule.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamReaderRule.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.rules.ExternalResource;
 
 public final class LogStreamReaderRule extends ExternalResource {
@@ -52,11 +50,6 @@ public final class LogStreamReaderRule extends ExternalResource {
       }
     }
     return null;
-  }
-
-  private DirectBuffer eventValue(final LoggedEvent event) {
-    assertThat(event).isNotNull();
-    return new UnsafeBuffer(event.getValueBuffer(), event.getValueOffset(), event.getValueLength());
   }
 
   public LogStreamReader resetReader() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClusteredBackupRestoreTest.java
@@ -19,10 +19,6 @@ import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupRuntimeResponse;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
-import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
-import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.cluster.TestClusterBuilder;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
@@ -113,18 +109,6 @@ public class ClusteredBackupRestoreTest {
 
       assertThatNoException().isThrownBy(() -> restoreApp.start());
     }
-  }
-
-  private static void configureBackupStore(final BrokerCfg brokerCfg) {
-    final var backup = brokerCfg.getData().getBackup();
-
-    final var storeConfig = new GcsBackupStoreConfig();
-    storeConfig.setAuth(GcsBackupStoreAuth.NONE);
-    storeConfig.setBucketName(BUCKET_NAME);
-    storeConfig.setHost(GCS.externalEndpoint());
-
-    backup.setStore(BackupStoreType.GCS);
-    backup.setGcs(storeConfig);
   }
 
   private static void configureBackupStore(final Camunda config) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
@@ -89,10 +89,6 @@ public class ClusterPurgeTest {
     }
   }
 
-  private static void getSet(final boolean newValue) {
-    PurgingExporter.BLOCK_PURGE.set(newValue);
-  }
-
   private void configureExporter(final ExporterCfg exporterCfg) {
     exporterCfg.setClassName(PurgingExporter.class.getName());
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/IdentitySetupInitializerIT.java
@@ -251,11 +251,6 @@ final class IdentitySetupInitializerIT {
   }
 
   private void createBroker(
-      final boolean authorizationsEnabled, final int partitionCount, final Path tempDir) {
-    createBroker(authorizationsEnabled, partitionCount, tempDir, cfg -> {});
-  }
-
-  private void createBroker(
       final boolean authorizationsEnabled,
       final int partitionCount,
       final Consumer<CamundaSecurityProperties> securityCfg) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
@@ -128,10 +128,6 @@ public final class SnapshotMetrics {
     return snapshotTransferDuration.get(encodeBoolean(isBootstrap));
   }
 
-  private static boolean decodeBoolean(final int i) {
-    return i == 1;
-  }
-
   private static int encodeBoolean(final boolean b) {
     return b ? 1 : 0;
   }


### PR DESCRIPTION
Done using openrewrite:

```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-static-analysis:RELEASE -Drewrite.activeRecipes=org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods -Drewrite.exportDatatables=true
```

with a bit of manual intervention after
