### PR TITLE
[Backport stable/8.6] 33043 reset bulk metrics when exporting stops

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -30,7 +30,7 @@ public class ElasticsearchMetrics {
     bulkMemorySize =
         StatefulGauge.builder(meterName("bulk.memory.size"))
             .description("Exporter bulk memory size")
-            .expiringState()
+            .valueExpires()
             .register(meterRegistry);
 
     flushDuration =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
@@ -30,6 +30,7 @@ public class OpensearchMetrics {
     bulkMemorySize =
         StatefulGauge.builder(meterName("bulk.memory.size"))
             .description("Exporter bulk memory size")
+            .valueExpires()
             .register(meterRegistry);
     flushDuration =
         Timer.builder(meterName("flush.duration.seconds"))

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -144,6 +144,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeState.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeState.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongUnaryOperator;
+
+class ExpiringGaugeState implements GaugeState {
+  private final Clock clock;
+  private final long expirationMillis;
+  private final long expiredValue;
+  private volatile long lastValueSetMillis;
+  private final AtomicLong value = new AtomicLong();
+
+  ExpiringGaugeState(final Duration expiration, final long expiredValue) {
+    this(Clock.systemUTC(), expiration, expiredValue);
+  }
+
+  @VisibleForTesting
+  ExpiringGaugeState(final Clock clock, final Duration expiration, final long expiredValue) {
+    this.clock = clock;
+    expirationMillis = expiration.toMillis();
+    this.expiredValue = expiredValue;
+  }
+
+  @Override
+  public void set(final long value) {
+    this.value.set(value);
+    lastValueSetMillis = clock.millis();
+  }
+
+  @Override
+  public long get() {
+    if ((clock.millis() - expirationMillis) > lastValueSetMillis) {
+      return expiredValue;
+    }
+    return value.get();
+  }
+
+  @Override
+  public long updateAndGet(final LongUnaryOperator updateFunction) {
+    throw new RuntimeException("not implemented");
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeState.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeState.java
@@ -47,6 +47,6 @@ class ExpiringGaugeState implements GaugeState {
 
   @Override
   public long updateAndGet(final LongUnaryOperator updateFunction) {
-    throw new RuntimeException("not implemented");
+    throw new UnsupportedOperationException("not supported for expiring gauges");
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/GaugeState.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/GaugeState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util.micrometer;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongUnaryOperator;
 
@@ -35,5 +36,9 @@ interface GaugeState {
         return state.updateAndGet(updateFunction);
       }
     };
+  }
+
+  static GaugeState expiring(final Duration expiration, final long expiredValue) {
+    return new ExpiringGaugeState(expiration, expiredValue);
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/GuageState.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/GuageState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongUnaryOperator;
+
+interface GaugeState {
+
+  void set(long value);
+
+  long get();
+
+  long updateAndGet(LongUnaryOperator updateFunction);
+
+  static GaugeState from(final AtomicLong state) {
+    return new GaugeState() {
+      @Override
+      public void set(final long value) {
+        state.set(value);
+      }
+
+      @Override
+      public long get() {
+        return state.get();
+      }
+
+      @Override
+      public long updateAndGet(final LongUnaryOperator updateFunction) {
+        return state.updateAndGet(updateFunction);
+      }
+    };
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulGauge.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulGauge.java
@@ -197,11 +197,35 @@ public final class StatefulGauge extends AbstractMeter implements Gauge {
       return this;
     }
 
-    public Builder expiringState() {
-      return expiringState(DistributionStatisticConfig.DEFAULT.getExpiry(), 0.0);
+    /**
+     * Sets a default expiration for the gauge value. After the expiration time, the gauge will
+     * return zero when queried.
+     *
+     * <p>This is useful for gauges that track values that may become stale over time, such as
+     * resource usage metrics.
+     *
+     * <p>NB increment/decremetment operation are unsupported on expiring gauges.
+     *
+     * @return The gauge builder with expiration configured.
+     */
+    public Builder valueExpires() {
+      return valueExpires(DistributionStatisticConfig.DEFAULT.getExpiry(), 0.0);
     }
 
-    public Builder expiringState(final Duration expiration, final double valueWhenExpired) {
+    /**
+     * Sets a custom expiration for the gauge value. After the expiration time, the gauge will
+     * return the provided value when queried.
+     *
+     * <p>This is useful for gauges that track values that may become stale over time, such as
+     * resource usage metrics.
+     *
+     * <p>NB increment/decremetment operation are unsupported on expiring gauges.
+     *
+     * @param expiration The duration after which the gauge value expires.
+     * @param valueWhenExpired The value to return when the gauge has expired.
+     * @return The gauge builder with expiration configured.
+     */
+    public Builder valueExpires(final Duration expiration, final double valueWhenExpired) {
       state = GaugeState.expiring(expiration, Double.doubleToLongBits(valueWhenExpired));
       return this;
     }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.util.micrometer;
 
+import io.camunda.zeebe.util.micrometer.StatefulGauge.Builder;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Collections;
@@ -36,12 +38,12 @@ final class StatefulMeterRegistry extends CompositeMeterRegistry {
     config().onMeterAdded(this::onMeterAdded).onMeterRemoved(this::onMeterRemoved);
   }
 
-  StatefulGauge registerIfNecessary(final Meter.Id id) {
-    return gauges.computeIfAbsent(id, this::registerStatefulGauge);
+  StatefulGauge registerIfNecessary(final Id id, final Builder builder) {
+    return gauges.computeIfAbsent(id, metricId -> registerStatefulGauge(metricId, builder));
   }
 
-  StatefulGauge registerStatefulGauge(final Meter.Id id) {
-    return StatefulGauge.registerAsGauge(id, this);
+  StatefulGauge registerStatefulGauge(final Id id, final Builder builder) {
+    return StatefulGauge.registerAsGauge(id, builder, this);
   }
 
   private void onMeterAdded(final Meter meter) {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeStateTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/ExpiringGaugeStateTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExpiringGaugeStateTest {
+  @Mock private Clock clock;
+  private ExpiringGaugeState state;
+
+  @BeforeEach
+  public void setup() {
+    state = new ExpiringGaugeState(clock, Duration.ofSeconds(60), 0L);
+  }
+
+  @Test
+  void getReturnsZeroByDefault() {
+    assertThat(state.get()).isEqualTo(0L);
+  }
+
+  @Test
+  void getReturnsPreviouslySetValueIfNotExpired() {
+    state.set(99L);
+    assertThat(state.get()).isEqualTo(99L);
+  }
+
+  @Test
+  void getReturnsZeroAfterValueExpires() {
+    when(clock.millis()).thenReturn(0L, 30_000L, 60_000L, 61_000L);
+
+    state.set(101L);
+
+    // not expired yet
+    assertThat(state.get()).isEqualTo(101L);
+    assertThat(state.get()).isEqualTo(101L);
+
+    // should have expired now
+    assertThat(state.get()).isEqualTo(0L);
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulGaugeTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulGaugeTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.util.micrometer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
 final class StatefulGaugeTest {
-  @AutoClose private MeterRegistry wrapped = new SimpleMeterRegistry();
+  @AutoClose private final MeterRegistry wrapped = new SimpleMeterRegistry();
   @AutoClose private final StatefulMeterRegistry registry = new StatefulMeterRegistry(wrapped);
 
   @Test
@@ -193,5 +194,29 @@ final class StatefulGaugeTest {
     // then - measurements are taken from the underlying gauge
     final var registered = registry.get("foo").gauge();
     assertThat(registered.measure()).allSatisfy(m -> assertThat(m.getValue()).isZero());
+  }
+
+  @Test
+  void shouldReturnDoubleValueWhenExpirySet() {
+    // given
+    final var gauge = StatefulGauge.builder("foo").valueExpires().register(registry);
+
+    // when
+    gauge.set(30.5223);
+
+    // then - measurements are taken from the underlying gauge
+    final var registered = registry.get("foo").gauge();
+    assertThat(registered.measure()).allSatisfy(m -> assertThat(m.getValue()).isEqualTo(30.5223));
+
+    assertThat(gauge.state()).isInstanceOf(ExpiringGaugeState.class);
+  }
+
+  @Test
+  void shouldNotSupportIncrementWhenExpirySet() {
+    final var gauge = StatefulGauge.builder("foo").valueExpires().register(registry);
+
+    assertThatThrownBy(() -> gauge.increment()).isInstanceOf(UnsupportedOperationException.class);
+
+    assertThat(gauge.state()).isInstanceOf(ExpiringGaugeState.class);
   }
 }


### PR DESCRIPTION
# Description
Backport of #41748 to `stable/8.6`.

relates to #33043