### PR TITLE
feat: include colorblocks when comparing files from wiki/docs

### DIFF
--- a/monorepo-docs-site/scripts/compare-wiki-content.sh
+++ b/monorepo-docs-site/scripts/compare-wiki-content.sh
@@ -2,23 +2,72 @@
 # compare-wiki-content.sh - Compare current wiki with migrated docs
 # Usage: ./scripts/compare-wiki-content.sh [WIKI_PAGE] [DOCS_FILE]
 
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
 # Default values (customize these for your migration)
 WIKI_PAGE="${1:-Development-Guide}"  # Replace with your wiki page name
 DOCS_FILE="${2:-../docs/monorepo-docs/development-guide.md}"  # Your docs file
 
-echo "🔄 Fetching current wiki content for: $WIKI_PAGE"
-curl -s "https://raw.githubusercontent.com/wiki/camunda/camunda/${WIKI_PAGE}.md" \
-  -o "/tmp/current-wiki-${WIKI_PAGE}.md"
+echo -e "${BLUE}🔄 Fetching current wiki content for: ${CYAN}$WIKI_PAGE${NC}"
 
-echo "📋 Comparing wiki vs documentation:"
-echo "Wiki (current): /tmp/current-wiki-${WIKI_PAGE}.md"
-echo "Docs (local):   $DOCS_FILE"
+# Download wiki content
+WIKI_TEMP="/tmp/current-wiki-${WIKI_PAGE}.md"
+curl -s "https://raw.githubusercontent.com/wiki/camunda/camunda/${WIKI_PAGE}.md" -o "$WIKI_TEMP"
+
+if [ ! -f "$WIKI_TEMP" ] || [ ! -s "$WIKI_TEMP" ]; then
+    echo -e "${RED}❌ Failed to download wiki content. Check the wiki page name.${NC}"
+    echo -e "${YELLOW}💡 Try URL encoding special characters (e.g., & becomes %26)${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}📋 Comparing files:${NC}"
+echo -e "Wiki (current): ${CYAN}$WIKI_TEMP${NC}"
+echo -e "Docs (local):   ${CYAN}$DOCS_FILE${NC}"
 echo ""
 
+# Check if local file exists
+if [ ! -f "$DOCS_FILE" ]; then
+    echo -e "${RED}❌ Local file not found: $DOCS_FILE${NC}"
+    rm -f "$WIKI_TEMP"
+    exit 1
+fi
+
 # Skip frontmatter when comparing (first 4 lines typically)
-echo "--- DIFFERENCES FOUND ---"
-tail -n +5 "$DOCS_FILE" > "/tmp/docs-content-only.md"
-diff -u "/tmp/current-wiki-${WIKI_PAGE}.md" "/tmp/docs-content-only.md" || echo "Files are identical!"
+DOCS_TEMP="/tmp/docs-content-only.md"
+tail -n +5 "$DOCS_FILE" > "$DOCS_TEMP"
+
+echo -e "${YELLOW}--- DIFFERENCES (colored diff) ---${NC}"
+
+# Use diff with color output if available, otherwise fall back to regular diff
+if command -v colordiff &> /dev/null; then
+    # Use colordiff if available
+    colordiff -u "$WIKI_TEMP" "$DOCS_TEMP" || echo -e "${GREEN}✅ Files are identical!${NC}"
+elif diff --color=always --help &> /dev/null; then
+    # Use diff with color if supported
+    diff --color=always -u "$WIKI_TEMP" "$DOCS_TEMP" || echo -e "${GREEN}✅ Files are identical!${NC}"
+else
+    # Fall back to regular diff with manual coloring
+    diff -u "$WIKI_TEMP" "$DOCS_TEMP" | while IFS= read -r line; do
+        case "$line" in
+            "+++"*) echo -e "${BLUE}$line${NC}" ;;
+            "---"*) echo -e "${BLUE}$line${NC}" ;;
+            "@@"*) echo -e "${CYAN}$line${NC}" ;;
+            "+"*) echo -e "${GREEN}$line${NC}" ;;
+            "-"*) echo -e "${RED}$line${NC}" ;;
+            *) echo "$line" ;;
+        esac
+    done || echo -e "${GREEN}✅ Files are identical!${NC}"
+fi
+
+echo ""
+echo -e "${YELLOW}💡 For side-by-side comparison in VS Code:${NC}"
+echo -e "${CYAN}code --diff $WIKI_TEMP $DOCS_FILE${NC}"
 
 # Cleanup
-rm "/tmp/current-wiki-${WIKI_PAGE}.md" "/tmp/docs-content-only.md"
+rm -f "$WIKI_TEMP" "$DOCS_TEMP"


### PR DESCRIPTION
## Description

This pull request enhances the `compare-wiki-content.sh` script to provide a more user-friendly and robust comparison experience when checking differences between a wiki page and its migrated documentation file. The improvements include better error handling, colored and clearer output, and guidance for users.
Relates to: https://github.com/camunda/camunda/issues/36946?reload=1

<img width="1045" height="640" alt="image" src="https://github.com/user-attachments/assets/6ef964e0-3463-4684-b6e4-b74c8a4d6979" />

<img width="1045" height="640" alt="image" src="https://github.com/user-attachments/assets/dfb516f0-69a0-428a-8e51-71c25a4aeb26" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #
