### PR TITLE
fix: use staleTime to prevent multiple requests

### DIFF
--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -45,6 +45,7 @@ const useElementInstancesSearch = (params: UseElementInstancesSearchParams) => {
       }
       throw error;
     },
+    staleTime: 10000,
     enabled,
   });
 };


### PR DESCRIPTION
## Description

Adds a stale time to the query to prevent re-renders

## Related issues

related to #44554 
