### PR TITLE
use larger runner for database ITs

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -51,7 +51,7 @@ jobs:
     name: "${{inputs.database-type}}"
     permissions: { }  # GITHUB_TOKEN unused in this job
     timeout-minutes: 20
-    runs-on: gcp-perf-core-8-default
+    runs-on: gcp-perf-core-16-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       IMAGE_VERSION: ${{inputs.database-image-version}}


### PR DESCRIPTION
This knocks 1-2 minutes off the time the database tests take (guessing maybe Elasticsearch/Opensearch were struggling a little).

Ideally we'd be smarter about how we speed these tests up, but that could get complicated.
