### PR TITLE
fix: remove unused incident table columns #44935

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -282,11 +282,9 @@
       <column name="ERROR_TYPE" type="VARCHAR(100)"/>
       <column name="STATE" type="VARCHAR(20)"/>
       <column name="CREATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
-      <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="TREE_PATH" type="VARCHAR(4000)"/>
       <column name="TENANT_ID" type="VARCHAR(${userCharColumnSize})"/>
       <column name="JOB_KEY" type="BIGINT"/>
-      <column name="SCOPE_KEY" type="BIGINT"/>
       <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 


### PR DESCRIPTION
## Description

Two columns SCOPE_KEY and END_DATE in the INCIDENT table seem to be leftovers from earlier project stages since they are never used in code or API. This PR removes them.

## Related issues

closes #44935 
