### PR TITLE
feat: do not filter by partition_id in history cleanup

### DIFF
--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -183,7 +183,8 @@
   <sql id="historyCleanup" databaseId="mssql">
     DELETE TOP (#{limit})
     FROM ${prefix}${tableName}
-    WHERE HISTORY_CLEANUP_DATE &lt; #{cleanupDate, jdbcType=TIMESTAMP}
+    WHERE PARTITION_ID = #{partitionId}
+      AND HISTORY_CLEANUP_DATE &lt; #{cleanupDate, jdbcType=TIMESTAMP}
   </sql>
   <sql id="historyCleanup" databaseId="oracle">
     DELETE

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -207,8 +207,7 @@
   <sql id="processInstanceHistoryDeletion">
     DELETE
     FROM ${prefix}${tableName}
-    WHERE PARTITION_ID = #{partitionId}
-      AND PROCESS_INSTANCE_KEY IN
+    WHERE PROCESS_INSTANCE_KEY IN
     <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
@@ -217,8 +216,7 @@
   <sql id="processInstanceHistoryDeletion" databaseId="mssql">
     DELETE TOP (#{limit})
     FROM ${prefix}${tableName}
-    WHERE PARTITION_ID = #{partitionId}
-      AND PROCESS_INSTANCE_KEY IN
+    WHERE PROCESS_INSTANCE_KEY IN
     <foreach collection="processInstanceKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
@@ -235,8 +233,7 @@
     FROM ${prefix}${tableName} t1
     WHERE ${keyColumn} IN (SELECT t2.${keyColumn}
                            FROM ${prefix}${tableName} t2
-                           WHERE t2.PARTITION_ID = #{partitionId}
-                             AND t2.PROCESS_INSTANCE_KEY IN (
+                           WHERE t2.PROCESS_INSTANCE_KEY IN (
                                SELECT COLUMN_VALUE
                                FROM XMLTABLE('/d/r'
                                     PASSING XMLTYPE(#{processInstanceKeys, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
@@ -255,8 +252,7 @@
     FROM ${prefix}${tableName} t1
     USING (SELECT ${keyColumn}
            FROM ${prefix}${tableName}
-           WHERE PARTITION_ID = #{partitionId}
-             AND PROCESS_INSTANCE_KEY = ANY(#{processInstanceKeys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
+           WHERE PROCESS_INSTANCE_KEY = ANY(#{processInstanceKeys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
            LIMIT #{limit}) t2
     WHERE t1.${keyColumn} = t2.${keyColumn}
   </sql>


### PR DESCRIPTION
Removes the ` WHERE PARTITION_ID = $` clause from the history cleanup SQLs. Originally these were introduced for the planned feature of RDBMS table partitioning, but the existence of this filter confuses the execution planner to use an inefficient index.

Since the cleanup uses specific `processInstanceKeys` to target the rows to delete, the `partition_id` is not even needed to select the rows to delete.