### PR TITLE
Much lower refresh interval for multidb tests

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -334,6 +334,6 @@ public class MultiDbConfigurator {
 
   private static void overrideRefreshInterval(final DocumentBasedSecondaryStorageDatabase db) {
     // make refresh interval lower so tests can run a bit faster
-    db.setRefreshIntervalByIndexName(Map.of("list-view", "1s"));
+    db.setRefreshInterval("100ms");
   }
 }


### PR DESCRIPTION
This shaves about a minute off the Elasticsearch database tests.