### PR TITLE
Update AlwaysGreen Workflow To Use New Downstream SaaS Workflow

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -414,7 +414,7 @@ jobs:
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             https://api.github.com/repos/camunda/c8-cross-component-e2e-tests/dispatches \
             -d '{
-                  "event_type": "run-saas-generation-smoke",
+                  "event_type": "run-saas-generation-smoke-mono",
                   "client_payload": {
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
@@ -452,7 +452,7 @@ jobs:
           echo "Waiting for E2E workflow to complete in camunda/c8-cross-component-e2e-tests triggered after $TRIGGER_TIME"
 
           TARGET_REPO="camunda/c8-cross-component-e2e-tests"
-          WORKFLOW_FILE="playwright_saas_pr_trigger_monorepo_8_9.yml"
+          WORKFLOW_FILE="playwright_saas_pr_trigger_monorepo.yml"
 
           # Wait up to 40 min (80 x 30s)
           for _ in {1..80}; do


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The downstream workflow is currently hard-coded to version 8.9, which prevents it from working when AlwaysGreen is backported to versions 8.6-8.8.

This change updates the downstream workflow to support multiple versions and modifies the existing AlwaysGreen workflow to call the new multi-version-compatible workflow.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
