### PR TITLE
feat: extend audit log schema with related and description entity fields

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -962,6 +962,9 @@
       <column name="DEPLOYMENT_KEY" type="BIGINT"/>
       <column name="FORM_KEY" type="BIGINT"/>
       <column name="RESOURCE_KEY" type="BIGINT"/>
+      <column name="RELATED_ENTITY_TYPE" type="VARCHAR(50)"/>
+      <column name="RELATED_ENTITY_KEY" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="ENTITY_DESCRIPTION" type="VARCHAR(255)"/>
       <column name="PARTITION_ID" type="NUMBER"/>
       <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
     </createTable>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
@@ -43,6 +43,9 @@ public class AuditLogEntityMapper {
         .deploymentKey(auditLogDbModel.deploymentKey())
         .formKey(auditLogDbModel.formKey())
         .resourceKey(auditLogDbModel.resourceKey())
+        .relatedEntityType(auditLogDbModel.relatedEntityType())
+        .relatedEntityKey(auditLogDbModel.relatedEntityKey())
+        .entityDescription(auditLogDbModel.entityDescription())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuditLogSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AuditLogSearchColumn.java
@@ -35,7 +35,10 @@ public enum AuditLogSearchColumn implements SearchColumn<AuditLogEntity> {
   DECISION_EVALUATION_KEY("decisionEvaluationKey"),
   DEPLOYMENT_KEY("deploymentKey"),
   FORM_KEY("formKey"),
-  RESOURCE_KEY("resourceKey");
+  RESOURCE_KEY("resourceKey"),
+  RELATED_ENTITY_TYPE("relatedEntityType"),
+  RELATED_ENTITY_KEY("relatedEntityKey"),
+  ENTITY_DESCRIPTION("entityDescription");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuditLogDbModel.java
@@ -46,6 +46,9 @@ public record AuditLogDbModel(
     Long deploymentKey,
     Long formKey,
     Long resourceKey,
+    AuditLogEntity.AuditLogEntityType relatedEntityType,
+    String relatedEntityKey,
+    String entityDescription,
     int partitionId,
     OffsetDateTime historyCleanupDate)
     implements DbModel<AuditLogDbModel> {
@@ -88,6 +91,9 @@ public record AuditLogDbModel(
                 .deploymentKey(deploymentKey)
                 .formKey(formKey)
                 .resourceKey(resourceKey)
+                .relatedEntityType(relatedEntityType)
+                .relatedEntityKey(relatedEntityKey)
+                .entityDescription(entityDescription)
                 .partitionId(partitionId)
                 .historyCleanupDate(historyCleanupDate))
         .build();
@@ -126,6 +132,9 @@ public record AuditLogDbModel(
         .deploymentKey(deploymentKey)
         .formKey(formKey)
         .resourceKey(resourceKey)
+        .relatedEntityType(relatedEntityType)
+        .relatedEntityKey(relatedEntityKey)
+        .entityDescription(entityDescription)
         .partitionId(partitionId)
         .historyCleanupDate(historyCleanupDate);
   }
@@ -164,6 +173,9 @@ public record AuditLogDbModel(
     private Long deploymentKey;
     private Long formKey;
     private Long resourceKey;
+    private AuditLogEntity.AuditLogEntityType relatedEntityType;
+    private String relatedEntityKey;
+    private String entityDescription;
     private int partitionId;
     private OffsetDateTime historyCleanupDate;
 
@@ -329,6 +341,21 @@ public record AuditLogDbModel(
       return this;
     }
 
+    public Builder relatedEntityType(final AuditLogEntity.AuditLogEntityType relatedEntityType) {
+      this.relatedEntityType = relatedEntityType;
+      return this;
+    }
+
+    public Builder relatedEntityKey(final String relatedEntityKey) {
+      this.relatedEntityKey = relatedEntityKey;
+      return this;
+    }
+
+    public Builder entityDescription(final String entityDescription) {
+      this.entityDescription = entityDescription;
+      return this;
+    }
+
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
       return this;
@@ -374,6 +401,9 @@ public record AuditLogDbModel(
           deploymentKey,
           formKey,
           resourceKey,
+          relatedEntityType,
+          relatedEntityKey,
+          entityDescription,
           partitionId,
           historyCleanupDate);
     }

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -54,6 +54,9 @@
         DEPLOYMENT_KEY,
         FORM_KEY,
         RESOURCE_KEY,
+        RELATED_ENTITY_TYPE,
+        RELATED_ENTITY_KEY,
+        ENTITY_DESCRIPTION,
         PARTITION_ID,
         HISTORY_CLEANUP_DATE
       FROM ${prefix}AUDIT_LOG
@@ -275,6 +278,24 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.relatedEntityTypeOperations != null and !filter.relatedEntityTypeOperations.isEmpty()">
+        <foreach collection="filter.relatedEntityTypeOperations" item="operation">
+          AND RELATED_ENTITY_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.relatedEntityKeyOperations != null and !filter.relatedEntityKeyOperations.isEmpty()">
+        <foreach collection="filter.relatedEntityKeyOperations" item="operation">
+          AND RELATED_ENTITY_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.entityDescriptionOperations != null and !filter.entityDescriptionOperations.isEmpty()">
+        <foreach collection="filter.entityDescriptionOperations" item="operation">
+          AND ENTITY_DESCRIPTION
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
     </where>
   </sql>
 
@@ -312,6 +333,9 @@
       DEPLOYMENT_KEY,
       FORM_KEY,
       RESOURCE_KEY,
+      RELATED_ENTITY_TYPE,
+      RELATED_ENTITY_KEY,
+      ENTITY_DESCRIPTION,
       PARTITION_ID,
       HISTORY_CLEANUP_DATE
     )
@@ -350,6 +374,9 @@
         #{auditLog.deploymentKey},
         #{auditLog.formKey},
         #{auditLog.resourceKey},
+        #{auditLog.relatedEntityType},
+        #{auditLog.relatedEntityKey},
+        #{auditLog.entityDescription},
         #{auditLog.partitionId},
         #{auditLog.historyCleanupDate, jdbcType=TIMESTAMP}
       )

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
@@ -126,6 +126,9 @@ class BatchInsertMergerTest {
             null,
             null,
             null,
+            null,
+            null,
+            null,
             1,
             OffsetDateTime.now());
 
@@ -154,6 +157,9 @@ class BatchInsertMergerTest {
             100L,
             201L,
             201L,
+            null,
+            null,
+            null,
             null,
             null,
             null,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
@@ -47,7 +47,10 @@ public class AuditLogEntityTransformer
         value.getDecisionEvaluationKey(),
         value.getDeploymentKey(),
         value.getFormKey(),
-        value.getResourceKey());
+        value.getResourceKey(),
+        mapEntityType(value.getRelatedEntityType()),
+        value.getRelatedEntityKey(),
+        value.getEntityDescription());
   }
 
   private AuditLogEntity.AuditLogEntityType mapEntityType(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuditLogFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuditLogFilterTransformer.java
@@ -65,7 +65,10 @@ public class AuditLogFilterTransformer extends IndexFilterTransformer<AuditLogFi
         stringOperations(RESULT, filter.resultOperations()),
         stringOperations(TENANT_ID, filter.tenantIdOperations()),
         dateTimeOperations(TIMESTAMP, filter.timestampOperations()),
-        longOperations(USER_TASK_KEY, filter.userTaskKeyOperations()));
+        longOperations(USER_TASK_KEY, filter.userTaskKeyOperations()),
+        stringOperations(RELATED_ENTITY_TYPE, filter.relatedEntityTypeOperations()),
+        stringOperations(RELATED_ENTITY_KEY, filter.relatedEntityKeyOperations()),
+        stringOperations(ENTITY_DESCRIPTION, filter.entityDescriptionOperations()));
   }
 
   /*

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -41,7 +41,10 @@ public record AuditLogEntity(
     Long decisionEvaluationKey,
     Long deploymentKey,
     Long formKey,
-    Long resourceKey)
+    Long resourceKey,
+    AuditLogEntityType relatedEntityType,
+    String relatedEntityKey,
+    String entityDescription)
     implements TenantOwnedEntity {
 
   @Override
@@ -79,6 +82,9 @@ public record AuditLogEntity(
     private Long deploymentKey;
     private Long formKey;
     private Long resourceKey;
+    private AuditLogEntityType relatedEntityType;
+    private String relatedEntityKey;
+    private String entityDescription;
 
     public Builder auditLogKey(final String auditLogKey) {
       this.auditLogKey = auditLogKey;
@@ -225,6 +231,21 @@ public record AuditLogEntity(
       return this;
     }
 
+    public Builder relatedEntityType(final AuditLogEntityType relatedEntityType) {
+      this.relatedEntityType = relatedEntityType;
+      return this;
+    }
+
+    public Builder relatedEntityKey(final String relatedEntityKey) {
+      this.relatedEntityKey = relatedEntityKey;
+      return this;
+    }
+
+    public Builder entityDescription(final String entityDescription) {
+      this.entityDescription = entityDescription;
+      return this;
+    }
+
     @Override
     public AuditLogEntity build() {
       return new AuditLogEntity(
@@ -256,7 +277,10 @@ public record AuditLogEntity(
           decisionEvaluationKey,
           deploymentKey,
           formKey,
-          resourceKey);
+          resourceKey,
+          relatedEntityType,
+          relatedEntityKey,
+          entityDescription);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuditLogFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuditLogFilter.java
@@ -43,7 +43,10 @@ public record AuditLogFilter(
     List<Operation<Long>> batchOperationKeyOperations,
     List<Operation<Long>> deploymentKeyOperations,
     List<Operation<Long>> formKeyOperations,
-    List<Operation<Long>> resourceKeyOperations)
+    List<Operation<Long>> resourceKeyOperations,
+    List<Operation<String>> relatedEntityKeyOperations,
+    List<Operation<String>> relatedEntityTypeOperations,
+    List<Operation<String>> entityDescriptionOperations)
     implements FilterBase {
 
   public static AuditLogFilter of(
@@ -78,7 +81,10 @@ public record AuditLogFilter(
         .batchOperationKeyOperations(batchOperationKeyOperations)
         .deploymentKeyOperations(deploymentKeyOperations)
         .formKeyOperations(formKeyOperations)
-        .resourceKeyOperations(resourceKeyOperations);
+        .resourceKeyOperations(resourceKeyOperations)
+        .relatedEntityKeyOperations(relatedEntityKeyOperations)
+        .relatedEntityTypeOperations(relatedEntityTypeOperations)
+        .entityDescriptionOperations(entityDescriptionOperations);
   }
 
   public static final class Builder implements ObjectBuilder<AuditLogFilter> {
@@ -108,6 +114,9 @@ public record AuditLogFilter(
     private List<Operation<Long>> deploymentKeyOperations;
     private List<Operation<Long>> formKeyOperations;
     private List<Operation<Long>> resourceKeyOperations;
+    private List<Operation<String>> entityDescriptionOperations;
+    private List<Operation<String>> relatedEntityTypeOperations;
+    private List<Operation<String>> relatedEntityKeyOperations;
 
     public Builder auditLogKeyOperations(final List<Operation<String>> operations) {
       if (operations != null) {
@@ -414,6 +423,39 @@ public record AuditLogFilter(
       return resourceKeyOperations(List.of(FilterUtil.mapDefaultToOperation(value, values)));
     }
 
+    public Builder relatedEntityKeyOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        relatedEntityKeyOperations = addValuesToList(relatedEntityKeyOperations, operations);
+      }
+      return this;
+    }
+
+    public Builder relatedEntityKeys(final String value, final String... values) {
+      return relatedEntityKeyOperations(List.of(FilterUtil.mapDefaultToOperation(value, values)));
+    }
+
+    public Builder relatedEntityTypeOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        relatedEntityTypeOperations = addValuesToList(relatedEntityTypeOperations, operations);
+      }
+      return this;
+    }
+
+    public Builder relatedEntityTypes(final String value, final String... values) {
+      return relatedEntityTypeOperations(List.of(FilterUtil.mapDefaultToOperation(value, values)));
+    }
+
+    public Builder entityDescriptionOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        entityDescriptionOperations = addValuesToList(entityDescriptionOperations, operations);
+      }
+      return this;
+    }
+
+    public Builder entityDescriptions(final String value, final String... values) {
+      return entityDescriptionOperations(List.of(FilterUtil.mapDefaultToOperation(value, values)));
+    }
+
     @Override
     public AuditLogFilter build() {
       return new AuditLogFilter(
@@ -442,7 +484,10 @@ public record AuditLogFilter(
           Objects.requireNonNullElse(batchOperationKeyOperations, List.of()),
           Objects.requireNonNullElse(deploymentKeyOperations, List.of()),
           Objects.requireNonNullElse(formKeyOperations, List.of()),
-          Objects.requireNonNullElse(resourceKeyOperations, List.of()));
+          Objects.requireNonNullElse(resourceKeyOperations, List.of()),
+          Objects.requireNonNullElse(relatedEntityKeyOperations, List.of()),
+          Objects.requireNonNullElse(relatedEntityTypeOperations, List.of()),
+          Objects.requireNonNullElse(entityDescriptionOperations, List.of()));
     }
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -52,6 +52,9 @@ public class AuditLogTemplate extends AbstractTemplateDescriptor
   public static final String TIMESTAMP = "timestamp";
   public static final String USER_TASK_KEY = "userTaskKey";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String RELATED_ENTITY_TYPE = "relatedEntityType";
+  public static final String RELATED_ENTITY_KEY = "relatedEntityKey";
+  public static final String ENTITY_DESCRIPTION = "entityDescription";
 
   public static final EntityJoinRelationFactory<AuditLogJoinRelationshipType>
       JOIN_RELATION_FACTORY =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntity.java
@@ -123,6 +123,15 @@ public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long rootProcessInstanceKey;
 
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private AuditLogEntityType relatedEntityType;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String relatedEntityKey;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String entityDescription;
+
   public String getEntityKey() {
     return entityKey;
   }
@@ -399,6 +408,33 @@ public class AuditLogEntity extends AbstractExporterEntity<AuditLogEntity> {
 
   public AuditLogEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
     this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  public AuditLogEntityType getRelatedEntityType() {
+    return relatedEntityType;
+  }
+
+  public AuditLogEntity setRelatedEntityType(final AuditLogEntityType relatedEntityType) {
+    this.relatedEntityType = relatedEntityType;
+    return this;
+  }
+
+  public String getRelatedEntityKey() {
+    return relatedEntityKey;
+  }
+
+  public AuditLogEntity setRelatedEntityKey(final String relatedEntityKey) {
+    this.relatedEntityKey = relatedEntityKey;
+    return this;
+  }
+
+  public String getEntityDescription() {
+    return entityDescription;
+  }
+
+  public AuditLogEntity setEntityDescription(final String entityDescription) {
+    this.entityDescription = entityDescription;
     return this;
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-audit-log.json
@@ -98,6 +98,15 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "relatedEntityType": {
+        "type": "keyword"
+      },
+      "relatedEntityKey": {
+        "type": "keyword"
+      },
+      "entityDescription": {
+        "type": "keyword"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-audit-log.json
@@ -98,6 +98,15 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "relatedEntityType": {
+        "type": "keyword"
+      },
+      "relatedEntityKey": {
+        "type": "keyword"
+      },
+      "entityDescription": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
## Description

Extend audit log schema with related and description entity fields
Add related and description entity fields to ES/OS
Add related and description entity fields to RDBMS

## Related issues

related to https://github.com/camunda/camunda/issues/44945
