### PR TITLE
fix: add module name for security/security-validation

### DIFF
--- a/security/security-validation/pom.xml
+++ b/security/security-validation/pom.xml
@@ -15,6 +15,7 @@
   </parent>
 
   <artifactId>camunda-security-validation</artifactId>
+  <name>Camunda Security Validation</name>
 
   <dependencies>
 


### PR DESCRIPTION
## Description

- required by Maven Central release publication
- popped up during 8.8.10 release build here: https://camunda.slack.com/archives/C06UWQNCU7M/p1770132502216359?thread_ts=1770132019.454219&cid=C06UWQNCU7M

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
