### PR TITLE
feat: add process decision instance deletion in `HistoryDeletionDeleteProcessor`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
@@ -48,6 +48,12 @@ public class HistoryDeletionClient {
     return this;
   }
 
+  public HistoryDeletionClient decisionInstance(final long decisionInstanceKey) {
+    record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
+    record.setResourceKey(decisionInstanceKey);
+    return this;
+  }
+
   public Record<HistoryDeletionRecordValue> delete() {
     final long position = writer.writeCommand(HistoryDeletionIntent.DELETE, record);
     return expectation.apply(position);


### PR DESCRIPTION
## Description

Extend the command processor for decision instance support
Refactor: remove duplicate code into `writeHistoryDeletionEvent`

## Related issues

closes #42399
