### PR TITLE
fix: add configuration for maximum incident search groups

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -18,8 +18,14 @@ public class OperateProperties {
   public static final String PREFIX = "camunda.operate";
 
   public static final long BATCH_OPERATION_MAX_SIZE_DEFAULT = 1_000_000L;
-
   private static final String UNKNOWN_VERSION = "unknown-version";
+
+  /**
+   * Maximum number of groups to request from Elasticsearch when searching incidents by error
+   * message.
+   */
+  @Value("${camunda.operate.max-incident-search-groups:1000}")
+  private int maxIncidentSearchGroups;
 
   private boolean importerEnabled = false;
   private boolean webappEnabled = true;
@@ -358,5 +364,13 @@ public class OperateProperties {
 
   public String getIndexPrefix() {
     return getIndexPrefix(database);
+  }
+
+  public int getMaxIncidentSearchGroups() {
+    return maxIncidentSearchGroups;
+  }
+
+  public void setMaxIncidentSearchGroups(final int maxIncidentSearchGroups) {
+    this.maxIncidentSearchGroups = maxIncidentSearchGroups;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -20,12 +20,7 @@ public class OperateProperties {
   public static final long BATCH_OPERATION_MAX_SIZE_DEFAULT = 1_000_000L;
   private static final String UNKNOWN_VERSION = "unknown-version";
 
-  /**
-   * Maximum number of groups to request from Elasticsearch when searching incidents by error
-   * message.
-   */
-  @Value("${camunda.operate.max-incident-search-groups:1000}")
-  private int maxIncidentSearchGroups;
+  private int maxIncidentSearchGroups = 1000;
 
   private boolean importerEnabled = false;
   private boolean webappEnabled = true;

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -22,12 +22,8 @@ public class OperateProperties {
 
   /**
    * Maximum number of groups to search for when searching for incidents. For the backward
-   * compatibility reasons, the default value is set to 10000, which is the default value for the
-   * maxClauseCount in Elasticsearch. We must keep it as 10000 to keep the behavior unchanged for
-   * the users.
-   *
-   * @see
-   *     io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TERMS_AGG_SIZE
+   * compatibility reasons we must keep it as 10000 to keep the behavior unchanged for the most of
+   * the users. For some users we need to override it to a smaller value to avoid Operate UI crash.
    */
   private int maxIncidentSearchGroups = 10000;
 

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -20,7 +20,16 @@ public class OperateProperties {
   public static final long BATCH_OPERATION_MAX_SIZE_DEFAULT = 1_000_000L;
   private static final String UNKNOWN_VERSION = "unknown-version";
 
-  private int maxIncidentSearchGroups = 1000;
+  /**
+   * Maximum number of groups to search for when searching for incidents. For the backward
+   * compatibility reasons, the default value is set to 10000, which is the default value for the
+   * maxClauseCount in Elasticsearch. We must keep it as 10000 to keep the behavior unchanged for
+   * the users.
+   *
+   * @see
+   *     io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations.TERMS_AGG_SIZE
+   */
+  private int maxIncidentSearchGroups = 10000;
 
   private boolean importerEnabled = false;
   private boolean webappEnabled = true;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -74,7 +74,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     when(permissionsService.getProcessesWithPermission(PermissionType.READ_PROCESS_DEFINITION))
         .thenReturn(PermissionsService.ResourcesAllowed.wildcard());
     // Default behavior for operate properties, can be overridden in specific tests
-    when(operateProperties.getMaxIncidentSearchGroups()).thenReturn(1000);
+    when(operateProperties.getMaxIncidentSearchGroups()).thenReturn(10000);
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -23,6 +23,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PR
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.STATE;
 
 import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ProcessStore;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.ConversionUtils;
@@ -72,6 +73,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   @Autowired private ListViewTemplate processInstanceTemplate;
   @Autowired private ProcessReader processReader;
   @Autowired private PermissionsService permissionsService;
+  @Autowired private OperateProperties operateProperties;
 
   @Override
   public Set<IncidentsByProcessGroupStatisticsDto> getProcessAndIncidentsStatistics() {
@@ -87,6 +89,8 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     final Set<IncidentsByErrorMsgStatisticsDto> result =
         new TreeSet<>(IncidentsByErrorMsgStatisticsDto.COMPARATOR);
 
+    final int termsAggSize = operateProperties.getMaxIncidentSearchGroups();
+
     final Map<Long, ProcessEntity> processes =
         processReader.getProcessesWithFields(
             ProcessIndex.KEY,
@@ -101,11 +105,11 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
     final var groupByProcessKeys =
-        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, TERMS_AGG_SIZE);
+        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, termsAggSize);
     final var errorMessage =
         topHitsAggregation(List.of(IncidentTemplate.ERROR_MSG, IncidentTemplate.ERROR_MSG_HASH), 1);
     final var groupByErrorMessageHash =
-        termAggregation(IncidentTemplate.ERROR_MSG_HASH, TERMS_AGG_SIZE);
+        termAggregation(IncidentTemplate.ERROR_MSG_HASH, termsAggSize);
 
     final var searchRequestBuilder =
         searchRequestBuilder(incidentTemplate, ONLY_RUNTIME)


### PR DESCRIPTION
## Description

- Fixes issue #44596: avoid extremely large responses from the incidents API by capping the number of incident search groups returned.
- Adds a configurable limit with a safe default and enforces it in the reader logic.

**What this change does**
- Initially the query results were limited by `ElasticsearchUtil` constant:
```
 public static final int TERMS_AGG_SIZE = 10000;
```
- Introduces a configurable property `camunda.operate.max-incident-search-groups` with a default of `1000`.
- The default is applied using the `@Value` fallback, so modules without a local properties file still get the default.
- Example declaration used: 

```
@Value("${camunda.operate.max-incident-search-groups:1000}")
private int maxIncidentSearchGroups;
```
- Enforces the limit in `IncidentStatisticsReader` so it truncates search groups to the configured maximum.

**Behavioral changes**
- API responses for incident statistics are now capped to at most `camunda.operate.max-incident-search-groups` groups (default `1000`).
- No breaking changes to API shape; only the number of returned items may be reduced when the raw count exceeds the configured limit.

**Testing**
To test this fix add an env variable `CAMUNDA_OPERATE_MAX_INCIDENT_SEARCH_GROUPS` to start configuration and change the value, for example, to `3` and trigger the endpoint 

```
GET http://localhost:8080/api/incidents/byError
```

Test results will be documented in the comments

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44596
