### PR TITLE
Mark StartupBean and OperationExecutor as Deprecated

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
@@ -9,6 +9,16 @@ package io.camunda.operate.property;
 
 import java.util.UUID;
 
+/**
+ * @deprecated This class is deprecated and will be removed in version 8.10.
+ *     <p>It is not safe to remove this class yet because the Operation Executor is still required
+ *     to process any pending operation batches in the `operate-operation` index. Removing it now
+ *     could result in user-initiated operations remaining unprocessed after an upgrade, breaking
+ *     user-space and leaving operations stuck indefinitely. The class should only be removed once
+ *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
+ *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
+ */
+@Deprecated(forRemoval = true, since = "8.10")
 public class OperationExecutorProperties {
 
   public static final int BATCH_SIZE_DEFAULT = 500;
@@ -46,7 +56,7 @@ public class OperationExecutorProperties {
     return batchSize;
   }
 
-  public void setBatchSize(int batchSize) {
+  public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
   }
 
@@ -54,7 +64,7 @@ public class OperationExecutorProperties {
     return deletionBatchSize;
   }
 
-  public void setDeletionBatchSize(int deletionBatchSize) {
+  public void setDeletionBatchSize(final int deletionBatchSize) {
     this.deletionBatchSize = deletionBatchSize;
   }
 
@@ -62,7 +72,7 @@ public class OperationExecutorProperties {
     return workerId;
   }
 
-  public void setWorkerId(String workerId) {
+  public void setWorkerId(final String workerId) {
     this.workerId = workerId;
   }
 
@@ -70,7 +80,7 @@ public class OperationExecutorProperties {
     return lockTimeout;
   }
 
-  public void setLockTimeout(long lockTimeout) {
+  public void setLockTimeout(final long lockTimeout) {
     this.lockTimeout = lockTimeout;
   }
 
@@ -78,7 +88,7 @@ public class OperationExecutorProperties {
     return executorEnabled;
   }
 
-  public void setExecutorEnabled(boolean executorEnabled) {
+  public void setExecutorEnabled(final boolean executorEnabled) {
     this.executorEnabled = executorEnabled;
   }
 
@@ -86,7 +96,7 @@ public class OperationExecutorProperties {
     return threadsCount;
   }
 
-  public void setThreadsCount(int threadsCount) {
+  public void setThreadsCount(final int threadsCount) {
     this.threadsCount = threadsCount;
   }
 
@@ -94,7 +104,7 @@ public class OperationExecutorProperties {
     return queueSize;
   }
 
-  public void setQueueSize(int queueSize) {
+  public void setQueueSize(final int queueSize) {
     this.queueSize = queueSize;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
@@ -18,7 +18,7 @@ import java.util.UUID;
  *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
  *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
  */
-@Deprecated(forRemoval = true, since = "8.10")
+@Deprecated(forRemoval = true, since = "8.9")
 public class OperationExecutorProperties {
 
   public static final int BATCH_SIZE_DEFAULT = 500;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -17,10 +17,6 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Component
-@DependsOn("searchEngineSchemaInitializer")
-@Profile({"!test", "test-executor"})
-@ConditionalOnRdbmsDisabled
 /**
  * @deprecated This class is deprecated and will be removed in version 8.10.
  *     <p>It is not safe to remove this class yet because the Operation Executor is still required
@@ -30,6 +26,10 @@ import org.springframework.stereotype.Component;
  *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
  *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
  */
+@Component
+@DependsOn("searchEngineSchemaInitializer")
+@Profile({"!test", "test-executor"})
+@ConditionalOnRdbmsDisabled
 @Deprecated(forRemoval = true, since = "8.10")
 public class StartupBean {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
 @DependsOn("searchEngineSchemaInitializer")
 @Profile({"!test", "test-executor"})
 @ConditionalOnRdbmsDisabled
-@Deprecated(forRemoval = true, since = "8.10")
+@Deprecated(forRemoval = true, since = "8.9")
 public class StartupBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StartupBean.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -21,6 +21,16 @@ import org.springframework.stereotype.Component;
 @DependsOn("searchEngineSchemaInitializer")
 @Profile({"!test", "test-executor"})
 @ConditionalOnRdbmsDisabled
+/**
+ * @deprecated This class is deprecated and will be removed in version 8.10.
+ *     <p>It is not safe to remove this class yet because the Operation Executor is still required
+ *     to process any pending operation batches in the `operate-operation` index. Removing it now
+ *     could result in user-initiated operations remaining unprocessed after an upgrade, breaking
+ *     user-space and leaving operations stuck indefinitely. The class should only be removed once
+ *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
+ *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
+ */
+@Deprecated(forRemoval = true, since = "8.10")
 public class StartupBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StartupBean.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Configuration
 @ConditionalOnRdbmsDisabled
-@Deprecated(forRemoval = true, since = "8.10")
+@Deprecated(forRemoval = true, since = "8.9")
 public class OperationExecutor extends Thread {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OperationExecutor.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
@@ -34,6 +34,16 @@ import org.springframework.stereotype.Component;
 @Component
 @Configuration
 @ConditionalOnRdbmsDisabled
+/**
+ * @deprecated This class is deprecated and will be removed in version 8.10.
+ *     <p>It is not safe to remove this class yet because the Operation Executor is still required
+ *     to process any pending operation batches in the `operate-operation` index. Removing it now
+ *     could result in user-initiated operations remaining unprocessed after an upgrade, breaking
+ *     user-space and leaving operations stuck indefinitely. The class should only be removed once
+ *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
+ *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
+ */
+@Deprecated(forRemoval = true, since = "8.10")
 public class OperationExecutor extends Thread {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OperationExecutor.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/OperationExecutor.java
@@ -31,9 +31,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
-@Component
-@Configuration
-@ConditionalOnRdbmsDisabled
 /**
  * @deprecated This class is deprecated and will be removed in version 8.10.
  *     <p>It is not safe to remove this class yet because the Operation Executor is still required
@@ -43,6 +40,9 @@ import org.springframework.stereotype.Component;
  *     it is guaranteed that no pending batches remain and all consumers have migrated to the V2
  *     API. See https://github.com/camunda/camunda/issues/44958 for migration progress and details.
  */
+@Component
+@Configuration
+@ConditionalOnRdbmsDisabled
 @Deprecated(forRemoval = true, since = "8.10")
 public class OperationExecutor extends Thread {
 


### PR DESCRIPTION
## Description

This PR marks the OperationExecutor class as deprecated and documents the conditions under which it can be safely removed, following the deprecation plan outlined in issue #44958.

**Details**
- Adds a detailed Javadoc to OperationExecutor explaining why immediate removal is unsafe.
- Documents that the executor is still required to process any pending operation batches in the operate-operation index.
- Explains that removing the executor now could leave user-initiated operations unprocessed after an upgrade, potentially breaking user-space.
- References the migration to the V2 API and the need to ensure no pending batches remain before removal.
- Marks the class as `@Deprecated(forRemoval = true, since = "8.10")` in accordance with the deprecation plan.

**Context**
The modify UI is being updated to use the V2 API, which should eliminate the creation of new Operate batches. However, as confirmed by @Mustafa Dagher, the executor is still needed to process any existing batches in the operate-operation index. Removing it prematurely could result in operations being stuck indefinitely, impacting users who upgrade before all batches are processed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44958