### PR TITLE
fix: AHSP instance child fetching

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -181,33 +181,10 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
       await screen.findByText('Ad Hoc Inner Subprocess Test'),
     ).toBeInTheDocument();
 
-    mockServer.use(
-      http.post(
-        endpoints.queryElementInstances.getUrl(),
-        async ({request}) => {
-          const body = await request.json();
-          const result = queryElementInstancesRequestBodySchema.safeParse(body);
-
-          if (
-            !result.success ||
-            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
-          ) {
-            return HttpResponse.json(
-              {
-                error:
-                  'Invalid payload: elementInstanceScopeKey must be in filter',
-              },
-              {status: 400},
-            );
-          }
-
-          return HttpResponse.json(
-            adHocSubProcessInnerInstanceElementInstances.emptyLevel,
-          );
-        },
-        {once: true},
-      ),
-    );
+    mockSearchElementInstances().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
 
     await user.click(
       await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
@@ -246,27 +223,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
       await screen.findByText('Ad Hoc Inner Subprocess Test'),
     ).toBeInTheDocument();
 
-    mockServer.use(
-      http.post(
-        endpoints.queryElementInstances.getUrl(),
-        async ({request}) => {
-          const body = await request.json();
-          const result = queryElementInstancesRequestBodySchema.safeParse(body);
-
-          if (
-            !result.success ||
-            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
-          ) {
-            throw new Error(
-              'Test assertion failed: Invalid payload structure. Expected filter.elementInstanceScopeKey="inner-1"',
-            );
-          }
-
-          return HttpResponse.json({error: 'an error occurred'}, {status: 400});
-        },
-        {once: true},
-      ),
-    );
+    mockSearchElementInstances().withNetworkError();
 
     await user.click(
       await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -23,6 +23,12 @@ import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {parseDiagramXML} from 'modules/utils/bpmn';
 import {businessObjectsParser} from 'modules/queries/processDefinitions/useBusinessObjects';
+import {mockServer} from 'modules/mock-server/node';
+import {http, HttpResponse} from 'msw';
+import {
+  endpoints,
+  queryElementInstancesRequestBodySchema,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 
 const diagramModel = await parseDiagramXML(adHocSubProcessInnerInstance);
 const businessObjects = businessObjectsParser({diagramModel});
@@ -111,8 +117,32 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
       await screen.findByText('Ad Hoc Inner Subprocess Test'),
     ).toBeInTheDocument();
 
-    mockSearchElementInstances().withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.level2,
+    mockServer.use(
+      http.post(
+        endpoints.queryElementInstances.getUrl(),
+        async ({request}) => {
+          const body = await request.json();
+          const result = queryElementInstancesRequestBodySchema.safeParse(body);
+
+          if (
+            !result.success ||
+            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
+          ) {
+            return HttpResponse.json(
+              {
+                error:
+                  'Invalid payload: elementInstanceScopeKey must be in filter',
+              },
+              {status: 400},
+            );
+          }
+
+          return HttpResponse.json(
+            adHocSubProcessInnerInstanceElementInstances.level2,
+          );
+        },
+        {once: true},
+      ),
     );
     await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
 
@@ -131,6 +161,8 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
         }),
       );
     });
+
+    expect(notificationsStore.notifications).toEqual([]);
   });
 
   it('should display warning notification when inner instance has no children', async () => {
@@ -149,8 +181,91 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
       await screen.findByText('Ad Hoc Inner Subprocess Test'),
     ).toBeInTheDocument();
 
-    mockSearchElementInstances().withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.emptyLevel,
+    mockServer.use(
+      http.post(
+        endpoints.queryElementInstances.getUrl(),
+        async ({request}) => {
+          const body = await request.json();
+          const result = queryElementInstancesRequestBodySchema.safeParse(body);
+
+          if (
+            !result.success ||
+            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
+          ) {
+            return HttpResponse.json(
+              {
+                error:
+                  'Invalid payload: elementInstanceScopeKey must be in filter',
+              },
+              {status: 400},
+            );
+          }
+
+          return HttpResponse.json(
+            adHocSubProcessInnerInstanceElementInstances.emptyLevel,
+          );
+        },
+        {once: true},
+      ),
+    );
+
+    await user.click(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='false']",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(notificationsStore.notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'warning',
+            title:
+              'No child instances found for Ad Hoc Sub Process Inner Instance',
+          }),
+        ]),
+      );
+    });
+
+    expect(flowNodeSelectionStore.state.selection).toEqual(originalSelection);
+  });
+
+  it('should display warning notification when fetching first child fails', async () => {
+    const {user} = render(
+      <ElementInstancesTree
+        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+        businessObjects={businessObjects}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+    const originalSelection = flowNodeSelectionStore.state.selection;
+
+    expect(
+      await screen.findByText('Ad Hoc Inner Subprocess Test'),
+    ).toBeInTheDocument();
+
+    mockServer.use(
+      http.post(
+        endpoints.queryElementInstances.getUrl(),
+        async ({request}) => {
+          const body = await request.json();
+          const result = queryElementInstancesRequestBodySchema.safeParse(body);
+
+          if (
+            !result.success ||
+            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
+          ) {
+            throw new Error(
+              'Test assertion failed: Invalid payload structure. Expected filter.elementInstanceScopeKey="inner-1"',
+            );
+          }
+
+          return HttpResponse.json({error: 'an error occurred'}, {status: 400});
+        },
+        {once: true},
+      ),
     );
 
     await user.click(

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -553,7 +553,7 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
       } = useElementInstanceHistoryTree();
       const {refetch: fetchFirstChild} = useSearchElementInstancesByScope(
         {
-          elementInstanceScopeKey: scopeKey,
+          filter: {elementInstanceScopeKey: scopeKey},
           page: {limit: 1, from: 0},
           sort: [{field: 'startDate', order: 'asc'}],
         },

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -155,7 +155,7 @@ const queryKeys = {
     },
     searchByScope: (
       payload: Pick<QueryElementInstancesRequestBody, 'page' | 'sort'> & {
-        elementInstanceScopeKey: string;
+        filter: {elementInstanceScopeKey: string};
       },
     ) => {
       return ['elementInstancesSearchByScope', ...Object.values(payload)];


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This issue only happens when we select an ad-hoc sub-process that's not expanded.

The type checking didn't pick this up because on the schemas we use `object()` and not [`strictObject()`](https://zod.dev/api#zstrictobject)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44895
