### PR TITLE
Validate global listener commands

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -49,7 +49,7 @@ import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
-import io.camunda.zeebe.engine.GlobalListenerConfiguration;
+import io.camunda.zeebe.engine.processing.globallistener.GlobalListenerValidator;
 import io.camunda.zeebe.engine.processing.identity.initialize.AuthorizationConfigurer;
 import io.camunda.zeebe.engine.processing.identity.initialize.GroupConfigurer;
 import io.camunda.zeebe.engine.processing.identity.initialize.RoleConfigurer;
@@ -57,6 +57,7 @@ import io.camunda.zeebe.engine.processing.identity.initialize.TenantConfigurer;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperationChunk;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -136,6 +137,7 @@ public final class SystemContext {
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+  private final GlobalListenerValidator globalListenerValidator;
 
   public SystemContext(
       final Duration shutdownTimeout,
@@ -164,6 +166,7 @@ public final class SystemContext {
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+    globalListenerValidator = new GlobalListenerValidator();
     initSystemContext();
   }
 
@@ -294,7 +297,7 @@ public final class SystemContext {
     Optional.of(experimental)
         .map(ExperimentalCfg::getEngine)
         .map(EngineCfg::getGlobalListeners)
-        .ifPresent(c -> validateListenersConfig(c));
+        .ifPresent(this::validateListenersConfig);
 
     Optional.of(experimental)
         .map(ExperimentalCfg::getRocksdb)
@@ -563,54 +566,76 @@ public final class SystemContext {
 
   private void validateListenersConfig(final GlobalListenersCfg listeners) {
     final String propertyLocation = "camunda.cluster.global-listeners.user-task";
-    final List<String> supportedEventTypes = GlobalListenerConfiguration.TASK_LISTENER_EVENT_TYPES;
     final List<GlobalListenerCfg> taskListeners = listeners.getUserTask();
 
     // Validate listeners and ignore invalid ones
     final List<GlobalListenerCfg> validListeners = new ArrayList<>();
     for (int i = 0; i < taskListeners.size(); i++) {
-      final GlobalListenerCfg listener = taskListeners.get(i);
+      final GlobalListenerCfg listenerCfg = taskListeners.get(i);
       final String propertyPrefix = String.format("%s.%d", propertyLocation, i);
 
-      // Check if type is present
-      if (listener.getType() == null || listener.getType().isBlank()) {
+      // Check if retries actually contains a number
+      try {
+        if (Integer.parseInt(listenerCfg.getRetries()) <= 0) {
+          throw new NumberFormatException();
+        }
+      } catch (final NumberFormatException e) {
         LOG.warn(
-            String.format(
-                "Missing job type for global listener; listener will be ignored [%s.type]",
-                propertyPrefix));
+            "Invalid retries for global listener: '{}'; listener will be ignored [{}.retries]",
+            listenerCfg.getRetries(),
+            propertyPrefix);
+        continue;
+      }
+
+      // Convert to record in order to use standard validation methods
+      final GlobalListenerRecord listenerRecord =
+          listenerCfg.createGlobalListenerConfiguration().toRecord();
+
+      // Check if id is present
+      if (globalListenerValidator.idProvided(listenerRecord).isLeft()) {
+        LOG.warn(
+            "Missing id for global listener; listener will be ignored [{}.type]", propertyPrefix);
+        continue;
+      }
+
+      // Check if type is present
+      if (globalListenerValidator.typeProvided(listenerRecord).isLeft()) {
+        LOG.warn(
+            "Missing job type for global listener; listener will be ignored [{}.type]",
+            propertyPrefix);
         continue;
       }
 
       // Validate event types
+      // Note: the validator is not used directly because autocorrection is attempted here
       final var eventTypes = // consider event types in lowercase for validation
-          listener.getEventTypes().stream().map(String::toLowerCase).toList();
+          listenerRecord.getEventTypes().stream().map(String::toLowerCase).toList();
       final boolean containsAllEventsKeyword =
-          eventTypes.contains(GlobalListenerConfiguration.ALL_EVENT_TYPES);
+          eventTypes.contains(GlobalListenerRecord.ALL_EVENT_TYPES);
+
       final List<String> validEventTypes =
           eventTypes.stream()
               .filter( // check if provided event types have valid values
                   eventType -> {
-                    if (GlobalListenerConfiguration.ALL_EVENT_TYPES.equals(eventType)
-                        || supportedEventTypes.contains(eventType)) {
+                    if (globalListenerValidator.isValidEventType(listenerRecord, eventType)) {
                       return true;
                     } else {
                       LOG.warn(
-                          String.format(
-                              "Invalid event type will be ignored: '%s' [%s.eventTypes]",
-                              eventType, propertyPrefix));
+                          "Invalid event type will be ignored: '{}' [{}.eventTypes]",
+                          eventType,
+                          propertyPrefix);
                       return false;
                     }
                   })
               .filter(
                   eventType -> { // check if "all" is used alongside other event types
-                    if (!GlobalListenerConfiguration.ALL_EVENT_TYPES.equals(eventType)
+                    if (!GlobalListenerRecord.ALL_EVENT_TYPES.equals(eventType)
                         && containsAllEventsKeyword) {
                       LOG.warn(
-                          String.format(
-                              "Extra event type defined alongside '%s' will be ignored: '%s' [%s.eventTypes]",
-                              GlobalListenerConfiguration.ALL_EVENT_TYPES,
-                              eventType,
-                              propertyPrefix));
+                          "Extra event type defined alongside '{}' will be ignored: '{}' [{}.eventTypes]",
+                          GlobalListenerRecord.ALL_EVENT_TYPES,
+                          eventType,
+                          propertyPrefix);
                       return false;
                     }
                     return true;
@@ -623,9 +648,9 @@ public final class SystemContext {
           eventType -> {
             if (uniqueEventTypes.contains(eventType)) {
               LOG.warn(
-                  String.format(
-                      "Duplicated event type will be considered only once: '%s' [%s.eventTypes]",
-                      eventType, propertyPrefix));
+                  "Duplicated event type will be considered only once: '{}' [{}.eventTypes]",
+                  eventType,
+                  propertyPrefix);
             } else {
               uniqueEventTypes.add(eventType);
             }
@@ -634,27 +659,13 @@ public final class SystemContext {
       // Check if valid event types have been provided
       if (uniqueEventTypes.isEmpty()) {
         LOG.warn(
-            String.format(
-                "Missing event types for global listener; listener will be ignored [%s.eventTypes]",
-                propertyPrefix));
+            "Missing event types for global listener; listener will be ignored [{}.eventTypes]",
+            propertyPrefix);
         continue;
       }
 
-      listener.setEventTypes(uniqueEventTypes);
-
-      // Check if retries actually contains a number
-      try {
-        if (Integer.parseInt(listener.getRetries()) <= 0) {
-          throw new NumberFormatException();
-        }
-      } catch (final NumberFormatException e) {
-        LOG.warn(
-            String.format(
-                "Invalid retries for global listener: '%s'; listener will be ignored [%s.retries]",
-                listener.getRetries(), propertyPrefix));
-        continue;
-      }
-      validListeners.add(listener);
+      listenerCfg.setEventTypes(uniqueEventTypes);
+      validListeners.add(listenerCfg);
     }
 
     listeners.setUserTask(validListeners);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.system.configuration.engine;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.GlobalListenerConfiguration;
-import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,9 +19,9 @@ public class GlobalListenerCfg implements ConfigurationEntry {
   private String id = "";
   private List<String> eventTypes = new ArrayList<>();
   private String type = "";
-  private String retries = String.valueOf(GlobalListenerRecord.DEFAULT_RETRIES);
+  private String retries = String.valueOf(GlobalListenerRecordValue.DEFAULT_RETRIES);
   private boolean afterNonGlobal = false;
-  private int priority = GlobalListenerRecord.DEFAULT_PRIORITY;
+  private int priority = GlobalListenerRecordValue.DEFAULT_PRIORITY;
   private GlobalListenerType listenerType = GlobalListenerType.USER_TASK;
 
   public String getId() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/GlobalListenerCfg.java
@@ -16,9 +16,9 @@ import java.util.List;
 
 public class GlobalListenerCfg implements ConfigurationEntry {
 
-  private String id;
+  private String id = "";
   private List<String> eventTypes = new ArrayList<>();
-  private String type;
+  private String type = "";
   private String retries = String.valueOf(GlobalListenerRecord.DEFAULT_RETRIES);
   private boolean afterNonGlobal = false;
   private int priority = GlobalListenerRecord.DEFAULT_PRIORITY;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -650,7 +650,7 @@ final class SystemContextTest {
         .setUserTask(
             List.of(
                 createListenerCfg("test", List.of("creating")),
-                createListenerCfg(null, List.of("assigning"))));
+                createListenerCfg("", List.of("assigning"))));
 
     // when
     initSystemContext(brokerCfg);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/GlobalListenerConfiguration.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine;
 
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import java.util.List;
-import java.util.stream.Stream;
 
 public record GlobalListenerConfiguration(
     String id,
@@ -21,10 +21,15 @@ public record GlobalListenerConfiguration(
     int priority,
     GlobalListenerType listenerType) {
 
-  public static final String ALL_EVENT_TYPES = "all";
-
-  // List of all possible task listener event types as strings, to be used while validating
-  // the configuration (ZeebeTaskListenerEventType is not accessible from the broker module)
-  public static final List<String> TASK_LISTENER_EVENT_TYPES =
-      Stream.of(ZeebeTaskListenerEventType.values()).map(Enum::name).toList();
+  public GlobalListenerRecord toRecord() {
+    return new GlobalListenerRecord()
+        .setId(this.id())
+        .setType(this.type())
+        .setEventTypes(this.eventTypes())
+        .setRetries(Integer.parseInt(this.retries()))
+        .setAfterNonGlobal(this.afterNonGlobal())
+        .setPriority(this.priority())
+        .setSource(GlobalListenerSource.CONFIGURATION)
+        .setListenerType(this.listenerType());
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebePriorityDefiniti
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.impl.StaticExpression;
-import io.camunda.zeebe.engine.GlobalListenerConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -34,6 +33,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -464,7 +464,7 @@ public final class BpmnUserTaskBehavior {
 
     // Extract the list of supported listener event types
     var eventTypes =
-        globalTaskListener.getEventTypes().contains(GlobalListenerConfiguration.ALL_EVENT_TYPES)
+        globalTaskListener.getEventTypes().contains(GlobalListenerRecord.ALL_EVENT_TYPES)
             ? List.of(ZeebeTaskListenerEventType.values())
             : globalTaskListener.getEventTypes().stream()
                 .map(ZeebeTaskListenerEventType::valueOf)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.globallistener;
 
-import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
@@ -21,11 +21,12 @@ import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListener
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 
-@ExcludeAuthorizationCheck
 public final class GlobalListenerCreateProcessor
     implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
 
@@ -96,7 +97,15 @@ public final class GlobalListenerCreateProcessor
 
   private Either<Rejection, GlobalListenerRecord> validateCommand(
       final TypedRecord<GlobalListenerRecord> command) {
-    return Either.right(command.getValue());
+    final AuthorizationRequest authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+            .permissionType(PermissionType.CREATE_TASK_LISTENER)
+            .build();
+    return authCheckBehavior
+        .isAuthorizedOrInternalCommand(authRequest)
+        .map(unused -> command.getValue());
   }
 
   private void emitChangeEvents(final GlobalListenerRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.globallistener;
 
-import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
@@ -21,11 +21,12 @@ import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListener
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 
-@ExcludeAuthorizationCheck
 public final class GlobalListenerDeleteProcessor
     implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
   private static final String LISTENER_NOT_EXISTS_ERROR_MESSAGE =
@@ -93,12 +94,21 @@ public final class GlobalListenerDeleteProcessor
 
   private Either<Rejection, GlobalListenerRecord> validateCommand(
       final TypedRecord<GlobalListenerRecord> command) {
-    // TODO: actual validation
-    final var record = command.getValue();
-    final var resolvedRecord =
-        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
-    record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
-    return Either.right(record);
+    final AuthorizationRequest authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+            .permissionType(PermissionType.DELETE_TASK_LISTENER)
+            .build();
+    return authCheckBehavior
+        .isAuthorizedOrInternalCommand(authRequest)
+        .map(unused -> {
+          final var record = command.getValue();
+          final var resolvedRecord =
+              globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+          record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
+          return record;
+        });
   }
 
   private void emitChangeEvents(final GlobalListenerRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.globallistener;
 
-import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
@@ -20,11 +20,12 @@ import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListener
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 
-@ExcludeAuthorizationCheck
 public final class GlobalListenerUpdateProcessor
     implements DistributedTypedRecordProcessor<GlobalListenerRecord> {
 
@@ -80,12 +81,22 @@ public final class GlobalListenerUpdateProcessor
 
   private Either<Rejection, GlobalListenerRecord> validateCommand(
       final TypedRecord<GlobalListenerRecord> command) {
-    // TODO: actual validation
-    final var record = command.getValue();
-    final var resolvedRecord =
-        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
-    record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
-    return Either.right(record);
+
+    final AuthorizationRequest authRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+            .permissionType(PermissionType.UPDATE_TASK_LISTENER)
+            .build();
+    return authCheckBehavior
+        .isAuthorizedOrInternalCommand(authRequest)
+        .map(unused -> {
+          final var record = command.getValue();
+          final var resolvedRecord =
+              globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+          record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
+          return record;
+        });
   }
 
   private void emitChangeEvents(final GlobalListenerRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerValidator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class GlobalListenerValidator {
+  private static final String LISTENER_NOT_EXISTS_ERROR_MESSAGE =
+      "Expected a global %s listener with id '%s' to exist, but it was not found";
+  private static final String LISTENER_EXISTS_ERROR_MESSAGE =
+      "Expected a global %s listener with id '%s' to not exist, but a listener with the same id was found";
+  private static final String MISSING_ID_ERROR_MESSAGE =
+      "Missing id for the provided global %s listener";
+  private static final String MISSING_TYPE_ERROR_MESSAGE =
+      "Missing type for the provided global %s listener with id '%s'";
+  private static final String MISSING_EVENT_TYPES_ERROR_MESSAGE =
+      "Missing event types for the provided global %s listener with id '%s'";
+  private static final String INVALID_EVENT_TYPE_ERROR_MESSAGE =
+      "Invalid event types for the provided global %s listener with id '%s': %s";
+
+  public GlobalListenerValidator() {}
+
+  public Either<Rejection, GlobalListenerRecord> resolveExistingListener(
+      final GlobalListenerRecord record, final GlobalListenersState globalListenersState) {
+    final var existingListener =
+        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+    if (existingListener == null) {
+      final var message =
+          LISTENER_NOT_EXISTS_ERROR_MESSAGE.formatted(record.getListenerType(), record.getId());
+      return Either.left(new Rejection(RejectionType.NOT_FOUND, message));
+    }
+    // Set the global listener key in the record from the information in the state
+    record.setGlobalListenerKey(existingListener.getGlobalListenerKey());
+    return Either.right(record);
+  }
+
+  public Either<Rejection, GlobalListenerRecord> listenerDoesNotExist(
+      final GlobalListenerRecord record, final GlobalListenersState globalListenersState) {
+    final var existingListener =
+        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+    if (existingListener != null) {
+      final var message =
+          LISTENER_EXISTS_ERROR_MESSAGE.formatted(record.getListenerType(), record.getId());
+      return Either.left(new Rejection(RejectionType.ALREADY_EXISTS, message));
+    }
+    return Either.right(record);
+  }
+
+  public Either<Rejection, GlobalListenerRecord> idProvided(final GlobalListenerRecord record) {
+    if (record.getId().isBlank()) {
+      final var message = MISSING_ID_ERROR_MESSAGE.formatted(record.getListenerType());
+      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, message));
+    }
+    return Either.right(record);
+  }
+
+  public Either<Rejection, GlobalListenerRecord> typeProvided(final GlobalListenerRecord record) {
+    if (record.getType().isBlank()) {
+      final var message =
+          MISSING_TYPE_ERROR_MESSAGE.formatted(record.getListenerType(), record.getId());
+      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, message));
+    }
+    return Either.right(record);
+  }
+
+  public Either<Rejection, GlobalListenerRecord> eventTypesProvided(
+      final GlobalListenerRecord record) {
+    if (record.getEventTypes() == null || record.getEventTypes().isEmpty()) {
+      final var message =
+          MISSING_EVENT_TYPES_ERROR_MESSAGE.formatted(record.getListenerType(), record.getId());
+      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, message));
+    }
+    return Either.right(record);
+  }
+
+  public Either<Rejection, GlobalListenerRecord> validEventTypes(
+      final GlobalListenerRecord record) {
+    final Set<String> invalidEventTypes =
+        record.getEventTypes().stream()
+            .filter(eventType -> !isValidEventType(record, eventType))
+            .collect(Collectors.toSet());
+    if (!invalidEventTypes.isEmpty()) {
+      final var message =
+          INVALID_EVENT_TYPE_ERROR_MESSAGE.formatted(
+              record.getListenerType(),
+              record.getId(),
+              invalidEventTypes.stream().collect(Collectors.joining("', '", "'", "'")));
+      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, message));
+    }
+    return Either.right(record);
+  }
+
+  public boolean isValidEventType(final GlobalListenerRecord record, final String eventType) {
+    return GlobalListenerRecord.ALL_EVENT_TYPES.equals(eventType)
+        || GlobalListenerRecord.TASK_LISTENER_EVENT_TYPES.contains(eventType);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializer.java
@@ -8,15 +8,14 @@
 package io.camunda.zeebe.engine.processing.globallistener;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.GlobalListenerConfiguration;
 import io.camunda.zeebe.engine.GlobalListenersConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
-import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
-import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.util.Objects;
@@ -75,17 +74,7 @@ public final class GlobalListenersInitializer implements StreamProcessorLifecycl
       final GlobalListenersConfiguration listeners) {
     final GlobalListenerBatchRecord record = new GlobalListenerBatchRecord();
     listeners.userTask().stream()
-        .map(
-            listener ->
-                new GlobalListenerRecord()
-                    .setId(listener.id())
-                    .setType(listener.type())
-                    .setEventTypes(listener.eventTypes())
-                    .setRetries(Integer.parseInt(listener.retries()))
-                    .setAfterNonGlobal(listener.afterNonGlobal())
-                    .setPriority(listener.priority())
-                    .setSource(GlobalListenerSource.CONFIGURATION)
-                    .setListenerType(listener.listenerType()))
+        .map(GlobalListenerConfiguration::toRecord)
         .forEach(record::addListener);
     return record;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -778,7 +778,7 @@ public class CommandDistributionIdempotencyTest {
                         .globalListener()
                         .withId("my-listener-to-create")
                         .withType("job1")
-                        .withEventType("all")
+                        .withEventTypes("all")
                         .create()),
             GlobalListenerCreateProcessor.class
           },
@@ -792,15 +792,14 @@ public class CommandDistributionIdempotencyTest {
                       .globalListener()
                       .withId("my-listener-to-update")
                       .withType("job1")
-                      .withEventType("all")
+                      .withEventTypes("all")
                       .create();
 
                   return ENGINE
                       .globalListener()
                       .withId("my-listener-to-update")
                       .withType("job2")
-                      .withEventType("creating")
-                      .withEventType("updating")
+                      .withEventTypes("creating", "updating")
                       .update();
                 }),
             GlobalListenerUpdateProcessor.class
@@ -815,7 +814,7 @@ public class CommandDistributionIdempotencyTest {
                       .globalListener()
                       .withId("my-listener-to-delete")
                       .withType("job1")
-                      .withEventType("all")
+                      .withEventTypes("all")
                       .create();
                   return ENGINE.globalListener().withId("my-listener-to-delete").delete();
                 }),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class GlobalListenerCreateTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateNewListenerWithMinimalData() {
+    final var result =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating", "updating")
+            .create();
+    assertThat(result.getValue())
+        .hasId("my-id")
+        .hasType("my-type")
+        .hasRetries(GlobalListenerRecordValue.DEFAULT_RETRIES)
+        .hasEventTypes("creating", "updating")
+        .isNotAfterNonGlobal()
+        .hasPriority(GlobalListenerRecordValue.DEFAULT_PRIORITY)
+        .hasSource(GlobalListenerRecordValue.DEFAULT_SOURCE)
+        .hasListenerType(GlobalListenerRecordValue.DEFAULT_LISTENER_TYPE);
+  }
+
+  @Test
+  public void shouldCreateNewListenerWithFullData() {
+    final var result =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withRetries(5)
+            .withEventTypes("creating", "updating")
+            .withAfterNonGlobal(true)
+            .withPriority(100)
+            .withSource(GlobalListenerSource.API)
+            .withListenerType(GlobalListenerType.USER_TASK)
+            .create();
+    assertThat(result.getValue())
+        .hasId("my-id")
+        .hasType("my-type")
+        .hasRetries(5)
+        .hasEventTypes("creating", "updating")
+        .isAfterNonGlobal()
+        .hasPriority(100)
+        .hasSource(GlobalListenerSource.API)
+        .hasListenerType(GlobalListenerType.USER_TASK);
+  }
+
+  @Test
+  public void shouldNotCreateListenerWithMissingId() {
+    final var rejection =
+        engine
+            .globalListener()
+            .withType("my-type")
+            .withEventTypes("creating")
+            .expectRejection()
+            .create();
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotCreateListenerWithMissingType() {
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withEventTypes("creating")
+            .expectRejection()
+            .create();
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotCreateListenerWithMissingEventTypes() {
+    final var rejection =
+        engine.globalListener().withId("my-id").withType("my-type").expectRejection().create();
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotCreateListenerWithInvalidEventTypes() {
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating")
+            .withEventTypes("start")
+            .expectRejection()
+            .create();
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotCreateListenerIfItAlreadyExists() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("creating").create();
+
+    // when
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating")
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.ALREADY_EXISTS);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
@@ -8,20 +8,29 @@
 package io.camunda.zeebe.engine.processing.globallistener;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class GlobalListenerCreateTest {
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @Test
@@ -131,5 +140,54 @@ public class GlobalListenerCreateTest {
 
     // then
     assertThat(rejection).hasRejectionType(RejectionType.ALREADY_EXISTS);
+  }
+
+  // Authorization tests
+
+  @Test
+  public void shouldBeAuthorizedToCreateListenerWithCorrectPermission() {
+    final var username = createUserWithPermissions(PermissionType.CREATE_TASK_LISTENER);
+    engine
+        .globalListener()
+        .withId("my-id")
+        .withType("my-type")
+        .withEventTypes("creating", "updating")
+        .create(username);
+  }
+
+  @Test
+  public void shouldNotBeAuthorizedToCreateListenerWithoutCorrectPermission() {
+    final var username =
+        createUserWithPermissions(
+            PermissionType.UPDATE_TASK_LISTENER, PermissionType.DELETE_TASK_LISTENER);
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating", "updating")
+            .expectRejection()
+            .create(username);
+    assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+  }
+
+  private String createUserWithoutPermissions() {
+    final var user = engine.user().newUser(UUID.randomUUID().toString()).create().getValue();
+    return user.getUsername();
+  }
+
+  private String createUserWithPermissions(final PermissionType... permissions) {
+    final var username = createUserWithoutPermissions();
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissions)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
+        .create();
+    return username;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
@@ -8,17 +8,26 @@
 package io.camunda.zeebe.engine.processing.globallistener;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class GlobalListenerDeleteTest {
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @Test
@@ -55,5 +64,47 @@ public class GlobalListenerDeleteTest {
 
     // then
     assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  // Authorization tests
+
+  @Test
+  public void shouldBeAuthorizedToDeleteListenerWithCorrectPermission() {
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("all").create();
+
+    final var username = createUserWithPermissions(PermissionType.DELETE_TASK_LISTENER);
+    engine.globalListener().withId("my-id").delete(username);
+  }
+
+  @Test
+  public void shouldNotBeAuthorizedToDeleteListenerWithoutCorrectPermission() {
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("all").create();
+
+    final var username =
+        createUserWithPermissions(
+            PermissionType.CREATE_TASK_LISTENER, PermissionType.UPDATE_TASK_LISTENER);
+    final var rejection =
+        engine.globalListener().withId("my-id").expectRejection().delete(username);
+    assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+  }
+
+  private String createUserWithoutPermissions() {
+    final var user = engine.user().newUser(UUID.randomUUID().toString()).create().getValue();
+    return user.getUsername();
+  }
+
+  private String createUserWithPermissions(final PermissionType... permissions) {
+    final var username = createUserWithoutPermissions();
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissions)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
+        .create();
+    return username;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class GlobalListenerDeleteTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeleteExistingListener() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("all").create();
+
+    // when
+    final var result = engine.globalListener().withId("my-id").delete();
+
+    // then
+    assertThat(result.getValue()).hasId("my-id");
+  }
+
+  @Test
+  public void shouldNotDeleteListenerWithMissingId() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("all").create();
+
+    // when
+    final var rejection = engine.globalListener().expectRejection().delete();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotDeleteListenerIfItIsNotFound() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("creating").create();
+
+    // when
+    final var rejection = engine.globalListener().withId("my-other-id").expectRejection().delete();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
@@ -8,20 +8,29 @@
 package io.camunda.zeebe.engine.processing.globallistener;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class GlobalListenerUpdateTest {
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @Test
@@ -176,5 +185,58 @@ public class GlobalListenerUpdateTest {
 
     // then
     assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  // Authorization tests
+
+  @Test
+  public void shouldBeAuthorizedToUpdateListenerWithCorrectPermission() {
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    final var username = createUserWithPermissions(PermissionType.UPDATE_TASK_LISTENER);
+    engine
+        .globalListener()
+        .withId("my-id")
+        .withType("my-type")
+        .withEventTypes("creating")
+        .update(username);
+  }
+
+  @Test
+  public void shouldNotBeAuthorizedToUpdateListenerWithoutCorrectPermission() {
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    final var username =
+        createUserWithPermissions(
+            PermissionType.CREATE_TASK_LISTENER, PermissionType.DELETE_TASK_LISTENER);
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating")
+            .expectRejection()
+            .update(username);
+    assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+  }
+
+  private String createUserWithoutPermissions() {
+    final var user = engine.user().newUser(UUID.randomUUID().toString()).create().getValue();
+    return user.getUsername();
+  }
+
+  private String createUserWithPermissions(final PermissionType... permissions) {
+    final var username = createUserWithoutPermissions();
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissions)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GLOBAL_LISTENER)
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
+        .create();
+    return username;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.globallistener;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class GlobalListenerUpdateTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldUpdateNewListenerWithMinimalData() {
+    // given
+    engine
+        .globalListener()
+        .withId("my-id")
+        .withType("my-old-type")
+        .withRetries(5)
+        .withEventTypes("all")
+        .withAfterNonGlobal(true)
+        .withPriority(100)
+        .withSource(GlobalListenerSource.API)
+        .withListenerType(GlobalListenerType.USER_TASK)
+        .create();
+
+    // when
+    final var result =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating", "updating")
+            .update();
+
+    // then
+    assertThat(result.getValue())
+        .hasId("my-id")
+        .hasType("my-type")
+        .hasRetries(GlobalListenerRecordValue.DEFAULT_RETRIES)
+        .hasEventTypes("creating", "updating")
+        .isNotAfterNonGlobal()
+        .hasPriority(GlobalListenerRecordValue.DEFAULT_PRIORITY)
+        .hasSource(GlobalListenerRecordValue.DEFAULT_SOURCE)
+        .hasListenerType(GlobalListenerRecordValue.DEFAULT_LISTENER_TYPE);
+  }
+
+  @Test
+  public void shouldUpdateNewListenerWithFullData() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    // when
+    final var result =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withRetries(5)
+            .withEventTypes("creating", "updating")
+            .withAfterNonGlobal(true)
+            .withPriority(100)
+            .withSource(GlobalListenerSource.API)
+            .withListenerType(GlobalListenerType.USER_TASK)
+            .update();
+
+    // then
+    assertThat(result.getValue())
+        .hasId("my-id")
+        .hasType("my-type")
+        .hasRetries(5)
+        .hasEventTypes("creating", "updating")
+        .isAfterNonGlobal()
+        .hasPriority(100)
+        .hasSource(GlobalListenerSource.API)
+        .hasListenerType(GlobalListenerType.USER_TASK);
+  }
+
+  @Test
+  public void shouldNotUpdateListenerWithMissingId() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    // when
+    final var rejection =
+        engine
+            .globalListener()
+            .withType("my-type")
+            .withEventTypes("creating")
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotUpdateListenerWithMissingType() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    // when
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withEventTypes("creating")
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotUpdateListenerWithMissingEventTypes() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    // when
+    final var rejection =
+        engine.globalListener().withId("my-id").withType("my-type").expectRejection().update();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotUpdateListenerWithInvalidEventTypes() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-old-type").withEventTypes("all").create();
+
+    // when
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-id")
+            .withType("my-type")
+            .withEventTypes("creating", "start")
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldNotUpdateListenerIfItIsNotFound() {
+    // given
+    engine.globalListener().withId("my-id").withType("my-type").withEventTypes("creating").create();
+
+    // when
+    final var rejection =
+        engine
+            .globalListener()
+            .withId("my-other-id")
+            .withType("my-type")
+            .withEventTypes("creating")
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
@@ -107,13 +107,31 @@ public final class GlobalListenerClient {
     return expectation.apply(position, GlobalListenerIntent.CREATED);
   }
 
+  public Record<GlobalListenerRecordValue> create(final String username) {
+    final long position =
+        writer.writeCommand(GlobalListenerIntent.CREATE, username, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.CREATED);
+  }
+
   public Record<GlobalListenerRecordValue> update() {
     final long position = writer.writeCommand(GlobalListenerIntent.UPDATE, globalListenerRecord);
     return expectation.apply(position, GlobalListenerIntent.UPDATED);
   }
 
+  public Record<GlobalListenerRecordValue> update(final String username) {
+    final long position =
+        writer.writeCommand(GlobalListenerIntent.UPDATE, username, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.UPDATED);
+  }
+
   public Record<GlobalListenerRecordValue> delete() {
     final long position = writer.writeCommand(GlobalListenerIntent.DELETE, globalListenerRecord);
+    return expectation.apply(position, GlobalListenerIntent.DELETED);
+  }
+
+  public Record<GlobalListenerRecordValue> delete(final String username) {
+    final long position =
+        writer.writeCommand(GlobalListenerIntent.DELETE, username, globalListenerRecord);
     return expectation.apply(position, GlobalListenerIntent.DELETED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GlobalListenerClient.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
 import java.util.function.BiFunction;
 
 public final class GlobalListenerClient {
@@ -58,7 +59,12 @@ public final class GlobalListenerClient {
     return this;
   }
 
-  public GlobalListenerClient withEventType(final String eventType) {
+  public GlobalListenerClient withEventTypes(final String... eventTypes) {
+    globalListenerRecord.setEventTypes(List.of(eventTypes));
+    return this;
+  }
+
+  public GlobalListenerClient addEventType(final String eventType) {
     globalListenerRecord.addEventType(eventType);
     return this;
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -7,7 +7,7 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3,
+      "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
     },

--- a/zeebe/protocol-impl/pom.xml
+++ b/zeebe/protocol-impl/pom.xml
@@ -108,6 +108,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-auth</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.globallistener;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
@@ -23,7 +24,9 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public final class GlobalListenerRecord extends UnifiedRecordValue
@@ -41,6 +44,11 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
       Comparator.comparingInt(GlobalListenerRecord::getPriority)
           .reversed()
           .thenComparing(GlobalListenerRecord::getId);
+
+  public static final String ALL_EVENT_TYPES = "all";
+  // Set of all possible task listener event types as strings, to be used while validating records
+  public static final Set<String> TASK_LISTENER_EVENT_TYPES =
+      Stream.of(ZeebeTaskListenerEventType.values()).map(Enum::name).collect(Collectors.toSet());
 
   private final LongProperty globalListenerKeyProp = new LongProperty("globalListenerKey", -1L);
   private final StringProperty idProp = new StringProperty("id", "");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -59,9 +59,9 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
   private final BooleanProperty afterNonGlobalProp = new BooleanProperty("afterNonGlobal", false);
   private final IntegerProperty priorityProp = new IntegerProperty("priority", DEFAULT_PRIORITY);
   private final EnumProperty<GlobalListenerSource> sourceProp =
-      new EnumProperty<>("source", GlobalListenerSource.class, GlobalListenerSource.CONFIGURATION);
+      new EnumProperty<>("source", GlobalListenerSource.class, DEFAULT_SOURCE);
   private final EnumProperty<GlobalListenerType> listenerTypeProp =
-      new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
+      new EnumProperty<>("listenerType", GlobalListenerType.class, DEFAULT_LISTENER_TYPE);
 
   private final LongProperty configKeyProp = new LongProperty("configKey", -1L);
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
@@ -31,6 +31,11 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableGlobalListenerRecordValue.Builder.class)
 public interface GlobalListenerRecordValue extends RecordValue {
 
+  int DEFAULT_RETRIES = 3;
+  int DEFAULT_PRIORITY = 50;
+  GlobalListenerSource DEFAULT_SOURCE = GlobalListenerSource.CONFIGURATION;
+  GlobalListenerType DEFAULT_LISTENER_TYPE = GlobalListenerType.USER_TASK;
+
   /**
    * Returns the unique key of the global listener.
    *


### PR DESCRIPTION
## Description

This PR introduces validation for `GLOBAL_LISTENER` commands:
- `CREATE`
  - require permission `GLOBAL_LISTENER:CREATE_TASK_LISTENER`
  - check that the id is provided
  - check that the provided id is not already in use
  - check that the type is provided
  - check that the eventTypes list is provided and validate its values
- `UPDATE`
  - require permission `GLOBAL_LISTENER:UPDATE_TASK_LISTENER`
  - check that the id is provided
  - check that the provided id is related to an existing listener
  - check that the type is provided
  - check that the eventTypes list is provided and validate its values
- `DELETE`
  - require permission `GLOBAL_LISTENER:DELETE_TASK_LISTENER`
  - check that the id is provided
  - check that the provided id is related to an existing listener

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43182 
closes #43186
