### PR TITLE
Perf/rdbms enhanche insert batching

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RdbmsInsertBatching.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsInsertBatching.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.InsertBatchingConfig;
 
 public class RdbmsInsertBatching {
-  private int maxVariableInsertBatchSize =
-      RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_VARIABLE_INSERT_BATCH_SIZE;
-  private int maxAuditLogInsertBatchSize =
-      RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
+  private int maxVariableInsertBatchSize = InsertBatchingConfig.DEFAULT_VARIABLE_INSERT_BATCH_SIZE;
+  private int maxAuditLogInsertBatchSize = InsertBatchingConfig.DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
+  private int maxJobInsertBatchSize = InsertBatchingConfig.DEFAULT_JOB_INSERT_BATCH_SIZE;
+  private int maxFlowNodeInsertBatchSize = InsertBatchingConfig.DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE;
 
   public int getMaxVariableInsertBatchSize() {
     return maxVariableInsertBatchSize;
@@ -29,5 +29,21 @@ public class RdbmsInsertBatching {
 
   public void setMaxAuditLogInsertBatchSize(final int maxAuditLogInsertBatchSize) {
     this.maxAuditLogInsertBatchSize = maxAuditLogInsertBatchSize;
+  }
+
+  public int getMaxJobInsertBatchSize() {
+    return maxJobInsertBatchSize;
+  }
+
+  public void setMaxJobInsertBatchSize(final int maxJobInsertBatchSize) {
+    this.maxJobInsertBatchSize = maxJobInsertBatchSize;
+  }
+
+  public int getMaxFlowNodeInsertBatchSize() {
+    return maxFlowNodeInsertBatchSize;
+  }
+
+  public void setMaxFlowNodeInsertBatchSize(final int maxFlowNodeInsertBatchSize) {
+    this.maxFlowNodeInsertBatchSize = maxFlowNodeInsertBatchSize;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -904,6 +904,14 @@ public class BrokerBasedPropertiesOverride {
                         .getInsertBatching()
                         .setMaxVariableInsertBatchSize(
                             database.getInsertBatching().getMaxVariableInsertBatchSize());
+                    config
+                        .getInsertBatching()
+                        .setMaxJobInsertBatchSize(
+                            database.getInsertBatching().getMaxJobInsertBatchSize());
+                    config
+                        .getInsertBatching()
+                        .setMaxFlowNodeInsertBatchSize(
+                            database.getInsertBatching().getMaxFlowNodeInsertBatchSize());
                   }
                 })
             .toArgs());

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -10,14 +10,11 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
-import io.camunda.util.ObjectBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public interface AuditLogMapper extends ProcessInstanceDependantMapper {
 
-  void insert(BatchInsertAuditLogsDto dto);
+  void insert(BatchInsertDto<AuditLogDbModel> dto);
 
   Long count(AuditLogDbQuery filter);
 
@@ -26,41 +23,4 @@ public interface AuditLogMapper extends ProcessInstanceDependantMapper {
   int deleteProcessDefinitionRelatedData(List<Long> processDefinitionKeys, int limit);
 
   int cleanupHistory(HistoryCleanupMapper.CleanupHistoryDto dto);
-
-  record BatchInsertAuditLogsDto(List<AuditLogDbModel> auditLogs)
-      implements BatchInsertDto<BatchInsertAuditLogsDto, AuditLogDbModel> {
-
-    @Override
-    public BatchInsertAuditLogsDto withAdditionalDbModel(final AuditLogDbModel auditLog) {
-      return new Builder().auditLogs(new ArrayList<>(auditLogs)).auditLog(auditLog).build();
-    }
-
-    @Override
-    public BatchInsertAuditLogsDto copy(
-        final Function<
-                ObjectBuilder<BatchInsertAuditLogsDto>, ObjectBuilder<BatchInsertAuditLogsDto>>
-            copyFunction) {
-      return copyFunction.apply(new Builder().auditLogs(new ArrayList<>(auditLogs))).build();
-    }
-
-    public static class Builder implements ObjectBuilder<BatchInsertAuditLogsDto> {
-
-      private List<AuditLogDbModel> auditLogs = new ArrayList<>();
-
-      public Builder auditLog(final AuditLogDbModel auditLog) {
-        auditLogs.add(auditLog);
-        return this;
-      }
-
-      public Builder auditLogs(final List<AuditLogDbModel> auditLogs) {
-        this.auditLogs = auditLogs;
-        return this;
-      }
-
-      @Override
-      public BatchInsertAuditLogsDto build() {
-        return new BatchInsertAuditLogsDto(auditLogs);
-      }
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
@@ -9,13 +9,14 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface FlowNodeInstanceMapper extends ProcessInstanceDependantMapper {
 
-  void insert(FlowNodeInstanceDbModel flowNode);
+  void insert(BatchInsertDto<FlowNodeInstanceDbModel> dto);
 
   void updateStateAndEndDate(EndFlowNodeDto dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
@@ -9,15 +9,55 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.JobDbQuery;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
+import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 public interface JobMapper extends ProcessInstanceDependantMapper {
 
-  void insert(JobDbModel job);
+  void insert(BatchInsertJobsDto dto);
 
   void update(JobDbModel job);
 
   Long count(JobDbQuery filter);
 
   List<JobDbModel> search(JobDbQuery filter);
+
+  record BatchInsertJobsDto(List<JobDbModel> jobs)
+      implements BatchInsertDto<BatchInsertJobsDto, JobDbModel> {
+
+    @Override
+    public BatchInsertJobsDto withAdditionalDbModel(final JobDbModel job) {
+      return new Builder().jobs(new ArrayList<>(jobs)).job(job).build();
+    }
+
+    @Override
+    public BatchInsertJobsDto copy(
+        final Function<ObjectBuilder<BatchInsertJobsDto>, ObjectBuilder<BatchInsertJobsDto>>
+            copyFunction) {
+      return copyFunction.apply(new Builder().jobs(new ArrayList<>(jobs))).build();
+    }
+
+    public static class Builder implements ObjectBuilder<BatchInsertJobsDto> {
+
+      private List<JobDbModel> jobs = new ArrayList<>();
+
+      public Builder job(final JobDbModel job) {
+        jobs.add(job);
+        return this;
+      }
+
+      public Builder jobs(final List<JobDbModel> jobs) {
+        this.jobs = jobs;
+        return this;
+      }
+
+      @Override
+      public BatchInsertJobsDto build() {
+        return new BatchInsertJobsDto(jobs);
+      }
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
@@ -10,54 +10,15 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.JobDbQuery;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
-import io.camunda.util.ObjectBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public interface JobMapper extends ProcessInstanceDependantMapper {
 
-  void insert(BatchInsertJobsDto dto);
+  void insert(BatchInsertDto<JobDbModel> dto);
 
   void update(JobDbModel job);
 
   Long count(JobDbQuery filter);
 
   List<JobDbModel> search(JobDbQuery filter);
-
-  record BatchInsertJobsDto(List<JobDbModel> jobs)
-      implements BatchInsertDto<BatchInsertJobsDto, JobDbModel> {
-
-    @Override
-    public BatchInsertJobsDto withAdditionalDbModel(final JobDbModel job) {
-      return new Builder().jobs(new ArrayList<>(jobs)).job(job).build();
-    }
-
-    @Override
-    public BatchInsertJobsDto copy(
-        final Function<ObjectBuilder<BatchInsertJobsDto>, ObjectBuilder<BatchInsertJobsDto>>
-            copyFunction) {
-      return copyFunction.apply(new Builder().jobs(new ArrayList<>(jobs))).build();
-    }
-
-    public static class Builder implements ObjectBuilder<BatchInsertJobsDto> {
-
-      private List<JobDbModel> jobs = new ArrayList<>();
-
-      public Builder job(final JobDbModel job) {
-        jobs.add(job);
-        return this;
-      }
-
-      public Builder jobs(final List<JobDbModel> jobs) {
-        this.jobs = jobs;
-        return this;
-      }
-
-      @Override
-      public BatchInsertJobsDto build() {
-        return new BatchInsertJobsDto(jobs);
-      }
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -12,13 +12,11 @@ import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.util.ObjectBuilder;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public interface VariableMapper extends ProcessInstanceDependantMapper {
 
-  void insert(BatchInsertVariablesDto dto);
+  void insert(BatchInsertDto<VariableDbModel> dto);
 
   void update(VariableDbModel variable);
 
@@ -48,43 +46,6 @@ public interface VariableMapper extends ProcessInstanceDependantMapper {
       @Override
       public MigrateToProcessDto build() {
         return new MigrateToProcessDto(variableKey, processDefinitionId);
-      }
-    }
-  }
-
-  record BatchInsertVariablesDto(List<VariableDbModel> variables)
-      implements BatchInsertDto<BatchInsertVariablesDto, VariableDbModel> {
-
-    @Override
-    public BatchInsertVariablesDto withAdditionalDbModel(final VariableDbModel variable) {
-      return new Builder().variables(new ArrayList<>(variables)).variable(variable).build();
-    }
-
-    @Override
-    public BatchInsertVariablesDto copy(
-        final Function<
-                ObjectBuilder<BatchInsertVariablesDto>, ObjectBuilder<BatchInsertVariablesDto>>
-            copyFunction) {
-      return copyFunction.apply(new Builder().variables(new ArrayList<>(variables))).build();
-    }
-
-    public static class Builder implements ObjectBuilder<BatchInsertVariablesDto> {
-
-      private List<VariableDbModel> variables = new ArrayList<>();
-
-      public Builder variable(final VariableDbModel variable) {
-        variables.add(variable);
-        return this;
-      }
-
-      public Builder variables(final List<VariableDbModel> variables) {
-        this.variables = variables;
-        return this;
-      }
-
-      @Override
-      public BatchInsertVariablesDto build() {
-        return new BatchInsertVariablesDto(variables);
       }
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -253,9 +253,14 @@ public record RdbmsWriterConfig(
       /*
        * The maximum size of audit log insert batches.
        */
-      int auditLogInsertBatchSize) {
+      int auditLogInsertBatchSize,
+      /*
+       * The maximum size of job insert batches.
+       */
+      int jobInsertBatchSize) {
     public static final int DEFAULT_VARIABLE_INSERT_BATCH_SIZE = 10;
     public static final int DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE = 10;
+    public static final int DEFAULT_JOB_INSERT_BATCH_SIZE = 10;
 
     public static InsertBatchingConfig.Builder builder() {
       return new InsertBatchingConfig.Builder();
@@ -265,6 +270,7 @@ public record RdbmsWriterConfig(
 
       private int variableInsertBatchSize = DEFAULT_VARIABLE_INSERT_BATCH_SIZE;
       private int auditLogInsertBatchSize = DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
+      private int jobInsertBatchSize = DEFAULT_JOB_INSERT_BATCH_SIZE;
 
       public Builder variableInsertBatchSize(final int variableInsertBatchSize) {
         this.variableInsertBatchSize = variableInsertBatchSize;
@@ -276,9 +282,15 @@ public record RdbmsWriterConfig(
         return this;
       }
 
+      public Builder jobInsertBatchSize(final int jobInsertBatchSize) {
+        this.jobInsertBatchSize = jobInsertBatchSize;
+        return this;
+      }
+
       @Override
       public InsertBatchingConfig build() {
-        return new InsertBatchingConfig(variableInsertBatchSize, auditLogInsertBatchSize);
+        return new InsertBatchingConfig(
+            variableInsertBatchSize, auditLogInsertBatchSize, jobInsertBatchSize);
       }
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -262,10 +262,12 @@ public record RdbmsWriterConfig(
        * The maximum size of flow node instance insert batches.
        */
       int flowNodeInsertBatchSize) {
-    public static final int DEFAULT_VARIABLE_INSERT_BATCH_SIZE = 10;
-    public static final int DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE = 10;
-    public static final int DEFAULT_JOB_INSERT_BATCH_SIZE = 10;
-    public static final int DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE = 10;
+
+    public static final int DEFAULT_VARIABLE_INSERT_BATCH_SIZE = 25;
+    // larger batch size for audit logs as they are written in larger volumes
+    public static final int DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE = 50;
+    public static final int DEFAULT_JOB_INSERT_BATCH_SIZE = 25;
+    public static final int DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE = 25;
 
     public static InsertBatchingConfig.Builder builder() {
       return new InsertBatchingConfig.Builder();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -257,10 +257,15 @@ public record RdbmsWriterConfig(
       /*
        * The maximum size of job insert batches.
        */
-      int jobInsertBatchSize) {
+      int jobInsertBatchSize,
+      /*
+       * The maximum size of flow node instance insert batches.
+       */
+      int flowNodeInsertBatchSize) {
     public static final int DEFAULT_VARIABLE_INSERT_BATCH_SIZE = 10;
     public static final int DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE = 10;
     public static final int DEFAULT_JOB_INSERT_BATCH_SIZE = 10;
+    public static final int DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE = 10;
 
     public static InsertBatchingConfig.Builder builder() {
       return new InsertBatchingConfig.Builder();
@@ -271,6 +276,7 @@ public record RdbmsWriterConfig(
       private int variableInsertBatchSize = DEFAULT_VARIABLE_INSERT_BATCH_SIZE;
       private int auditLogInsertBatchSize = DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
       private int jobInsertBatchSize = DEFAULT_JOB_INSERT_BATCH_SIZE;
+      private int flowNodeInsertBatchSize = DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE;
 
       public Builder variableInsertBatchSize(final int variableInsertBatchSize) {
         this.variableInsertBatchSize = variableInsertBatchSize;
@@ -287,10 +293,18 @@ public record RdbmsWriterConfig(
         return this;
       }
 
+      public Builder flowNodeInsertBatchSize(final int flowNodeInsertBatchSize) {
+        this.flowNodeInsertBatchSize = flowNodeInsertBatchSize;
+        return this;
+      }
+
       @Override
       public InsertBatchingConfig build() {
         return new InsertBatchingConfig(
-            variableInsertBatchSize, auditLogInsertBatchSize, jobInsertBatchSize);
+            variableInsertBatchSize,
+            auditLogInsertBatchSize,
+            jobInsertBatchSize,
+            flowNodeInsertBatchSize);
       }
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -146,7 +146,8 @@ public class RdbmsWriters {
             config,
             vendorDatabaseProperties));
     writers.put(
-        JobWriter.class, new JobWriter(executionQueue, jobMapper, vendorDatabaseProperties));
+        JobWriter.class,
+        new JobWriter(executionQueue, jobMapper, vendorDatabaseProperties, config));
     writers.put(JobMetricsBatchWriter.class, new JobMetricsBatchWriter(executionQueue));
     writers.put(
         SequenceFlowWriter.class, new SequenceFlowWriter(executionQueue, sequenceFlowMapper));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -117,7 +117,7 @@ public class RdbmsWriters {
     writers.put(DecisionRequirementsWriter.class, new DecisionRequirementsWriter(executionQueue));
     writers.put(
         FlowNodeInstanceWriter.class,
-        new FlowNodeInstanceWriter(executionQueue, flowNodeInstanceMapper));
+        new FlowNodeInstanceWriter(executionQueue, flowNodeInstanceMapper, config));
     writers.put(GroupWriter.class, new GroupWriter(executionQueue));
     writers.put(
         IncidentWriter.class,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/BatchInsertDto.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/BatchInsertDto.java
@@ -8,7 +8,48 @@
 package io.camunda.db.rdbms.write.queue;
 
 import io.camunda.db.rdbms.write.domain.Copyable;
+import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
 
-public interface BatchInsertDto<T extends Copyable<T>, M> extends Copyable<T> {
-  T withAdditionalDbModel(M model);
+public record BatchInsertDto<M>(List<M> dbModels) implements Copyable<BatchInsertDto<M>> {
+
+  @SafeVarargs
+  public BatchInsertDto(final M... dbModel) {
+    this(new ArrayList<>());
+    dbModels.addAll(Arrays.asList(dbModel));
+  }
+
+  public BatchInsertDto<M> withAdditionalDbModel(final M dbModel) {
+    return new Builder().dbModels(new ArrayList<>(dbModels)).dbModel(dbModel).build();
+  }
+
+  @Override
+  public BatchInsertDto<M> copy(
+      final Function<ObjectBuilder<BatchInsertDto<M>>, ObjectBuilder<BatchInsertDto<M>>>
+          copyFunction) {
+    return copyFunction.apply(new Builder().dbModels(new ArrayList<>(dbModels))).build();
+  }
+
+  public class Builder implements ObjectBuilder<BatchInsertDto<M>> {
+
+    private List<M> dbModels = new ArrayList<>();
+
+    public Builder dbModel(final M dbModel) {
+      dbModels.add(dbModel);
+      return this;
+    }
+
+    private Builder dbModels(final List<M> dbModels) {
+      this.dbModels = dbModels;
+      return this;
+    }
+
+    @Override
+    public BatchInsertDto<M> build() {
+      return new BatchInsertDto<>(dbModels);
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertAuditLogMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertAuditLogMerger.java
@@ -7,18 +7,11 @@
  */
 package io.camunda.db.rdbms.write.queue;
 
-import io.camunda.db.rdbms.sql.AuditLogMapper.BatchInsertAuditLogsDto;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 
-public class InsertAuditLogMerger
-    extends BatchInsertMerger<BatchInsertAuditLogsDto, AuditLogDbModel> {
+public class InsertAuditLogMerger extends BatchInsertMerger<AuditLogDbModel> {
 
   public InsertAuditLogMerger(final AuditLogDbModel auditLog, final int maxBatchSize) {
-    super(
-        ContextType.AUDIT_LOG,
-        BatchInsertAuditLogsDto.class,
-        auditLog,
-        dto -> dto.auditLogs().size(),
-        maxBatchSize);
+    super(ContextType.AUDIT_LOG, auditLog, maxBatchSize);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertFlowNodeInstanceMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertFlowNodeInstanceMerger.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.db.rdbms.write.queue;
 
-import io.camunda.db.rdbms.write.domain.VariableDbModel;
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 
-public class InsertVariableMerger extends BatchInsertMerger<VariableDbModel> {
+public class InsertFlowNodeInstanceMerger extends BatchInsertMerger<FlowNodeInstanceDbModel> {
 
-  public InsertVariableMerger(final VariableDbModel variable, final int maxBatchSize) {
-    super(ContextType.VARIABLE, variable, maxBatchSize);
+  public InsertFlowNodeInstanceMerger(
+      final FlowNodeInstanceDbModel flowNodeInstance, final int maxBatchSize) {
+    super(ContextType.FLOW_NODE, flowNodeInstance, maxBatchSize);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
@@ -7,12 +7,11 @@
  */
 package io.camunda.db.rdbms.write.queue;
 
-import io.camunda.db.rdbms.sql.JobMapper.BatchInsertJobsDto;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
 
-public class InsertJobMerger extends BatchInsertMerger<BatchInsertJobsDto, JobDbModel> {
+public class InsertJobMerger extends BatchInsertMerger<JobDbModel> {
 
   public InsertJobMerger(final JobDbModel job, final int maxBatchSize) {
-    super(ContextType.JOB, BatchInsertJobsDto.class, job, dto -> dto.jobs().size(), maxBatchSize);
+    super(ContextType.JOB, job, maxBatchSize);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/InsertJobMerger.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+import io.camunda.db.rdbms.sql.JobMapper.BatchInsertJobsDto;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+
+public class InsertJobMerger extends BatchInsertMerger<BatchInsertJobsDto, JobDbModel> {
+
+  public InsertJobMerger(final JobDbModel job, final int maxBatchSize) {
+    super(ContextType.JOB, BatchInsertJobsDto.class, job, dto -> dto.jobs().size(), maxBatchSize);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ListParameterUpsertMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ListParameterUpsertMerger.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+import io.camunda.db.rdbms.write.domain.Copyable;
+import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A merger that can handle upsert operations on queue items where the parameter is a BatchInsertDto
+ * containing a list of models. This merger scans the list to find a matching item by key and merges
+ * the update into that item.
+ *
+ * @param <M> The type of the model contained in the list
+ */
+public class ListParameterUpsertMerger<M extends Copyable<M>> implements QueueItemMerger {
+
+  private final ContextType contextType;
+  private final long id;
+  private final Function<M, Long> keyExtractor;
+  private final Function<ObjectBuilder<M>, ObjectBuilder<M>> mergeFunction;
+
+  public ListParameterUpsertMerger(
+      final ContextType contextType,
+      final long id,
+      final Function<M, Long> keyExtractor,
+      final Function<? extends ObjectBuilder<M>, ? extends ObjectBuilder<M>> mergeFunction) {
+    this.contextType = contextType;
+    this.id = id;
+    this.keyExtractor = keyExtractor;
+    this.mergeFunction = (Function<ObjectBuilder<M>, ObjectBuilder<M>>) mergeFunction;
+  }
+
+  @Override
+  public boolean canBeMerged(final QueueItem queueItem) {
+    if (queueItem.contextType() != contextType) {
+      return false;
+    }
+
+    if (!(queueItem.parameter() instanceof BatchInsertDto)) {
+      return false;
+    }
+
+    final BatchInsertDto<M> dto = (BatchInsertDto<M>) queueItem.parameter();
+    final List<M> items = dto.dbModels();
+
+    return items.stream().anyMatch(item -> keyExtractor.apply(item).equals(id));
+  }
+
+  @Override
+  public QueueItem merge(final QueueItem originalItem) {
+    final BatchInsertDto<M> originalDto = (BatchInsertDto<M>) originalItem.parameter();
+    final List<M> originalItems = originalDto.dbModels();
+
+    // Create a new list with the updated item
+    final List<M> updatedItems = new ArrayList<>();
+    for (final M item : originalItems) {
+      if (keyExtractor.apply(item).equals(id)) {
+        // Apply the merge function to update this item
+        updatedItems.add(item.copy(mergeFunction));
+      } else {
+        updatedItems.add(item);
+      }
+    }
+
+    // Use the copy function to create a new DTO with the updated list
+    return originalItem.copy(b -> b.parameter(new BatchInsertDto<>(updatedItems)));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.InsertAuditLogMerger;
@@ -65,9 +66,7 @@ public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWri
               WriteStatementType.INSERT,
               finalAuditLog.auditLogKey(),
               "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
-              new AuditLogMapper.BatchInsertAuditLogsDto.Builder()
-                  .auditLog(finalAuditLog)
-                  .build()));
+              new BatchInsertDto<>(finalAuditLog)));
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -11,12 +11,15 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel.Builder;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.InsertJobMerger;
+import io.camunda.db.rdbms.write.queue.ListParameterUpsertMerger;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.function.Function;
 
 public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
@@ -57,12 +60,48 @@ public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
   }
 
   public void update(final JobDbModel job) {
-    executionQueue.executeInQueue(
-        new QueueItem(
-            ContextType.JOB,
-            WriteStatementType.UPDATE,
+    final boolean wasMerged =
+        mergeToQueue(
             job.jobKey(),
-            "io.camunda.db.rdbms.sql.JobMapper.update",
-            job));
+            b ->
+                b.type(job.type())
+                    .worker(job.worker())
+                    .state(job.state())
+                    .kind(job.kind())
+                    .listenerEventType(job.listenerEventType())
+                    .retries(job.retries())
+                    .isDenied(job.isDenied())
+                    .deniedReason(job.deniedReason())
+                    .hasFailedWithRetriesLeft(job.hasFailedWithRetriesLeft())
+                    .errorCode(job.errorCode())
+                    .errorMessage(job.errorMessage())
+                    .customHeaders(job.customHeaders())
+                    .deadline(job.deadline())
+                    .endTime(job.endTime())
+                    .processDefinitionId(job.processDefinitionId())
+                    .processDefinitionKey(job.processDefinitionKey())
+                    .processInstanceKey(job.processInstanceKey())
+                    .rootProcessInstanceKey(job.rootProcessInstanceKey())
+                    .elementId(job.elementId())
+                    .elementInstanceKey(job.elementInstanceKey())
+                    .tenantId(job.tenantId())
+                    .partitionId(job.partitionId())
+                    .creationTime(job.creationTime())
+                    .lastUpdateTime(job.lastUpdateTime()));
+
+    if (!wasMerged) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.JOB,
+              WriteStatementType.UPDATE,
+              job.jobKey(),
+              "io.camunda.db.rdbms.sql.JobMapper.update",
+              job));
+    }
+  }
+
+  private boolean mergeToQueue(final long key, final Function<Builder, Builder> mergeFunction) {
+    return executionQueue.tryMergeWithExistingQueueItem(
+        new ListParameterUpsertMerger<>(ContextType.JOB, key, JobDbModel::jobKey, mergeFunction));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.InsertJobMerger;
@@ -51,7 +52,7 @@ public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
               WriteStatementType.INSERT,
               -1,
               "io.camunda.db.rdbms.sql.JobMapper.insert",
-              new JobMapper.BatchInsertJobsDto.Builder().job(truncatedJob).build()));
+              new BatchInsertDto<>(truncatedJob)));
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.InsertVariableMerger;
@@ -52,9 +53,7 @@ public class VariableWriter extends ProcessInstanceDependant implements RdbmsWri
               WriteStatementType.INSERT,
               truncatedVariable.variableKey(),
               "io.camunda.db.rdbms.sql.VariableMapper.insert",
-              new VariableMapper.BatchInsertVariablesDto.Builder()
-                  .variable(truncatedVariable)
-                  .build()));
+              new BatchInsertDto<>(truncatedVariable)));
     }
   }
 

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -254,7 +254,7 @@
     </where>
   </sql>
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.sql.AuditLogMapper$BatchInsertAuditLogsDto">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}AUDIT_LOG (
       AUDIT_LOG_KEY,
       ENTITY_KEY,
@@ -292,7 +292,7 @@
       HISTORY_CLEANUP_DATE
     )
     VALUES
-    <foreach collection="auditLogs" item="auditLog" separator=",">
+    <foreach collection="dbModels" item="auditLog" separator=",">
       (
         #{auditLog.auditLogKey},
         #{auditLog.entityKey},

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -187,15 +187,18 @@
     </constructor>
   </resultMap>
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}FLOW_NODE_INSTANCE (FLOW_NODE_INSTANCE_KEY, FLOW_NODE_ID, FLOW_NODE_NAME, FLOW_NODE_SCOPE_KEY, PROCESS_INSTANCE_KEY,
                                              ROOT_PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, TYPE, STATE,
                                              START_DATE, END_DATE, TENANT_ID, TREE_PATH,
                                              INCIDENT_KEY, NUM_SUBPROCESS_INCIDENTS, PARTITION_ID)
-    VALUES (#{flowNodeInstanceKey}, #{flowNodeId}, #{flowNodeName}, #{flowNodeScopeKey}, #{processInstanceKey},
-            #{rootProcessInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{type}, #{state},
-            #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
-            #{treePath}, #{incidentKey}, #{numSubprocessIncidents}, #{partitionId})
+    VALUES
+    <foreach collection="dbModels" item="flowNode" separator=",">
+      (#{flowNode.flowNodeInstanceKey}, #{flowNode.flowNodeId}, #{flowNode.flowNodeName}, #{flowNode.flowNodeScopeKey}, #{flowNode.processInstanceKey},
+       #{flowNode.rootProcessInstanceKey}, #{flowNode.processDefinitionId}, #{flowNode.processDefinitionKey}, #{flowNode.type}, #{flowNode.state},
+       #{flowNode.startDate, jdbcType=TIMESTAMP}, #{flowNode.endDate, jdbcType=TIMESTAMP}, #{flowNode.tenantId},
+       #{flowNode.treePath}, #{flowNode.incidentKey}, #{flowNode.numSubprocessIncidents}, #{flowNode.partitionId})
+    </foreach>
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel">

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -247,12 +247,12 @@
   </resultMap>
 
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.sql.JobMapper$BatchInsertJobsDto">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
     TENANT_ID, TYPE, WORKER, STATE, RETRIES, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
     DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
     VALUES
-    <foreach collection="jobs" item="job" separator=",">
+    <foreach collection="dbModels" item="job" separator=",">
       (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
       #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
       #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -247,13 +247,16 @@
   </resultMap>
 
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobDbModel">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.sql.JobMapper$BatchInsertJobsDto">
     INSERT INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
     TENANT_ID, TYPE, WORKER, STATE, RETRIES, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
     DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
-    VALUES (#{jobKey}, #{partitionId}, #{processInstanceKey}, #{rootProcessInstanceKey}, #{elementInstanceKey}, #{processDefinitionId},
-    #{processDefinitionKey}, #{tenantId}, #{type}, #{worker}, #{state}, #{retries}, #{errorMessage}, #{errorCode}, #{endTime, jdbcType=TIMESTAMP}, #{serializedCustomHeaders}, #{kind}, #{elementId}, #{isDenied},
-    #{deniedReason}, #{listenerEventType}, #{deadline, jdbcType=TIMESTAMP}, #{hasFailedWithRetriesLeft}, #{creationTime, jdbcType=TIMESTAMP}, #{lastUpdateTime, jdbcType=TIMESTAMP})
+    VALUES
+    <foreach collection="jobs" item="job" separator=",">
+      (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
+      #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
+      #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})
+    </foreach>
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.JobDbModel">

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -138,12 +138,12 @@
     </constructor>
   </resultMap>
 
-  <insert id="insert" parameterType="io.camunda.db.rdbms.sql.VariableMapper$BatchInsertVariablesDto">
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
                                    LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW,
                                    PARTITION_ID)
     VALUES
-    <foreach collection="variables" item="variable" separator=",">
+    <foreach collection="dbModels" item="variable" separator=",">
       (#{variable.variableKey}, #{variable.processInstanceKey}, #{variable.rootProcessInstanceKey}, #{variable.processDefinitionId}, #{variable.scopeKey}, #{variable.type}, #{variable.name}, #{variable.doubleValue, jdbcType=DOUBLE},
        #{variable.longValue, jdbcType=NUMERIC}, #{variable.value}, #{variable.fullValue}, #{variable.tenantId}, #{variable.isPreview}, #{variable.partitionId})
     </foreach>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
@@ -10,8 +10,6 @@ package io.camunda.db.rdbms.write.queue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.camunda.db.rdbms.sql.AuditLogMapper.BatchInsertAuditLogsDto;
-import io.camunda.db.rdbms.sql.VariableMapper.BatchInsertVariablesDto;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
@@ -75,7 +73,7 @@ class BatchInsertMergerTest {
             1);
 
     final var merger = new InsertVariableMerger(variable2, 50);
-    final var parameter = new BatchInsertVariablesDto(List.of(variable1));
+    final var parameter = new BatchInsertDto<>(List.of(variable1));
     final var queueItem =
         new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
 
@@ -83,12 +81,12 @@ class BatchInsertMergerTest {
 
     final var mergedItem = merger.merge(queueItem);
     assertThat(mergedItem.parameter())
-        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertVariablesDto.class))
+        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertDto.class))
         .satisfies(
             p -> {
-              assertThat(p.variables()).hasSize(2);
-              assertThat(p.variables().get(0)).isEqualTo(variable1);
-              assertThat(p.variables().get(1)).isEqualTo(variable2);
+              assertThat(p.dbModels()).hasSize(2);
+              assertThat(p.dbModels().get(0)).isEqualTo(variable1);
+              assertThat(p.dbModels().get(1)).isEqualTo(variable2);
             });
   }
 
@@ -169,7 +167,7 @@ class BatchInsertMergerTest {
             OffsetDateTime.now());
 
     final var merger = new InsertAuditLogMerger(auditLog2, 50);
-    final var parameter = new BatchInsertAuditLogsDto(List.of(auditLog1));
+    final var parameter = new BatchInsertDto<>(List.of(auditLog1));
     final var queueItem =
         new QueueItem(
             ContextType.AUDIT_LOG, WriteStatementType.INSERT, "key1", "statement", parameter);
@@ -178,12 +176,12 @@ class BatchInsertMergerTest {
 
     final var mergedItem = merger.merge(queueItem);
     assertThat(mergedItem.parameter())
-        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertAuditLogsDto.class))
+        .asInstanceOf(InstanceOfAssertFactories.type(BatchInsertDto.class))
         .satisfies(
             p -> {
-              assertThat(p.auditLogs()).hasSize(2);
-              assertThat(p.auditLogs().get(0)).isEqualTo(auditLog1);
-              assertThat(p.auditLogs().get(1)).isEqualTo(auditLog2);
+              assertThat(p.dbModels()).hasSize(2);
+              assertThat(p.dbModels().get(0)).isEqualTo(auditLog1);
+              assertThat(p.dbModels().get(1)).isEqualTo(auditLog2);
             });
   }
 
@@ -208,8 +206,7 @@ class BatchInsertMergerTest {
 
     final var merger = new InsertVariableMerger(variable, 2); // Max batch size of 2
 
-    final var parameter =
-        new BatchInsertVariablesDto(List.of(variable, variable)); // Already at max size
+    final var parameter = new BatchInsertDto<>(List.of(variable, variable)); // Already at max size
 
     final var queueItem =
         new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);
@@ -238,7 +235,7 @@ class BatchInsertMergerTest {
 
     final var merger = new InsertVariableMerger(variable, 1); // Max batch size of 1
 
-    final var parameter = new BatchInsertVariablesDto(List.of(variable));
+    final var parameter = new BatchInsertDto<>(List.of(variable));
 
     final var queueItem =
         new QueueItem(ContextType.VARIABLE, WriteStatementType.INSERT, 1L, "statement", parameter);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/ListParameterUpsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/ListParameterUpsertMergerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel.Builder;
+import io.camunda.search.entities.JobEntity.JobState;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class ListParameterUpsertMergerTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @Test
+  void shouldMergeWithItemInBatchList() {
+    // Given a batch insert with 3 jobs
+    final var job1 = createJob(100L, JobState.CREATED, null);
+    final var job2 = createJob(101L, JobState.CREATED, null);
+    final var job3 = createJob(102L, JobState.CREATED, null);
+
+    final var batchDto = new BatchInsertDto<>(job1, job2, job3);
+
+    final var queueItem =
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.INSERT,
+            101L,
+            "io.camunda.db.rdbms.sql.JobMapper.insert",
+            batchDto);
+
+    // When we try to merge an update for jobKey=101
+    final var merger =
+        new ListParameterUpsertMerger<JobDbModel>(
+            ContextType.JOB,
+            101L,
+            JobDbModel::jobKey,
+            b -> ((Builder) b).state(JobState.COMPLETED).endTime(NOW));
+
+    // Then it should be able to merge
+    assertThat(merger.canBeMerged(queueItem)).isTrue();
+
+    // And when we perform the merge
+    final var mergedItem = merger.merge(queueItem);
+
+    // Then the batch should contain the updated item
+    final var mergedDto = (BatchInsertDto<JobDbModel>) mergedItem.parameter();
+    assertThat(mergedDto.dbModels()).hasSize(3);
+
+    // The first and third items should be unchanged
+    assertThat(mergedDto.dbModels().get(0).jobKey()).isEqualTo(100L);
+    assertThat(mergedDto.dbModels().get(0).state()).isEqualTo(JobState.CREATED);
+    assertThat(mergedDto.dbModels().get(0).endTime()).isNull();
+
+    assertThat(mergedDto.dbModels().get(2).jobKey()).isEqualTo(102L);
+    assertThat(mergedDto.dbModels().get(2).state()).isEqualTo(JobState.CREATED);
+    assertThat(mergedDto.dbModels().get(2).endTime()).isNull();
+
+    // The second item should be updated
+    assertThat(mergedDto.dbModels().get(1).jobKey()).isEqualTo(101L);
+    assertThat(mergedDto.dbModels().get(1).state()).isEqualTo(JobState.COMPLETED);
+    assertThat(mergedDto.dbModels().get(1).endTime()).isEqualTo(NOW);
+  }
+
+  @Test
+  void shouldNotMergeWhenKeyNotInBatchList() {
+    // Given a batch insert with 2 jobs
+    final var job1 = createJob(100L, JobState.CREATED, null);
+    final var job2 = createJob(102L, JobState.CREATED, null);
+
+    final var batchDto = new BatchInsertDto<>(job1, job2);
+
+    final var queueItem =
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.INSERT,
+            100L,
+            "io.camunda.db.rdbms.sql.JobMapper.insert",
+            batchDto);
+
+    // When we try to merge an update for jobKey=101 (not in the batch)
+    final var merger =
+        new ListParameterUpsertMerger<JobDbModel>(
+            ContextType.JOB, 101L, JobDbModel::jobKey, b -> b);
+
+    // Then it should not be able to merge
+    assertThat(merger.canBeMerged(queueItem)).isFalse();
+  }
+
+  @Test
+  void shouldNotMergeWhenContextTypeDifferent() {
+    // Given a batch insert with the JOB context
+    final var job = createJob(100L, JobState.CREATED, null);
+
+    final var batchDto = new BatchInsertDto<>(job);
+
+    final var queueItem =
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.INSERT,
+            100L,
+            "io.camunda.db.rdbms.sql.JobMapper.insert",
+            batchDto);
+
+    // When we try to merge with a different context type
+    final var merger =
+        new ListParameterUpsertMerger<JobDbModel>(
+            ContextType.PROCESS_INSTANCE, // Different context type
+            100L,
+            JobDbModel::jobKey,
+            b -> b);
+
+    // Then it should not be able to merge
+    assertThat(merger.canBeMerged(queueItem)).isFalse();
+  }
+
+  @Test
+  void shouldNotMergeWhenParameterIsNotBatchInsertDto() {
+    // Given a queue item with a single JobDbModel (not a batch)
+    final var job = createJob(100L, JobState.CREATED, null);
+
+    final var queueItem =
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.UPDATE,
+            100L,
+            "io.camunda.db.rdbms.sql.JobMapper.update",
+            job); // Single model, not BatchInsertDto
+
+    // When we try to merge
+    final var merger =
+        new ListParameterUpsertMerger<JobDbModel>(
+            ContextType.JOB, 100L, JobDbModel::jobKey, b -> b);
+
+    // Then it should not be able to merge
+    assertThat(merger.canBeMerged(queueItem)).isFalse();
+  }
+
+  private JobDbModel createJob(
+      final Long jobKey, final JobState state, final OffsetDateTime endTime) {
+    return new JobDbModel.Builder()
+        .jobKey(jobKey)
+        .state(state)
+        .endTime(endTime)
+        .type("test-type")
+        .retries(3)
+        .partitionId(1)
+        .build();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AuditLogWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AuditLogWriterTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
-import io.camunda.db.rdbms.sql.AuditLogMapper.BatchInsertAuditLogsDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
@@ -48,10 +48,10 @@ class AuditLogWriterTest {
                         && queueItem
                             .statementId()
                             .equals("io.camunda.db.rdbms.sql.AuditLogMapper.insert")
-                        && queueItem.parameter() instanceof BatchInsertAuditLogsDto
-                        && ((BatchInsertAuditLogsDto) queueItem.parameter()).auditLogs().size() == 1
-                        && ((BatchInsertAuditLogsDto) queueItem.parameter())
-                            .auditLogs()
+                        && queueItem.parameter() instanceof BatchInsertDto
+                        && ((BatchInsertDto) queueItem.parameter()).dbModels().size() == 1
+                        && ((BatchInsertDto) queueItem.parameter())
+                            .dbModels()
                             .getFirst()
                             .equals(model)));
   }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
@@ -83,7 +83,9 @@ class JobWriterTest {
   }
 
   @Test
-  void shouldUpdateJob() {
+  void shouldUpdateJobWhenNotMerged() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any())).thenReturn(false);
+
     final var model = mock(JobDbModel.class);
     when(model.jobKey()).thenReturn(123L);
 
@@ -98,5 +100,17 @@ class JobWriterTest {
                     123L,
                     "io.camunda.db.rdbms.sql.JobMapper.update",
                     model)));
+  }
+
+  @Test
+  void shouldMergeJobUpdateWhenPossible() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any())).thenReturn(true);
+
+    final var model = mock(JobDbModel.class);
+    when(model.jobKey()).thenReturn(123L);
+
+    writer.update(model);
+
+    verify(executionQueue, never()).executeInQueue(any(QueueItem.class));
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/JobWriterTest.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
@@ -60,7 +61,7 @@ class JobWriterTest {
                     WriteStatementType.INSERT,
                     -1,
                     "io.camunda.db.rdbms.sql.JobMapper.insert",
-                    new JobMapper.BatchInsertJobsDto.Builder().job(truncatedModel).build())));
+                    new BatchInsertDto<>(truncatedModel))));
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/VariableWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/VariableWriterTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.VariableMapper;
-import io.camunda.db.rdbms.sql.VariableMapper.BatchInsertVariablesDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
+import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
@@ -57,10 +57,10 @@ class VariableWriterTest {
                         && queueItem
                             .statementId()
                             .equals("io.camunda.db.rdbms.sql.VariableMapper.insert")
-                        && queueItem.parameter() instanceof BatchInsertVariablesDto
-                        && ((BatchInsertVariablesDto) queueItem.parameter()).variables().size() == 1
-                        && ((BatchInsertVariablesDto) queueItem.parameter())
-                            .variables()
+                        && queueItem.parameter() instanceof BatchInsertDto
+                        && ((BatchInsertDto) queueItem.parameter()).dbModels().size() == 1
+                        && ((BatchInsertDto) queueItem.parameter())
+                            .dbModels()
                             .getFirst()
                             .equals(truncatedModel)));
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -223,6 +223,7 @@ public class ExporterConfiguration {
             InsertBatchingConfig.builder()
                 .auditLogInsertBatchSize(insertBatching.getMaxAuditLogInsertBatchSize())
                 .variableInsertBatchSize(insertBatching.getMaxVariableInsertBatchSize())
+                .jobInsertBatchSize(insertBatching.getMaxJobInsertBatchSize())
                 .build())
         .build();
   }
@@ -277,6 +278,8 @@ public class ExporterConfiguration {
         RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_VARIABLE_INSERT_BATCH_SIZE;
     private int maxAuditLogInsertBatchSize =
         RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
+    private int maxJobInsertBatchSize =
+        RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_JOB_INSERT_BATCH_SIZE;
 
     public int getMaxVariableInsertBatchSize() {
       return maxVariableInsertBatchSize;
@@ -294,6 +297,14 @@ public class ExporterConfiguration {
       this.maxAuditLogInsertBatchSize = maxAuditLogInsertBatchSize;
     }
 
+    public int getMaxJobInsertBatchSize() {
+      return maxJobInsertBatchSize;
+    }
+
+    public void setMaxJobInsertBatchSize(final int maxJobInsertBatchSize) {
+      this.maxJobInsertBatchSize = maxJobInsertBatchSize;
+    }
+
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
 
@@ -309,6 +320,13 @@ public class ExporterConfiguration {
             String.format(
                 "insertBatching.maxAuditLogInsertBatchSize must be greater than 0 but was %d",
                 maxAuditLogInsertBatchSize));
+      }
+
+      if (maxJobInsertBatchSize < 1) {
+        errors.add(
+            String.format(
+                "insertBatching.maxJobInsertBatchSize must be greater than 0 but was %d",
+                maxJobInsertBatchSize));
       }
 
       return errors;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -224,6 +224,7 @@ public class ExporterConfiguration {
                 .auditLogInsertBatchSize(insertBatching.getMaxAuditLogInsertBatchSize())
                 .variableInsertBatchSize(insertBatching.getMaxVariableInsertBatchSize())
                 .jobInsertBatchSize(insertBatching.getMaxJobInsertBatchSize())
+                .flowNodeInsertBatchSize(insertBatching.getMaxFlowNodeInsertBatchSize())
                 .build())
         .build();
   }
@@ -280,6 +281,8 @@ public class ExporterConfiguration {
         RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_AUDIT_LOG_INSERT_BATCH_SIZE;
     private int maxJobInsertBatchSize =
         RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_JOB_INSERT_BATCH_SIZE;
+    private int maxFlowNodeInsertBatchSize =
+        RdbmsWriterConfig.InsertBatchingConfig.DEFAULT_FLOW_NODE_INSERT_BATCH_SIZE;
 
     public int getMaxVariableInsertBatchSize() {
       return maxVariableInsertBatchSize;
@@ -305,6 +308,14 @@ public class ExporterConfiguration {
       this.maxJobInsertBatchSize = maxJobInsertBatchSize;
     }
 
+    public int getMaxFlowNodeInsertBatchSize() {
+      return maxFlowNodeInsertBatchSize;
+    }
+
+    public void setMaxFlowNodeInsertBatchSize(final int maxFlowNodeInsertBatchSize) {
+      this.maxFlowNodeInsertBatchSize = maxFlowNodeInsertBatchSize;
+    }
+
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
 
@@ -327,6 +338,13 @@ public class ExporterConfiguration {
             String.format(
                 "insertBatching.maxJobInsertBatchSize must be greater than 0 but was %d",
                 maxJobInsertBatchSize));
+      }
+
+      if (maxFlowNodeInsertBatchSize < 1) {
+        errors.add(
+            String.format(
+                "insertBatching.maxFlowNodeInsertBatchSize must be greater than 0 but was %d",
+                maxFlowNodeInsertBatchSize));
       }
 
       return errors;


### PR DESCRIPTION
## Description

Expands the insert-batching feature also to `Job` and `FlowNodeInstance`, since they are also write heavy.

Also increase the defaults to 50 for AuditLog and to 25 for the other entities