### PR TITLE
[Backport stable/8.7] Add migration to fix broken distributions that are not in the queue or retriable column families.

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -227,6 +227,15 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
+  public boolean hasQueuedDistribution(
+      final String queueId, final long distributionKey, final int partition) {
+    this.queueId.wrapString(queueId);
+    this.distributionKey.wrapLong(distributionKey);
+    partitionKey.wrapInt(partition);
+    return queuedCommandDistributionColumnFamily.exists(queuedDistributionKey);
+  }
+
+  @Override
   public boolean hasPendingDistribution(final long distributionKey, final int partition) {
     this.distributionKey.wrapLong(distributionKey);
     partitionKey.wrapInt(partition);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -38,6 +38,16 @@ public interface DistributionState {
   boolean hasRetriableDistribution(long distributionKey, int partition);
 
   /**
+   * Returns whether a specific distribution for a specific partition is queued.
+   *
+   * @param queueId the id of the queue
+   * @param distributionKey the key of the distribution that may be queued
+   * @param partition the id of the partition for which the distribution might be queued
+   * @return {@code true} if the specific queued distribution exists, otherwise {@code false}.
+   */
+  boolean hasQueuedDistribution(String queueId, long distributionKey, int partition);
+
+  /**
    * Returns whether a specific distribution for a specific partition is pending.
    *
    * @param distributionKey the key of the distribution that may be pending

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -510,4 +510,22 @@ public class DbMigrationState implements MutableMigrationState {
   public void migrateOrderedCommandDistribution() {
     distributionState.migratePendingDistributionsToRetriableDistributions();
   }
+<<<<<<< HEAD
+=======
+
+  @Override
+  public void migrateIdempotentCommandDistribution() {
+    distributionState8dot7.migrateIdempotentCommandDistributions();
+  }
+
+  @Override
+  public void migrateMissingPermissionsForAuthorizations() {
+    permissionMigrationState.migrateMissingPermissionsForAuthorizations();
+  }
+
+  @Override
+  public void ensureRetriableDeploymentDistributions() {
+    distributionState8dot7.ensureRetriableDeploymentDistributions();
+  }
+>>>>>>> f3e612fe (fix: ensure pending distributions that are not queued and/or are first in queue but not retriable are inserted in the CF)
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -24,6 +24,12 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDe
 import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
+<<<<<<< HEAD
+=======
+import io.camunda.zeebe.engine.state.migration.to_8_7.EnsureRetriableDeploymentDistributionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_7.IdempotentCommandDistributionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_8.PermissionStateCorrectionMigration;
+>>>>>>> f3e612fe (fix: ensure pending distributions that are not queued and/or are first in queue but not retriable are inserted in the CF)
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
@@ -58,7 +64,14 @@ public class DbMigratorImpl implements DbMigrator {
           new MultiTenancySignalSubscriptionStateMigration(),
           new JobBackoffRestoreMigration(),
           new RoutingInfoInitializationMigration(),
+<<<<<<< HEAD
           new OrderedCommandDistributionMigration());
+=======
+          new OrderedCommandDistributionMigration(),
+          new IdempotentCommandDistributionMigration(),
+          new EnsureRetriableDeploymentDistributionMigration(),
+          new PermissionStateCorrectionMigration());
+>>>>>>> f3e612fe (fix: ensure pending distributions that are not queued and/or are first in queue but not retriable are inserted in the CF)
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
   // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbInt;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.distribution.PersistedCommandDistribution;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashSet;
+import org.slf4j.Logger;
+
+public class DbDistributionMigrationState8dot7 {
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
+
+  private final DbLong distributionKey;
+  private final DbInt partitionKey;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbInt> distributionPartitionKey;
+
+  /** [distribution key | partition id] => [DbNil] */
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
+      pendingDistributionColumnFamily;
+
+  /** [distribution key | partition id] => [DbNil] */
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
+      retriableDistributionColumnFamily;
+
+  /** [distribution key] => [persisted command distribution] */
+  private final ColumnFamily<DbLong, PersistedCommandDistribution>
+      commandDistributionRecordColumnFamily;
+
+  /** [queue id | partition id | distribution key ] => [] */
+  private final ColumnFamily<
+          DbCompositeKey<DbString, DbCompositeKey<DbInt, DbForeignKey<DbLong>>>, DbNil>
+      queuedCommandDistributionColumnFamily;
+
+  private final DbString queueId;
+  private final DbCompositeKey<DbString, DbInt> queuePerPartitionKey;
+  private final DbCompositeKey<DbString, DbCompositeKey<DbInt, DbForeignKey<DbLong>>>
+      queuedDistributionKey;
+
+  /** [queue id | continuation key] => persisted continuation command */
+  private final ColumnFamily<DbCompositeKey<DbString, DbLong>, PersistedCommandDistribution>
+      continuationCommandColumnFamily;
+
+  private final DbLong continuationKey;
+  private final DbCompositeKey<DbString, DbLong> continuationByQueueKey;
+
+  public DbDistributionMigrationState8dot7(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    distributionKey = new DbLong();
+    final DbForeignKey<DbLong> fkDistribution =
+        new DbForeignKey<>(distributionKey, ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD);
+    commandDistributionRecordColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD,
+            transactionContext,
+            distributionKey,
+            new PersistedCommandDistribution());
+
+    partitionKey = new DbInt();
+    distributionPartitionKey = new DbCompositeKey<>(fkDistribution, partitionKey);
+    pendingDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
+
+    retriableDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.RETRIABLE_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
+
+    queueId = new DbString();
+    queuePerPartitionKey = new DbCompositeKey<>(queueId, partitionKey);
+    queuedDistributionKey =
+        new DbCompositeKey<>(queueId, new DbCompositeKey<>(partitionKey, fkDistribution));
+    queuedCommandDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.QUEUED_DISTRIBUTION,
+            transactionContext,
+            queuedDistributionKey,
+            DbNil.INSTANCE);
+
+    continuationKey = new DbLong();
+    continuationByQueueKey = new DbCompositeKey<>(queueId, continuationKey);
+    continuationCommandColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DISTRIBUTION_CONTINUATION,
+            transactionContext,
+            continuationByQueueKey,
+            new PersistedCommandDistribution());
+  }
+
+  public void migrateIdempotentCommandDistributions() {
+    queueId.wrapString(DistributionQueue.DEPLOYMENT.getQueueId());
+    final var isFirstInQueue = new AtomicBoolean(true);
+
+    pendingDistributionColumnFamily.forEach(
+        (compositeKey, nil) -> {
+          final var distributionKey = compositeKey.first().inner().getValue();
+          final var partitionId = compositeKey.second().getValue();
+          this.distributionKey.wrapLong(distributionKey);
+          partitionKey.wrapInt(partitionId);
+
+          final var persistedDistribution =
+              commandDistributionRecordColumnFamily.get(this.distributionKey);
+
+          final var valueType = persistedDistribution.getValueType();
+          final var isDeploymentOrDeletion =
+              valueType == ValueType.DEPLOYMENT || valueType == ValueType.RESOURCE_DELETION;
+
+          if (isDeploymentOrDeletion && persistedDistribution.getQueueId().isEmpty()) {
+            persistedDistribution.setQueueId(DistributionQueue.DEPLOYMENT.getQueueId());
+            commandDistributionRecordColumnFamily.update(
+                this.distributionKey, persistedDistribution);
+            queuedCommandDistributionColumnFamily.insert(queuedDistributionKey, DbNil.INSTANCE);
+
+            if (isFirstInQueue.get()) {
+              isFirstInQueue.set(false);
+            } else {
+              retriableDistributionColumnFamily.deleteExisting(distributionPartitionKey);
+            }
+          }
+        });
+  }
+
+  public void ensureRetriableDeploymentDistributions() {
+    queueId.wrapString(DistributionQueue.DEPLOYMENT.getQueueId());
+    final var partitionsWithRetriableDistribution = new HashSet<Integer>();
+
+    pendingDistributionColumnFamily.forEach(
+        (compositeKey, nil) -> {
+          final var distributionKey = compositeKey.first().inner().getValue();
+          final var partitionId = compositeKey.second().getValue();
+          this.distributionKey.wrapLong(distributionKey);
+          partitionKey.wrapInt(partitionId);
+
+          final var isInQueuedCF =
+              queuedCommandDistributionColumnFamily.exists(queuedDistributionKey);
+          if (!isInQueuedCF) {
+            queuedCommandDistributionColumnFamily.insert(queuedDistributionKey, DbNil.INSTANCE);
+          }
+
+          final var isFirstInQueue = !partitionsWithRetriableDistribution.contains(partitionId);
+          if (isFirstInQueue) {
+            final var isInRetriableCF =
+                retriableDistributionColumnFamily.exists(distributionPartitionKey);
+            if (!isInRetriableCF) {
+              retriableDistributionColumnFamily.insert(distributionPartitionKey, DbNil.INSTANCE);
+            }
+            partitionsWithRetriableDistribution.add(partitionId);
+          }
+        });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/EnsureRetriableDeploymentDistributionMigration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContext;
+import io.camunda.zeebe.engine.state.migration.MutableMigrationTaskContext;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EnsureRetriableDeploymentDistributionMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final MigrationTaskContext context) {
+    final var distributionState = context.processingState().getDistributionState();
+    final var queueId = DistributionQueue.DEPLOYMENT.getQueueId();
+    final var shouldRun = new AtomicBoolean(false);
+    final var partitionsWithRetriableDistribution = new HashSet<Integer>();
+
+    distributionState.foreachPendingDistribution(
+        (distributionKey, record) -> {
+          // Continue the loop if the distribution is not for the deployment queue.
+          if (!Objects.equals(record.getQueueId(), queueId)) {
+            return true;
+          }
+
+          final var partitionId = record.getPartitionId();
+
+          // If the pending distribution is not queued, we should run the migration. We can stop the
+          // loop early.
+          if (!distributionState.hasQueuedDistribution(queueId, distributionKey, partitionId)) {
+            shouldRun.set(true);
+            return false;
+          }
+
+          // If the pending distribution is the first in the queue and there is no retriable
+          // distribution for the distribution we must run the migration. We can stop the loop
+          // early.
+          // If there is a retriable distribution we should continue the loop in case other
+          // distributions are not queued.
+          final var isFirstInQueue = !partitionsWithRetriableDistribution.contains(partitionId);
+          if (isFirstInQueue) {
+            if (!distributionState.hasRetriableDistribution(distributionKey, partitionId)) {
+              shouldRun.set(true);
+              return false;
+            } else {
+              partitionsWithRetriableDistribution.add(partitionId);
+              return true;
+            }
+          }
+
+          return true;
+        });
+
+    return shouldRun.get();
+  }
+
+  @Override
+  public void runMigration(final MutableMigrationTaskContext context) {
+    context.processingState().getMigrationState().ensureRetriableDeploymentDistributions();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -52,4 +52,13 @@ public interface MutableMigrationState extends MigrationState {
   void correctColumnFamilyPrefix();
 
   void migrateOrderedCommandDistribution();
+<<<<<<< HEAD
+=======
+
+  void migrateIdempotentCommandDistribution();
+
+  void migrateMissingPermissionsForAuthorizations();
+
+  void ensureRetriableDeploymentDistributions();
+>>>>>>> f3e612fe (fix: ensure pending distributions that are not queued and/or are first in queue but not retriable are inserted in the CF)
 }


### PR DESCRIPTION
# Description
Backport of #44968 to `stable/8.7`.

relates to #44908