### PR TITLE
[Backport stable/8.8] [CPT] fix: Skip beforeAll/afterAll for nested test classes

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda;
+
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
+import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.CamundaProcessTest;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class ProcessNestedUnitTest {
+
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @BeforeEach
+  public void setUp() {
+    client
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("bpmn/order-process.bpmn")
+        .send()
+        .join();
+  }
+
+  @Nested
+  @DisplayName("Happy path")
+  class HappyPathTests {
+    @Test
+    void happyPath() {
+      // given
+      final String shippingId = "shipping-1";
+
+      processTestContext.mockJobWorker("collect-money").thenComplete();
+      processTestContext.mockJobWorker("fetch-items").thenComplete();
+      processTestContext
+          .mockJobWorker("ship-parcel")
+          .thenComplete(Map.of("shipping_id", shippingId));
+
+      final var processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("order-process")
+              .latestVersion()
+              .variable("order_id", "order-1")
+              .send()
+              .join();
+
+      // when
+      assertThat(processInstance).hasActiveElements(byName("Received tracking code"));
+
+      client
+          .newPublishMessageCommand()
+          .messageName("Received tracking code")
+          .correlationKey(shippingId)
+          .variable("tracking_code", "tracking-1")
+          .send();
+
+      // then
+      assertThat(processInstance)
+          .hasCompletedElements(
+              byName("Collect money"),
+              byName("Fetch items"),
+              byName("Ship parcel"),
+              byName("Received tracking code"))
+          .isCompleted();
+    }
+  }
+
+  @Nested
+  class ExceptionalTests {
+    @Test
+    void requestTrackingCode() {
+      // given
+      final String shippingId = "shipping-2";
+
+      processTestContext.mockJobWorker("collect-money").thenComplete();
+      processTestContext.mockJobWorker("fetch-items").thenComplete();
+      processTestContext
+          .mockJobWorker("ship-parcel")
+          .thenComplete(Map.of("shipping_id", shippingId));
+      processTestContext.mockJobWorker("request-tracking-code").thenComplete();
+
+      final var processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("order-process")
+              .latestVersion()
+              .variable("order_id", "order-2")
+              .send()
+              .join();
+
+      // when
+      assertThat(processInstance).hasActiveElements(byName("Received tracking code"));
+
+      processTestContext.increaseTime(Duration.ofDays(2));
+
+      // then
+      assertThat(processInstance)
+          .hasCompletedElements(byName("Request tracking code"))
+          .hasActiveElements(byName("Received tracking code"))
+          .isActive();
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.slf4j.Logger;
@@ -140,6 +141,11 @@ public class CamundaProcessTestExtension
 
   @Override
   public void beforeAll(final ExtensionContext context) {
+    if (!hasProcessTestAnnotation(context)) {
+      // test class is not annotated as CamundaProcessTest so skip
+      return;
+    }
+
     // create runtime
     runtime = runtimeBuilder.build();
     runtime.start();
@@ -194,6 +200,10 @@ public class CamundaProcessTestExtension
     } else if (zeebeJsonMapper != null) {
       CamundaAssert.setJsonMapper(zeebeJsonMapper);
     }
+  }
+
+  private boolean hasProcessTestAnnotation(final ExtensionContext context) {
+    return AnnotationUtils.isAnnotated(context.getTestClass(), CamundaProcessTest.class);
   }
 
   @Override
@@ -263,7 +273,7 @@ public class CamundaProcessTestExtension
     }
 
     try {
-      processCoverage.collectTestRunCoverage(context.getDisplayName());
+      processCoverage.collectTestRunCoverage(getCoverageTestName(context));
     } catch (final Throwable t) {
       LOG.warn("Failed to collect test process coverage, skipping.", t);
     }
@@ -278,6 +288,19 @@ public class CamundaProcessTestExtension
     // the other way around leads to race conditions and inconsistencies in the tests
     resetRuntimeClock();
     deleteRuntimeData();
+  }
+
+  private String getCoverageTestName(final ExtensionContext context) {
+    final StringBuilder prefix = new StringBuilder();
+
+    ExtensionContext parentContext = context.getParent().orElse(null);
+
+    while (parentContext != null && !hasProcessTestAnnotation(parentContext)) {
+      prefix.insert(0, parentContext.getDisplayName() + "#");
+      parentContext = parentContext.getParent().orElse(null);
+    }
+
+    return prefix + context.getDisplayName();
   }
 
   private void printTestResults() {
@@ -326,6 +349,10 @@ public class CamundaProcessTestExtension
   public void afterAll(final ExtensionContext context) throws Exception {
     if (runtime == null) {
       // Skip if the runtime is not created.
+      return;
+    }
+    if (!hasProcessTestAnnotation(context)) {
+      // runtime was not initialized in this hierarchy level
       return;
     }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -141,8 +141,9 @@ public class CamundaProcessTestExtension
 
   @Override
   public void beforeAll(final ExtensionContext context) {
-    if (!hasProcessTestAnnotation(context)) {
-      // test class is not annotated as CamundaProcessTest so skip
+    if (!hasProcessTestExtension(context)) {
+      // Skip the initialization for nested process tests. The runtime is initialized in the
+      // top-level process test.
       return;
     }
 
@@ -202,8 +203,25 @@ public class CamundaProcessTestExtension
     }
   }
 
-  private boolean hasProcessTestAnnotation(final ExtensionContext context) {
+  private boolean hasProcessTestExtension(final ExtensionContext context) {
+    return hasProcessTestAnnotation(context) || hasProcessTestField(context);
+  }
+
+  private static boolean hasProcessTestAnnotation(final ExtensionContext context) {
     return AnnotationUtils.isAnnotated(context.getTestClass(), CamundaProcessTest.class);
+  }
+
+  private static boolean hasProcessTestField(final ExtensionContext context) {
+    return context
+        .getTestClass()
+        .map(
+            testClass ->
+                ReflectionUtils.findFields(
+                    testClass,
+                    field -> field.getType().isAssignableFrom(CamundaProcessTestExtension.class),
+                    ReflectionUtils.HierarchyTraversalMode.TOP_DOWN))
+        .map(fields -> !fields.isEmpty())
+        .orElse(false);
   }
 
   @Override
@@ -295,7 +313,7 @@ public class CamundaProcessTestExtension
 
     ExtensionContext parentContext = context.getParent().orElse(null);
 
-    while (parentContext != null && !hasProcessTestAnnotation(parentContext)) {
+    while (parentContext != null && !hasProcessTestExtension(parentContext)) {
       prefix.insert(0, parentContext.getDisplayName() + "#");
       parentContext = parentContext.getParent().orElse(null);
     }
@@ -347,12 +365,8 @@ public class CamundaProcessTestExtension
 
   @Override
   public void afterAll(final ExtensionContext context) throws Exception {
-    if (runtime == null) {
-      // Skip if the runtime is not created.
-      return;
-    }
-    if (!hasProcessTestAnnotation(context)) {
-      // runtime was not initialized in this hierarchy level
+    if (runtime == null || !hasProcessTestExtension(context)) {
+      // Skip if the runtime is not created, or if this is a nested process test.
       return;
     }
 


### PR DESCRIPTION
# Description
Backport of #41045 to `stable/8.8`.

relates to camunda/camunda#39454