### PR TITLE
[Backport main] Add migration to fix broken distributions that are not in the queue or retriable column families.

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -227,6 +227,15 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
+  public boolean hasQueuedDistribution(
+      final String queueId, final long distributionKey, final int partition) {
+    this.queueId.wrapString(queueId);
+    this.distributionKey.wrapLong(distributionKey);
+    partitionKey.wrapInt(partition);
+    return queuedCommandDistributionColumnFamily.exists(queuedDistributionKey);
+  }
+
+  @Override
   public boolean hasPendingDistribution(final long distributionKey, final int partition) {
     this.distributionKey.wrapLong(distributionKey);
     partitionKey.wrapInt(partition);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -39,6 +39,16 @@ public interface DistributionState {
   boolean hasRetriableDistribution(long distributionKey, int partition);
 
   /**
+   * Returns whether a specific distribution for a specific partition is queued.
+   *
+   * @param queueId the id of the queue
+   * @param distributionKey the key of the distribution that may be queued
+   * @param partition the id of the partition for which the distribution might be queued
+   * @return {@code true} if the specific queued distribution exists, otherwise {@code false}.
+   */
+  boolean hasQueuedDistribution(String queueId, long distributionKey, int partition);
+
+  /**
    * Returns whether a specific distribution for a specific partition is pending.
    *
    * @param distributionKey the key of the distribution that may be pending

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -526,4 +526,9 @@ public class DbMigrationState implements MutableMigrationState {
   public void migrateMissingPermissionsForAuthorizations() {
     permissionMigrationState.migrateMissingPermissionsForAuthorizations();
   }
+
+  @Override
+  public void ensureRetriableDeploymentDistributions() {
+    distributionState8dot7.ensureRetriableDeploymentDistributions();
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDe
 import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_7.EnsureRetriableDeploymentDistributionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_7.IdempotentCommandDistributionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_8.PermissionStateCorrectionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -63,6 +64,7 @@ public class DbMigratorImpl implements DbMigrator {
           new RoutingInfoInitializationMigration(),
           new OrderedCommandDistributionMigration(),
           new IdempotentCommandDistributionMigration(),
+          new EnsureRetriableDeploymentDistributionMigration(),
           new PermissionStateCorrectionMigration());
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.distribution.PersistedCommandDistribution;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashSet;
 import org.slf4j.Logger;
 
 public class DbDistributionMigrationState8dot7 {
@@ -138,6 +139,35 @@ public class DbDistributionMigrationState8dot7 {
             } else {
               retriableDistributionColumnFamily.deleteExisting(distributionPartitionKey);
             }
+          }
+        });
+  }
+
+  public void ensureRetriableDeploymentDistributions() {
+    queueId.wrapString(DistributionQueue.DEPLOYMENT.getQueueId());
+    final var partitionsWithRetriableDistribution = new HashSet<Integer>();
+
+    pendingDistributionColumnFamily.forEach(
+        (compositeKey, nil) -> {
+          final var distributionKey = compositeKey.first().inner().getValue();
+          final var partitionId = compositeKey.second().getValue();
+          this.distributionKey.wrapLong(distributionKey);
+          partitionKey.wrapInt(partitionId);
+
+          final var isInQueuedCF =
+              queuedCommandDistributionColumnFamily.exists(queuedDistributionKey);
+          if (!isInQueuedCF) {
+            queuedCommandDistributionColumnFamily.insert(queuedDistributionKey, DbNil.INSTANCE);
+          }
+
+          final var isFirstInQueue = !partitionsWithRetriableDistribution.contains(partitionId);
+          if (isFirstInQueue) {
+            final var isInRetriableCF =
+                retriableDistributionColumnFamily.exists(distributionPartitionKey);
+            if (!isInRetriableCF) {
+              retriableDistributionColumnFamily.insert(distributionPartitionKey, DbNil.INSTANCE);
+            }
+            partitionsWithRetriableDistribution.add(partitionId);
           }
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
@@ -15,6 +15,10 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * This migration is introduced to combat <a
+ * href="https://github.com/camunda/camunda/issues/44908">this bug</a>
+ */
 public class EnsureRetriableDeploymentDistributionMigration implements MigrationTask {
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContext;
+import io.camunda.zeebe.engine.state.migration.MutableMigrationTaskContext;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EnsureRetriableDeploymentDistributionMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final MigrationTaskContext context) {
+    final var distributionState = context.processingState().getDistributionState();
+    final var queueId = DistributionQueue.DEPLOYMENT.getQueueId();
+    final var shouldRun = new AtomicBoolean(false);
+    final var partitionsWithRetriableDistribution = new HashSet<Integer>();
+
+    distributionState.foreachPendingDistribution(
+        (distributionKey, record) -> {
+          // Continue the loop if the distribution is not for the deployment queue.
+          if (!Objects.equals(record.getQueueId(), queueId)) {
+            return true;
+          }
+
+          final var partitionId = record.getPartitionId();
+
+          // If the pending distribution is not queued, we should run the migration. We can stop the
+          // loop early.
+          if (!distributionState.hasQueuedDistribution(queueId, distributionKey, partitionId)) {
+            shouldRun.set(true);
+            return false;
+          }
+
+          // If the pending distribution is the first in the queue and there is no retriable
+          // distribution for the distribution we must run the migration. We can stop the loop
+          // early.
+          // If there is a retriable distribution we should continue the loop in case other
+          // distributions are not queued.
+          final var isFirstInQueue = !partitionsWithRetriableDistribution.contains(partitionId);
+          if (isFirstInQueue) {
+            if (!distributionState.hasRetriableDistribution(distributionKey, partitionId)) {
+              shouldRun.set(true);
+              return false;
+            } else {
+              partitionsWithRetriableDistribution.add(partitionId);
+              return true;
+            }
+          }
+
+          return true;
+        });
+
+    return shouldRun.get();
+  }
+
+  @Override
+  public void runMigration(final MutableMigrationTaskContext context) {
+    context.processingState().getMigrationState().ensureRetriableDeploymentDistributions();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -56,4 +56,6 @@ public interface MutableMigrationState extends MigrationState {
   void migrateIdempotentCommandDistribution();
 
   void migrateMissingPermissionsForAuthorizations();
+
+  void ensureRetriableDeploymentDistributions();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigrationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContextImpl;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class EnsureRetriableDeploymentDistributionMigrationTest {
+
+  public static final String QUEUE_ID = DistributionQueue.DEPLOYMENT.getQueueId();
+  final EnsureRetriableDeploymentDistributionMigration sut =
+      new EnsureRetriableDeploymentDistributionMigration();
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private MutableProcessingState processingState;
+  private TransactionContext transactionContext;
+
+  private DbDistributionState state;
+  private DbDistributionMigrationState8dot7 migrationState;
+
+  @BeforeEach
+  void setup() {
+    state = new DbDistributionState(zeebeDb, transactionContext);
+    migrationState = new DbDistributionMigrationState8dot7(zeebeDb, transactionContext);
+  }
+
+  @Test
+  void shouldNotRunMigrationIfNoPendingDistributions() {
+    // given
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    final var needsToRun = sut.needsToRun(context);
+
+    // then
+    assertThat(needsToRun).isFalse();
+  }
+
+  @Test
+  void shouldNotRunMigrationIfNoPendingDeploymentDistributions() {
+    // given
+    final var distributionKey = 123L;
+    final var partitionId = 2;
+    state.addCommandDistribution(distributionKey, createClockRecord());
+    state.addPendingDistribution(distributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    final var needsToRun = sut.needsToRun(context);
+
+    // then
+    assertThat(needsToRun).isFalse();
+  }
+
+  @Test
+  void shouldNotRunMigrationIfDeploymentDistributionIsRetriableAndQueued() {
+    // given
+    final var distributionKey = 123L;
+    final var partitionId = 2;
+    state.addCommandDistribution(distributionKey, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey, partitionId);
+    state.addRetriableDistribution(distributionKey, partitionId);
+    state.enqueueCommandDistribution(QUEUE_ID, distributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    final var needsToRun = sut.needsToRun(context);
+
+    // then
+    assertThat(needsToRun).isFalse();
+  }
+
+  @Test
+  void shouldRunMigrationIfDeploymentDistributionIsNotQueued() {
+    // given
+    final var distributionKey = 123L;
+    final var partitionId = 2;
+    state.addCommandDistribution(distributionKey, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey, partitionId);
+    state.addRetriableDistribution(distributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    final var needsToRun = sut.needsToRun(context);
+    assertThat(needsToRun).isTrue();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasRetriableDistribution(distributionKey, partitionId)).isTrue();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey, partitionId)).isTrue();
+  }
+
+  @Test
+  void shouldRunMigrationIfDeploymentDistributionIsNotRetriable() {
+    // given
+    final var distributionKey = 123L;
+    final var partitionId = 2;
+    state.addCommandDistribution(distributionKey, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey, partitionId);
+    state.enqueueCommandDistribution(QUEUE_ID, distributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    final var needsToRun = sut.needsToRun(context);
+    assertThat(needsToRun).isTrue();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasRetriableDistribution(distributionKey, partitionId)).isTrue();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey, partitionId)).isTrue();
+  }
+
+  @Test
+  void shouldRunMigrationIfSecondDeploymentOnSamePartitionIsNotQueued() {
+    // given
+    final var distributionKey = 123L;
+    final var distributionKey2 = 456L;
+    final var partitionId = 2;
+    state.addCommandDistribution(distributionKey, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey, partitionId);
+    state.addRetriableDistribution(distributionKey, partitionId);
+    state.enqueueCommandDistribution(QUEUE_ID, distributionKey, partitionId);
+
+    state.addCommandDistribution(distributionKey2, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey2, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(2), processingState);
+    final var needsToRun = sut.needsToRun(context);
+    assertThat(needsToRun).isTrue();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasRetriableDistribution(distributionKey, partitionId)).isTrue();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey, partitionId)).isTrue();
+    assertThat(state.hasRetriableDistribution(distributionKey2, partitionId)).isFalse();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey2, partitionId)).isTrue();
+  }
+
+  @Test
+  void shouldRunMigrationIfOtherPartitionIsNotRetriableAndQueued() {
+    // given
+    final var distributionKey = 123L;
+    final var partitionId1 = 2;
+    final var partitionId2 = 3;
+    state.addCommandDistribution(distributionKey, createDeploymentCreateRecord());
+    state.addPendingDistribution(distributionKey, partitionId1);
+    state.addRetriableDistribution(distributionKey, partitionId1);
+    state.enqueueCommandDistribution(QUEUE_ID, distributionKey, partitionId1);
+
+    state.addPendingDistribution(distributionKey, partitionId2);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(2), processingState);
+    final var needsToRun = sut.needsToRun(context);
+    assertThat(needsToRun).isTrue();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasRetriableDistribution(distributionKey, partitionId1)).isTrue();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey, partitionId1)).isTrue();
+    assertThat(state.hasRetriableDistribution(distributionKey, partitionId2)).isTrue();
+    assertThat(state.hasQueuedDistribution(QUEUE_ID, distributionKey, partitionId2)).isTrue();
+  }
+
+  private CommandDistributionRecord createDeploymentCreateRecord() {
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord
+        .resources()
+        .add()
+        .setResourceName("my_first_bpmn.bpmn")
+        .setResource(wrapString("This is the contents of the BPMN"));
+    deploymentRecord
+        .processesMetadata()
+        .add()
+        .setKey(123)
+        .setVersion(1)
+        .setBpmnProcessId("my_first_process")
+        .setResourceName("my_first_bpmn.bpmn")
+        .setChecksum(wrapString("sha1"));
+
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setQueueId(QUEUE_ID)
+        .setValueType(ValueType.DEPLOYMENT)
+        .setIntent(DeploymentIntent.CREATE)
+        .setCommandValue(deploymentRecord);
+  }
+
+  private CommandDistributionRecord createClockRecord() {
+    final var clockRecord = new ClockRecord().pinAt(1000L);
+
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setValueType(ValueType.CLOCK)
+        .setIntent(ClockIntent.PIN)
+        .setCommandValue(clockRecord);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #44968 to `main`.

relates to #44908