### PR TITLE
feat: create a proper clean up for JobMetricsBatch

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -22,25 +22,7 @@ public class RetentionConfiguration {
   private String policyName = DEFAULT_RETENTION_POLICY_NAME;
   private String usageMetricsMinimumAge = DEFAULT_USAGE_METRICS_MINIMUM_AGE;
   private String usageMetricsPolicyName = DEFAULT_USAGE_METRICS_POLICY_NAME;
-  private String jobMetricsBatchMinimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
-  private String jobMetricsBatchPolicyName = DEFAULT_RETENTION_POLICY_NAME;
   private Duration applyPolicyJobInterval = DEFAULT_APPLY_POLICY_JOB_INTERVAL;
-
-  public String getJobMetricsBatchMinimumAge() {
-    return jobMetricsBatchMinimumAge;
-  }
-
-  public void setJobMetricsBatchMinimumAge(final String jobMetricsBatchMinimumAge) {
-    this.jobMetricsBatchMinimumAge = jobMetricsBatchMinimumAge;
-  }
-
-  public String getJobMetricsBatchPolicyName() {
-    return jobMetricsBatchPolicyName;
-  }
-
-  public void setJobMetricsBatchPolicyName(final String jobMetricsBatchPolicyName) {
-    this.jobMetricsBatchPolicyName = jobMetricsBatchPolicyName;
-  }
 
   public boolean isEnabled() {
     return enabled;

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -22,7 +22,25 @@ public class RetentionConfiguration {
   private String policyName = DEFAULT_RETENTION_POLICY_NAME;
   private String usageMetricsMinimumAge = DEFAULT_USAGE_METRICS_MINIMUM_AGE;
   private String usageMetricsPolicyName = DEFAULT_USAGE_METRICS_POLICY_NAME;
+  private String jobMetricsBatchMinimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
+  private String jobMetricsBatchPolicyName = DEFAULT_RETENTION_POLICY_NAME;
   private Duration applyPolicyJobInterval = DEFAULT_APPLY_POLICY_JOB_INTERVAL;
+
+  public String getJobMetricsBatchMinimumAge() {
+    return jobMetricsBatchMinimumAge;
+  }
+
+  public void setJobMetricsBatchMinimumAge(final String jobMetricsBatchMinimumAge) {
+    this.jobMetricsBatchMinimumAge = jobMetricsBatchMinimumAge;
+  }
+
+  public String getJobMetricsBatchPolicyName() {
+    return jobMetricsBatchPolicyName;
+  }
+
+  public void setJobMetricsBatchPolicyName(final String jobMetricsBatchPolicyName) {
+    this.jobMetricsBatchPolicyName = jobMetricsBatchPolicyName;
+  }
 
   public boolean isEnabled() {
     return enabled;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -63,6 +63,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of standalone-decisions that have been archived. */
   private final Counter standaloneDecisionsArchived;
 
+  /** Count of job-batch-metrics that are in progress of archiving. */
+  private final Counter jobBatchMetricsArchiving;
+
+  /** Count of job-batch-metrics that have been archived. */
+  private final Counter jobBatchMetricsArchived;
+
   /** Count of incident updates that needed retrying. */
   private final Counter incidentUpdatesRetriesNeeded;
 
@@ -155,6 +161,17 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed standalone-decisions that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    jobBatchMetricsArchived =
+        Counter.builder(meterName("archiver.job.batch.metrics"))
+            .tag("state", "archived")
+            .description("Count of completed job-batch-metrics, that have been archived.")
+            .register(meterRegistry);
+    jobBatchMetricsArchiving =
+        Counter.builder(meterName("archiver.job.batch.metrics"))
+            .tag("state", "archiving")
+            .description(
+                "Count of completed job-batch-metrics that have been found, and are now in progress of archiving.")
             .register(meterRegistry);
     archiverSearchTimer =
         Timer.builder(meterName("archiver.request.duration"))
@@ -300,6 +317,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     standaloneDecisionsArchiving.increment(count);
   }
 
+  public void recordJobBatchMetricsArchived(final int count) {
+    jobBatchMetricsArchived.increment(count);
+  }
+
+  public void recordJobBatchMetricsArchiving(final int count) {
+    jobBatchMetricsArchiving.increment(count);
+  }
+
   public void recordIncidentUpdatesRetriesNeeded(final int count) {
     incidentUpdatesRetriesNeeded.increment(count);
   }
@@ -376,6 +401,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(incidentUpdatesRetriesNeeded);
     meterRegistry.remove(incidentUpdatesProcessed);
     meterRegistry.remove(incidentUpdatesDocumentsUpdated);
+    meterRegistry.remove(jobBatchMetricsArchiving);
+    meterRegistry.remove(jobBatchMetricsArchived);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -20,6 +20,7 @@ import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
+import io.camunda.exporter.tasks.archiver.JobBatchMetricsArchiverJob;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
@@ -46,6 +47,7 @@ import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
@@ -248,6 +250,7 @@ public final class BackgroundTaskManagerFactory {
     }
     tasks.add(buildUsageMetricsArchiverJob());
     tasks.add(buildUsageMetricsTUArchiverJob());
+    tasks.add(buildJobBatchMetricsArchiverJob());
     tasks.add(buildStandaloneDecisionArchiverJob());
     if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationArchiverJob());
@@ -372,6 +375,16 @@ public final class BackgroundTaskManagerFactory {
         new UsageMetricTUArchiverJob(
             archiverRepository,
             resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class),
+            metrics,
+            logger,
+            executor));
+  }
+
+  private ReschedulingTask buildJobBatchMetricsArchiverJob() {
+    return buildReschedulingArchiverTask(
+        new JobBatchMetricsArchiverJob(
+            archiverRepository,
+            resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class),
             metrics,
             logger,
             executor));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -250,11 +250,11 @@ public final class BackgroundTaskManagerFactory {
     }
     tasks.add(buildUsageMetricsArchiverJob());
     tasks.add(buildUsageMetricsTUArchiverJob());
-    tasks.add(buildJobBatchMetricsArchiverJob());
     tasks.add(buildStandaloneDecisionArchiverJob());
     if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationArchiverJob());
       tasks.add(buildBatchOperationUpdateTask());
+      tasks.add(buildJobBatchMetricsArchiverJob());
       if (config.getHistory().getRetention().isEnabled()) {
         tasks.add(buildRolloverPeriodJob());
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -11,7 +11,6 @@ import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import java.util.List;
@@ -28,8 +27,7 @@ public interface ArchiverRepository extends AutoCloseable {
   Map<String, Function<RetentionConfiguration, String>> INDEX_TO_RETENTION_POLICY_FIELD =
       Map.of(
           UsageMetricTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
-          UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
-          JobMetricsBatchTemplate.INDEX_NAME, RetentionConfiguration::getJobMetricsBatchPolicyName);
+          UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
 
   CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import java.util.List;
@@ -27,7 +28,8 @@ public interface ArchiverRepository extends AutoCloseable {
   Map<String, Function<RetentionConfiguration, String>> INDEX_TO_RETENTION_POLICY_FIELD =
       Map.of(
           UsageMetricTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
-          UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName);
+          UsageMetricTUTemplate.INDEX_NAME, RetentionConfiguration::getUsageMetricsPolicyName,
+          JobMetricsBatchTemplate.INDEX_NAME, RetentionConfiguration::getJobMetricsBatchPolicyName);
 
   CompletableFuture<ProcessInstanceArchiveBatch> getProcessInstancesNextBatch();
 
@@ -36,6 +38,8 @@ public interface ArchiverRepository extends AutoCloseable {
   CompletableFuture<BasicArchiveBatch> getUsageMetricTUNextBatch();
 
   CompletableFuture<BasicArchiveBatch> getUsageMetricNextBatch();
+
+  CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch();
 
   CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -43,6 +43,7 @@ import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -70,6 +71,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final IndexTemplateDescriptor batchOperationTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTUTemplateDescriptor;
+  private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
@@ -96,6 +98,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class);
     usageMetricTUTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class);
+    jobMetricsBatchTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
     this.metrics = metrics;
@@ -194,6 +198,24 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                     response,
                     UsageMetricTemplate.END_TIME,
                     usageMetricTemplateDescriptor,
+                    config.getUsageMetricsRolloverInterval()),
+            executor);
+  }
+
+  @Override
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+    final var searchRequest = createJobBatchMetricsSearchRequest();
+
+    final var timer = Timer.start();
+    return client
+        .search(searchRequest, Object.class)
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .thenComposeAsync(
+            response ->
+                createBasicBatch(
+                    response,
+                    JobMetricsBatchTemplate.END_TIME,
+                    jobMetricsBatchTemplateDescriptor,
                     config.getUsageMetricsRolloverInterval()),
             executor);
   }
@@ -554,6 +576,21 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         batchOperationTemplateDescriptor.getFullQualifiedName(),
         endDateQ,
         BatchOperationTemplate.END_DATE);
+  }
+
+  private SearchRequest createJobBatchMetricsSearchRequest() {
+    final var endDateQ =
+        QueryBuilders.range(
+            q ->
+                q.date(
+                    d ->
+                        d.field(JobMetricsBatchTemplate.END_TIME)
+                            .lte(config.getArchivingTimePoint())));
+
+    return createSearchRequest(
+        jobMetricsBatchTemplateDescriptor.getFullQualifiedName(),
+        endDateQ,
+        JobMetricsBatchTemplate.END_TIME);
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -213,10 +213,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenComposeAsync(
             response ->
                 createBasicBatch(
-                    response,
-                    JobMetricsBatchTemplate.END_TIME,
-                    jobMetricsBatchTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
+                    response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor),
             executor);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJob.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class JobBatchMetricsArchiverJob extends ArchiverJob<BasicArchiveBatch> {
+
+  private final JobMetricsBatchTemplate jobMetricsBatchTemplate;
+
+  public JobBatchMetricsArchiverJob(
+      final ArchiverRepository repository,
+      final JobMetricsBatchTemplate jobMetricsBatchTemplate,
+      final CamundaExporterMetrics exporterMetrics,
+      final Logger logger,
+      final Executor executor) {
+    super(
+        repository,
+        exporterMetrics,
+        logger,
+        executor,
+        exporterMetrics::recordJobBatchMetricsArchiving,
+        exporterMetrics::recordJobBatchMetricsArchived);
+    this.jobMetricsBatchTemplate = jobMetricsBatchTemplate;
+  }
+
+  @Override
+  public String getJobName() {
+    return JobMetricsBatchTemplate.INDEX_NAME;
+  }
+
+  @Override
+  public CompletableFuture<BasicArchiveBatch> getNextBatch() {
+    return getArchiverRepository().getJobBatchMetricsNextBatch();
+  }
+
+  @Override
+  public JobMetricsBatchTemplate getTemplateDescriptor() {
+    return jobMetricsBatchTemplate;
+  }
+
+  @Override
+  protected Map<String, List<String>> createIdsByFieldMap(
+      final IndexTemplateDescriptor templateDescriptor, final BasicArchiveBatch batch) {
+    return Map.of(JobMetricsBatchTemplate.ID, batch.ids());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -25,6 +25,7 @@ import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
@@ -75,6 +76,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final IndexTemplateDescriptor batchOperationTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTemplateDescriptor;
   private final IndexTemplateDescriptor usageMetricTUTemplateDescriptor;
+  private final IndexTemplateDescriptor jobMetricsBatchTemplateDescriptor;
   private final IndexTemplateDescriptor decisionInstanceTemplateDescriptor;
   private final Collection<IndexTemplateDescriptor> allTemplatesDescriptors;
   private final CamundaExporterMetrics metrics;
@@ -103,6 +105,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTemplate.class);
     usageMetricTUTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(UsageMetricTUTemplate.class);
+    jobMetricsBatchTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(JobMetricsBatchTemplate.class);
     decisionInstanceTemplateDescriptor =
         resourceProvider.getIndexTemplateDescriptor(DecisionInstanceTemplate.class);
     this.metrics = metrics;
@@ -198,6 +202,23 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                     response,
                     UsageMetricTemplate.END_TIME,
                     usageMetricTemplateDescriptor,
+                    config.getUsageMetricsRolloverInterval()),
+            executor);
+  }
+
+  @Override
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+    final var searchRequest = createJobBatchMetricsSearchRequest();
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .thenComposeAsync(
+            response ->
+                createBasicBatch(
+                    response,
+                    JobMetricsBatchTemplate.END_TIME,
+                    jobMetricsBatchTemplateDescriptor,
                     config.getUsageMetricsRolloverInterval()),
             executor);
   }
@@ -488,6 +509,19 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         batchOperationTemplateDescriptor.getFullQualifiedName(),
         endDateQ.toQuery(),
         BatchOperationTemplate.END_DATE);
+  }
+
+  private SearchRequest createJobBatchMetricsSearchRequest() {
+    final var endDateQ =
+        QueryBuilders.range()
+            .field(JobMetricsBatchTemplate.END_TIME)
+            .lte(JsonData.of(config.getArchivingTimePoint()))
+            .build();
+
+    return createSearchRequest(
+        jobMetricsBatchTemplateDescriptor.getFullQualifiedName(),
+        endDateQ.toQuery(),
+        JobMetricsBatchTemplate.END_TIME);
   }
 
   private SearchRequest createStandaloneDecisionSearchRequest() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -216,10 +216,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenComposeAsync(
             response ->
                 createBasicBatch(
-                    response,
-                    JobMetricsBatchTemplate.END_TIME,
-                    jobMetricsBatchTemplateDescriptor,
-                    config.getUsageMetricsRolloverInterval()),
+                    response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor),
             executor);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactoryTest.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
+import io.camunda.exporter.tasks.archiver.JobBatchMetricsArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
@@ -165,10 +166,11 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should always schedule incident and usage metrics tasks regardless of PI config")
-        .hasSize(8)
+        .hasSize(9)
         .anyMatch(task -> isTaskOfType(task, IncidentUpdateTask.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricTUArchiverJob.class))
+        .anyMatch(task -> isTaskOfType(task, JobBatchMetricsArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, StandaloneDecisionArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, BatchOperationUpdateTask.class))
@@ -188,7 +190,7 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should not schedule ApplyRolloverPeriodJob when retention is disabled")
-        .hasSize(9)
+        .hasSize(10)
         .noneMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 
@@ -204,7 +206,7 @@ class BackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should schedule ApplyRolloverPeriodJob when retention is enabled")
-        .hasSize(10)
+        .hasSize(11)
         .anyMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
+import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class JobBatchMetricsArchiverJobTest extends ArchiverJobRecordingMetricsAbstractTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(JobBatchMetricsArchiverJobTest.class);
+
+  private final Executor executor = Runnable::run;
+
+  private final TestRepository repository = new TestRepository();
+  private final JobMetricsBatchTemplate jobMetricsBatchTemplate =
+      new JobMetricsBatchTemplate("", true);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+
+  private final JobBatchMetricsArchiverJob job =
+      new JobBatchMetricsArchiverJob(
+          repository, jobMetricsBatchTemplate, metrics, LOGGER, executor);
+
+  @BeforeEach
+  void setUp() {
+    // given
+    repository.batch = new BasicArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+  }
+
+  @AfterEach
+  void cleanUp() {
+    meterRegistry.clear();
+  }
+
+  @Override
+  ArchiverJob<?> getArchiverJob() {
+    return job;
+  }
+
+  @Override
+  SimpleMeterRegistry getMeterRegistry() {
+    return meterRegistry;
+  }
+
+  @Override
+  String getJobMetricName() {
+    return "zeebe.camunda.exporter.archiver.job.batch.metrics";
+  }
+
+  @Test
+  void shouldMoveJobBatchMetrics() {
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then
+    assertThat(count).isEqualTo(3); // batch has 3 ids
+    assertArchivingCounts(count); // asserted as 3 above
+    assertArchiverTimer(1);
+
+    // then should move
+    assertThat(repository.moves)
+        .containsExactly(
+            new DocumentMove(
+                jobMetricsBatchTemplate.getFullQualifiedName(),
+                jobMetricsBatchTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(JobMetricsBatchTemplate.ID, List.of("1", "2", "3")),
+                executor));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -39,6 +39,12 @@ public class NoopArchiverRepository implements ArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+    return CompletableFuture.completedFuture(
+        new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));
+  }
+
+  @Override
   public CompletableFuture<ArchiveBatch.BasicArchiveBatch> getStandaloneDecisionNextBatch() {
     return CompletableFuture.completedFuture(
         new ArchiveBatch.BasicArchiveBatch("2024-01-01", List.of()));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -44,6 +44,11 @@ final class TestRepository extends NoopArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<BasicArchiveBatch> getJobBatchMetricsNextBatch() {
+    return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
+  }
+
+  @Override
   public CompletableFuture<BasicArchiveBatch> getStandaloneDecisionNextBatch() {
     return CompletableFuture.completedFuture((BasicArchiveBatch) batch);
   }


### PR DESCRIPTION
This pull request introduces support for archiving job batch metrics, including configuration, metrics tracking, and integration with both Elasticsearch and OpenSearch repositories. It adds a new background archiver job, updates the retention configuration, and ensures that metrics for job batch metrics archiving are properly tracked and cleaned up. The changes are grouped below by theme.

**Job Batch Metrics Archiving Support:**

* Added a new `JobBatchMetricsArchiverJob` class to handle the archiving of job batch metrics, including logic for fetching batches and mapping IDs.
* Integrated the new job into the background task manager so it runs as part of the scheduled archiver jobs. [[1]](diffhunk://#diff-be9788005a2d636977104fe5104d07e230e7ae31d8c31536aa7b13d063ef7cffR23) [[2]](diffhunk://#diff-be9788005a2d636977104fe5104d07e230e7ae31d8c31536aa7b13d063ef7cffR50) [[3]](diffhunk://#diff-be9788005a2d636977104fe5104d07e230e7ae31d8c31536aa7b13d063ef7cffR253) [[4]](diffhunk://#diff-be9788005a2d636977104fe5104d07e230e7ae31d8c31536aa7b13d063ef7cffR383-R392)

**Repository Enhancements:**

* Extended both `ElasticsearchArchiverRepository` and `OpenSearchArchiverRepository` to support fetching the next batch of job batch metrics to archive, including new search request methods. [[1]](diffhunk://#diff-0a0c45d1b98894e671b4c33324bb81e58b7447ad4a97b650d5d18bd07130326bR48) [[2]](diffhunk://#diff-0a0c45d1b98894e671b4c33324bb81e58b7447ad4a97b650d5d18bd07130326bR76) [[3]](diffhunk://#diff-0a0c45d1b98894e671b4c33324bb81e58b7447ad4a97b650d5d18bd07130326bR103-R104) [[4]](diffhunk://#diff-0a0c45d1b98894e671b4c33324bb81e58b7447ad4a97b650d5d18bd07130326bR207-R224) [[5]](diffhunk://#diff-0a0c45d1b98894e671b4c33324bb81e58b7447ad4a97b650d5d18bd07130326bR578-R592) [[6]](diffhunk://#diff-442b5186ecdc15898943ce6d10efcbdce8f0d3752f962ad66e1189c5a3c402b4R28) [[7]](diffhunk://#diff-442b5186ecdc15898943ce6d10efcbdce8f0d3752f962ad66e1189c5a3c402b4R78) [[8]](diffhunk://#diff-442b5186ecdc15898943ce6d10efcbdce8f0d3752f962ad66e1189c5a3c402b4R107-R108) [[9]](diffhunk://#diff-442b5186ecdc15898943ce6d10efcbdce8f0d3752f962ad66e1189c5a3c402b4R208-R224) [[10]](diffhunk://#diff-442b5186ecdc15898943ce6d10efcbdce8f0d3752f962ad66e1189c5a3c402b4R518-R530)
* Updated the `ArchiverRepository` interface and mapping to include job batch metrics batch retrieval and retention policy field mapping. [[1]](diffhunk://#diff-665dae5de684d66a7c72d2952420976f59fe97e17a49f86fc0b979e7825bc0bcR14) [[2]](diffhunk://#diff-665dae5de684d66a7c72d2952420976f59fe97e17a49f86fc0b979e7825bc0bcL30-R32) [[3]](diffhunk://#diff-665dae5de684d66a7c72d2952420976f59fe97e17a49f86fc0b979e7825bc0bcR42-R43)

**Metrics and Monitoring:**

* Added counters to `CamundaExporterMetrics` to track job batch metrics archiving and archived events, along with methods to record and clean up these metrics. [[1]](diffhunk://#diff-d41070e3ee5acb76fb5f440ba255a164cebdd853ac1b57c8504fbbdb2d1f3714R66-R71) [[2]](diffhunk://#diff-d41070e3ee5acb76fb5f440ba255a164cebdd853ac1b57c8504fbbdb2d1f3714R165-R175) [[3]](diffhunk://#diff-d41070e3ee5acb76fb5f440ba255a164cebdd853ac1b57c8504fbbdb2d1f3714R320-R327) [[4]](diffhunk://#diff-d41070e3ee5acb76fb5f440ba255a164cebdd853ac1b57c8504fbbdb2d1f3714R404-R405)

## Related issues

closes #43040