### PR TITLE
[Backport main] fix: add module name for security/security-validation

### DIFF
--- a/security/security-validation/pom.xml
+++ b/security/security-validation/pom.xml
@@ -15,6 +15,7 @@
   </parent>
 
   <artifactId>camunda-security-validation</artifactId>
+  <name>Camunda Security Validation</name>
 
   <name>Camunda Security Validation</name>
 


### PR DESCRIPTION
# Description
Backport of #44969 to `main`.

relates to 