### PR TITLE
ci: add includeOptimize param for <8.8 release workflow

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,6 +32,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -60,6 +65,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven Central, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        type: boolean
+        required: false
+        default: false
 defaults:
   run:
     shell: bash
@@ -68,6 +78,8 @@ env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   RELEASE_TAG: ${{ inputs.releaseProcessDryRun && format('dryrun-{0}', inputs.releaseVersion) || inputs.releaseVersion }}
+  # Always force includeOptimize to false to maintain consistent behavior - Optimize is always excluded
+  INCLUDE_OPTIMIZE: false
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 jobs:
   # Release job performs Maven prepare and perform release operations, managing release artifacts and repository changes.


### PR DESCRIPTION
## Description

This pull request makes a small update to the `.github/workflows/camunda-platform-release.yml` workflow configuration to improve backward compatibility with older dispatch calls. A legacy parameter is introduced to prevent failures, and its behavior is clarified and enforced.

Workflow configuration and backward compatibility:

* Added a new input parameter `includeOptimize` to the workflow dispatch inputs, described as a legacy parameter for backward compatibility. This ensures older dispatch calls that expect this parameter will not fail, even though Optimize is always excluded from the release process. (`.github/workflows/camunda-platform-release.yml`) [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R35-R39) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R68-R72)
* Explicitly set the environment variable `INCLUDE_OPTIMIZE` to `false` to guarantee consistent behavior, ensuring Optimize is always excluded regardless of input. (`.github/workflows/camunda-platform-release.yml`)

Related to: https://github.com/camunda/camunda/issues/40184?reload=1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
