### PR TITLE
fix: internal server error after user task migration

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration;
+
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestTasklistClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Job-based user tasks don't work with RDBMS")
+public class UserTaskProcessInstanceMigrationIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication().withAuthorizationsDisabled();
+
+  private static CamundaClient client;
+  @AutoClose private static TestRestTasklistClient tasklistClient;
+
+  private static final String FROM_PROCESS_ID = "migration-user-task_v1";
+  private static final String TO_PROCESS_ID = "migration-user-task_v2";
+  private static final String TASK_ID = "task1";
+  private static final String EXAMPLE_DUE_DATE = "2017-07-21T19:32:28+02:00";
+  private static final String EXAMPLE_FOLLOW_UP_DATE = "2017-07-22T19:32:28+02:00";
+
+  private static long formKey;
+
+  @BeforeAll
+  static void setup(final CamundaClient camundaClient) {
+    tasklistClient = STANDALONE_CAMUNDA.newTasklistClient();
+    formKey =
+        client
+            .newDeployResourceCommand()
+            .addResourceStringUtf8(getForm("linkedform"), "linkedForm.form")
+            .send()
+            .join()
+            .getForm()
+            .getFirst()
+            .getFormKey();
+  }
+
+  @ParameterizedTest
+  @MethodSource("migrationTestCases")
+  void shouldMigrateProcessInstance(
+      final Consumer<UserTaskBuilder> jobWorkerUserTask,
+      final Consumer<UserTaskBuilder> camundaUserTask,
+      final ExpectedUserTask expectedTask) {
+
+    // given
+    final BpmnModelInstance jwProcess =
+        Bpmn.createExecutableProcess(FROM_PROCESS_ID)
+            .startEvent()
+            .userTask(TASK_ID, jobWorkerUserTask)
+            .endEvent()
+            .done();
+    final BpmnModelInstance cutProcess =
+        Bpmn.createExecutableProcess(TO_PROCESS_ID)
+            .startEvent()
+            .userTask(TASK_ID, camundaUserTask)
+            .endEvent()
+            .done();
+
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(jwProcess, FROM_PROCESS_ID + ".bpmn")
+            .addProcessModel(cutProcess, TO_PROCESS_ID + ".bpmn")
+            .send()
+            .join();
+    final var pd2 =
+        deploymentEvent.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals(TO_PROCESS_ID))
+            .findFirst()
+            .get()
+            .getProcessDefinitionKey();
+    final var processInstanceKey =
+        startProcessInstance(
+                client, FROM_PROCESS_ID, Map.of("varAssignee", "demo", "varPriority", 20))
+            .getProcessInstanceKey();
+    // wait for task to be exported - use V1 because V2 does not return job worker user tasks
+    waitForTaskExported(processInstanceKey);
+
+    // when
+    migrateProcessInstance(
+        client,
+        processInstanceKey,
+        MigrationPlan.newBuilder()
+            .withTargetProcessDefinitionKey(pd2)
+            .addMappingInstruction(TASK_ID, TASK_ID)
+            .build());
+
+    // then
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      client
+                          .newUserTaskSearchRequest()
+                          .filter(
+                              f ->
+                                  f.processDefinitionKey(pd2)
+                                      .bpmnProcessId(TO_PROCESS_ID)
+                                      .processInstanceKey(processInstanceKey)
+                                      .assignee(expectedTask.assignee))
+                          // right task
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(1);
+            });
+    final UserTask migratedTask =
+        client
+            .newUserTaskSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(pd2)
+                        .bpmnProcessId(TO_PROCESS_ID)
+                        .processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .singleItem();
+
+    assertThat(migratedTask.getAssignee()).isEqualTo(expectedTask.assignee);
+    assertThat(migratedTask.getCandidateGroups()).isEqualTo(List.of("g1", "g2"));
+    assertThat(migratedTask.getCandidateUsers()).isEqualTo(List.of("u1", "u2"));
+    assertThat(migratedTask.getDueDate()).isEqualTo(EXAMPLE_DUE_DATE);
+    assertThat(migratedTask.getFollowUpDate()).isEqualTo(EXAMPLE_FOLLOW_UP_DATE);
+    assertThat(migratedTask.getPriority()).isEqualTo(expectedTask.priority);
+    assertThat(migratedTask.getFormKey()).isEqualTo(expectedTask.formKey);
+    assertThat(migratedTask.getExternalFormReference())
+        .isEqualTo(expectedTask.externalFormReference);
+  }
+
+  static Stream<Arguments> migrationTestCases() {
+    // Test case with assignee and priority expressions
+    final Consumer<UserTaskBuilder> fromPriorityAndAssignee =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
+                .zeebeAssignee("original");
+    final Consumer<UserTaskBuilder> toPriorityAndAssignee =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssigneeExpression("varAssignee")
+                .zeebeTaskPriorityExpression("2*varPriority");
+
+    // Test case where assignee and priority are removed
+    final Consumer<UserTaskBuilder> fromWithoutAssigneeAndPriority =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE);
+    final Consumer<UserTaskBuilder> toWithoutAssigneeAndPriority =
+        AbstractUserTaskBuilder::zeebeUserTask;
+
+    // Test case migrating from embedded form to external form reference
+    final Consumer<UserTaskBuilder> fromEmbeddedForm =
+        t ->
+            t.zeebeCandidateGroups("g1,g2")
+                .zeebeUserTaskForm(getForm("testform"))
+                .zeebeCandidateUsers("u1,u2")
+                .zeebeDueDate(EXAMPLE_DUE_DATE)
+                .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
+                .zeebeAssignee("original");
+    final Consumer<UserTaskBuilder> toExternalForm =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssigneeExpression("varAssignee")
+                .zeebeExternalFormReference("localhost:8080//example.form");
+
+    // Test case migrating from embedded form to internal form
+    final Consumer<UserTaskBuilder> toInternalForm =
+        t ->
+            t.zeebeUserTask()
+                .zeebeAssignee("targetAssignee")
+                .zeebeTaskPriority("10")
+                .zeebeFormId("linkedform");
+
+    return Stream.of(
+        Arguments.of(
+            fromPriorityAndAssignee,
+            toPriorityAndAssignee,
+            new ExpectedUserTask("demo", 40, null, null)),
+        Arguments.of(
+            fromWithoutAssigneeAndPriority,
+            toWithoutAssigneeAndPriority,
+            new ExpectedUserTask(null, 50, null, null)),
+        Arguments.of(
+            fromEmbeddedForm,
+            toExternalForm,
+            new ExpectedUserTask("demo", 50, "localhost:8080//example.form", null)),
+        Arguments.of(
+            fromEmbeddedForm,
+            toInternalForm,
+            new ExpectedUserTask("targetAssignee", 10, null, formKey)));
+  }
+
+  private static String getForm(final String formId) {
+    return "{\n"
+        + "  \"components\": [],\n"
+        + "  \"type\": \"default\",\n"
+        + "  \"id\": \""
+        + formId
+        + "\",\n"
+        + "  \"executionPlatform\": \"Camunda Cloud\",\n"
+        + "  \"executionPlatformVersion\": \"8.7.0\",\n"
+        + "  \"exporter\": {\n"
+        + "    \"name\": \"Camunda Modeler\",\n"
+        + "    \"version\": \"5.38.1\"\n"
+        + "  },\n"
+        + "  \"schemaVersion\": 19\n"
+        + "}";
+  }
+
+  private void migrateProcessInstance(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final MigrationPlan migrationPlan) {
+    client
+        .newMigrateProcessInstanceCommand(processInstanceKey)
+        .migrationPlan(migrationPlan)
+        .send()
+        .join();
+  }
+
+  private void waitForTaskExported(final Long processInstanceKey) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final TaskSearchResponse[] tasks =
+                  tasklistClient.searchAndParseTasks(processInstanceKey);
+              assertThat(tasks).hasSize(1);
+              assertThat(tasks[0].getProcessInstanceKey()).isEqualTo(processInstanceKey.toString());
+            });
+  }
+
+  record ExpectedUserTask(
+      String assignee, Integer priority, String externalFormReference, Long formKey) {}
+}

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -104,6 +104,10 @@
       <artifactId>operate-webapp</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-webapp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -64,6 +64,7 @@ import io.camunda.exporter.handlers.UsageMetricExportedHandler;
 import io.camunda.exporter.handlers.UserCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.UserDeletedHandler;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler;
+import io.camunda.exporter.handlers.UserTaskCreatingHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
 import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
@@ -279,9 +280,13 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new MessageSubscriptionFromProcessMessageSubscriptionHandler(
                 indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
                 exporterMetadata),
-            new UserTaskHandler(
+            new UserTaskCreatingHandler(
                 indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 formCache,
+                processCache,
+                exporterMetadata),
+            new UserTaskHandler(
+                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 processCache,
                 exporterMetadata),
             new UserTaskJobBasedHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTaskRecordValue> {
+
+  private static final Set<UserTaskIntent> SUPPORTED_INTENTS = EnumSet.of(UserTaskIntent.CREATING);
+
+  private final String indexName;
+  private final ExporterEntityCache<String, CachedFormEntity> formCache;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ExporterMetadata exporterMetadata;
+
+  public UserTaskCreatingHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedFormEntity> formCache,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ExporterMetadata exporterMetadata) {
+    this.indexName = indexName;
+    this.formCache = formCache;
+    this.processCache = processCache;
+    this.exporterMetadata = exporterMetadata;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER_TASK;
+  }
+
+  @Override
+  public Class<TaskEntity> getEntityType() {
+    return TaskEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserTaskRecordValue> record) {
+    return SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserTaskRecordValue> record) {
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, record.getKey());
+    if (refersToPreviousVersionRecord(record.getKey())) {
+      return List.of(String.valueOf(record.getKey()));
+    }
+    return List.of(String.valueOf(record.getValue().getElementInstanceKey()));
+  }
+
+  @Override
+  public TaskEntity createNewEntity(final String id) {
+    return new TaskEntity().setId(id).setChangedAttributes(new ArrayList<>());
+  }
+
+  @Override
+  public void updateEntity(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+    entity.setProcessInstanceId(String.valueOf(record.getValue().getProcessInstanceKey()));
+    entity.setAction(record.getValue().getAction());
+    entity.setKey(record.getKey());
+    createTaskEntity(entity, record);
+    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
+    joinRelation.setName(TaskJoinRelationshipType.TASK.getType());
+    joinRelation.setParent(Long.parseLong(entity.getProcessInstanceId()));
+    entity.setJoin(joinRelation);
+  }
+
+  @Override
+  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+    final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
+
+    batchRequest.addWithRouting(
+        indexName,
+        entity,
+        previousVersionRecord ? String.valueOf(entity.getKey()) : entity.getProcessInstanceId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private void createTaskEntity(final TaskEntity entity, final Record<UserTaskRecordValue> record) {
+    final var taskValue = record.getValue();
+    final var formKey = taskValue.getFormKey() > 0 ? String.valueOf(taskValue.getFormKey()) : null;
+
+    entity
+        .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
+        .setState(TaskState.CREATING)
+        .setFlowNodeInstanceId(String.valueOf(taskValue.getElementInstanceKey()))
+        .setProcessInstanceId(String.valueOf(taskValue.getProcessInstanceKey()))
+        .setFlowNodeBpmnId(taskValue.getElementId())
+        .setName(
+            ProcessCacheUtil.getFlowNodeName(
+                    processCache, taskValue.getProcessDefinitionKey(), taskValue.getElementId())
+                .orElse(null))
+        .setBpmnProcessId(taskValue.getBpmnProcessId())
+        .setProcessDefinitionId(String.valueOf(taskValue.getProcessDefinitionKey()))
+        .setProcessDefinitionVersion(taskValue.getProcessDefinitionVersion())
+        .setFormKey(!ExporterUtil.isEmpty(formKey) ? formKey : null)
+        .setExternalFormReference(
+            ExporterUtil.isEmpty(taskValue.getExternalFormReference())
+                ? null
+                : taskValue.getExternalFormReference())
+        .setCustomHeaders(taskValue.getCustomHeaders())
+        .setPartitionId(record.getPartitionId())
+        .setTenantId(taskValue.getTenantId())
+        .setPosition(record.getPosition())
+        .setAction(ExporterUtil.isEmpty(taskValue.getAction()) ? null : taskValue.getAction())
+        .setCreationTime(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .setDueDate(ExporterUtil.toOffsetDateTime(taskValue.getDueDate()))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(taskValue.getFollowUpDate()))
+        .setPriority(taskValue.getPriority())
+        .setCandidateGroups(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateGroupsList()))
+        .setCandidateUsers(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateUsersList()));
+
+    if (taskValue.getTags() != null && !taskValue.getTags().isEmpty()) {
+      entity.setTags(taskValue.getTags());
+    }
+
+    if (!ExporterUtil.isEmpty(formKey)) {
+      formCache
+          .get(formKey)
+          .ifPresent(c -> entity.setFormId(c.formId()).setFormVersion(c.formVersion()));
+    }
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
+  }
+
+  private boolean refersToPreviousVersionRecord(final long key) {
+    return exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK) == -1
+        || key < exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.cache.TestFormCache;
+import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usertask.TaskState;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UserTaskCreatingHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-tasklist-creating-task";
+  private final TestFormCache formCache = new TestFormCache();
+  private final TestProcessCache processCache = new TestProcessCache();
+  private final ExporterMetadata exporterMetadata =
+      new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final UserTaskCreatingHandler underTest =
+      new UserTaskCreatingHandler(indexName, formCache, processCache, exporterMetadata);
+
+  @BeforeEach
+  void resetMetadata() {
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, -1);
+  }
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER_TASK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(TaskEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.CREATING));
+    // when - then
+    assertThat(underTest.handlesRecord(userTaskRecord))
+        .describedAs("Expect to handle intent %s", UserTaskIntent.CREATING)
+        .isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdForNewVersionReferenceRecord() {
+    // given
+    /* For 8.7 Ingested records, the recordKey has to be greater than the firstIngestedUserTaskKey */
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 110;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder()
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withUserTaskKey(recordKey)
+                            .withElementInstanceKey(flowNodeInstanceKey)
+                            .build()));
+
+    // when
+    final var idList = underTest.generateIds(userTaskRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(flowNodeInstanceKey));
+  }
+
+  @Test
+  void shouldGenerateIdForPreviousVersionReferenceRecord() {
+    // given
+    /* For 8.7 Ingested records referencing 8.6 records, the recordKey has to be less than the firstIngestedUserTaskKey */
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 90;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder()
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withUserTaskKey(recordKey)
+                            .withElementInstanceKey(flowNodeInstanceKey)
+                            .build()));
+
+    // when
+    final var idList = underTest.generateIds(userTaskRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(recordKey));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlushForNewVersionReefrenceRecord() {
+    // given
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 110;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final TaskEntity inputEntity =
+        new TaskEntity()
+            .setId(String.valueOf(flowNodeInstanceKey))
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setKey(recordKey)
+            .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+
+    verify(mockRequest, times(1))
+        .addWithRouting(indexName, inputEntity, String.valueOf(processInstanceKey));
+  }
+
+  @Test
+  void shouldAddEntityOnFlushForPreviousVersionReferenceRecord() {
+    // given
+    final long firstIngestedUserTaskKey = 100;
+    final long recordKey = 90;
+    final long processInstanceKey = 111;
+    final long flowNodeInstanceKey = 211;
+    exporterMetadata.setFirstUserTaskKey(
+        TaskImplementation.ZEEBE_USER_TASK, firstIngestedUserTaskKey);
+    final TaskEntity inputEntity =
+        new TaskEntity()
+            .setId(String.valueOf(recordKey))
+            .setProcessInstanceId(String.valueOf(processInstanceKey))
+            .setKey(recordKey)
+            .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+
+    verify(mockRequest, times(1)).addWithRouting(indexName, inputEntity, String.valueOf(recordKey));
+  }
+
+  @Test
+  void shouldCreateEntityFromRecord() {
+    // given
+    final long processInstanceKey = 123;
+    final long processDefinitionKey = 555;
+    final long flowNodeInstanceKey = 456;
+    final long recordKey = 110;
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, 100);
+    final var dateTime = OffsetDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+    final var formKey = 456L;
+    final var elementId = "elementId";
+    final var rootProcessInstanceKey = 999L;
+    final UserTaskRecordValue taskRecordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withAssignee("")
+            .withChangedAttributes(List.of())
+            .withFollowUpDate(dateTime)
+            .withDueDate(dateTime)
+            .withCandidateGroupsList(Arrays.asList("group1", "group2"))
+            .withCandidateUsersList(Arrays.asList("user1", "user2"))
+            .withProcessInstanceKey(processInstanceKey)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withElementInstanceKey(flowNodeInstanceKey)
+            .withFormKey(formKey)
+            .withElementId(elementId)
+            .withRootProcessInstanceKey(rootProcessInstanceKey)
+            .build();
+
+    final Record<UserTaskRecordValue> taskCreatingRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.CREATING)
+                    .withKey(recordKey)
+                    .withValue(taskRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    formCache.put(String.valueOf(formKey), new CachedFormEntity("my-form", 987L));
+    processCache.put(
+        processDefinitionKey,
+        new CachedProcessEntity(
+            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node")));
+
+    // when
+    final TaskEntity taskEntity =
+        new TaskEntity().setId(String.valueOf(taskRecordValue.getElementInstanceKey()));
+    underTest.updateEntity(taskCreatingRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getId())
+        .isEqualTo(String.valueOf(taskRecordValue.getElementInstanceKey()));
+    assertThat(taskEntity.getKey()).isEqualTo(taskCreatingRecord.getKey());
+    assertThat(taskEntity.getTenantId()).isEqualTo(taskRecordValue.getTenantId());
+    assertThat(taskEntity.getPartitionId()).isEqualTo(taskCreatingRecord.getPartitionId());
+    assertThat(taskEntity.getPosition()).isEqualTo(taskCreatingRecord.getPosition());
+    assertThat(taskEntity.getProcessInstanceId()).isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo(taskRecordValue.getElementId());
+    assertThat(taskEntity.getName()).isEqualTo("my-flow-node");
+    assertThat(taskEntity.getBpmnProcessId()).isEqualTo(taskRecordValue.getBpmnProcessId());
+    assertThat(taskEntity.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(taskRecordValue.getProcessDefinitionKey()));
+    assertThat(taskEntity.getProcessDefinitionVersion())
+        .isEqualTo(taskRecordValue.getProcessDefinitionVersion());
+    assertThat(taskEntity.getFormKey()).isEqualTo(String.valueOf(taskRecordValue.getFormKey()));
+    assertThat(taskEntity.getFormId()).isEqualTo("my-form");
+    assertThat(taskEntity.getFormVersion()).isEqualTo(987L);
+    assertThat(taskEntity.getExternalFormReference())
+        .isEqualTo(taskRecordValue.getExternalFormReference());
+    assertThat(taskEntity.getCustomHeaders()).isEqualTo(taskRecordValue.getCustomHeaders());
+    assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
+    assertThat(taskEntity.getAction()).isEqualTo(taskRecordValue.getAction());
+    assertThat(taskEntity.getDueDate()).isEqualTo(dateTime);
+    assertThat(taskEntity.getFollowUpDate()).isEqualTo(dateTime);
+    assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
+        .isEqualTo(taskRecordValue.getCandidateGroupsList());
+    assertThat(Arrays.stream(taskEntity.getCandidateUsers()).toList())
+        .isEqualTo(taskRecordValue.getCandidateUsersList());
+    assertThat(taskEntity.getAssignee()).isNull();
+    assertThat(taskEntity.getJoin()).isNotNull();
+    assertThat(taskEntity.getJoin().getParent()).isEqualTo(processInstanceKey);
+    assertThat(taskEntity.getJoin().getName()).isEqualTo(TaskJoinRelationshipType.TASK.getType());
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATING);
+    assertThat(taskEntity.getCreationTime())
+        .isEqualTo(
+            ExporterUtil.toZonedOffsetDateTime(
+                Instant.ofEpochMilli(taskCreatingRecord.getTimestamp())));
+    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
+    assertThat(taskEntity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldNotSetRootProcessInstanceKeyWhenUndefined() {
+    // given
+    final UserTaskRecordValue taskRecordValue =
+        ImmutableUserTaskRecordValue.builder().withRootProcessInstanceKey(-1L).build();
+
+    final Record<UserTaskRecordValue> taskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withIntent(UserTaskIntent.CREATING).withValue(taskRecordValue));
+
+    // when
+    final TaskEntity taskEntity = underTest.createNewEntity("id");
+    underTest.updateEntity(taskRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getRootProcessInstanceKey()).isNull();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix error in tasklist after user task migration.

V2 API requires the `formKey` to be a long, but for job worker user tasks the `formKey` is a String. When the new user task is created, it did not update the `formKey` value in the secondary storage because the `updateField` only got set when `formKey` is not `null`, so the old job-worker string remained in secondary storage which then caused a long parsing error in the controller. We need to update the `formKey` to null if it is set to null when the entity is newly created.

The external form reference was also missing from the update fields.

I refactored the acceptance tests to be in an own class and made them parameterized tests. I also added a test case for embedded form -> external form reference. This will make it easier to add more test cases with https://github.com/camunda/camunda/issues/44635

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

relates to https://github.com/camunda/camunda/issues/44911
