### PR TITLE
test: skip test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -62,6 +62,8 @@ class OperateProcessesPage {
     rowIndex?: number,
     cellIndex?: number,
   ) => Locator;
+  readonly batchOperationStartedMessage: (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') => Locator;
+  readonly processCouldntBeFoundMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -181,6 +183,9 @@ class OperateProcessesPage {
         .nth(rowIndex)
         .getByRole('cell')
         .nth(cellIndex);
+    this.batchOperationStartedMessage = (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') =>
+      page.getByText(`Batch operation \"${batchOperationType}\" has been started`);
+    this.processCouldntBeFoundMessage = this.page.getByRole('status').getByText('Process could not be found');
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -269,7 +274,7 @@ class OperateProcessesPage {
   }
 
   getCanceledIcon(processInstanceKey: string): Locator {
-    return this.page.getByTestId(`CANCELED-icon-${processInstanceKey}`);
+    return this.page.getByTestId(`TERMINATED-icon-${processInstanceKey}`);
   }
 
   getRetryInstanceButton(processInstanceKey: string): Locator {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -62,7 +62,12 @@ class OperateProcessesPage {
     rowIndex?: number,
     cellIndex?: number,
   ) => Locator;
-  readonly batchOperationStartedMessage: (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') => Locator;
+  readonly batchOperationStartedMessage: (
+    batchOperationType:
+      | 'Resolve Incident'
+      | 'Retry'
+      | 'Cancel Process Instance',
+  ) => Locator;
   readonly processCouldNotBeFoundMessage: Locator;
 
   constructor(page: Page) {
@@ -183,9 +188,18 @@ class OperateProcessesPage {
         .nth(rowIndex)
         .getByRole('cell')
         .nth(cellIndex);
-    this.batchOperationStartedMessage = (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') =>
-      page.getByText(`Batch operation \"${batchOperationType}\" has been started`);
-    this.processCouldNotBeFoundMessage = this.page.getByRole('status').getByText('Process could not be found');
+    this.batchOperationStartedMessage = (
+      batchOperationType:
+        | 'Resolve Incident'
+        | 'Retry'
+        | 'Cancel Process Instance',
+    ) =>
+      page.getByText(
+        `Batch operation \"${batchOperationType}\" has been started`,
+      );
+    this.processCouldNotBeFoundMessage = this.page
+      .getByRole('status')
+      .getByText('Process could not be found');
   }
 
   async filterByProcessName(name: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -63,7 +63,7 @@ class OperateProcessesPage {
     cellIndex?: number,
   ) => Locator;
   readonly batchOperationStartedMessage: (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') => Locator;
-  readonly processCouldntBeFoundMessage: Locator;
+  readonly processCouldNotBeFoundMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -185,7 +185,7 @@ class OperateProcessesPage {
         .nth(cellIndex);
     this.batchOperationStartedMessage = (batchOperationType: 'Resolve Incident' | 'Retry' | 'Cancel Process Instance') =>
       page.getByText(`Batch operation \"${batchOperationType}\" has been started`);
-    this.processCouldntBeFoundMessage = this.page.getByRole('status').getByText('Process could not be found');
+    this.processCouldNotBeFoundMessage = this.page.getByRole('status').getByText('Process could not be found');
   }
 
   async filterByProcessName(name: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -138,7 +138,6 @@ test.describe('Dashboard', () => {
   test.skip('Navigate to processes view (same truncated error message)', async ({
     operateDashboardPage,
     operateProcessInstancePage,
-    page,
   }) => {
     await test.step('Select incident type A and verify details', async () => {
       await operateDashboardPage.clickIncidentByType(/type a/i);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -143,16 +143,9 @@ test.describe('Dashboard', () => {
     await test.step('Select incident type A and verify details', async () => {
       await operateDashboardPage.clickIncidentByType(/type a/i);
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(
-            operateDashboardPage.processInstancesHeading(1, false),
-          ).toBeVisible({timeout: 30000});
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
+      await expect(
+        operateDashboardPage.processInstancesHeading(1, false),
+      ).toBeVisible();
 
       await operateDashboardPage.clickViewInstanceLink();
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -134,15 +134,25 @@ test.describe('Dashboard', () => {
     });
   });
 
-  test('Navigate to processes view (same truncated error message)', async ({
+  // skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
+  test.skip('Navigate to processes view (same truncated error message)', async ({
     operateDashboardPage,
     operateProcessInstancePage,
+    page,
   }) => {
     await test.step('Select incident type A and verify details', async () => {
       await operateDashboardPage.clickIncidentByType(/type a/i);
-      await expect(
-        operateDashboardPage.processInstancesHeading(1, false),
-      ).toBeVisible();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateDashboardPage.processInstancesHeading(1, false),
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
 
       await operateDashboardPage.clickViewInstanceLink();
       await expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -150,18 +150,7 @@ test.describe('Operations', () => {
       await operateProcessesPage.applyButton.click();
       await sleep(1000);
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect
-            .poll(async () => {
-              return operateProcessesPage.scheduledOperationsIcons.count();
-            })
-            .toBe(instances.length);
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
+      await expect(operateProcessesPage.batchOperationStartedMessage('Resolve Incident')).toBeVisible({timeout: 60000});
     });
 
     await test.step('Cancel all instances', async () => {
@@ -172,6 +161,8 @@ test.describe('Operations', () => {
 
       await operateProcessesPage.clickProcessIncidentsCheckbox();
       await operateProcessesPage.clickProcessCanceledCheckbox();
+
+      await expect(operateProcessesPage.batchOperationStartedMessage('Cancel Process Instance')).toBeVisible({timeout: 60000});
 
       await waitForAssertion({
         assertion: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -150,7 +150,9 @@ test.describe('Operations', () => {
       await operateProcessesPage.applyButton.click();
       await sleep(1000);
 
-      await expect(operateProcessesPage.batchOperationStartedMessage('Resolve Incident')).toBeVisible({timeout: 60000});
+      await expect(
+        operateProcessesPage.batchOperationStartedMessage('Resolve Incident'),
+      ).toBeVisible({timeout: 60000});
     });
 
     await test.step('Cancel all instances', async () => {
@@ -162,7 +164,11 @@ test.describe('Operations', () => {
       await operateProcessesPage.clickProcessIncidentsCheckbox();
       await operateProcessesPage.clickProcessCanceledCheckbox();
 
-      await expect(operateProcessesPage.batchOperationStartedMessage('Cancel Process Instance')).toBeVisible({timeout: 60000});
+      await expect(
+        operateProcessesPage.batchOperationStartedMessage(
+          'Cancel Process Instance',
+        ),
+      ).toBeVisible({timeout: 60000});
 
       await waitForAssertion({
         assertion: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -47,7 +47,8 @@ test.describe('Process Instance Modifications', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Should apply/remove edit variable modifications', async ({
+  // skipped due to update described in issue 41143: https://github.com/camunda/camunda/issues/41143
+  test.skip('Should apply/remove edit variable modifications', async ({
     operateProcessInstancePage,
   }) => {
     await test.step('Navigate to process instance', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -47,7 +47,7 @@ test.describe('Process Instance Modifications', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to update described in issue 41143: https://github.com/camunda/camunda/issues/41143
+  // skipped due to bug 41143: https://github.com/camunda/camunda/issues/41143
   test.skip('Should apply/remove edit variable modifications', async ({
     operateProcessInstancePage,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -68,7 +68,8 @@ test.describe('Process Instances Filters', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Interaction between diagram and filters', async ({
+  // skipped due to bug 45156: https://github.com/camunda/camunda/issues/45156
+  test.skip('Interaction between diagram and filters', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
     page,
@@ -106,7 +107,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 60000});
+          ).toBeVisible({timeout: 90000});
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -277,7 +277,9 @@ test.describe('Process Instances Table', () => {
       await operateFiltersPanelPage.selectVersion('1');
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText(`${amountOfInstancesForInfiniteScroll} results`)).toBeVisible();
+          await expect(
+            page.getByText(`${amountOfInstancesForInfiniteScroll} results`),
+          ).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -21,6 +21,7 @@ let processA: ProcessInstance;
 let processB_v_1: ProcessInstance;
 let processB_v_2: ProcessInstance;
 let scrollingInstances: ProcessInstance[];
+const amountOfInstancesForInfiniteScroll = 350;
 
 test.beforeAll(async () => {
   await deploy([
@@ -54,7 +55,7 @@ test.beforeAll(async () => {
   const createdInstances = await createInstances(
     'instancesTableProcessForInfiniteScroll',
     1,
-    350,
+    amountOfInstancesForInfiniteScroll,
   );
   scrollingInstances = createdInstances.map((instance) => ({
     processInstanceKey: Number(instance.processInstanceKey),
@@ -276,7 +277,7 @@ test.describe('Process Instances Table', () => {
       await operateFiltersPanelPage.selectVersion('1');
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('350 results')).toBeVisible();
+          await expect(page.getByText(`${amountOfInstancesForInfiniteScroll} results`)).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -54,7 +54,7 @@ test.beforeAll(async () => {
   const createdInstances = await createInstances(
     'instancesTableProcessForInfiniteScroll',
     1,
-    300,
+    350,
   );
   scrollingInstances = createdInstances.map((instance) => ({
     processInstanceKey: Number(instance.processInstanceKey),
@@ -276,7 +276,7 @@ test.describe('Process Instances Table', () => {
       await operateFiltersPanelPage.selectVersion('1');
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('300 results')).toBeVisible();
+          await expect(page.getByText('350 results')).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();
@@ -319,19 +319,38 @@ test.describe('Process Instances Table', () => {
       await expect
         .poll(() => instanceRows.nth(199).innerText())
         .toContain(descendingInstanceIds[199].toString());
-      await page
-        .getByRole('row', {name: `Instance ${descendingInstanceIds[199]}`})
-        .scrollIntoViewIfNeeded();
-      await expect(instanceRows).toHaveCount(200);
     });
 
     await test.step('Scroll to 250th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[199]}`})
+        .scrollIntoViewIfNeeded();
+      await sleep(500);
+      await expect(instanceRows).toHaveCount(250);
+
+      await expect
+        .poll(() => instanceRows.nth(0).innerText())
+        .toContain(descendingInstanceIds[0].toString());
+
+      await expect
+        .poll(() => instanceRows.nth(249).innerText())
+        .toContain(descendingInstanceIds[249].toString());
+    });
+
+    await test.step('Scroll to 300th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[249]}`})
+        .scrollIntoViewIfNeeded();
+      await sleep(500);
+      await expect(instanceRows).toHaveCount(250);
+
       await expect
         .poll(() => instanceRows.nth(0).innerText())
         .toContain(descendingInstanceIds[50].toString());
+
       await expect
-        .poll(() => instanceRows.nth(199).innerText())
-        .toContain(descendingInstanceIds[249].toString());
+        .poll(() => instanceRows.nth(249).innerText())
+        .toContain(descendingInstanceIds[299].toString());
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -77,6 +77,8 @@ test.describe('Processes', () => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
+  const baseUrl =
+        process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
 
   test('Processes Page Initial Load', async ({
     operateProcessesPage,
@@ -242,14 +244,12 @@ test.describe('Processes', () => {
     page,
   }) => {
     await test.step('Navigate to non-existent process', async () => {
-      const baseUrl =
-        process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
       await page.goto(
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );
 
       await expect(page).toHaveURL(`${baseUrl}/operate/processes?process=testProcess&version=1`);
-      await expect(operateProcessesPage.processCouldntBeFoundMessage).toBeVisible();
+      await expect(operateProcessesPage.processCouldNotBeFoundMessage).toBeVisible();
 
       await waitForAssertion({
         assertion: async () => {
@@ -258,7 +258,7 @@ test.describe('Processes', () => {
           });
         },
         onFailure: async () => {
-          page.reload();
+          await page.reload();
         },
         maxRetries: 5,
       });
@@ -268,8 +268,6 @@ test.describe('Processes', () => {
       await deploy(['./resources/newProcess.bpmn']);
       await sleep(5000);
 
-      const baseUrl =
-        process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
       await page.goto(
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -77,8 +77,7 @@ test.describe('Processes', () => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
-  const baseUrl =
-        process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
+  const baseUrl = process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
 
   test('Processes Page Initial Load', async ({
     operateProcessesPage,
@@ -129,7 +128,9 @@ test.describe('Processes', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(operateProcessesPage.dataList).toBeVisible();
-          await expect(operateProcessesPage.processInstancesTable).toHaveCount(2);
+          await expect(operateProcessesPage.processInstancesTable).toHaveCount(
+            2,
+          );
         },
         onFailure: async () => {
           await page.reload();
@@ -248,8 +249,12 @@ test.describe('Processes', () => {
         `${baseUrl}/operate/processes?process=testProcess&version=1`,
       );
 
-      await expect(page).toHaveURL(`${baseUrl}/operate/processes?process=testProcess&version=1`);
-      await expect(operateProcessesPage.processCouldNotBeFoundMessage).toBeVisible();
+      await expect(page).toHaveURL(
+        `${baseUrl}/operate/processes?process=testProcess&version=1`,
+      );
+      await expect(
+        operateProcessesPage.processCouldNotBeFoundMessage,
+      ).toBeVisible();
 
       await waitForAssertion({
         assertion: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -249,6 +249,7 @@ test.describe('Processes', () => {
       );
 
       await expect(page).toHaveURL(`${baseUrl}/operate/processes?process=testProcess&version=1`);
+      await expect(operateProcessesPage.processCouldntBeFoundMessage).toBeVisible();
 
       await waitForAssertion({
         assertion: async () => {
@@ -261,15 +262,19 @@ test.describe('Processes', () => {
         },
         maxRetries: 5,
       });
-
-      await expect(operateDiagramPage.diagramSpinner).toBeVisible();
     });
 
     await test.step('Deploy new process and verify it loads', async () => {
       await deploy(['./resources/newProcess.bpmn']);
       await sleep(5000);
 
-      await expect(operateDiagramPage.diagram).toBeInViewport({timeout: 20000});
+      const baseUrl =
+        process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
+      await page.goto(
+        `${baseUrl}/operate/processes?process=testProcess&version=1`,
+      );
+
+      await expect(operateDiagramPage.diagram).toBeInViewport();
 
       await expect(operateDiagramPage.diagramSpinner).toBeHidden();
 


### PR DESCRIPTION
## Description

This PR addresses nightly test fails on main:

-  `Process Instance Modifications › Should apply/remove edit variable modifications` - test skipped due to not yet prepared manual testing for updated behaviour in Operate described [here](https://github.com/camunda/camunda/issues/41143)
- `Dashboard › Navigate to processes view (same truncated error message)` - test is skipped due to #45129 
- `Operations › Retry and cancel multiple instances` - changed due to updates on operations and batch operation
- `Processes › Wait for process creation` - changed as in main it doesn't wait anymore and navigates to "no matching instances" automatically
- `Process Instances Filters › Interaction between diagram and filters` - skipped sue to #45156 
- `Process Instances Table › Scrolling of process instances` - updated according to changes in scrolling behaviour


## Related issues

related #41143, #45129,  #45156 

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21747894167)
