### PR TITLE
Restore app can work with dynamic node id

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -193,6 +193,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/configuration/src/main/java/io/camunda/configuration/Restore.java
+++ b/configuration/src/main/java/io/camunda/configuration/Restore.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.dynamic.nodeid.fs.VersionedDirectoryLayout;
 import java.util.List;
 import java.util.Set;
 
@@ -21,7 +22,8 @@ public class Restore {
       Set.of("zeebe.restore.ignoreFilesInTarget");
 
   private boolean validateConfig = true;
-  private List<String> ignoreFilesInTarget = List.of("lost+found");
+  private List<String> ignoreFilesInTarget =
+      List.of("lost+found", VersionedDirectoryLayout.DIRECTORY_INITIALIZED_FILE);
 
   public boolean isValidateConfig() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import io.camunda.configuration.Cluster;
+import io.camunda.configuration.NodeIdProvider.S3;
+import io.camunda.zeebe.broker.system.BrokerDataDirectoryCopier;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.RepositoryNodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryCopier;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Utility class to create NodeIdProvider related objects based on the configuration.
+ *
+ * <p>Used by both the broker and the restore application.
+ */
+public class NodeIProviderConfigurationUtils {
+  public static S3NodeIdRepository getS3NodeIdRepository(final Cluster cluster) {
+    return switch (cluster.getNodeIdProvider().getType()) {
+      case FIXED -> null;
+      case S3 -> {
+        final var clientConfig = makeS3ClientConfig(cluster.getNodeIdProvider().s3());
+        final var s3Config = cluster.getNodeIdProvider().s3();
+        final var config =
+            new S3NodeIdRepository.Config(
+                s3Config.getBucketName(),
+                s3Config.getLeaseDuration(),
+                s3Config.getReadinessCheckTimeout());
+        yield S3NodeIdRepository.of(clientConfig, config, Clock.systemUTC());
+      }
+    };
+  }
+
+  public static NodeIdProvider getNodeIdProvider(
+      final Logger log,
+      final Cluster cluster,
+      final Optional<NodeIdRepository> nodeIdRepository,
+      final Runnable shutdownHelper) {
+    final var nodeIdProvider =
+        switch (cluster.getNodeIdProvider().getType()) {
+          case FIXED -> {
+            final var nodeId = cluster.getNodeId();
+            yield NodeIdProvider.staticProvider(nodeId);
+          }
+          case S3 -> {
+            final var config = cluster.getNodeIdProvider().s3();
+            if (nodeIdRepository.isEmpty()) {
+              throw new IllegalStateException(
+                  "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");
+            }
+            final var taskId = config.getTaskId().orElse(UUID.randomUUID().toString());
+            log.debug("Node configured with taskId {}", taskId);
+            yield new RepositoryNodeIdProvider(
+                nodeIdRepository.get(),
+                Clock.systemUTC(),
+                config.getLeaseDuration(),
+                config.getLeaseAcquireMaxDelay(),
+                config.getReadinessCheckTimeout(),
+                taskId,
+                () -> {
+                  log.warn("NodeIdProvider terminating the process");
+                  shutdownHelper.run();
+                });
+          }
+        };
+    nodeIdProvider.initialize(cluster.getSize()).join();
+    return nodeIdProvider;
+  }
+
+  private static S3ClientConfig makeS3ClientConfig(final S3 s3) {
+    final var credentials =
+        s3.getAccessKey()
+            .flatMap(
+                accessKey ->
+                    s3.getSecretKey()
+                        .map(secretKey -> new S3ClientConfig.Credentials(accessKey, secretKey)));
+    return new S3ClientConfig(
+        credentials,
+        s3.getRegion().map(Region::of),
+        s3.getEndpoint().map(URI::create),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.ofNullable(s3.getApiCallTimeout()));
+  }
+
+  // brokerCopier does not implement the interface because it's defined in zeebe-broker module
+  // which does not depend on dynamic-node-id-provider module.
+  public static DataDirectoryCopier fromBrokerCopier(final BrokerDataDirectoryCopier brokerCopier) {
+    return new DataDirectoryCopier() {
+      @Override
+      public void copy(
+          final Path source,
+          final Path target,
+          final String markerFileName,
+          final boolean useHardLinks)
+          throws IOException {
+        brokerCopier.copy(source, target, markerFileName, useHardLinks);
+      }
+
+      @Override
+      public void validate(final Path source, final Path target, final String markerFileName)
+          throws IOException {
+        brokerCopier.validate(source, target, markerFileName);
+      }
+    };
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/S3NodeIdProviderRestoreAcceptanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/S3NodeIdProviderRestoreAcceptanceIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.cluster.dynamicnodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.NodeIdProvider.Type;
+import io.camunda.configuration.PrimaryStorageBackup;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.it.util.TestHelper;
+import io.camunda.management.backups.BackupInfo;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Testcontainers
+@ZeebeIntegration
+public final class S3NodeIdProviderRestoreAcceptanceIT {
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices("s3")
+          .withEnv("LS_LOG", "trace");
+
+  @AutoClose private static S3Client s3Client;
+  private static final String NODE_ID_BUCKET_NAME = "node-id" + UUID.randomUUID().toString();
+  private static final String BACKUP_BUCKET_NAME = "backup" + UUID.randomUUID().toString();
+  private static final int CLUSTER_SIZE = 3;
+  private static final int PARTITIONS_COUNT = 3;
+  private static final int REPLICATION_FACTOR = 1;
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(20);
+
+  private static @TempDir Path workingDirectory;
+
+  @TestZeebe
+  private final TestCluster testCluster =
+      TestCluster.builder()
+          .withName("s3-node-id-backup-restore-test")
+          .withBrokersCount(CLUSTER_SIZE)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withoutNodeId()
+          .withBrokerConfig(b -> b.withWorkingDirectory(workingDirectory))
+          .withNodeConfig(
+              app ->
+                  app.withProperty(
+                          "camunda.data.secondary-storage.type", SecondaryStorageType.none.name())
+                      .withUnifiedConfig(
+                          cfg -> {
+                            configureNodeIdProvider(cfg);
+                            configureBackupStore(cfg);
+                          }))
+          .build();
+
+  @BeforeAll
+  static void setupAll() {
+    s3Client =
+        S3NodeIdRepository.buildClient(
+            new S3NodeIdRepository.S3ClientConfig(
+                java.util.Optional.of(
+                    new S3NodeIdRepository.S3ClientConfig.Credentials(
+                        S3.getAccessKey(), S3.getSecretKey())),
+                java.util.Optional.of(Region.of(S3.getRegion())),
+                java.util.Optional.of(S3.getEndpoint())));
+
+    s3Client.createBucket(b -> b.bucket(NODE_ID_BUCKET_NAME));
+    s3Client.createBucket(b -> b.bucket(BACKUP_BUCKET_NAME));
+  }
+
+  @AfterEach
+  void cleanup() {
+    final var objects = s3Client.listObjects(b -> b.bucket(NODE_ID_BUCKET_NAME));
+    objects.contents().parallelStream()
+        .forEach(obj -> s3Client.deleteObject(b -> b.bucket(NODE_ID_BUCKET_NAME).key(obj.key())));
+  }
+
+  @Test
+  void shouldBackupAndRestoreWithS3NodeIdProvider() throws IOException {
+    final var backupId = 42L;
+    final var processInstancesCount = 3;
+
+    // given - deploy process and create instances
+    try (final var client = testCluster.newClientBuilder().build()) {
+      TestHelper.deployResource(client, "process/service_tasks_v1.bpmn");
+
+      for (int i = 0; i < processInstancesCount; i++) {
+        TestHelper.startProcessInstance(client, "service_tasks_v1");
+      }
+    }
+
+    // when - take backup
+    takeBackup(backupId);
+
+    // shutdown cluster
+    testCluster.shutdown();
+
+    // restore from backup
+    restoreBackup(backupId);
+
+    // restart cluster
+    testCluster.start();
+    testCluster.awaitCompleteTopology();
+
+    // then - verify process instances can be completed
+    assertThatJobsFromAllInstancesCanBeActivated(processInstancesCount);
+  }
+
+  private void assertThatJobsFromAllInstancesCanBeActivated(final int processInstancesCount) {
+    try (final var client = testCluster.newClientBuilder().build()) {
+      final var completedJobs = new ArrayList<ActivatedJob>();
+
+      while (completedJobs.size() < processInstancesCount) {
+        final var jobActivation =
+            client
+                .newActivateJobsCommand()
+                .jobType("taskA")
+                .maxJobsToActivate(processInstancesCount)
+                .send()
+                .toCompletableFuture();
+        assertThat(jobActivation).succeedsWithin(Duration.ofSeconds(30));
+
+        final var jobs = jobActivation.join().getJobs();
+        assertThat(jobs).isNotEmpty();
+
+        for (final var job : jobs) {
+          TestHelper.completeJob(client, job.getKey());
+          completedJobs.add(job);
+        }
+      }
+
+      assertThat(completedJobs).hasSize(processInstancesCount);
+    }
+  }
+
+  private void takeBackup(final long backupId) {
+    final var broker = testCluster.brokers().values().iterator().next();
+    final var actuator = BackupActuator.of(broker);
+
+    assertThatNoException().isThrownBy(() -> actuator.take(backupId));
+
+    Awaitility.await("until a backup exists with the given ID")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var status = actuator.status(backupId);
+              assertThat(status)
+                  .extracting(BackupInfo::getBackupId, BackupInfo::getState)
+                  .containsExactly(backupId, StateCode.COMPLETED);
+            });
+  }
+
+  private void restoreBackup(final long backupId) throws IOException {
+    final var restoreTasks = new ArrayList<CompletableFuture<Void>>();
+
+    FileUtil.deleteFolder(workingDirectory);
+
+    for (int nodeId = 0; nodeId < CLUSTER_SIZE; nodeId++) {
+      final var task = new CompletableFuture<Void>();
+      // Restore must run in parallel as each restore will wait for other nodes to complete restore
+      Thread.ofVirtual()
+          .start(
+              () -> {
+                final var restore =
+                    new TestRestoreApp()
+                        .withWorkingDirectory(workingDirectory)
+                        .withUnifiedConfig(
+                            cfg -> {
+                              cfg.getCluster().setSize(CLUSTER_SIZE);
+                              cfg.getCluster().setPartitionCount(PARTITIONS_COUNT);
+                              cfg.getCluster().setReplicationFactor(REPLICATION_FACTOR);
+                              configureNodeIdProvider(cfg);
+                              configureBackupStore(cfg);
+                            })
+                        .withBackupId(backupId)
+                        .start();
+                restore.close();
+                task.complete(null);
+              });
+      restoreTasks.add(task);
+    }
+
+    // Wait for all restore operations to complete
+    CompletableFuture.allOf(restoreTasks.toArray(new CompletableFuture[0])).join();
+  }
+
+  private void configureNodeIdProvider(final Camunda cfg) {
+    cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+    cfg.getCluster().getNodeIdProvider().setType(Type.S3);
+
+    final var s3 = cfg.getCluster().getNodeIdProvider().s3();
+    s3.setTaskId(UUID.randomUUID().toString());
+    s3.setBucketName(NODE_ID_BUCKET_NAME);
+    s3.setLeaseDuration(LEASE_DURATION);
+    s3.setEndpoint(S3.getEndpoint().toString());
+    s3.setRegion(S3.getRegion());
+    s3.setAccessKey(S3.getAccessKey());
+    s3.setSecretKey(S3.getSecretKey());
+  }
+
+  public void configureBackupStore(final Camunda cfg) {
+    // Configure backup store to use S3 to ensure no conflicts with node id provider which is also
+    // using s3
+    final var backup = cfg.getData().getPrimaryStorage().getBackup();
+    backup.setStore(PrimaryStorageBackup.BackupStoreType.S3);
+
+    final var s3 = backup.getS3();
+    s3.setRegion(S3.getRegion());
+    s3.setSecretKey(S3.getSecretKey());
+    s3.setBucketName(BACKUP_BUCKET_NAME);
+    s3.setEndpoint(S3.getEndpoint().toString());
+    s3.setAccessKey(S3.getAccessKey());
+    s3.setForcePathStyleAccess(true);
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.zeebe.dynamic.nodeid;
+
+import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus.RestoreStatus;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestoreStatusManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreStatusManager.class);
+  private static final Duration RETRY_DELAY = Duration.ofMillis(1000);
+
+  private final NodeIdRepository repository;
+
+  public RestoreStatusManager(final NodeIdRepository repository) {
+    this.repository = repository;
+  }
+
+  /** Initializes restore. If a restore object already exists, does nothing. */
+  public void initializeRestore() throws InterruptedException {
+    while (true) {
+      try {
+        final var existingStatus = repository.getRestoreStatus();
+        if (existingStatus != null) {
+          LOG.debug("Restore status is already initialized {}", existingStatus.restoreStatus());
+          return;
+        }
+      } catch (final Exception e) {
+        LOG.debug("Error checking existing restore status, proceeding with initialization", e);
+      }
+
+      final var initialStatus = new RestoreStatus(Set.of());
+      try {
+        repository.updateRestoreStatus(initialStatus, null);
+        LOG.info("Initialized restore status: {}", initialStatus);
+        return;
+      } catch (final Exception e) {
+        LOG.debug("Failed to initialize restore, retrying", e);
+        // Most likely due to concurrent update, retry to ensure restore status is initialized
+        Thread.sleep(RETRY_DELAY);
+      }
+    }
+  }
+
+  /**
+   * Updates the restore status by marking the given node ID as completed. Retries on concurrent
+   * update conflicts.
+   *
+   * @param nodeId the node ID that completed restore
+   */
+  public void markNodeRestored(final int nodeId) throws InterruptedException {
+
+    // retry forever
+    while (true) {
+      try {
+        final var storedStatus = repository.getRestoreStatus();
+        if (storedStatus == null) {
+          throw new IllegalStateException("Restore status not initialized");
+        }
+
+        final var currentStatus = storedStatus.restoreStatus();
+        if (currentStatus.restoredNodes().contains(nodeId)) {
+          LOG.debug("Node {} already marked as restored", nodeId);
+          return;
+        }
+
+        final var updatedCompletedNodes = new HashSet<>(currentStatus.restoredNodes());
+        updatedCompletedNodes.add(nodeId);
+
+        final var updatedStatus = new RestoreStatus(updatedCompletedNodes);
+
+        repository.updateRestoreStatus(updatedStatus, storedStatus.etag());
+        LOG.info("Marked node {} as restored", nodeId);
+        return;
+
+      } catch (final Exception e) {
+        LOG.debug("Concurrent update conflict marking node {} as restored, retrying", nodeId);
+        Thread.sleep(RETRY_DELAY);
+      }
+    }
+  }
+
+  /**
+   * Waits until all nodes in the cluster have completed restore.
+   *
+   * @param clusterSize the total number of nodes in the cluster
+   * @param pollInterval the interval between status checks
+   * @throws InterruptedException if interrupted while waiting
+   * @throws IllegalStateException if timeout is reached or restore status is not initialized
+   */
+  public void waitForAllNodesRestored(final int clusterSize, final Duration pollInterval)
+      throws InterruptedException {
+    final var expectedNodeIds = IntStream.range(0, clusterSize).boxed().collect(Collectors.toSet());
+
+    while (true) {
+      final var storedStatus = repository.getRestoreStatus();
+      if (storedStatus == null) {
+        throw new IllegalStateException("Restore status not initialized");
+      }
+
+      final var completedNodeIds = storedStatus.restoreStatus().restoredNodes();
+      if (completedNodeIds.containsAll(expectedNodeIds)) {
+        LOG.info("All {} nodes have completed restore", clusterSize);
+        return;
+      }
+
+      LOG.debug(
+          "Waiting for restore completion: {}/{} nodes completed",
+          completedNodeIds.size(),
+          clusterSize);
+      Thread.sleep(pollInterval.toMillis());
+    }
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * A record that holds the restore status. The etag is used for conflict detection during updates.
+ */
+public record StoredRestoreStatus(RestoreStatus restoreStatus, String etag) {
+  public record RestoreStatus(Set<Integer> restoredNodes) {
+
+    public byte[] toJsonBytes(final ObjectMapper objectMapper) {
+      try {
+        return objectMapper.writeValueAsBytes(this);
+      } catch (final JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public static RestoreStatus fromJsonBytes(final ObjectMapper objectMapper, final byte[] json)
+        throws IOException {
+      return objectMapper.readValue(json, RestoreStatus.class);
+    }
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.nodeid.repository;
 
 import io.camunda.zeebe.dynamic.nodeid.Lease;
 import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus;
 import io.camunda.zeebe.dynamic.nodeid.Version;
 import java.time.Duration;
 import java.time.InstantSource;
@@ -53,6 +54,21 @@ public interface NodeIdRepository extends AutoCloseable {
    * @param lease the lease to release
    */
   void release(StoredLease.Initialized lease);
+
+  /**
+   * Update the restore status in the repository
+   *
+   * @param restoreStatus the new restore status
+   * @param etag the etag of the current restore status in the repository
+   */
+  void updateRestoreStatus(StoredRestoreStatus.RestoreStatus restoreStatus, String etag);
+
+  /**
+   * Get the current restore status from the repository
+   *
+   * @return the current restore status, or null if none exists
+   */
+  StoredRestoreStatus getRestoreStatus();
 
   /**
    * A StoredLease represents the Lease stored in a Repository such as S3. It can be

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.dynamic.nodeid.repository.s3;
 import static io.camunda.zeebe.dynamic.nodeid.Lease.OBJECT_MAPPER;
 
 import io.camunda.zeebe.dynamic.nodeid.Lease;
+import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus;
+import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus.RestoreStatus;
 import io.camunda.zeebe.dynamic.nodeid.repository.Metadata;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
 import java.io.IOException;
@@ -124,6 +126,58 @@ public class S3NodeIdRepository implements NodeIdRepository {
       LOG.debug("Lease released gracefully: {}", lease);
     } catch (final Exception e) {
       LOG.warn("Failed to release the lease gracefully {}", lease, e);
+    }
+  }
+
+  @Override
+  public void updateRestoreStatus(final RestoreStatus restoreStatus, final String etag) {
+    final PutObjectRequest.Builder putRequestBuilder =
+        PutObjectRequest.builder()
+            .bucket(config.bucketName)
+            .key("restore")
+            .contentType("application/json");
+
+    if (etag == null || etag.isEmpty()) {
+      putRequestBuilder.ifNoneMatch("*");
+    } else {
+      putRequestBuilder.ifMatch(etag);
+    }
+
+    final var putRequest = putRequestBuilder.build();
+
+    try {
+      LOG.debug("Marking restore status as {}", restoreStatus);
+      final var response =
+          client.putObject(
+              putRequest, RequestBody.fromBytes(restoreStatus.toJsonBytes(OBJECT_MAPPER)));
+      LOG.debug("Restore status marked successfully with ETag {}", response.eTag());
+    } catch (final Exception e) {
+      LOG.warn("Failed to mark restore status {}", restoreStatus, e);
+      throw e;
+    }
+  }
+
+  @Override
+  public StoredRestoreStatus getRestoreStatus() {
+    final var request = GetObjectRequest.builder().bucket(config.bucketName).key("restore").build();
+    try {
+      final var response = client.getObject(request);
+      final var bytes = response.readAllBytes();
+      if (bytes.length > 0) {
+        final var restoreStatus = RestoreStatus.fromJsonBytes(OBJECT_MAPPER, bytes);
+        LOG.trace("Restore status is {}", restoreStatus);
+        return new StoredRestoreStatus(restoreStatus, response.response().eTag());
+      }
+      return null;
+    } catch (final S3Exception e) {
+      if (e.statusCode() == 404) {
+        LOG.debug("Restore status object not found");
+        return null;
+      }
+      LOG.warn("Failed to get restore status", e);
+      throw e;
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus.RestoreStatus;
+import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RestoreStatusManagerTest {
+
+  private NodeIdRepository repository;
+
+  private RestoreStatusManager restoreStatusManager;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(NodeIdRepository.class);
+    restoreStatusManager = new RestoreStatusManager(repository);
+  }
+
+  @Test
+  void shouldInitializeRestoreWhenNoExistingStatus() throws InterruptedException {
+    // given
+    when(repository.getRestoreStatus()).thenReturn(null);
+
+    // when
+    restoreStatusManager.initializeRestore();
+
+    // then
+    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of())), isNull());
+  }
+
+  @Test
+  void shouldNotInitializeRestoreWhenStatusAlreadyExists() throws InterruptedException {
+    // given
+    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
+    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+
+    // when
+    restoreStatusManager.initializeRestore();
+
+    // then
+    verify(repository, never()).updateRestoreStatus(any(), any());
+  }
+
+  @Test
+  void shouldRetryInitializeRestoreOnConcurrentUpdateConflict() throws InterruptedException {
+    // given
+    final var callCount = new AtomicInteger(0);
+    when(repository.getRestoreStatus())
+        .thenAnswer(
+            inv -> {
+              if (callCount.getAndIncrement() == 0) {
+                return null;
+              }
+              // After first attempt, return existing status to stop retry loop
+              return new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag");
+            });
+    doThrow(new RuntimeException("Concurrent update"))
+        .when(repository)
+        .updateRestoreStatus(any(), isNull());
+
+    // when
+    restoreStatusManager.initializeRestore();
+
+    // then
+    verify(repository, times(1)).updateRestoreStatus(any(), isNull());
+  }
+
+  @Test
+  void shouldMarkNodeAsRestored() throws InterruptedException {
+    // given
+    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
+    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+
+    // when
+    restoreStatusManager.markNodeRestored(0);
+
+    // then
+    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of(0))), eq("etag123"));
+  }
+
+  @Test
+  void shouldNotMarkNodeAsRestoredWhenAlreadyMarked() throws InterruptedException {
+    // given
+    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1)), "etag123");
+    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+
+    // when
+    restoreStatusManager.markNodeRestored(0);
+
+    // then
+    verify(repository, never()).updateRestoreStatus(any(), any());
+  }
+
+  @Test
+  void shouldRetryMarkNodeRestoredOnConcurrentUpdateConflict() throws InterruptedException {
+    // given
+    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
+
+    // Both calls return status without node 0 marked (simulating that another node updated etag)
+    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+
+    // First call throws exception (concurrent update), second call succeeds
+    doThrow(new RuntimeException("Concurrent update"))
+        .doNothing()
+        .when(repository)
+        .updateRestoreStatus(any(), any());
+
+    // when
+    restoreStatusManager.markNodeRestored(0);
+
+    // then
+    verify(repository, times(2)).getRestoreStatus();
+    verify(repository, times(2)).updateRestoreStatus(any(), any());
+  }
+
+  @Test
+  void shouldAddNodeToExistingRestoredNodes() throws InterruptedException {
+    // given
+    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 2)), "etag123");
+    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+
+    // when
+    restoreStatusManager.markNodeRestored(1);
+
+    // then
+    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of(0, 1, 2))), eq("etag123"));
+  }
+
+  @Test
+  void shouldReturnImmediatelyWhenAllNodesAlreadyRestored() throws InterruptedException {
+    // given
+    final var completeStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1, 2)), "etag");
+    when(repository.getRestoreStatus()).thenReturn(completeStatus);
+
+    // when
+    restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10));
+
+    // then
+    verify(repository, times(1)).getRestoreStatus();
+  }
+
+  @Test
+  void shouldThrowWhenWaitingAndRestoreStatusNotInitialized() {
+    // given
+    when(repository.getRestoreStatus()).thenReturn(null);
+
+    // when/then
+    assertThatThrownBy(() -> restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Restore status not initialized");
+  }
+
+  @Test
+  void shouldWaitForSingleNodeCluster() throws InterruptedException {
+    // given
+    final var completeStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0)), "etag");
+    when(repository.getRestoreStatus()).thenReturn(completeStatus);
+
+    // when
+    restoreStatusManager.waitForAllNodesRestored(1, Duration.ofMillis(10));
+
+    // then
+    verify(repository, times(1)).getRestoreStatus();
+  }
+
+  @Test
+  void shouldContinuePollingUntilAllNodesRestored() throws InterruptedException {
+    // given
+    final var status1 = new StoredRestoreStatus(new RestoreStatus(Set.of(0)), "etag1");
+    final var status2 = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1)), "etag2");
+    final var status3 = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1, 2)), "etag3");
+
+    when(repository.getRestoreStatus()).thenReturn(status1, status2, status3);
+
+    // when
+    restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10));
+
+    // then
+    verify(repository, times(3)).getRestoreStatus();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support to support restore from backup when using a dynamic node id and versioned directory.

* Restore status of nodes is tracked using a shared object stored in the same s3 bucker configured for the node id provider
* RestoreStatusManager adds mechanism for nodes to mark themselves as restored and to wait until all nodes have completed restore. 
* Versioned directory provider similar to the broker is also configured when dynamic node id is configured. 
* A pluggable pre-restore and post-restore actions are created when dynamic node id is configured.
* In pre-restore, the restore status for the node is initialized 
* In post-restore, the node is marked as restored. And it waits until all other nodes are also restored. 
* The app exists gracefully after the post-restore action.

PS:- There is a bit of duplicate code between `RestoreNodeIdProviderConfiguration` and corresponding broker configuration. I find it easier to keep them separate even though there is a bit of duplication. There are some minor changes between them. 

PS:- A follow up PR will be added to skip the restore if it is a retry.

## Related issues

related to #44873 
