### PR TITLE
feat: add decision instance deletion endpoint

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -24,6 +24,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.U
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.DELETE_DECISION_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.DELETE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_DECISION_DEFINITION;
@@ -265,6 +266,10 @@ public record Authorization<T>(
 
     public Builder<T> deleteProcessInstance() {
       return permissionType(DELETE_PROCESS_INSTANCE);
+    }
+
+    public Builder<T> deleteDecisionInstance() {
+      return permissionType(DELETE_DECISION_INSTANCE);
     }
 
     public Builder<T> batchOperation() {

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -9,18 +9,25 @@ package io.camunda.service;
 
 import static io.camunda.search.query.SearchQueryBuilders.decisionInstanceSearchQuery;
 import static io.camunda.security.auth.Authorization.withAuthorization;
+import static io.camunda.service.authorization.Authorizations.DECISION_DEFINITION_DELETE_DECISION_INSTANCE_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.DECISION_INSTANCE_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.DecisionInstanceSearchClient;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.util.concurrent.CompletableFuture;
 
 public final class DecisionInstanceServices
     extends SearchQueryService<
@@ -93,5 +100,32 @@ public final class DecisionInstanceServices
                             DECISION_INSTANCE_READ_AUTHORIZATION,
                             DecisionInstanceEntity::decisionDefinitionId)))
                 .getDecisionInstance(decisionInstanceId));
+  }
+
+  public CompletableFuture<BatchOperationCreationRecord> deleteDecisionInstance(
+      final String decisionInstanceId, final Long operationReference) {
+
+    // make sure decision instance exists before deletion, otherwise return not found
+    final var decisionInstance = getById(decisionInstanceId);
+
+    final var brokerRequest =
+        new BrokerCreateBatchOperationRequest()
+            .setFilter(
+                new DecisionInstanceFilter.Builder()
+                    .decisionInstanceIds(decisionInstanceId)
+                    .build())
+            .setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE)
+            .setAuthentication(authentication)
+            // the user only needs single instance delete permission, not batch
+            .setAuthorizationCheck(
+                Authorization.withAuthorization(
+                    DECISION_DEFINITION_DELETE_DECISION_INSTANCE_AUTHORIZATION,
+                    decisionInstance.decisionDefinitionId()));
+
+    if (operationReference != null) {
+      brokerRequest.setOperationReference(operationReference);
+    }
+
+    return sendBrokerRequest(brokerRequest);
   }
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -125,4 +125,8 @@ public abstract class Authorizations {
   public static final Authorization<ProcessInstanceEntity>
       PROCESS_DEFINITION_DELETE_PROCESS_INSTANCE_AUTHORIZATION =
           Authorization.of(a -> a.processDefinition().deleteProcessInstance());
+
+  public static final Authorization<DecisionInstanceEntity>
+      DECISION_DEFINITION_DELETE_DECISION_INSTANCE_AUTHORIZATION =
+          Authorization.of(a -> a.decisionDefinition().deleteDecisionInstance());
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -70,6 +70,55 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
+  /decision-instances/{decisionEvaluationInstanceKey}/deletion:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Decision instance
+      operationId: deleteDecisionInstance
+      summary: Delete decision instance
+      description: Deletes a decision instance. Only instances that are completed or terminated can be deleted.
+      parameters:
+        - name: decisionEvaluationInstanceKey
+          in: path
+          required: true
+          description: The key of the decision instance to delete.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/DecisionInstanceKey'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteDecisionInstanceRequest'
+      responses:
+        "200":
+          description: The operation to delete the decision instance was created.
+          content:
+            application/json:
+              schema:
+                $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: The decision instance is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: The decision instance is not in a completed or terminated state and cannot be deleted.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+
 ## Schema definitions
 
 components:
@@ -180,6 +229,14 @@ components:
           description: The key of the root decision definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
+
+    DeleteDecisionInstanceRequest:
+      type: object
+      nullable: true
+      additionalProperties: false
+      properties:
+        operationReference:
+          $ref: 'keys.yaml#/components/schemas/OperationReference'
 
     DecisionInstanceSearchQueryResult:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -70,16 +70,16 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
-  /decision-instances/{decisionEvaluationInstanceKey}/deletion:
+  /decision-instances/{decisionInstanceKey}/deletion:
     post:
       x-eventually-consistent: true
       tags:
         - Decision instance
       operationId: deleteDecisionInstance
       summary: Delete decision instance
-      description: Deletes a decision instance. Only instances that are completed or terminated can be deleted.
+      description: Delete all associated decision evaluations based on provided key.
       parameters:
-        - name: decisionEvaluationInstanceKey
+        - name: decisionInstanceKey
           in: path
           required: true
           description: The key of the decision instance to delete.
@@ -104,12 +104,6 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "404":
           description: The decision instance is not found.
-          content:
-            application/problem+json:
-              schema:
-                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
-        "409":
-          description: The decision instance is not in a completed or terminated state and cannot be deleted.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -134,8 +134,8 @@ paths:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1search'
   /decision-instances/{decisionEvaluationInstanceKey}:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}'
-  /decision-instances/{decisionEvaluationInstanceKey}/deletion:
-    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}~1deletion'
+  /decision-instances/{decisionInstanceKey}/deletion:
+    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionInstanceKey}~1deletion'
 
   # Decision requirements endpoints
   /decision-requirements/search:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -134,6 +134,8 @@ paths:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1search'
   /decision-instances/{decisionEvaluationInstanceKey}:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}'
+  /decision-instances/{decisionEvaluationInstanceKey}/deletion:
+    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}~1deletion'
 
   # Decision requirements endpoints
   /decision-requirements/search:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -67,16 +67,16 @@ public class DecisionInstanceController {
   }
 
   @RequiresSecondaryStorage
-  @CamundaPostMapping(path = "/{decisionEvaluationInstanceKey}/deletion")
+  @CamundaPostMapping(path = "/{decisionInstanceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteDecisionInstance(
-      @PathVariable("decisionEvaluationInstanceKey") final String decisionEvaluationInstanceKey,
+      @PathVariable("decisionInstanceKey") final long decisionInstanceKey,
       @RequestBody(required = false) final DeleteDecisionInstanceRequest request) {
     return RequestExecutor.executeServiceMethod(
         () ->
             decisionInstanceServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteDecisionInstance(
-                    decisionEvaluationInstanceKey,
+                    decisionInstanceKey,
                     Objects.nonNull(request) ? request.getOperationReference() : null),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.DecisionInstanceServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = DecisionInstanceController.class)
+public class DecisionInstanceControllerTest extends RestControllerTest {
+
+  static final String DECISION_INSTANCES_BASE_URL = "/v2/decision-instances";
+  static final String DELETE_DECISION_URL = DECISION_INSTANCES_BASE_URL + "/%s/deletion";
+
+  @MockitoBean private DecisionInstanceServices decisionInstanceServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(decisionInstanceServices.withAuthentication(any(CamundaAuthentication.class)))
+        .thenReturn(decisionInstanceServices);
+  }
+
+  @Test
+  void shouldDeleteDecisionInstance() {
+    // given
+    final var record = new BatchOperationCreationRecord();
+    record.setBatchOperationKey(123L);
+    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+
+    when(decisionInstanceServices.deleteDecisionInstance("1-1", 123L))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    final var request =
+        """
+            {
+              "operationReference": 123
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("1-1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {"batchOperationKey":"123","batchOperationType":"DELETE_DECISION_INSTANCE"}
+        """,
+            JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("1-1", 123L);
+  }
+
+  @Test
+  void shouldDeleteDecisionInstanceWithNoBody() {
+    // given
+    final var record = new BatchOperationCreationRecord();
+    record.setBatchOperationKey(456L);
+    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+
+    when(decisionInstanceServices.deleteDecisionInstance("2-2", null))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("2-2"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {"batchOperationKey":"456","batchOperationType":"DELETE_DECISION_INSTANCE"}
+        """,
+            JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("2-2", null);
+  }
+
+  @Test
+  void shouldDeleteDecisionInstanceWithEmptyBody() {
+    // given
+    final var record = new BatchOperationCreationRecord();
+    record.setBatchOperationKey(789L);
+    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+
+    when(decisionInstanceServices.deleteDecisionInstance("3-3", null))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    final var request =
+        """
+        {}""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("3-3"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {"batchOperationKey":"789","batchOperationType":"DELETE_DECISION_INSTANCE"}
+        """,
+            JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("3-3", null);
+  }
+
+  @Test
+  void shouldRejectDeleteDecisionInstanceOnDecisionInstanceNotFound() {
+    // given
+    when(decisionInstanceServices.deleteDecisionInstance("999-999", null))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new io.camunda.service.exception.ServiceException(
+                    "Decision Instance with key '999-999' not found",
+                    io.camunda.service.exception.ServiceException.Status.NOT_FOUND)));
+
+    final var expectedBody =
+        """
+            {
+                "type": "about:blank",
+                "title": "NOT_FOUND",
+                "status": 404,
+                "detail": "Decision Instance with key '999-999' not found",
+                "instance": "%s"
+            }"""
+            .formatted(DELETE_DECISION_URL.formatted("999-999"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("999-999"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("999-999", null);
+  }
+
+  @Test
+  void shouldRejectDeleteDecisionInstanceOnForbidden() {
+    // given
+    when(decisionInstanceServices.deleteDecisionInstance("4-4", null))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new io.camunda.service.exception.ServiceException(
+                    "Unauthorized to perform operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
+                    io.camunda.service.exception.ServiceException.Status.FORBIDDEN)));
+
+    final var expectedBody =
+        """
+            {
+                "type": "about:blank",
+                "title": "FORBIDDEN",
+                "status": 403,
+                "detail": "Unauthorized to perform operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
+                "instance": "%s"
+            }"""
+            .formatted(DELETE_DECISION_URL.formatted("4-4"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("4-4"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("4-4", null);
+  }
+
+  @Test
+  void shouldRejectDeleteDecisionInstanceOnConflict() {
+    // given
+    when(decisionInstanceServices.deleteDecisionInstance("5-5", null))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new io.camunda.service.exception.ServiceException(
+                    "Decision Instance with key '5-5' is not in a completed or terminated state and cannot be deleted",
+                    io.camunda.service.exception.ServiceException.Status.INVALID_STATE)));
+
+    final var expectedBody =
+        """
+            {
+                "type": "about:blank",
+                "title": "INVALID_STATE",
+                "status": 409,
+                "detail": "Decision Instance with key '5-5' is not in a completed or terminated state and cannot be deleted",
+                "instance": "%s"
+            }"""
+            .formatted(DELETE_DECISION_URL.formatted("5-5"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(DELETE_DECISION_URL.formatted("5-5"))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(409)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verify(decisionInstanceServices).deleteDecisionInstance("5-5", null);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class DecisionInstanceControllerTest extends RestControllerTest {
 
   static final String DECISION_INSTANCES_BASE_URL = "/v2/decision-instances";
-  static final String DELETE_DECISION_URL = DECISION_INSTANCES_BASE_URL + "/%s/deletion";
+  static final String DELETE_DECISION_URL = DECISION_INSTANCES_BASE_URL + "/%d/deletion";
 
   @MockitoBean private DecisionInstanceServices decisionInstanceServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
@@ -49,7 +49,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationKey(123L);
     record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance("1-1", 123L))
+    when(decisionInstanceServices.deleteDecisionInstance(1L, 123L))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -61,7 +61,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     // when / then
     webClient
         .post()
-        .uri(DELETE_DECISION_URL.formatted("1-1"))
+        .uri(DELETE_DECISION_URL.formatted(1L))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)
@@ -77,7 +77,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         """,
             JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance("1-1", 123L);
+    verify(decisionInstanceServices).deleteDecisionInstance(1L, 123L);
   }
 
   @Test
@@ -87,13 +87,13 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationKey(456L);
     record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance("2-2", null))
+    when(decisionInstanceServices.deleteDecisionInstance(2L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     // when / then
     webClient
         .post()
-        .uri(DELETE_DECISION_URL.formatted("2-2"))
+        .uri(DELETE_DECISION_URL.formatted(2L))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -107,7 +107,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         """,
             JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance("2-2", null);
+    verify(decisionInstanceServices).deleteDecisionInstance(2L, null);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationKey(789L);
     record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance("3-3", null))
+    when(decisionInstanceServices.deleteDecisionInstance(3L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -127,7 +127,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     // when / then
     webClient
         .post()
-        .uri(DELETE_DECISION_URL.formatted("3-3"))
+        .uri(DELETE_DECISION_URL.formatted(3L))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)
@@ -143,13 +143,13 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         """,
             JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance("3-3", null);
+    verify(decisionInstanceServices).deleteDecisionInstance(3L, null);
   }
 
   @Test
   void shouldRejectDeleteDecisionInstanceOnDecisionInstanceNotFound() {
     // given
-    when(decisionInstanceServices.deleteDecisionInstance("999-999", null))
+    when(decisionInstanceServices.deleteDecisionInstance(999L, null))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new io.camunda.service.exception.ServiceException(
@@ -165,12 +165,12 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
                 "detail": "Decision Instance with key '999-999' not found",
                 "instance": "%s"
             }"""
-            .formatted(DELETE_DECISION_URL.formatted("999-999"));
+            .formatted(DELETE_DECISION_URL.formatted(999L));
 
     // when / then
     webClient
         .post()
-        .uri(DELETE_DECISION_URL.formatted("999-999"))
+        .uri(DELETE_DECISION_URL.formatted(999L))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -180,13 +180,13 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance("999-999", null);
+    verify(decisionInstanceServices).deleteDecisionInstance(999L, null);
   }
 
   @Test
   void shouldRejectDeleteDecisionInstanceOnForbidden() {
     // given
-    when(decisionInstanceServices.deleteDecisionInstance("4-4", null))
+    when(decisionInstanceServices.deleteDecisionInstance(4L, null))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new io.camunda.service.exception.ServiceException(
@@ -202,12 +202,12 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
                 "detail": "Unauthorized to perform operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
                 "instance": "%s"
             }"""
-            .formatted(DELETE_DECISION_URL.formatted("4-4"));
+            .formatted(DELETE_DECISION_URL.formatted(4L));
 
     // when / then
     webClient
         .post()
-        .uri(DELETE_DECISION_URL.formatted("4-4"))
+        .uri(DELETE_DECISION_URL.formatted(4L))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -217,43 +217,6 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance("4-4", null);
-  }
-
-  @Test
-  void shouldRejectDeleteDecisionInstanceOnConflict() {
-    // given
-    when(decisionInstanceServices.deleteDecisionInstance("5-5", null))
-        .thenReturn(
-            CompletableFuture.failedFuture(
-                new io.camunda.service.exception.ServiceException(
-                    "Decision Instance with key '5-5' is not in a completed or terminated state and cannot be deleted",
-                    io.camunda.service.exception.ServiceException.Status.INVALID_STATE)));
-
-    final var expectedBody =
-        """
-            {
-                "type": "about:blank",
-                "title": "INVALID_STATE",
-                "status": 409,
-                "detail": "Decision Instance with key '5-5' is not in a completed or terminated state and cannot be deleted",
-                "instance": "%s"
-            }"""
-            .formatted(DELETE_DECISION_URL.formatted("5-5"));
-
-    // when / then
-    webClient
-        .post()
-        .uri(DELETE_DECISION_URL.formatted("5-5"))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isEqualTo(409)
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody, JsonCompareMode.STRICT);
-
-    verify(decisionInstanceServices).deleteDecisionInstance("5-5", null);
+    verify(decisionInstanceServices).deleteDecisionInstance(4L, null);
   }
 }


### PR DESCRIPTION
## Description

- Add delete decision instance specs
- Add delete decision instance service to propagate request to broker
- Add delete decision instance endpoint
- Add service and controller UT

## Related issues

closes #42397
