### PR TITLE
feat: add decision instances item provider for deletion batch operation

### DIFF
--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -175,6 +175,9 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.partitionId != null">
+        AND di.PARTITION_ID = #{filter.partitionId}
+      </if>
     </where>
   </sql>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -108,7 +108,8 @@ public class DecisionInstanceSpecificFilterIT {
                     .rootDecisionDefinitionKey(rootDecisionDefinitionKey)
                     .evaluationFailure("failure-42")
                     .tenantId("unique-tenant-42")
-                    .result("result-42")));
+                    .result("result-42")
+                    .partitionId(1)));
 
     final var searchResult =
         decisionInstanceReader.search(
@@ -146,6 +147,7 @@ public class DecisionInstanceSpecificFilterIT {
         DecisionInstanceFilter.of(b -> b.evaluationDateOperations(Operation.lte(THEN))),
         DecisionInstanceFilter.of(b -> b.rootDecisionDefinitionKeys(200L)),
         DecisionInstanceFilter.of(b -> b.rootDecisionDefinitionKeyOperations(Operation.eq(200L))),
-        DecisionInstanceFilter.of(b -> b.tenantIds("unique-tenant-42", "foo")));
+        DecisionInstanceFilter.of(b -> b.tenantIds("unique-tenant-42", "foo")),
+        DecisionInstanceFilter.of(b -> b.partitionId(1)));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -15,6 +15,8 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PARTITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_NAME;
@@ -73,6 +75,11 @@ public final class DecisionInstanceFilterTransformer
     queries.addAll(
         getRootDecisionDefinitionKeysQuery(filter.rootDecisionDefinitionKeyOperations()));
     ofNullable(getTenantIdsQuery(filter.tenantIds())).ifPresent(queries::add);
+
+    if (filter.partitionId() != null) {
+      queries.add(term(PARTITION_ID, filter.partitionId()));
+    }
+
     return and(queries);
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
@@ -267,6 +267,25 @@ class DecisionInstanceQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByPartitionId() {
+    // given
+    final var decisionInstanceFilter = FilterBuilders.decisionInstance(f -> f.partitionId(3));
+
+    // when
+    final var searchRequest = transformQuery(decisionInstanceFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("partitionId");
+              assertThat(t.value().intValue()).isEqualTo(3);
+            });
+  }
+
+  @Test
   public void shouldApplyAuthorizationCheck() {
     // given
     final var authorization =

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
@@ -36,12 +36,33 @@ public record DecisionInstanceFilter(
     List<Integer> decisionDefinitionVersions,
     List<DecisionDefinitionType> decisionTypes,
     List<Operation<Long>> rootDecisionDefinitionKeyOperations,
-    List<String> tenantIds)
+    List<String> tenantIds,
+    Integer partitionId)
     implements FilterBase {
 
   public static DecisionInstanceFilter of(
       final Function<DecisionInstanceFilter.Builder, ObjectBuilder<DecisionInstanceFilter>> fn) {
     return FilterBuilders.decisionInstance(fn);
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .decisionInstanceKeys(decisionInstanceKeys)
+        .decisionInstanceIdOperations(decisionInstanceIdOperations)
+        .stateOperations(stateOperations)
+        .evaluationDateOperations(evaluationDateOperations)
+        .evaluationFailures(evaluationFailures)
+        .processDefinitionKeys(processDefinitionKeys)
+        .processInstanceKeys(processInstanceKeys)
+        .flowNodeInstanceKeyOperations(flowNodeInstanceKeyOperations)
+        .decisionDefinitionKeyOperations(decisionDefinitionKeyOperations)
+        .decisionDefinitionIds(decisionDefinitionIds)
+        .decisionDefinitionNames(decisionDefinitionNames)
+        .decisionDefinitionVersions(decisionDefinitionVersions)
+        .decisionTypes(decisionTypes)
+        .rootDecisionDefinitionKeyOperations(rootDecisionDefinitionKeyOperations)
+        .tenantIds(tenantIds)
+        .partitionId(partitionId);
   }
 
   public static final class Builder implements ObjectBuilder<DecisionInstanceFilter> {
@@ -61,6 +82,7 @@ public record DecisionInstanceFilter(
     private List<DecisionDefinitionType> decisionTypes;
     private List<Operation<Long>> rootDecisionDefinitionKeyOperations;
     private List<String> tenantIds;
+    private Integer partitionId;
 
     public Builder decisionInstanceKeys(final List<Long> values) {
       decisionInstanceKeys = addValuesToList(decisionInstanceKeys, values);
@@ -232,6 +254,11 @@ public record DecisionInstanceFilter(
       return tenantIds(collectValuesAsList(values));
     }
 
+    public Builder partitionId(final Integer value) {
+      partitionId = value;
+      return this;
+    }
+
     @Override
     public DecisionInstanceFilter build() {
       return new DecisionInstanceFilter(
@@ -249,7 +276,8 @@ public record DecisionInstanceFilter(
           Objects.requireNonNullElse(decisionDefinitionVersions, Collections.emptyList()),
           Objects.requireNonNullElse(decisionTypes, Collections.emptyList()),
           Objects.requireNonNullElse(rootDecisionDefinitionKeyOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          partitionId);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
@@ -19,12 +19,8 @@ import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
 
 public class DecisionInstanceItemProvider implements ItemProvider {
-
-  private static final Logger LOG =
-      org.slf4j.LoggerFactory.getLogger(DecisionInstanceItemProvider.class);
 
   private final SearchClientsProxy searchClientsProxy;
   private final BatchOperationMetrics metrics;
@@ -65,7 +61,7 @@ public class DecisionInstanceItemProvider implements ItemProvider {
 
     return new ItemPage(
         result.items().stream()
-            .map(di -> new Item(di.decisionInstanceKey(), di.decisionInstanceKey()))
+            .map(di -> new Item(di.decisionInstanceKey(), di.processInstanceKey()))
             .collect(Collectors.toList()),
         result.endCursor(),
         result.total(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.page.SearchQueryPageBuilders;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.SecurityContext;
+import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+public class DecisionInstanceItemProvider implements ItemProvider {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(DecisionInstanceItemProvider.class);
+
+  private final SearchClientsProxy searchClientsProxy;
+  private final BatchOperationMetrics metrics;
+  private final SecurityContext securityContext;
+  private final DecisionInstanceFilter filter;
+
+  public DecisionInstanceItemProvider(
+      final SearchClientsProxy searchClientsProxy,
+      final BatchOperationMetrics metrics,
+      final DecisionInstanceFilter filter,
+      final CamundaAuthentication authentication) {
+    this.searchClientsProxy = searchClientsProxy;
+    this.metrics = metrics;
+    this.filter = filter;
+    securityContext =
+        createSecurityContext(
+            authentication, Authorization.of(a -> a.decisionDefinition().readDecisionInstance()));
+  }
+
+  @Override
+  public ItemPage fetchItemPage(final String cursor, final int pageSize) {
+    final var page = SearchQueryPageBuilders.page().size(pageSize).after(cursor).build();
+    final var query =
+        SearchQueryBuilders.decisionInstanceSearchQuery().filter(filter).page(page).build();
+
+    final SearchQueryResult<DecisionInstanceEntity> result;
+
+    try {
+      metrics.recordQueryAgainstSecondaryDatabase();
+      result =
+          searchClientsProxy.withSecurityContext(securityContext).searchDecisionInstances(query);
+    } catch (final Exception e) {
+      metrics.recordFailedQueryAgainstSecondaryDatabase();
+      throw e;
+    }
+
+    final boolean isLastPage = result.items().isEmpty() || result.total() < pageSize;
+
+    return new ItemPage(
+        result.items().stream()
+            .map(di -> new Item(di.decisionInstanceKey(), di.decisionInstanceKey()))
+            .collect(Collectors.toList()),
+        result.endCursor(),
+        result.total(),
+        isLastPage);
+  }
+
+  @VisibleForTesting
+  public DecisionInstanceFilter getFilter() {
+    return filter;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.security.auth.CamundaAuthentication;
@@ -52,7 +53,10 @@ public class ItemProviderFactory {
           forDeleteProcessInstance(
               batchOperation.getEntityFilter(ProcessInstanceFilter.class),
               batchOperation.getAuthentication());
-      case DELETE_DECISION_INSTANCE -> forDeleteDecisionInstance();
+      case DELETE_DECISION_INSTANCE ->
+          forDeleteDecisionInstance(
+              batchOperation.getEntityFilter(DecisionInstanceFilter.class),
+              batchOperation.getAuthentication());
     };
   }
 
@@ -114,13 +118,12 @@ public class ItemProviderFactory {
         authentication);
   }
 
-  private ItemProvider forDeleteDecisionInstance() {
-    // Fake implementation - real implementation will be added in a future issue
-    return new ItemProvider() {
-      @Override
-      public ItemPage fetchItemPage(final String cursor, final int pageSize) {
-        return new ItemPage(java.util.Collections.emptyList(), null, 0, true);
-      }
-    };
+  private ItemProvider forDeleteDecisionInstance(
+      final DecisionInstanceFilter filter, final CamundaAuthentication authentication) {
+    return new DecisionInstanceItemProvider(
+        searchClientsProxy,
+        metrics,
+        filter.toBuilder().partitionId(partitionId).build(),
+        authentication);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -389,8 +389,11 @@ abstract class AbstractBatchOperationTest {
         .getBatchOperationKey();
   }
 
-  protected DecisionInstanceEntity fakeDecisionInstanceEntity(final long decisionInstanceKey) {
-    return new DecisionInstanceEntity.Builder().decisionInstanceKey(decisionInstanceKey).build();
+  protected DecisionInstanceEntity fakeDecisionInstanceEntity(final long itemKey) {
+    return new DecisionInstanceEntity.Builder()
+        .decisionInstanceKey(itemKey)
+        .processInstanceKey(itemKey)
+        .build();
   }
 
   protected UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/DeleteDecisionInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/DeleteDecisionInstanceBatchExecutorTest.java
@@ -9,9 +9,12 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.Map;
@@ -51,21 +54,16 @@ public final class DeleteDecisionInstanceBatchExecutorTest extends AbstractBatch
         createDeleteDecisionInstanceBatchOperation(List.of(decisionKey), claims);
 
     // then verify history deletion
-    // TODO uncomment this assertion when the DELETE command gets appended
-    // https://github.com/camunda/camunda/issues/42400
-    //
-    // assertThat(RecordingExporter.historyDeletionRecords().withResourceKey(decisionKey).limit(2))
-    //        .hasSize(2)
-    //        .extracting(
-    //            Record::getIntent,
-    //            r -> r.getValue().getResourceKey(),
-    //            r -> r.getValue().getResourceType())
-    //        .containsExactly(
-    //            tuple(HistoryDeletionIntent.DELETE, decisionKey,
-    // HistoryDeletionType.DECISION_INSTANCE),
-    //            tuple(
-    //                HistoryDeletionIntent.DELETED, decisionKey,
-    // HistoryDeletionType.DECISION_INSTANCE));
+    assertThat(RecordingExporter.historyDeletionRecords().withResourceKey(decisionKey).limit(2))
+        .hasSize(2)
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getResourceKey(),
+            r -> r.getValue().getResourceType())
+        .containsExactly(
+            tuple(HistoryDeletionIntent.DELETE, decisionKey, HistoryDeletionType.DECISION_INSTANCE),
+            tuple(
+                HistoryDeletionIntent.DELETED, decisionKey, HistoryDeletionType.DECISION_INSTANCE));
 
     // then verify batch operation completed
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProviderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.itemprovider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
+import java.util.List;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DecisionInstanceItemProviderTest {
+
+  private SearchClientsProxy searchClientsProxy = mock(SearchClientsProxy.class);
+  private final BatchOperationMetrics metrics = mock(BatchOperationMetrics.class);
+
+  private DecisionInstanceItemProvider provider;
+
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+
+  @BeforeEach
+  void setUp() {
+    searchClientsProxy = mock(SearchClientsProxy.class);
+
+    final EngineConfiguration engineConfiguration = mock(EngineConfiguration.class);
+    when(engineConfiguration.getBatchOperationQueryPageSize()).thenReturn(5);
+    when(engineConfiguration.getBatchOperationQueryInClauseSize()).thenReturn(5);
+
+    when(searchClientsProxy.withSecurityContext(any())).thenReturn(searchClientsProxy);
+
+    provider =
+        new DecisionInstanceItemProvider(
+            searchClientsProxy,
+            metrics,
+            new DecisionInstanceFilter.Builder().build(),
+            authentication);
+  }
+
+  @Test
+  public void shouldFetchPage() {
+    final var queryCaptor = ArgumentCaptor.forClass(DecisionInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<DecisionInstanceEntity>()
+            .items(
+                List.of(
+                    createDecisionInstanceEntity(1L, "1-1"),
+                    createDecisionInstanceEntity(2L, "2-1"),
+                    createDecisionInstanceEntity(3L, "3-1"),
+                    createDecisionInstanceEntity(4L, "4-1"),
+                    createDecisionInstanceEntity(5L, "5-1")))
+            .total(5)
+            .endCursor("5")
+            .build();
+    when(searchClientsProxy.searchDecisionInstances(queryCaptor.capture())).thenReturn(result);
+
+    // when
+    final var resultPage = provider.fetchItemPage("-1", 5);
+
+    // then
+    assertThat(resultPage.items()).hasSize(5);
+    assertThat(resultPage.endCursor()).isEqualTo("5");
+    assertThat(resultPage.isLastPage()).isFalse();
+    assertThat(resultPage.items().getFirst().itemKey()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldFetchEmptyPage() {
+    final var queryCaptor = ArgumentCaptor.forClass(DecisionInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<DecisionInstanceEntity>()
+            .items(List.of())
+            .total(0)
+            .endCursor("0")
+            .build();
+    when(searchClientsProxy.searchDecisionInstances(queryCaptor.capture())).thenReturn(result);
+
+    // when
+    final var resultPage = provider.fetchItemPage("-1", 5);
+
+    // then
+    assertThat(resultPage.items()).hasSize(0);
+    assertThat(resultPage.endCursor()).isEqualTo("0");
+    assertThat(resultPage.isLastPage()).isTrue();
+  }
+
+  @Test
+  public void shouldFetchSmallerPage() {
+    final var queryCaptor = ArgumentCaptor.forClass(DecisionInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<DecisionInstanceEntity>()
+            .items(
+                List.of(
+                    createDecisionInstanceEntity(1L, "1"),
+                    createDecisionInstanceEntity(2L, "2"),
+                    createDecisionInstanceEntity(3L, "3")))
+            .total(3)
+            .endCursor("3")
+            .build();
+    when(searchClientsProxy.searchDecisionInstances(queryCaptor.capture())).thenReturn(result);
+
+    // when
+    final var resultPage = provider.fetchItemPage(null, 5);
+
+    // then
+    assertThat(resultPage.items()).hasSize(3);
+    assertThat(resultPage.endCursor()).isEqualTo("3");
+    assertThat(resultPage.isLastPage()).isTrue();
+    assertThat(resultPage.items().get(0).itemKey()).isEqualTo(1L);
+    assertThat(resultPage.items().get(1).itemKey()).isEqualTo(2L);
+    assertThat(resultPage.items().get(2).itemKey()).isEqualTo(3L);
+  }
+
+  private DecisionInstanceEntity createDecisionInstanceEntity(
+      final long decisionInstanceKey, final String decisionInstanceId) {
+    return Instancio.of(DecisionInstanceEntity.class)
+        .set(field(DecisionInstanceEntity::decisionInstanceKey), decisionInstanceKey)
+        .set(field(DecisionInstanceEntity::decisionInstanceId), decisionInstanceId)
+        .create();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProviderTest.java
@@ -63,11 +63,11 @@ class DecisionInstanceItemProviderTest {
         new SearchQueryResult.Builder<DecisionInstanceEntity>()
             .items(
                 List.of(
-                    createDecisionInstanceEntity(1L, "1-1"),
-                    createDecisionInstanceEntity(2L, "2-1"),
-                    createDecisionInstanceEntity(3L, "3-1"),
-                    createDecisionInstanceEntity(4L, "4-1"),
-                    createDecisionInstanceEntity(5L, "5-1")))
+                    createDecisionInstanceEntity(1L),
+                    createDecisionInstanceEntity(2L),
+                    createDecisionInstanceEntity(3L),
+                    createDecisionInstanceEntity(4L),
+                    createDecisionInstanceEntity(5L)))
             .total(5)
             .endCursor("5")
             .build();
@@ -114,9 +114,9 @@ class DecisionInstanceItemProviderTest {
         new SearchQueryResult.Builder<DecisionInstanceEntity>()
             .items(
                 List.of(
-                    createDecisionInstanceEntity(1L, "1"),
-                    createDecisionInstanceEntity(2L, "2"),
-                    createDecisionInstanceEntity(3L, "3")))
+                    createDecisionInstanceEntity(1L),
+                    createDecisionInstanceEntity(2L),
+                    createDecisionInstanceEntity(3L)))
             .total(3)
             .endCursor("3")
             .build();
@@ -134,11 +134,9 @@ class DecisionInstanceItemProviderTest {
     assertThat(resultPage.items().get(2).itemKey()).isEqualTo(3L);
   }
 
-  private DecisionInstanceEntity createDecisionInstanceEntity(
-      final long decisionInstanceKey, final String decisionInstanceId) {
+  private DecisionInstanceEntity createDecisionInstanceEntity(final long decisionInstanceKey) {
     return Instancio.of(DecisionInstanceEntity.class)
         .set(field(DecisionInstanceEntity::decisionInstanceKey), decisionInstanceKey)
-        .set(field(DecisionInstanceEntity::decisionInstanceId), decisionInstanceId)
         .create();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.zeebe.engine.metrics.BatchOperationMetrics;
@@ -127,6 +128,26 @@ class ItemProviderFactoryTest {
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
     final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
+    assertThat(usedFilter.partitionId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSetFiltersForDeleteDecisionInstance() {
+    // Arrange
+    final var filter = new DecisionInstanceFilter.Builder().build();
+    final var batchOperation = mock(PersistedBatchOperation.class);
+    when(batchOperation.getBatchOperationType())
+        .thenReturn(BatchOperationType.DELETE_DECISION_INSTANCE);
+    when(batchOperation.getEntityFilter(DecisionInstanceFilter.class)).thenReturn(filter);
+
+    // Act
+    final var itemProvider = factory.fromBatchOperation(batchOperation);
+
+    // Assert
+    assertThat(itemProvider).isNotNull();
+    assertThat(itemProvider).isInstanceOf(DecisionInstanceItemProvider.class);
+
+    final var usedFilter = ((DecisionInstanceItemProvider) itemProvider).getFilter();
     assertThat(usedFilter.partitionId()).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- The `ItemProviderFactory` knows how to deal with the new batch operation type `DELETE_DECISION_INSTACE`
- We can query keys according to the user provided filter from secondary storage. (added partitionId)
- Uncomment the assertion in the DeleteDecisionInstanceBatchExecutorTest
- added UTs

## Related issues

closes #42400
