### PR TITLE
feat: add decision instance deletion endpoint batch operation

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -82,6 +82,7 @@ import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
 import io.camunda.gateway.protocol.model.UserTaskAssignmentRequest;
 import io.camunda.gateway.protocol.model.UserTaskCompletionRequest;
 import io.camunda.gateway.protocol.model.UserTaskUpdateRequest;
+import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
@@ -862,6 +863,17 @@ public class RequestMapper {
                 getKeyOrDefault(request, DecisionEvaluationByKey::getDecisionDefinitionKey, -1L),
                 getMapOrEmpty(request, DecisionEvaluationByKey::getVariables),
                 tenantId));
+  }
+
+  public static Either<ProblemDetail, DecisionInstanceFilter> toRequiredDecisionInstanceFilter(
+      final io.camunda.gateway.protocol.model.DecisionInstanceFilter request) {
+
+    final var filter = SearchQueryFilterMapper.toRequiredDecisionInstanceFilter(request);
+    if (filter.isLeft()) {
+      return Either.left(createProblemDetail(filter.getLeft()).get());
+    }
+
+    return Either.right(filter.get());
   }
 
   public static Either<ProblemDetail, AdHocSubProcessActivateActivitiesRequest>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -454,6 +454,17 @@ public class SearchQueryFilterMapper {
     return toProcessInstanceFilter(filter);
   }
 
+  public static Either<List<String>, DecisionInstanceFilter> toRequiredDecisionInstanceFilter(
+      final io.camunda.gateway.protocol.model.DecisionInstanceFilter filter) {
+    if (filter == null) {
+      return Either.left(List.of(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter")));
+    }
+    if (filter.equals(SearchQueryRequestMapper.EMPTY_DECISION_INSTANCE_FILTER)) {
+      return Either.left(List.of(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("filter criteria")));
+    }
+    return Either.right(toDecisionInstanceFilter(filter));
+  }
+
   public static Either<List<String>, ProcessInstanceFilter> toProcessInstanceFilter(
       final io.camunda.gateway.protocol.model.ProcessInstanceFilter filter) {
     final List<String> validationErrors = new ArrayList<>();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -70,6 +70,9 @@ public final class SearchQueryRequestMapper {
   public static final BasicStringFilter EMPTY_BASIC_STRING_FILTER = new BasicStringFilter();
   public static final io.camunda.gateway.protocol.model.ProcessInstanceFilter
       EMPTY_PROCESS_INSTANCE_FILTER = new io.camunda.gateway.protocol.model.ProcessInstanceFilter();
+  public static final io.camunda.gateway.protocol.model.DecisionInstanceFilter
+      EMPTY_DECISION_INSTANCE_FILTER =
+          new io.camunda.gateway.protocol.model.DecisionInstanceFilter();
 
   public static final io.camunda.gateway.protocol.model
           .IncidentProcessInstanceStatisticsByDefinitionFilter

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -148,4 +148,14 @@ public final class DecisionInstanceServices
 
     return sendBrokerRequest(brokerRequest);
   }
+
+  public CompletableFuture<BatchOperationCreationRecord> deleteDecisionInstancesBatchOperation(
+      final DecisionInstanceFilter filter) {
+    final var brokerRequest =
+        new BrokerCreateBatchOperationRequest()
+            .setFilter(filter)
+            .setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE)
+            .setAuthentication(authentication);
+    return sendBrokerRequest(brokerRequest);
+  }
 }

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -228,7 +228,8 @@ class DecisionInstanceServiceTest {
   void shouldDeleteProcessInstanceBatchOperationWithResult() {
     // given
     final var filter =
-        FilterBuilders.decisionInstance(b -> b.decisionDefinitionIds("test-process-definition-id"));
+        FilterBuilders.decisionInstance(
+            b -> b.decisionDefinitionIds("test-decision-definition-id"));
 
     final long batchOperationKey = 123L;
     final var record = new BatchOperationCreationRecord();
@@ -251,8 +252,9 @@ class DecisionInstanceServiceTest {
     final var enrichedRecord = captor.getValue().getRequestWriter();
 
     assertThat(
-        MsgPackConverter.convertToObject(
-            enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
+            MsgPackConverter.convertToObject(
+                enrichedRecord.getAuthenticationBuffer(), CamundaAuthentication.class))
         .isEqualTo(authentication);
+    assertThat(enrichedRecord.getEntityFilter()).contains("test-decision-definition-id");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -885,6 +885,7 @@ message BatchOperationCreatedResult {
     MODIFY_PROCESS_INSTANCE = 6;
     RESOLVE_INCIDENT = 7;
     UPDATE_VARIABLE = 8;
+    DELETE_DECISION_INSTANCE = 9;
   }
 
   // The batch operation key created to delete the resource.

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -467,6 +467,20 @@ components:
           description: the error message from the engine in case of a failed operation.
           type: string
 
+    DecisionInstanceDeletionBatchOperationRequest:
+      type: object
+      additionalProperties: false
+      description: The decision instance filter that defines which decision instances should be deleted.
+      properties:
+        filter:
+          allOf:
+            - $ref: 'decision-instances.yaml#/components/schemas/DecisionInstanceFilter'
+          description: The decision instance filter.
+        operationReference:
+          $ref: 'keys.yaml#/components/schemas/OperationReference'
+      required:
+        - filter
+
     ProcessInstanceCancellationBatchOperationRequest:
       type: object
       additionalProperties: false

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -122,7 +122,6 @@ paths:
       summary: Delete decision instances (batch)
       description: |
         Delete multiple decision instances. This will delete the historic data from secondary storage.
-        Only decision instances in a final state (COMPLETED or TERMINATED) can be deleted.
         This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
       requestBody:
         required: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -113,6 +113,45 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
 
+  /decision-instances/deletion:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Decision instance
+      operationId: deleteDecisionInstancesBatchOperation
+      summary: Delete decision instances (batch)
+      description: |
+        Delete multiple decision instances. This will delete the historic data from secondary storage.
+        Only decision instances in a final state (COMPLETED or TERMINATED) can be deleted.
+        This is done asynchronously, the progress can be tracked using the batchOperationKey from the response and the batch operation status endpoint (/batch-operations/{batchOperationKey}).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'batch-operations.yaml#/components/schemas/DecisionInstanceDeletionBatchOperationRequest'
+      responses:
+        "200":
+          description: The batch operation request was created.
+          content:
+            application/json:
+              schema:
+                $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
+        "400":
+          description: >
+            The decision instance batch operation failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
 ## Schema definitions
 
 components:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -136,6 +136,8 @@ paths:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionEvaluationInstanceKey}'
   /decision-instances/{decisionInstanceKey}/deletion:
     $ref: 'decision-instances.yaml#/paths/~1decision-instances~1{decisionInstanceKey}~1deletion'
+  /decision-instances/deletion:
+    $ref: 'decision-instances.yaml#/paths/~1decision-instances~1deletion'
 
   # Decision requirements endpoints
   /decision-requirements/search:


### PR DESCRIPTION
## Description

- Add delete decision instance batch operation specs
- Add delete decision instance query filter and map
- Add delete decision instance service to propagate batch operation `DELETE_DECISION_INSTANCE` request to broker
- Add delete decision instance batch operation endpoint
- Add service and controller UT

## Links

closes #42396
Relative [discussion](https://camunda.slack.com/archives/C08HB8KJFG8/p1770213847052649)
