### PR TITLE
Default Record Filter introduction

### DIFF
--- a/zeebe/exporter-filter/pom.xml
+++ b/zeebe/exporter-filter/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -37,6 +42,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-api</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/zeebe/exporter-filter/pom.xml
+++ b/zeebe/exporter-filter/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.Collections;
+
+public final class DefaultRecordFilter implements Context.RecordFilter {
+
+  private final ExportRecordFilterChain exportRecordFilterChain;
+  private final FilterConfiguration configuration;
+
+  public DefaultRecordFilter(final FilterConfiguration configuration) {
+    this.configuration = configuration;
+
+    // The next PR will implement the filters to be added in the chain
+    exportRecordFilterChain = new ExportRecordFilterChain(Collections.emptyList());
+  }
+
+  @Override
+  public boolean acceptType(final RecordType recordType) {
+    return configuration.shouldIndexRecordType(recordType);
+  }
+
+  @Override
+  public boolean acceptValue(final ValueType valueType) {
+    return configuration.shouldIndexValueType(valueType);
+  }
+
+  @Override
+  public boolean acceptRecord(final Record<?> record) {
+    return exportRecordFilterChain.acceptRecord(record);
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChain.java
@@ -8,8 +8,12 @@
 package io.camunda.zeebe.exporter.filter;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Applies a chain of {@link ExporterRecordFilter}s to determine whether a record should be
@@ -20,6 +24,8 @@ import java.util.Objects;
  */
 public final class ExportRecordFilterChain {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ExportRecordFilterChain.class);
+
   private final List<ExporterRecordFilter> recordFilters;
 
   public ExportRecordFilterChain(final List<ExporterRecordFilter> recordFilters) {
@@ -29,6 +35,55 @@ public final class ExportRecordFilterChain {
 
   /** Returns {@code true} if the record passes all configured filters. */
   public boolean acceptRecord(final Record<?> record) {
-    return recordFilters.stream().allMatch(filter -> filter.accept(record));
+    return recordFilters.stream()
+        .allMatch(
+            filter -> {
+              if (filter instanceof final RecordVersionFilter versionFilter) {
+                if (!shouldApplyVersionedFilter(record, versionFilter)) {
+                  // For records from older brokers, skip this filter => treat as "passed"
+                  return true;
+                }
+              }
+
+              // Apply the filter normally
+              return filter.accept(record);
+            });
+  }
+
+  private boolean shouldApplyVersionedFilter(
+      final Record<?> record, final RecordVersionFilter versionFilter) {
+
+    final SemanticVersion minVersion = versionFilter.minRecordBrokerVersion();
+    final String rawBrokerVersion = record.getBrokerVersion();
+    final Optional<SemanticVersion> brokerVersion = SemanticVersion.parse(rawBrokerVersion);
+
+    if (brokerVersion.isEmpty()) {
+      // Unparseable broker version -> conservatively NOT apply the filter
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Unable to parse broker version '{}' for record {} when applying filter {} "
+                + "(minRecordBrokerVersion={}). Not applying the filter conservatively.",
+            rawBrokerVersion,
+            summarizeRecord(record),
+            versionFilter.getClass().getSimpleName(),
+            minVersion);
+      }
+      return false;
+    }
+
+    return brokerVersion.get().compareTo(minVersion) >= 0;
+  }
+
+  private String summarizeRecord(final Record<?> record) {
+    return "type="
+        + record.getValueType()
+        + ", intent="
+        + record.getIntent()
+        + ", key="
+        + record.getKey()
+        + ", partitionId="
+        + record.getPartitionId()
+        + ", position="
+        + record.getPosition();
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+
+/**
+ * Configuration for exporter record filtering.
+ *
+ * <p>Implementations define which {@link RecordType} and {@link ValueType} should be indexed by an
+ * exporter. This provides a shared, backend-agnostic configuration that can be used by both the
+ * Elasticsearch and OpenSearch exporters to decide which records to export, while leaving the
+ * actual indexing mechanics to each exporter.
+ */
+public interface FilterConfiguration {
+
+  boolean shouldIndexValueType(ValueType valueType);
+
+  boolean shouldIndexRequiredValueType(ValueType valueType);
+
+  boolean shouldIndexRecordType(RecordType recordType);
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/RecordVersionFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/RecordVersionFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.util.SemanticVersion;
+
+/**
+ * Marks a filter as only applicable from a given broker/record version onward.
+ *
+ * <p>When used in an {@link ExportRecordFilterChain}, filters implementing this interface are
+ * applied only if the record's broker version is greater than or equal to {@link
+ * #minRecordBrokerVersion()}. For older records, the filter is skipped and treated as if it had
+ * accepted the record.
+ */
+@FunctionalInterface
+public interface RecordVersionFilter {
+
+  /**
+   * The minimum broker/record version (e.g. {@code "8.9.0"}) from which this filter should be
+   * applied.
+   */
+  SemanticVersion minRecordBrokerVersion();
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.exporter.filter.config.TestConfiguration;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.junit.jupiter.api.Test;
+
+final class DefaultRecordFilterTest {
+
+  @Test
+  void shouldAcceptOnlyConfiguredRecordTypes() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedRecordType(RecordType.COMMAND);
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptType(RecordType.EVENT)).isTrue();
+    assertThat(filter.acceptType(RecordType.COMMAND)).isTrue();
+
+    assertThat(filter.acceptType(RecordType.COMMAND_REJECTION)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptOnlyConfiguredValueTypes() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedValueType(ValueType.VARIABLE)
+            .withIndexedValueType(ValueType.PROCESS_INSTANCE);
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptValue(ValueType.VARIABLE)).isTrue();
+    assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE)).isTrue();
+
+    assertThat(filter.acceptValue(ValueType.JOB)).isFalse();
+  }
+
+  @Test
+  void shouldNotTreatRequiredOnlyValueTypesAsNormalIndexed() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            // Only mark JOB as "required", not normal
+            .withRequiredValueType(ValueType.JOB);
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptValue(ValueType.JOB))
+        .as("Required-only value types should not be accepted as normal indexed types")
+        .isFalse();
+
+    assertThat(configuration.shouldIndexRequiredValueType(ValueType.JOB)).isTrue();
+  }
+
+  @Test
+  void shouldAcceptAllRecordsWithEmptyFilterChain() {
+    // given
+    final var configuration = new TestConfiguration();
+    final var filter = new DefaultRecordFilter(configuration);
+    final Record<?> record = mock(Record.class);
+
+    // when
+    final boolean accepted = filter.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChainTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/ExportRecordFilterChainTest.java
@@ -13,11 +13,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class ExportRecordFilterChainTest {
+
+  public static final SemanticVersion VERSION_8_8_0 = SemanticVersion.parse("8.8.0").orElseThrow();
+  public static final SemanticVersion VERSION_8_9_0 = SemanticVersion.parse("8.9.0").orElseThrow();
+  public static final SemanticVersion VERSION_8_10_0 =
+      SemanticVersion.parse("8.10.0").orElseThrow();
 
   private final Record<?> record = mock(Record.class);
 
@@ -92,5 +101,305 @@ class ExportRecordFilterChainTest {
     assertThat(accepted).isFalse();
     verify(filter1).accept(record);
     verify(filter2).accept(record);
+  }
+
+  @Test
+  void shouldAcceptRecordWhenNoRecordFiltersConfigured() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final var chain = new ExportRecordFilterChain(List.of() /* no filters */);
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldApplyNonVersionedFilter() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          calls.incrementAndGet();
+          return false; // actively reject
+        };
+
+    final var chain = new ExportRecordFilterChain(List.of(nonVersionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSkipVersionedFilterForOlderBrokerVersion() {
+    // given
+    // Broker version lower than 8.9.0
+    when(record.getBrokerVersion()).thenReturn("8.8.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ false, calls);
+
+    final var chain = new ExportRecordFilterChain(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    // For older versions, versioned filter should be skipped; record should be accepted.
+    assertThat(accepted).isTrue();
+    assertThat(calls.get())
+        .as("Versioned filter should not be called for records below min version")
+        .isZero();
+  }
+
+  @Test
+  void shouldApplyVersionedFilterForNewerOrEqualBrokerVersion() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.9.0"); // equal to min version
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ false, calls);
+
+    final var chain = new ExportRecordFilterChain(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(calls.get()).as("Versioned filter must be applied for >= min version").isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotApplyVersionedFilterWhenBrokerVersionUnparseable() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("not-a-semver");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger calls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ false, calls);
+
+    final var chain = new ExportRecordFilterChain(List.of(versionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    // Unparseable broker version -> conservatively NOT apply the filter
+    assertThat(accepted).isTrue();
+    assertThat(calls.get()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldShortCircuitOnFirstRejectingFilter() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.9.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final ExporterRecordFilter firstFilter =
+        r -> {
+          firstCalls.incrementAndGet();
+          return false;
+        };
+    final ExporterRecordFilter secondFilter =
+        r -> {
+          secondCalls.incrementAndGet();
+          return true;
+        };
+
+    final var chain = new ExportRecordFilterChain(List.of(firstFilter, secondFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(accepted).isFalse();
+    assertThat(firstCalls.get()).isEqualTo(1);
+    assertThat(secondCalls.get())
+        .as("Subsequent filters should not be evaluated after first reject")
+        .isZero();
+  }
+
+  @Test
+  void shouldSkipVersionedFilterButApplyNonVersionedFilterForOlderBrokerVersion() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.8.0"); // < 8.9.0
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger versionedCalls = new AtomicInteger(0);
+    final AtomicInteger nonVersionedCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter versionedFilter =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ true, versionedCalls);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          nonVersionedCalls.incrementAndGet();
+          return false; // actively reject
+        };
+
+    final var chain = new ExportRecordFilterChain(List.of(versionedFilter, nonVersionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    // Versioned filter skipped due to older broker version; non-versioned filter still applied
+    assertThat(accepted).isFalse();
+    assertThat(versionedCalls.get())
+        .as("Versioned filter should not be called for records below min version")
+        .isZero();
+    assertThat(nonVersionedCalls.get())
+        .as("Non-versioned filter should still be evaluated")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldApplyOnlyQualifiedVersionedFiltersInChain() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.8.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter firstVersioned =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ true, firstCalls);
+    final TestVersionedFilter secondVersioned =
+        new TestVersionedFilter(VERSION_8_8_0, /* acceptResult= */ false, secondCalls);
+
+    final var chain = new ExportRecordFilterChain(List.of(firstVersioned, secondVersioned));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    // First versioned filter skipped (min=8.9.0, record=8.8.0)
+    assertThat(firstCalls.get()).isZero();
+    // Second versioned filter applied (min=8.8.0, record=8.8.0) and rejects
+    assertThat(secondCalls.get()).isEqualTo(1);
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldApplyAllQualifiedVersionedFilters() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.10.0");
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger firstCalls = new AtomicInteger(0);
+    final AtomicInteger secondCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter firstVersioned =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ true, firstCalls);
+    final TestVersionedFilter secondVersioned =
+        new TestVersionedFilter(VERSION_8_10_0, /* acceptResult= */ false, secondCalls);
+
+    final var chain = new ExportRecordFilterChain(List.of(firstVersioned, secondVersioned));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(firstCalls.get())
+        .as("First versioned filter should be applied for >= 8.9.0")
+        .isEqualTo(1);
+    assertThat(secondCalls.get())
+        .as("Second versioned filter should be applied for >= 8.10.0")
+        .isEqualTo(1);
+    assertThat(accepted).isFalse();
+  }
+
+  @Test
+  void shouldAcceptWhenAllVersionedFiltersAreSkippedAndNonVersionedFilterAccepts() {
+    // given
+    when(record.getBrokerVersion()).thenReturn("8.7.0"); // < 8.8.0 and < 8.9.0
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+
+    final AtomicInteger v1Calls = new AtomicInteger(0);
+    final AtomicInteger v2Calls = new AtomicInteger(0);
+    final AtomicInteger nonVersionedCalls = new AtomicInteger(0);
+
+    final TestVersionedFilter v1 =
+        new TestVersionedFilter(VERSION_8_8_0, /* acceptResult= */ false, v1Calls);
+    final TestVersionedFilter v2 =
+        new TestVersionedFilter(VERSION_8_9_0, /* acceptResult= */ false, v2Calls);
+
+    final ExporterRecordFilter nonVersionedFilter =
+        r -> {
+          nonVersionedCalls.incrementAndGet();
+          return true; // accept
+        };
+
+    final var chain = new ExportRecordFilterChain(List.of(v1, v2, nonVersionedFilter));
+
+    // when
+    final boolean accepted = chain.acceptRecord(record);
+
+    // then
+    assertThat(v1Calls.get()).isZero();
+    assertThat(v2Calls.get()).isZero();
+    assertThat(nonVersionedCalls.get()).isEqualTo(1);
+    assertThat(accepted).isTrue();
+  }
+
+  /** Simple test implementation of a versioned filter. */
+  private static final class TestVersionedFilter
+      implements ExporterRecordFilter, RecordVersionFilter {
+
+    private final SemanticVersion minVersion;
+    private final boolean acceptResult;
+    private final AtomicInteger calls;
+
+    private TestVersionedFilter(
+        final SemanticVersion minVersion, final boolean acceptResult, final AtomicInteger calls) {
+      this.minVersion = minVersion;
+      this.acceptResult = acceptResult;
+      this.calls = calls;
+    }
+
+    @Override
+    public boolean accept(final Record<?> record) {
+      calls.incrementAndGet();
+      return acceptResult;
+    }
+
+    @Override
+    public SemanticVersion minRecordBrokerVersion() {
+      return minVersion;
+    }
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter.config;
+
+import io.camunda.zeebe.exporter.filter.DefaultRecordFilter;
+import io.camunda.zeebe.exporter.filter.FilterConfiguration;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Minimal test configuration implementing {@link FilterConfiguration} so tests can exercise {@link
+ * DefaultRecordFilter} in isolation.
+ *
+ * <p>By default, nothing is indexed. Tests must explicitly enable record/value types via the fluent
+ * helpers.
+ */
+public final class TestConfiguration implements FilterConfiguration {
+
+  private final Map<ValueType, Boolean> normalFlags = new EnumMap<>(ValueType.class);
+  private final Map<ValueType, Boolean> requiredFlags = new EnumMap<>(ValueType.class);
+  private final Map<RecordType, Boolean> recordTypeFlags = new EnumMap<>(RecordType.class);
+
+  /** Mark a {@link ValueType} as normally indexed. */
+  public TestConfiguration withIndexedValueType(final ValueType valueType) {
+    normalFlags.put(valueType, true);
+    return this;
+  }
+
+  /** Mark a {@link ValueType} as required-indexed. */
+  public TestConfiguration withRequiredValueType(final ValueType valueType) {
+    requiredFlags.put(valueType, true);
+    return this;
+  }
+
+  /** Mark a {@link RecordType} as indexed. */
+  public TestConfiguration withIndexedRecordType(final RecordType recordType) {
+    recordTypeFlags.put(recordType, true);
+    return this;
+  }
+
+  @Override
+  public boolean shouldIndexValueType(final ValueType valueType) {
+    return normalFlags.getOrDefault(valueType, false);
+  }
+
+  @Override
+  public boolean shouldIndexRequiredValueType(final ValueType valueType) {
+    return requiredFlags.getOrDefault(valueType, false);
+  }
+
+  @Override
+  public boolean shouldIndexRecordType(final RecordType recordType) {
+    return recordTypeFlags.getOrDefault(recordType, false);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-filter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -14,9 +14,8 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.filter.DefaultRecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class ElasticsearchExporter implements Exporter {
     validate(configuration);
     pluginRepository.load(configuration.getInterceptorPlugins());
 
-    context.setFilter(new ElasticsearchRecordFilter(configuration));
+    context.setFilter(new DefaultRecordFilter(configuration));
     registry = context.getMeterRegistry();
   }
 
@@ -264,7 +263,7 @@ public class ElasticsearchExporter implements Exporter {
   /**
    * Determine whether a record should be exported or not. For Camunda 8.8 we require Optimize
    * records to be exported, or if the configuration explicitly enables the export of all records
-   * {@link ElasticsearchExporterConfiguration#includeEnabledRecords}. For past versions, we
+   * {@link ElasticsearchExporterConfiguration#getIsIncludeEnabledRecords()}. For past versions, we
    * continue to export all records.
    *
    * @param record The record to check
@@ -287,24 +286,5 @@ public class ElasticsearchExporter implements Exporter {
                     "Unsupported record broker version: ["
                         + version
                         + "] Must be a semantic version."));
-  }
-
-  private static class ElasticsearchRecordFilter implements Context.RecordFilter {
-
-    private final ElasticsearchExporterConfiguration configuration;
-
-    ElasticsearchRecordFilter(final ElasticsearchExporterConfiguration configuration) {
-      this.configuration = configuration;
-    }
-
-    @Override
-    public boolean acceptType(final RecordType recordType) {
-      return configuration.shouldIndexRecordType(recordType);
-    }
-
-    @Override
-    public boolean acceptValue(final ValueType valueType) {
-      return configuration.shouldIndexValueType(valueType);
-    }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.exporter;
 
 import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ElasticsearchExporterConfiguration {
+public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";
 
@@ -64,11 +64,7 @@ public class ElasticsearchExporterConfiguration {
         + '}';
   }
 
-  public boolean shouldIndexRecord(final Record<?> record) {
-    return shouldIndexRecordType(record.getRecordType())
-        && shouldIndexValueType(record.getValueType());
-  }
-
+  @Override
   public boolean shouldIndexValueType(final ValueType valueType) {
     return switch (valueType) {
       case DEPLOYMENT -> index.deployment;
@@ -125,6 +121,7 @@ public class ElasticsearchExporterConfiguration {
    * @param valueType the value type of the record
    * @return true if the record should be indexed, false otherwise
    */
+  @Override
   public boolean shouldIndexRequiredValueType(final ValueType valueType) {
     return switch (valueType) {
       case DEPLOYMENT -> index.deployment;
@@ -138,6 +135,7 @@ public class ElasticsearchExporterConfiguration {
     };
   }
 
+  @Override
   public boolean shouldIndexRecordType(final RecordType recordType) {
     return switch (recordType) {
       case EVENT -> index.event;

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-filter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -14,15 +14,12 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.filter.DefaultRecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.HashSet;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +42,6 @@ public class OpensearchExporter implements Exporter {
   private OpensearchExporterSchemaManager schemaManager;
 
   private long lastPosition = -1;
-  private Set<String> indexTemplatesCreated;
 
   @Override
   public void configure(final Context context) {
@@ -56,8 +52,7 @@ public class OpensearchExporter implements Exporter {
     validate(configuration);
     pluginRepository.load(configuration.getInterceptorPlugins());
 
-    context.setFilter(new OpensearchRecordFilter(configuration));
-    indexTemplatesCreated = new HashSet<>();
+    context.setFilter(new DefaultRecordFilter(configuration));
     meterRegistry = context.getMeterRegistry();
   }
 
@@ -147,8 +142,8 @@ public class OpensearchExporter implements Exporter {
   /**
    * Determine whether a record should be exported or not. For Camunda 8.8 we require Optimize
    * records to be exported, or if the configuration explicitly enables the export of all records
-   * {@link OpensearchExporterConfiguration#includeEnabledRecords}. For past versions, we continue
-   * to export all records.
+   * {@link OpensearchExporterConfiguration#getIsIncludeEnabledRecords()}. For past versions, we
+   * continue to export all records.
    *
    * @param record The record to check
    * @return Whether the record should be exported or not
@@ -254,24 +249,5 @@ public class OpensearchExporter implements Exporter {
                     "Unsupported record broker version: ["
                         + version
                         + "] Must be a semantic version."));
-  }
-
-  private static class OpensearchRecordFilter implements Context.RecordFilter {
-
-    private final OpensearchExporterConfiguration configuration;
-
-    OpensearchRecordFilter(final OpensearchExporterConfiguration configuration) {
-      this.configuration = configuration;
-    }
-
-    @Override
-    public boolean acceptType(final RecordType recordType) {
-      return configuration.shouldIndexRecordType(recordType);
-    }
-
-    @Override
-    public boolean acceptValue(final ValueType valueType) {
-      return configuration.shouldIndexValueType(valueType);
-    }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.exporter.opensearch;
 
 import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.List;
 
-public class OpensearchExporterConfiguration {
+public class OpensearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";
 
@@ -63,11 +63,7 @@ public class OpensearchExporterConfiguration {
         + '}';
   }
 
-  public boolean shouldIndexRecord(final Record<?> record) {
-    return shouldIndexRecordType(record.getRecordType())
-        && shouldIndexValueType(record.getValueType());
-  }
-
+  @Override
   public boolean shouldIndexValueType(final ValueType valueType) {
     return switch (valueType) {
       case DEPLOYMENT -> index.deployment;
@@ -124,6 +120,7 @@ public class OpensearchExporterConfiguration {
    * @param valueType the value type of the record
    * @return true if the record should be indexed, false otherwise
    */
+  @Override
   public boolean shouldIndexRequiredValueType(final ValueType valueType) {
     return switch (valueType) {
       case DEPLOYMENT -> index.deployment;
@@ -137,6 +134,7 @@ public class OpensearchExporterConfiguration {
     };
   }
 
+  @Override
   public boolean shouldIndexRecordType(final RecordType recordType) {
     return switch (recordType) {
       case EVENT -> index.event;


### PR DESCRIPTION
## Description

- Introduce a DefaultRecordFilter whose main responsibility is to provide a common record-filter handler used by both Elasticsearch and OpenSearch exporters.
- Deduplicate filter logic by replacing the exporter-specific filter implementations in ElasticsearchExporter and OpensearchExporter with the shared DefaultRecordFilter.
- Introduce a FilterConfiguration interface and make exporter configuration classes implement it, so they can provide common filter properties/configuration to DefaultRecordFilter.
- Add/extend record version–aware filtering: any class implementing ExportRecordFilter and RecordVersionFilter will only be evaluated when the broker record version is greater than or equal to the configured version.
- Add a new exporter-filter module and declare it as a dependency where needed so exporters can use DefaultRecordFilter.

## Related issues

closes #
[#44906](https://github.com/camunda/camunda/issues/44906)