### PR TITLE
Search correlated message subscriptions api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/doubleMessageCatchEvent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/doubleMessageCatchEvent.bpmn
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="8a3bc75" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_double_message_catch" name="doubleMessageCatchEvent" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1qg5s6k</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_Up">
+      <bpmn:incoming>Flow_0xi9tty</bpmn:incoming>
+      <bpmn:outgoing>Flow_078p8w5</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_05isuyu" messageRef="Message_256spvh" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_0nz1025">
+      <bpmn:incoming>Flow_0rnwptn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1qg5s6k" sourceRef="StartEvent_1" targetRef="Gateway_15dc6hj" />
+    <bpmn:parallelGateway id="Gateway_15dc6hj">
+      <bpmn:incoming>Flow_1qg5s6k</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xi9tty</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0we0s83</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0xi9tty" sourceRef="Gateway_15dc6hj" targetRef="Event_Up" />
+    <bpmn:sequenceFlow id="Flow_0we0s83" sourceRef="Gateway_15dc6hj" targetRef="Event_down" />
+    <bpmn:intermediateCatchEvent id="Event_down">
+      <bpmn:incoming>Flow_0we0s83</bpmn:incoming>
+      <bpmn:outgoing>Flow_1eim40u</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0qv7wq2" messageRef="Message_1tu3d5h" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1eim40u" sourceRef="Event_down" targetRef="Gateway_00ntuqs" />
+    <bpmn:parallelGateway id="Gateway_00ntuqs">
+      <bpmn:incoming>Flow_1eim40u</bpmn:incoming>
+      <bpmn:incoming>Flow_078p8w5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rnwptn</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_078p8w5" sourceRef="Event_Up" targetRef="Gateway_00ntuqs" />
+    <bpmn:sequenceFlow id="Flow_0rnwptn" sourceRef="Gateway_00ntuqs" targetRef="Event_0nz1025" />
+  </bpmn:process>
+  <bpmn:message id="Message_256spvh" name="Message_256spvh">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=9324715" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1tu3d5h" name="Message_1tu3d5h">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=191919" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_double_message_catch">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="122" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_12w6jqv_di" bpmnElement="Gateway_15dc6hj">
+        <dc:Bounds x="205" y="195" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gotl89_di" bpmnElement="Event_Up">
+        <dc:Bounds x="302" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11fz5g2_di" bpmnElement="Event_down">
+        <dc:Bounds x="302" y="252" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1t5et67_di" bpmnElement="Gateway_00ntuqs">
+        <dc:Bounds x="395" y="195" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nz1025_di" bpmnElement="Event_0nz1025">
+        <dc:Bounds x="542" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1qg5s6k_di" bpmnElement="Flow_1qg5s6k">
+        <di:waypoint x="158" y="220" />
+        <di:waypoint x="205" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xi9tty_di" bpmnElement="Flow_0xi9tty">
+        <di:waypoint x="230" y="195" />
+        <di:waypoint x="230" y="160" />
+        <di:waypoint x="302" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0we0s83_di" bpmnElement="Flow_0we0s83">
+        <di:waypoint x="230" y="245" />
+        <di:waypoint x="230" y="270" />
+        <di:waypoint x="302" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1eim40u_di" bpmnElement="Flow_1eim40u">
+        <di:waypoint x="338" y="270" />
+        <di:waypoint x="420" y="270" />
+        <di:waypoint x="420" y="245" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_078p8w5_di" bpmnElement="Flow_078p8w5">
+        <di:waypoint x="338" y="160" />
+        <di:waypoint x="420" y="160" />
+        <di:waypoint x="420" y="195" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rnwptn_di" bpmnElement="Flow_0rnwptn">
+        <di:waypoint x="445" y="220" />
+        <di:waypoint x="542" y="220" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -1,0 +1,452 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect, APIRequestContext} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertRequiredFields,
+  assertEqualsForKeys,
+  paginatedResponseFields,
+  assertStatusCode,
+  assertBadRequest,
+  assertUnauthorizedRequest,
+  encode,
+} from '../../../../utils/http';
+import {
+  CORRELATE_MESSAGE,
+  CORRELATE_MESSAGE1,
+  CORRELATE_MESSAGE2,
+  CORRELATE_MESSAGE_DOUBLE_1,
+  CORRELATE_MESSAGE_DOUBLE_2,
+  correlateMessageRequiredFields,
+  correlatedMessageSubscriptionRequiredFields,
+} from '../../../../utils/beans/requestBeans';
+import {createInstances, deploy} from '../../../../utils/zeebeClient';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponse} from 'json-body-assertions';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  expectProcessInstanceCanBeFound,
+  type CorrelatedMessageSubscription,
+  searchCorrelatedMessageSubscriptions,
+  CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+  grantUserResourceAuthorization,
+  createUser,
+} from '@requestHelpers';
+
+test.describe.serial('Correlated Message Subscriptions API Tests', () => {
+  const state: Record<string, string> = {};
+  const expectedCorrelationSubscriptionSearchResponse1 = {
+    correlationKey: '3838383',
+    elementId: 'Event_17u9bac',
+    messageName: 'Message_3tvi9o8',
+    partitionId: 1,
+    processDefinitionId: 'messageCatchEvent3',
+    tenantId: '<default>',
+  };
+
+  let messageKeys: string[] = [];
+  const cleanups: ((request: APIRequestContext) => Promise<void>)[] = [];
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Deploy processes', async () => {
+      await deploy([
+        './resources/messageCatchEvent3.bpmn',
+        './resources/messageCatchEvent1.bpmn',
+        './resources/messageCatchEvent2.bpmn',
+        './resources/doubleMessageCatchEvent.bpmn',
+      ]);
+    });
+
+    await test.step('Create process instances', async () => {
+      const [procA] = await createInstances('messageCatchEvent3', 1, 1);
+      const [procB] = await createInstances('messageCatchEvent1', 1, 1);
+      const [procC] = await createInstances('messageCatchEvent2', 1, 1);
+      const [procD] = await createInstances(
+        'Process_double_message_catch',
+        1,
+        1,
+      );
+      state.processInstance1 = procA.processInstanceKey;
+      state.processInstance2 = procB.processInstanceKey;
+      state.processInstance3 = procC.processInstanceKey;
+      state.processInstance4 = procD.processInstanceKey;
+    });
+
+    await test.step('Poll process instances', async () => {
+      await expectProcessInstanceCanBeFound(request, state.processInstance1);
+      await expectProcessInstanceCanBeFound(request, state.processInstance2);
+      await expectProcessInstanceCanBeFound(request, state.processInstance3);
+      await expectProcessInstanceCanBeFound(request, state.processInstance4);
+    });
+
+    await test.step('Correlate messages', async () => {
+      const correlationPayloads = [
+        {body: CORRELATE_MESSAGE, stateKey: 'messageKeyPrimary'},
+        {body: CORRELATE_MESSAGE2, stateKey: 'messageKeySecondary'},
+        {body: CORRELATE_MESSAGE1, stateKey: 'messageKeyTertiary'},
+        {body: CORRELATE_MESSAGE_DOUBLE_1, stateKey: 'messageKeyDouble1'},
+        {body: CORRELATE_MESSAGE_DOUBLE_2, stateKey: 'messageKeyDouble2'},
+      ];
+
+      for (const payload of correlationPayloads) {
+        const res = await request.post(buildUrl('/messages/correlation'), {
+          headers: jsonHeaders(),
+          data: payload.body,
+        });
+        expect(res.status()).toBe(200);
+        await validateResponse(
+          {
+            path: '/messages/correlation',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        assertRequiredFields(json, correlateMessageRequiredFields);
+        state[payload.stateKey] = json.messageKey;
+        messageKeys.push(json.messageKey);
+      }
+    });
+
+    await test.step('Wait for message subscriptions to be created', async () => {
+      for (const key of messageKeys) {
+        await searchCorrelatedMessageSubscriptions(request, key);
+      }
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    for (const key of Object.keys(state)) {
+      delete state[key];
+    }
+    for (const cleanup of cleanups) {
+      await cleanup(request);
+    }
+  });
+
+  test('Search Message Subscriptions - by message key, single result - 200 Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              messageKey: state.messageKeyPrimary,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      await validateResponse(
+        {
+          path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(1);
+      const subscription = json.items[0] as CorrelatedMessageSubscription;
+      assertRequiredFields(
+        subscription,
+        correlatedMessageSubscriptionRequiredFields,
+      );
+      expect(subscription.messageKey).toBe(state.messageKeyPrimary);
+      expect(subscription.tenantId).toBe('<default>');
+      assertEqualsForKeys(
+        subscription,
+        expectedCorrelationSubscriptionSearchResponse1,
+        [
+          'correlationKey',
+          'elementId',
+          'messageName',
+          'partitionId',
+          'processDefinitionId',
+          'tenantId',
+        ],
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Message Subscriptions - multiple result - 200 Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            sort: [
+              {
+                field: 'correlationTime',
+                order: 'DESC',
+              },
+            ],
+            page: {limit: 50},
+          },
+        },
+      );
+
+      expect(res.status()).toBe(200);
+      await validateResponse(
+        {
+          path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(3);
+
+      const subscriptions = json.items as CorrelatedMessageSubscription[];
+      for (const subscription of subscriptions) {
+        assertRequiredFields(
+          subscription,
+          correlatedMessageSubscriptionRequiredFields,
+        );
+      }
+
+      const resultMessageKeys = subscriptions.map((s) => s.messageKey);
+      expect(resultMessageKeys).toEqual(expect.arrayContaining(messageKeys));
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Message Subscriptions - no result - 200 Success', async ({
+    request,
+  }) => {
+    const someNotExistingMessageKey = '9999999999999';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              messageKey: someNotExistingMessageKey,
+            },
+          },
+        },
+      );
+      expect(res.status()).toBe(200);
+      await validateResponse(
+        {
+          path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const json = await res.json();
+      assertRequiredFields(json, paginatedResponseFields);
+      expect(json.page.totalItems).toBe(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Message Subscriptions - multiple filter - 200 Success', async ({
+    request,
+  }) => {
+    const processInstanceKeyToSearch = state.processInstance4;
+    await test.step('Search by process instance key and tenant id', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToSearch,
+                tenantId: '<default>',
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBe(2);
+        const subscriptions = json.items as CorrelatedMessageSubscription[];
+        for (const subscription of subscriptions) {
+          assertRequiredFields(
+            subscription,
+            correlatedMessageSubscriptionRequiredFields,
+          );
+          expect(subscription.processInstanceKey).toBe(
+            processInstanceKeyToSearch,
+          );
+          expect(subscription.tenantId).toBe('<default>');
+        }
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search by process instance key and correlationKey', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processInstanceKey: processInstanceKeyToSearch,
+                correlationKey: CORRELATE_MESSAGE_DOUBLE_2.correlationKey,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        assertRequiredFields(json, paginatedResponseFields);
+        expect(json.page.totalItems).toBe(1);
+
+        const subscription = json.items[0] as CorrelatedMessageSubscription;
+        assertRequiredFields(
+          subscription,
+          correlatedMessageSubscriptionRequiredFields,
+        );
+        expect(subscription.processInstanceKey).toBe(
+          processInstanceKeyToSearch,
+        );
+        expect(subscription.correlationKey).toBe(
+          CORRELATE_MESSAGE_DOUBLE_2.correlationKey,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Search Message Subscriptions - invalid filter field - 400 Bad Request', async ({
+    request,
+  }) => {
+    const invalidField = 'invalidFieldMeow';
+    const res = await request.post(
+      buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            [invalidField]: 'someValue',
+          },
+        },
+      },
+    );
+    await assertBadRequest(
+      res,
+      `Request property [filter.${invalidField}] cannot be parsed`,
+    );
+  });
+
+  test('Search Message Subscriptions - invalid filter value - 400 Bad Request', async ({
+    request,
+  }) => {
+    const invalidFieldValue = 'invalidMeow';
+    const res = await request.post(
+      buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: invalidFieldValue,
+          },
+        },
+      },
+    );
+    await assertBadRequest(res, `For input string: \"${invalidFieldValue}\"`);
+  });
+
+  test('Search Message Subscriptions - 401 Unauthorized', async ({request}) => {
+    const res = await request.post(
+      buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+      {
+        // No auth headers
+        data: {
+          filter: {
+            messageKey: state.messageKeyPrimary,
+          },
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search Message Subscriptions - Forbidden search - 200 Empty Results', async ({request}) => {
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    await test.step('Setup - Create user for authorization tests', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+      cleanups.push(async (request) => {
+        await cleanupUsers(request, [
+          userWithResourcesAuthorizationToSendRequest.username,
+        ]);
+      });
+    });
+
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+
+    await test.step('Attempt to search correlated message subscriptions without proper authorization', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {
+              filter: {
+                messageKey: state.messageKeyPrimary,
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -239,6 +239,19 @@ export const correlateMessageRequiredFields: string[] = [
   'messageKey',
   'processInstanceKey',
 ];
+export const correlatedMessageSubscriptionRequiredFields: string[] = [
+  'correlationKey',
+  'correlationTime',
+  'elementId',
+  'elementInstanceKey',
+  'messageKey',
+  'messageName',
+  'partitionId',
+  'processDefinitionId',
+  'processInstanceKey',
+  'subscriptionKey',
+  'tenantId',
+];
 export const usageMetricsGetResponseRequiredFields: string[] = [
   'activeTenants',
   'tenants',
@@ -266,6 +279,22 @@ export const expectedMessageSubscription3 = {
   tenantId: '<default>',
   elementId: 'Event_17u9bac',
   processDefinitionId: 'messageCatchEvent1',
+};
+
+export const expectedMessageSubscription1DoubleProcess = {
+  messageName: 'Message_256spvh',
+  correlationKey: '9324715',
+  tenantId: '<default>',
+  elementId: 'Event_Up',
+  processDefinitionId: 'Process_double_message_catch',
+};
+
+export const expectedMessageSubscription2DoubleProcess = {
+  messageName: 'Message_1tu3d5h',
+  correlationKey: '191919',
+  tenantId: '<default>',
+  elementId: 'Event_down',
+  processDefinitionId: 'Process_double_message_catch',
 };
 
 export function CREATE_NEW_GROUP() {
@@ -365,6 +394,28 @@ export const CORRELATE_MESSAGE = {
   name: expectedMessageSubscription3.messageName,
   correlationKey: expectedMessageSubscription3.correlationKey,
   variables: {foo: 'bar'},
+};
+
+export const CORRELATE_MESSAGE1 = {
+  name: expectedMessageSubscription1.messageName,
+  correlationKey: expectedMessageSubscription1.correlationKey,
+  variables: {foo: 'bar'},
+};
+
+export const CORRELATE_MESSAGE2 = {
+  name: expectedMessageSubscription2.messageName,
+  correlationKey: expectedMessageSubscription2.correlationKey,
+  variables: {foo: 'bar'},
+};
+
+export const CORRELATE_MESSAGE_DOUBLE_1 = {
+  name: expectedMessageSubscription1DoubleProcess.messageName,
+  correlationKey: expectedMessageSubscription1DoubleProcess.correlationKey,
+};
+
+export const CORRELATE_MESSAGE_DOUBLE_2 = {
+  name: expectedMessageSubscription2DoubleProcess.messageName,
+  correlationKey: expectedMessageSubscription2DoubleProcess.correlationKey,
 };
 
 export function CREATE_TXT_DOCUMENT_REQUEST() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -66,3 +66,8 @@ export {
   type DecisionInstance,
 } from './decision-instance-requestHelpers';
 export {createProcessInstanceAndRetrieveTimeStamp} from './clock-requestHelpers';
+export {
+  type CorrelatedMessageSubscription,
+  searchCorrelatedMessageSubscriptions,
+  CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+} from './message-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/message-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/message-requestHelpers.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {APIRequestContext} from 'playwright-core';
+import {expect} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+
+export interface CorrelatedMessageSubscription {
+  correlationKey: string;
+  correlationTime: string;
+  elementId: string;
+  elementInstanceKey: string;
+  messageKey: string;
+  messageName: string;
+  partitionId: number;
+  processDefinitionId: string;
+  processInstanceKey: string;
+  subscriptionKey: string;
+  tenantId: string;
+}
+
+export const CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT =
+  '/correlated-message-subscriptions/search';
+
+export async function searchCorrelatedMessageSubscriptions(
+  request: APIRequestContext,
+  messageKey: string,
+) {
+  await expect(async () => {
+    const res = await request.post(
+      buildUrl(CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            messageKey: messageKey,
+          },
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const json = await res.json();
+    expect(json.page.totalItems).toEqual(1);
+    expect(json.items.length).toEqual(1);
+    const item = json.items[0];
+    expect(item.messageKey).toEqual(messageKey);
+  }).toPass({
+    intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+    timeout: 180_000,
+  });
+}


### PR DESCRIPTION
## Description

This PR covers Search correlated message subscriptions API tests including happy path tests:

- Search Message Subscriptions - by message key, single result - 200 Success
- Search Message Subscriptions - multiple result - 200 Success
- Search Message Subscriptions - no result - 200 Success
- Search Message Subscriptions - multiple filter - 200 Success

and unhappy paths:

- Search Message Subscriptions - invalid filter field - 400 Bad Request
- Search Message Subscriptions - invalid filter value - 400 Bad Request
- Search Message Subscriptions - 401 Unauthorized
- Search Message Subscriptions - Forbidden search - 200 Empty Results

Also there are pagination limit tests:

- Search Message Subscriptions - Negative pagination - 400 Bad Request - skipped due to t[his bug](https://github.com/camunda/camunda/issues/39372)
- Search Message Subscriptions - Pagination 0

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

related #37204

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21664173431)
