### PR TITLE
[backport-8.8]: refactor: add optimize-zeebe-it profile with test dependencies

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -755,25 +755,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-it-source</id>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <phase>generate-test-sources</phase>
-            <configuration>
-              <sources>
-                <source>src/it/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${version.spring-boot}</version>
@@ -827,6 +808,71 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>optimize-zeebe-it-support</id>
+      <activation>
+        <property>
+          <name>skipQaBuild</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-qa-util</artifactId>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>io.camunda</groupId>
+              <artifactId>camunda-gateway-mcp</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.liquibase</groupId>
+              <artifactId>liquibase-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>configuration</artifactId>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.liquibase</groupId>
+              <artifactId>liquibase-core</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>io.camunda</groupId>
+          <artifactId>zeebe-broker</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-it-source</id>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <phase>generate-test-sources</phase>
+                <configuration>
+                  <sources>
+                    <source>src/it/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>it</id>
       <build>

--- a/optimize/backend/src/test/java/io/camunda/optimize/test/it/extension/IntegrationTestConfigurationUtil.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/test/it/extension/IntegrationTestConfigurationUtil.java
@@ -18,7 +18,7 @@ import io.camunda.optimize.test.util.PropertyUtil;
 import java.util.Properties;
 import org.springframework.context.ApplicationContext;
 
-public class IntegrationTestConfigurationUtil {
+public final class IntegrationTestConfigurationUtil {
 
   private static final String DEFAULT_PROPERTIES_PATH = "integration-extensions.properties";
   private static final Properties PROPERTIES = PropertyUtil.loadProperties(DEFAULT_PROPERTIES_PATH);

--- a/optimize/backend/src/test/java/io/camunda/optimize/util/FileReaderUtil.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/util/FileReaderUtil.java
@@ -13,7 +13,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 
-public class FileReaderUtil {
+public final class FileReaderUtil {
 
   private FileReaderUtil() {}
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/util/ZeebeBpmnModels.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/util/ZeebeBpmnModels.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import java.time.Duration;
 import java.util.function.Consumer;
 
-public class ZeebeBpmnModels {
+public final class ZeebeBpmnModels {
 
   public static final String ACTIVATE_ELEMENTS = "activateElements";
   public static final String ADHOC_SUB_PROCESS = "adhocSubProcess";

--- a/optimize/backend/src/test/resources/integration-extensions.properties
+++ b/optimize/backend/src/test/resources/integration-extensions.properties
@@ -6,5 +6,4 @@
 zeebe.docker.version=${zeebe.docker.version}
 database.type=${database.type}
 
-# Note: this needs to be in sync with the default name configured in it-config.yaml
 camunda.optimize.engine.default.name=integrationTest

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -327,4 +327,28 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>optimize-zeebe-it-support</id>
+      <activation>
+        <property>
+          <name>skipQaBuild</name>
+          <value>!true</value>
+        </property>
+      </activation>
+    </profile>
+    <profile>
+      <id>skip-upgrade-tests-without-it-support</id>
+      <activation>
+        <property>
+          <name>skipQaBuild</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
After updating the zeebe dependency to 8.8.10, the zeebe build tools not found error repeared on 8.8. 
To resolve it, i created this PR as a backport of https://github.com/camunda/camunda/pull/44180

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
