### PR TITLE
[Backport stable/8.6] ci: add includeOptimize param for <8.8 release workflow

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -32,6 +32,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        type: boolean
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       releaseBranch:
@@ -60,6 +65,11 @@ on:
         description: 'Activates E2E testing mode for the release process. This mode creates real, temporary changes and artifacts in GitHub and Maven, which are left for manual inspection. A separate process (dryrun_cleanup.bpmn) is responsible for their final reversion, ensuring no lasting impact on production. This flag acts separately to dryRun flag and should be used with dryRun=false. If both flags are active then dryRun takes precedence.'
         type: boolean
         default: false
+      includeOptimize:
+        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        type: boolean
+        required: false
+        default: false
 defaults:
   run:
     shell: bash
@@ -68,6 +78,8 @@ env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   RELEASE_TAG: ${{ inputs.releaseProcessDryRun && format('dryrun-{0}', inputs.releaseVersion) || inputs.releaseVersion }}
+  # Always force includeOptimize to false to maintain consistent behavior - Optimize is always excluded
+  INCLUDE_OPTIMIZE: false
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
   GITHUB_TOKEN_USR: ${{ github.token }} # needs to be available for the SCM URL in pom.xml
 jobs:


### PR DESCRIPTION
# Description
Backport of #44953 to `stable/8.6`.

relates to 