### PR TITLE
ci: add 500 open PRs limit to the cleanup-orphaned-preview job for docs

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -53,7 +53,7 @@ jobs:
           echo ""
 
           # Get open PRs and extract preview directories
-          open_prs=$(gh pr list --state open --json number --jq '.[].number' | sort -n)
+          open_prs=$(gh pr list --state open --json number --jq '.[].number' --limit 500 | sort -n)
           cleaned_count=0
           
           echo "Open PRs: $(echo "$open_prs" | tr '\n' ' ')"


### PR DESCRIPTION
## Description

This pull request makes a minor update to the documentation preview cleanup workflow to ensure all open pull requests are considered when cleaning up preview directories.

It should fix the issue that appear here https://github.com/camunda/camunda/pull/44672#issuecomment-3792268135 where the preview docs was deleted by the clean-up workflow: https://github.com/camunda/camunda/actions/runs/21556273171/job/62112992579#step:3:95

Related to: https://github.com/camunda/camunda/issues/36946?reload=1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
