### PR TITLE
feat: add es9 CI job

### DIFF
--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -10,11 +10,17 @@ inputs:
     general-unit-tests-flaky:
         description: 'Flaky tests from the general unit tests job'
         required: true
-    elasticsearch-tests-result:
-        description: 'Result of the Elasticsearch integration tests job'
+    elasticsearch8-tests-result:
+        description: 'Result of the Elasticsearch 8 integration tests job'
         required: true
-    elasticsearch-tests-flaky:
-        description: 'Flaky tests from the Elasticsearch integration tests job'
+    elasticsearch8-tests-flaky:
+        description: 'Flaky tests from the Elasticsearch 8 integration tests job'
+        required: true
+    elasticsearch9-tests-result:
+        description: 'Result of the Elasticsearch 9 integration tests job'
+        required: true
+    elasticsearch9-tests-flaky:
+        description: 'Flaky tests from the Elasticsearch 9 integration tests job'
         required: true
     opensearch-tests-result:
         description: 'Result of the OpenSearch integration tests job'
@@ -76,7 +82,8 @@ runs:
 
         # Collect from single jobs
         collect_from_single_job "general-unit-tests" "${{ inputs.general-unit-tests-result }}" "${{ inputs.general-unit-tests-flaky }}"
-        collect_from_single_job "elasticsearch-integration-tests" "${{ inputs.elasticsearch-tests-result }}" "${{ inputs.elasticsearch-tests-flaky }}"
+        collect_from_single_job "elasticsearch8-integration-tests" "${{ inputs.elasticsearch8-tests-result }}" "${{ inputs.elasticsearch8-tests-flaky }}"
+        collect_from_single_job "elasticsearch9-integration-tests" "${{ inputs.elasticsearch9-tests-result }}" "${{ inputs.elasticsearch9-tests-flaky }}"
         collect_from_single_job "opensearch-integration-tests" "${{ inputs.opensearch-tests-result }}" "${{ inputs.opensearch-tests-flaky }}"
         collect_from_single_job "rdbms-h2-integration-tests" "${{ inputs.rdbms-h2-tests-result }}" "${{ inputs.rdbms-h2-tests-flaky }}"
         collect_from_single_job "rdbms-integration-tests" "${{ inputs.rdbms-tests-result }}" "${{ inputs.rdbms-tests-flaky }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  elasticsearch-integration-tests:
+  elasticsearch8-integration-tests:
     name: "Database Integration Tests / Elasticsearch"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
@@ -1356,7 +1356,7 @@ jobs:
       - detect-changes
       - docker-checks
       - elasticsearch-history-tests
-      - elasticsearch-integration-tests
+      - elasticsearch8-integration-tests
       - elasticsearch9-integration-tests
       - general-unit-tests
       - h2-history-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,7 +1076,8 @@ jobs:
     needs:
       - archunit-tests
       - docker-checks
-      - elasticsearch-integration-tests
+      - elasticsearch8-integration-tests
+      - elasticsearch9-integration-tests
       - general-unit-tests
       - integration-tests
       - opensearch-integration-tests
@@ -1106,8 +1107,10 @@ jobs:
         with:
           general-unit-tests-result: ${{ needs.general-unit-tests.result }}
           general-unit-tests-flaky: ${{ needs.general-unit-tests.outputs.flakyTests }}
-          elasticsearch-tests-result: ${{ needs.elasticsearch-integration-tests.result }}
-          elasticsearch-tests-flaky: ${{ needs.elasticsearch-integration-tests.outputs.flakyTests }}
+          elasticsearch8-tests-result: ${{ needs.elasticsearch8-integration-tests.result }}
+          elasticsearch8-tests-flaky: ${{ needs.elasticsearch8-integration-tests.outputs.flakyTests }}
+          elasticsearch9-tests-result: ${{ needs.elasticsearch9-integration-tests.result }}
+          elasticsearch9-tests-flaky: ${{ needs.elasticsearch9-integration-tests.outputs.flakyTests }}
           opensearch-tests-result: ${{ needs.opensearch-integration-tests.result }}
           opensearch-tests-flaky: ${{ needs.opensearch-integration-tests.outputs.flakyTests }}
           rdbms-h2-tests-result: ${{ needs.rdbms-h2-integration-tests.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1357,6 +1357,7 @@ jobs:
       - docker-checks
       - elasticsearch-history-tests
       - elasticsearch-integration-tests
+      - elasticsearch9-integration-tests
       - general-unit-tests
       - h2-history-tests
       - identity-frontend-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,17 @@ jobs:
       database-image-version: "8.18.4"
       it-database-type: "es"
 
+  elasticsearch9-integration-tests:
+    name: "Database Integration Tests / Elasticsearch 9"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "elasticsearch"
+      database-image-version: "9.2.4"
+      it-database-type: "es"
+
   opensearch-integration-tests:
     name: "Database Integration Tests / Opensearch"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -35,6 +35,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
@@ -45,6 +46,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.ssl.TrustStrategy;
 import org.elasticsearch.client.*;
@@ -93,8 +95,15 @@ public class ElasticsearchConnector {
       final ElasticsearchProperties elsConfig, final PluginRepository pluginRepository) {
     LOGGER.debug("Creating Elasticsearch connection...");
 
+    final Header[] defaultHeaders =
+        new Header[] {
+          new BasicHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=8"),
+          new BasicHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=8")
+        };
+
     final RestClientBuilder restClientBuilder =
         RestClient.builder(getHttpHosts(elsConfig))
+            .setDefaultHeaders(defaultHeaders)
             .setHttpClientConfigCallback(
                 httpClientBuilder ->
                     configureHttpClient(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -18,6 +18,7 @@ import io.camunda.search.connect.configuration.SecurityConfiguration;
 import io.camunda.search.connect.jackson.JacksonConfiguration;
 import io.camunda.search.connect.plugin.PluginRepository;
 import io.camunda.search.connect.util.SecurityUtil;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
@@ -26,6 +27,7 @@ import org.apache.http.client.config.RequestConfig.Builder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.message.BasicHeader;
 import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,8 +100,15 @@ public final class ElasticsearchConnector {
       restClientBuilder.setRequestConfigCallback(
           configCallback -> setTimeouts(configCallback, configuration));
     }
+
+    final Header[] defaultHeaders =
+        new Header[] {
+          new BasicHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=8"),
+          new BasicHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=8")
+        };
     final var restClient =
         restClientBuilder
+            .setDefaultHeaders(defaultHeaders)
             .setHttpClientConfigCallback(
                 httpClientBuilder ->
                     configureHttpClient(

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -44,6 +44,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
@@ -54,6 +55,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.ssl.TrustStrategy;
 import org.elasticsearch.client.RestClient;
@@ -92,8 +94,15 @@ public class ElasticsearchConnector {
       final ElasticsearchProperties elsConfig, final PluginRepository pluginRepository) {
     LOGGER.debug("Creating Elasticsearch connection...");
 
+    final Header[] defaultHeaders =
+        new Header[] {
+          new BasicHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=8"),
+          new BasicHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=8")
+        };
+
     final RestClientBuilder restClientBuilder =
         RestClient.builder(getHttpHosts(elsConfig))
+            .setDefaultHeaders(defaultHeaders)
             .setHttpClientConfigCallback(
                 httpClientBuilder ->
                     configureHttpClient(


### PR DESCRIPTION
## Description

Add a CI job for database integration tests against Elasticsearch 9


## Related issues

closes https://github.com/camunda/camunda/issues/40526
