### PR TITLE
[Backport stable/8.8] fix: add module name for security/security-validation

### DIFF
--- a/security/security-validation/pom.xml
+++ b/security/security-validation/pom.xml
@@ -15,6 +15,7 @@
   </parent>
 
   <artifactId>camunda-security-validation</artifactId>
+  <name>Camunda Security Validation</name>
 
   <dependencies>
 


### PR DESCRIPTION
# Description
Backport of #44969 to `stable/8.8`.

relates to 