### PR TITLE
fix: restart connectors to clear state in CPT

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -189,6 +189,12 @@ public class CamundaProcessTestContainerRuntime
   }
 
   @Override
+  public void restartConnectors() {
+    connectorsContainer.stop();
+    connectorsContainer.start();
+  }
+
+  @Override
   public URI getCamundaRestApiAddress() {
     return getCamundaContainer().getRestApiAddress();
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntime.java
@@ -22,6 +22,10 @@ public interface CamundaProcessTestRuntime extends AutoCloseable {
 
   void start();
 
+  default void restartConnectors() {
+    // noop
+  }
+
   URI getCamundaRestApiAddress();
 
   URI getCamundaGrpcApiAddress();

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -290,6 +290,12 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
       final Duration duration = Duration.between(startTime, endTime);
       LOG.debug("Runtime data deleted in {}", duration);
 
+      // connectors are stateful on e.g. cached definitions, after a purge we can have key conflicts
+      // thus we need to restart them
+      if (containerRuntimeBuilder.isConnectorsEnabled()) {
+        runtime.restartConnectors();
+      }
+
     } catch (final Throwable t) {
       LOG.warn(
           "Failed to delete the runtime data, skipping. Check the runtime for details. "


### PR DESCRIPTION
## Description

Connectors maintains internal caches e.g. for process definitions. When the engine is purged, there is a potential for key conflict. This change addressed this for the TestContainerRuntime by restarting connectors.

**WIP** This is only a prototype as the issue still exists for the RemoteRuntime. We thus need to way to reset state within connectors reliably.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44168
