### PR TITLE
refactor: generate SBE code without forking

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,4 @@
+--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -43,6 +43,12 @@
       <artifactId>maven-surefire-common</artifactId>
       <version>3.5.4</version>
     </dependency>
+    <dependency>
+      <groupId>uk.co.real-logic</groupId>
+      <artifactId>sbe-tool</artifactId>
+      <version>1.37.1</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/build-tools/src/main/java/io/camunda/zeebe/SbeGenerator.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/SbeGenerator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.xml.sax.InputSource;
+import uk.co.real_logic.sbe.SbeTool;
+import uk.co.real_logic.sbe.generation.CodeGenerator;
+import uk.co.real_logic.sbe.generation.java.JavaGenerator;
+import uk.co.real_logic.sbe.generation.java.JavaOutputManager;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+import uk.co.real_logic.sbe.xml.XmlSchemaParser;
+
+public final class SbeGenerator {
+
+  public static void main(final String[] args) throws Exception {
+    if (args.length < 1) {
+      printUsage();
+      System.exit(1);
+    }
+
+    final List<String> filenames = new ArrayList<>();
+    final Map<String, String> cliOptions = new HashMap<>();
+
+    for (final String arg : args) {
+      if (arg.startsWith("-D")) {
+        final int eqPos = arg.indexOf('=');
+        if (eqPos > 2) {
+          final String key = arg.substring(2, eqPos);
+          final String value = arg.substring(eqPos + 1);
+          cliOptions.put(key, value);
+        }
+      } else {
+        filenames.add(arg);
+      }
+    }
+
+    if (filenames.isEmpty()) {
+      printUsage();
+      System.exit(1);
+    }
+
+    final String outputDir = cliOptions.getOrDefault(SbeTool.OUTPUT_DIR, ".");
+    final String targetLanguage = cliOptions.getOrDefault(SbeTool.TARGET_LANGUAGE, "Java");
+    final String targetNamespace = cliOptions.get(SbeTool.TARGET_NAMESPACE);
+    final boolean xIncludeAware =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.XINCLUDE_AWARE, "false"));
+    final boolean stopOnError =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.VALIDATION_STOP_ON_ERROR, "false"));
+    final boolean warningsFatal =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.VALIDATION_WARNINGS_FATAL, "false"));
+    final boolean suppressOutput =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.VALIDATION_SUPPRESS_OUTPUT, "false"));
+    final boolean generateInterfaces =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.JAVA_GENERATE_INTERFACES, "false"));
+    final boolean decodeUnknownEnumValues =
+        Boolean.parseBoolean(cliOptions.getOrDefault(SbeTool.DECODE_UNKNOWN_ENUM_VALUES, "false"));
+
+    if (!"Java".equalsIgnoreCase(targetLanguage)) {
+      throw new IllegalArgumentException("Only Java target language is supported by this tool.");
+    }
+
+    final ParserOptions options =
+        ParserOptions.builder()
+            .stopOnError(stopOnError)
+            .warningsFatal(warningsFatal)
+            .suppressOutput(suppressOutput)
+            .xIncludeAware(xIncludeAware)
+            .build();
+
+    for (final String filename : filenames) {
+      try (final InputStream in =
+          Files.newInputStream(FileSystems.getDefault().getPath(filename))) {
+        final InputSource inputSource = new InputSource(in);
+        inputSource.setSystemId(filename);
+        final MessageSchema schema = XmlSchemaParser.parse(inputSource, options);
+        final Ir ir = new IrGenerator().generate(schema, targetNamespace);
+
+        final CodeGenerator codeGenerator =
+            new JavaGenerator(
+                ir,
+                SbeTool.JAVA_DEFAULT_ENCODING_BUFFER_TYPE,
+                SbeTool.JAVA_DEFAULT_DECODING_BUFFER_TYPE,
+                false,
+                generateInterfaces,
+                decodeUnknownEnumValues,
+                new JavaOutputManager(outputDir, ir.applicableNamespace()));
+
+        codeGenerator.generate();
+      }
+    }
+  }
+
+  private static void printUsage() {
+    System.err.println("Usage: SbeGenerator <filenames>... [-Doption=value]...");
+    System.err.println("Options:");
+    System.err.println("  -Dsbe.output.dir=<dir>                Output directory");
+    System.err.println(
+        "  -Dsbe.target.language=Java            Target language (only Java supported)");
+    System.err.println("  -Dsbe.java.generate.interfaces=true|false");
+    System.err.println("  -Dsbe.decode.unknown.enum.values=true|false");
+    System.err.println("  -Dsbe.xinclude.aware=true|false");
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2601,47 +2601,28 @@
           <version>${plugin.version.exec}</version>
           <dependencies>
             <dependency>
-              <groupId>uk.co.real-logic</groupId>
-              <artifactId>sbe-tool</artifactId>
-              <version>${version.sbe}</version>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${project.version}</version>
             </dependency>
           </dependencies>
           <executions>
-            <!--
-              Use exec:exec to generate SBE instead of exec:java, as exec:java does not fork the
-              process, and the SBE tool is not thread safe, i.e. could not be used with a parallel
-              multi-module maven build.
-              See: https://github.com/camunda/camunda/issues/16029
-            -->
             <execution>
               <id>generate-sbe</id>
               <goals>
-                <goal>exec</goal>
+                <goal>java</goal>
               </goals>
               <!-- not bound by default since it would execute in places where we don't want SBE generation -->
               <phase>none</phase>
               <configuration>
-                <!--
-                  we have to use the goal exec with the java executable as otherwise the process
-                  will not fork, and this can cause thread safety issues in a parallel multi-module
-                  build
-                -->
-                <executable>java</executable>
+                <mainClass>io.camunda.zeebe.SbeGenerator</mainClass>
                 <includePluginDependencies>true</includePluginDependencies>
-                <longClasspath>true</longClasspath>
                 <arguments combine.children="append">
                   <argument>-Dsbe.output.dir=${project.build.directory}/generated-sources/sbe</argument>
                   <argument>-Dsbe.java.generate.interfaces=true</argument>
                   <argument>-Dsbe.decode.unknown.enum.values=true</argument>
                   <argument>-Dsbe.xinclude.aware=true</argument>
-                  <argument>-Dsbe.generate.ir=true</argument>
-                  <argument>-classpath</argument>
-                  <!-- automatically creates the classpath using all project dependencies,
-                     also adding the project build directory -->
-                  <classpath/>
-                  <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
-                <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
This replaces the official `SbeTool` with a custom copy called `SbeGenerator` that does not rely on system properties for configuration. The maven goal can now directly call the generator instead of forking the maven process, making the build process a bit faster and simpler.
Among other benefits, it gets us closer to being able to use the "Generate Sources & Update Folders" button in IntelliJ.