### PR TITLE
fix: Importer runs before schema initialization

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -60,7 +60,6 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
       final CompletableFuture<Void> future, final ExecutorService executor) throws Exception {
     try {
       future.get();
-      initialized.set(true);
       LOGGER.info("Search engine schema initialization complete.");
     } catch (final InterruptedException ie) {
       LOGGER.debug(
@@ -87,7 +86,6 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
           if (error != null) {
             LOGGER.warn("Failed to initialize search engine schema", error);
           } else {
-            initialized.set(true);
             LOGGER.info("Search engine schema initialization complete.");
           }
           executor.close();
@@ -109,8 +107,9 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
                     clientAdapter.objectMapper())
                 .withMetrics(schemaManagerMetrics)) {
       schemaManager.startup();
+      initialized.set(true);
     } catch (final IOException e) {
-      LOGGER.debug("Failed to create schema and/or close search client", e);
+      LOGGER.debug("Failed to close the search client", e);
     }
   }
 

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -37,6 +37,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>operate-importer-8_7</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
@@ -10,6 +10,7 @@ package io.camunda.operate.zeebeimport;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ImportStore;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -56,8 +57,15 @@ public class ImportPositionHolder {
 
   @Autowired private Metrics metrics;
 
+  @Autowired private SchemaManagerContainer schemaManagerContainer;
+
   @PostConstruct
   private void init() {
+    if (!schemaManagerContainer.isInitialized()) {
+      LOGGER.info(
+          "INIT: Skipping import position updater start - search engine schema not initialized (application may be shutting down).");
+      return;
+    }
     LOGGER.info("INIT: Start import position updater...");
     scheduleImportPositionUpdateTask();
   }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ZeebeImporter.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ZeebeImporter.java
@@ -9,6 +9,7 @@ package io.camunda.operate.zeebeimport;
 
 import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.search.schema.SchemaManagerContainer;
 import jakarta.annotation.PostConstruct;
 import java.util.Collection;
 import org.slf4j.Logger;
@@ -37,9 +38,16 @@ public class ZeebeImporter {
 
   @Autowired private Metrics metrics;
 
+  @Autowired private SchemaManagerContainer schemaManagerContainer;
+
   @PostConstruct
   public void startImportingData() {
     if (operateProperties.getImporter().isStartLoadingDataOnStartup()) {
+      if (!schemaManagerContainer.isInitialized()) {
+        LOGGER.info(
+            "INIT: Skipping data import - search engine schema not initialized (application may be shutting down).");
+        return;
+      }
       scheduleReaders();
     }
   }

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -54,7 +54,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp;
 
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
+import io.camunda.search.schema.SchemaManagerContainer;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +26,15 @@ public class StartupBean {
 
   @Autowired private OperationExecutor operationExecutor;
 
+  @Autowired private SchemaManagerContainer schemaManagerContainer;
+
   @PostConstruct
   public void initApplication() {
+    if (!schemaManagerContainer.isInitialized()) {
+      LOGGER.info(
+          "INIT: Skipping operation executor start - search engine schema not initialized (application may be shutting down).");
+      return;
+    }
     LOGGER.info("INIT: Start operation executor...");
     operationExecutor.startExecuting();
     LOGGER.info("INIT: DONE");

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+public interface SchemaManagerContainer {
+  boolean isInitialized();
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
@@ -10,6 +10,11 @@ package io.camunda.search.schema;
 import static io.camunda.zeebe.test.util.testcontainers.TestSearchContainers.createDefeaultElasticsearchContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +48,7 @@ class SchemaManagerStartupIT {
 
   private static final String CAMUNDA_TEST_IMAGE_NAME =
       Optional.ofNullable(System.getenv("CAMUNDA_TEST_DOCKER_IMAGE"))
-          .orElse("camunda/camunda:SNAPSHOT");
+          .orElse("camunda/camunda:8.8-SNAPSHOT");
 
   private static final int MONITORING_PORT = 9600;
 
@@ -51,7 +56,6 @@ class SchemaManagerStartupIT {
   private final GenericContainer<?> camunda =
       new GenericContainer<>(CAMUNDA_TEST_IMAGE_NAME)
           .withLogConsumer(new Slf4jLogConsumer(LOG))
-          .withEnv("SPRING_PROFILES_ACTIVE", "broker,dev")
           // Unified Configuration: DB type
           .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", DB_TYPE_ELASTICSEARCH)
           .withEnv("CAMUNDA_DATABASE_TYPE", DB_TYPE_ELASTICSEARCH)
@@ -65,16 +69,12 @@ class SchemaManagerStartupIT {
           .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", ELASTICSEARCH_URL)
           .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", ELASTICSEARCH_URL)
           // ---
-          .withEnv("SPRING_PROFILES_ACTIVE", "broker")
           .withEnv("LOGGING_LEVEL_IO_CAMUNDA", "DEBUG")
           .withNetwork(Network.SHARED);
 
   @Container
   private final ElasticsearchContainer es =
       createDefeaultElasticsearchContainer()
-          // Enable security in ES for to trigger the retry logic as application does not have
-          // credentials
-          .withEnv("xpack.security.enabled", "true")
           .withNetwork(Network.SHARED)
           .withNetworkAliases("test-elasticsearch");
 
@@ -88,30 +88,57 @@ class SchemaManagerStartupIT {
   //   true is to test with embedded gateway enabled (sync schema startup)
   void shouldGracefullyShutdownWhenSchemaStartupStillRunning(
       final boolean waitForSchemaStartupBeforeShutdown, final boolean gatewayEnabled)
-      throws InterruptedException {
+      throws InterruptedException, IOException {
     // given
     final var shutdownLatch = new CountDownLatch(1);
 
-    camunda
-        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", String.valueOf(gatewayEnabled))
-        .waitingFor(
-            new WaitStrategy() {
-              @Override
-              public void waitUntilReady(final WaitStrategyTarget waitStrategyTarget) {
-                // Wait until the application is shutdown
-                try {
-                  shutdownLatch.await(60, TimeUnit.SECONDS);
-                } catch (final InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                  throw new RuntimeException("Interrupted while waiting for shutdown", e);
-                }
-              }
+    // create the role index with incorrect mapping to force the schema manager to retry
+    final ConnectConfiguration cfg = new ConnectConfiguration();
+    cfg.setUrl(es.getHttpHostAddress());
+    try (final var esClient = new ElasticsearchConnector(cfg).createClient()) {
+      esClient
+          .indices()
+          .create(
+              r ->
+                  r.index(new RoleIndex("", true).getFullQualifiedName())
+                      .mappings(
+                          m ->
+                              m.dynamic(DynamicMapping.Strict)
+                                  .properties("roleId", p -> p.long_(l -> l))));
+    }
 
-              @Override
-              public WaitStrategy withStartupTimeout(final Duration startupTimeout) {
-                return this;
-              }
-            });
+    if (gatewayEnabled) {
+      // enable embedded gateway and operate/tasklist webapps and their importers
+      camunda
+          .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
+          .withEnv("SPRING_PROFILES_ACTIVE", "broker,operate,tasklist,dev")
+          .withEnv("CAMUNDA_OPERATE_IMPORTER_ENABLED", "true")
+          .withEnv("CAMUNDA_TASKLIST_IMPORTER_ENABLED", "true")
+          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_HEALTHCHECK_ENABLED", "false")
+          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_HEALTHCHECK_ENABLED", "false");
+    } else {
+      camunda
+          .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false")
+          .withEnv("SPRING_PROFILES_ACTIVE", "broker,dev");
+    }
+    camunda.waitingFor(
+        new WaitStrategy() {
+          @Override
+          public void waitUntilReady(final WaitStrategyTarget waitStrategyTarget) {
+            // Wait until the application is shutdown
+            try {
+              shutdownLatch.await(60, TimeUnit.SECONDS);
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException("Interrupted while waiting for shutdown", e);
+            }
+          }
+
+          @Override
+          public WaitStrategy withStartupTimeout(final Duration startupTimeout) {
+            return this;
+          }
+        });
     final var thread = Thread.ofVirtual().start(() -> camunda.start());
 
     final var logToWaitFor =
@@ -142,7 +169,10 @@ class SchemaManagerStartupIT {
                     .contains("io.camunda.zeebe.broker.system - Broker shut down"));
     assertThat(camunda.getLogs())
         .doesNotContain("Failed to start application")
-        .doesNotContain("BeanCreationException");
+        .doesNotContain("BeanCreationException")
+        .doesNotContain("Start importing data")
+        .doesNotContain("Start import position updater")
+        .doesNotContain("Start operation executor");
   }
 
   @Test
@@ -150,6 +180,7 @@ class SchemaManagerStartupIT {
     // given
     camunda
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false")
+        .withEnv("SPRING_PROFILES_ACTIVE", "broker,dev")
         .withExposedPorts(MONITORING_PORT)
         .waitingFor(newDefaultWaitStrategy());
 

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+
     <!-- SPRING -->
 
     <dependency>

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.zeebeimport;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
@@ -50,10 +51,17 @@ public abstract class ImportPositionHolderAbstract implements ImportPositionHold
   @Qualifier("tasklistImportPositionUpdateThreadPoolExecutor")
   protected ThreadPoolTaskScheduler importPositionUpdateExecutor;
 
+  @Autowired private SchemaManagerContainer schemaManagerContainer;
+
   private final Map<String, Boolean> mostRecentProcessedImportPositions = new HashMap<>();
 
   @PostConstruct
   private void init() {
+    if (!schemaManagerContainer.isInitialized()) {
+      LOGGER.info(
+          "INIT: Skipping import position updater start - search engine schema not initialized (application may be shutting down).");
+      return;
+    }
     LOGGER.info("INIT: Start import position updater...");
     scheduleImportPositionUpdateTask();
   }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ZeebeImporter.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ZeebeImporter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.zeebeimport;
 
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.tasklist.property.TasklistProperties;
 import jakarta.annotation.PostConstruct;
 import java.util.Collection;
@@ -35,9 +36,16 @@ public class ZeebeImporter {
   @Qualifier("tasklistRecordsReaderThreadPoolExecutor")
   private ThreadPoolTaskScheduler readersExecutor;
 
+  @Autowired private SchemaManagerContainer schemaManagerContainer;
+
   @PostConstruct
   public void startImportingData() {
     if (tasklistProperties.getImporter().isStartLoadingDataOnStartup()) {
+      if (!schemaManagerContainer.isInitialized()) {
+        LOGGER.info(
+            "INIT: Skipping data import - search engine schema not initialized (application may be shutting down).");
+        return;
+      }
       scheduleReaders();
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This fixes a scenario when the application is stopped during startup (with a SIGTERM for example), the schema manager is gracefully interrupted (without throwing any exceptions), but this does not prevent Spring from continuing starting the other beans, and causes the zeebe importers to run and start writing data, even when the schema is not completely initialized.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44623 
