### PR TITLE
refactor: instrument userinfo requests as well

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -54,10 +54,6 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.authentication.config;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
+import org.springframework.http.client.observation.ClientHttpObservationDocumentation.LowCardinalityKeyNames;
 import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.client.observation.DefaultClientRequestObservationConvention;
 import org.springframework.lang.NonNull;
@@ -37,5 +39,25 @@ public class CustomDefaultClientRequestObservationConvention
             status(context),
             uri(context))
         .and(commonTags);
+  }
+
+  /**
+   * Required because some requests do not have a URI template, so we need to use the raw URI
+   * directly.
+   */
+  protected KeyValue uri(ClientRequestObservationContext context) {
+    if (context.getUriTemplate() != null) {
+      return super.uri(context);
+    }
+
+    final var uri = context.getCarrier().getURI();
+    if (uri != null) {
+      final var path = uri.getPath();
+      if (path != null) {
+        return KeyValue.of(LowCardinalityKeyNames.URI, (path.startsWith("/") ? path : "/" + path));
+      }
+    }
+
+    return KeyValue.of(LowCardinalityKeyNames.URI, KeyValue.NONE_VALUE);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CustomDefaultClientRequestObservationConvention.java
@@ -50,8 +50,9 @@ public class CustomDefaultClientRequestObservationConvention
       return super.uri(context);
     }
 
-    final var uri = context.getCarrier().getURI();
-    if (uri != null) {
+    final var carrier = context.getCarrier();
+    if (carrier != null) {
+      final var uri = context.getCarrier().getURI();
       final var path = uri.getPath();
       if (path != null) {
         return KeyValue.of(LowCardinalityKeyNames.URI, (path.startsWith("/") ? path : "/" + path));

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -45,7 +45,6 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
@@ -93,9 +92,11 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGra
 import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
@@ -122,6 +123,7 @@ import org.springframework.security.web.header.writers.CrossOriginResourcePolicy
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Configuration
@@ -758,11 +760,11 @@ public class WebSecurityConfig {
     public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
         final OidcAuthenticationConfigurationRepository oidcAuthenticationConfigurationRepository,
         final AssertionJwkProvider assertionJwkProvider,
-        final MeterRegistry meterRegistry) {
+        final ObservationRegistry observationRegistry) {
       return new OidcTokenEndpointCustomizer(
           oidcAuthenticationConfigurationRepository,
           assertionJwkProvider,
-          restClient(meterRegistry));
+          restClient(observationRegistry));
     }
 
     @Bean
@@ -770,14 +772,14 @@ public class WebSecurityConfig {
         final ClientRegistrationRepository registrations,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final AssertionJwkProvider assertionJwkProvider,
-        final MeterRegistry meterRegistry) {
+        final ObservationRegistry observationRegistry) {
 
       final var manager =
           new DefaultOAuth2AuthorizedClientManager(registrations, authorizedClientRepository);
 
       // we build a refresh token flow client manually to add support for private_key_jwt
       final var refreshClient = new RestClientRefreshTokenTokenResponseClient();
-      refreshClient.setRestClient(restClient(meterRegistry));
+      refreshClient.setRestClient(restClient(observationRegistry));
       final var assertionConverter =
           new NimbusJwtClientAuthenticationParametersConverter<OAuth2RefreshTokenGrantRequest>(
               registration -> assertionJwkProvider.createJwk(registration.getRegistrationId()));
@@ -792,6 +794,27 @@ public class WebSecurityConfig {
 
       manager.setAuthorizedClientProvider(provider);
       return manager;
+    }
+
+    @Bean
+    public OidcUserService oidcUserService(final ObservationRegistry observationRegistry) {
+      final var oauthUserService = new DefaultOAuth2UserService();
+      final var oidcUserService = new OidcUserService();
+      oidcUserService.setOauth2UserService(oauthUserService);
+
+      // see DefaultOauth2UserService#setRestOperations for the minimum handlers/converters required
+      final var restOperations = new RestTemplate();
+      restOperations.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
+
+      // instrument them so we can see additional external requests
+      restOperations.setObservationConvention(
+          new CustomDefaultClientRequestObservationConvention(
+              CAMUNDA_AUTHENTICATION_OBSERVATION_NAME,
+              CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS));
+      restOperations.setObservationRegistry(observationRegistry);
+
+      oauthUserService.setRestOperations(restOperations);
+      return oidcUserService;
     }
 
     @Bean
@@ -866,7 +889,8 @@ public class WebSecurityConfig {
         final CookieCsrfTokenRepository csrfTokenRepository,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final OAuth2AuthorizedClientManager authorizedClientManager,
-        final OidcTokenEndpointCustomizer tokenEndpointCustomizer)
+        final OidcTokenEndpointCustomizer tokenEndpointCustomizer,
+        final OidcUserService oidcUserService)
         throws Exception {
       final var filterChainBuilder =
           httpSecurity
@@ -902,6 +926,7 @@ public class WebSecurityConfig {
                     oauthLoginConfigurer
                         .clientRegistrationRepository(clientRegistrationRepository)
                         .authorizedClientRepository(authorizedClientRepository)
+                        .userInfoEndpoint(c -> c.oidcUserService(oidcUserService))
                         .redirectionEndpoint(
                             redirectionEndpointConfig ->
                                 redirectionEndpointConfig.baseUri("/sso-callback"))
@@ -975,14 +1000,7 @@ public class WebSecurityConfig {
       };
     }
 
-    private RestClient restClient(final MeterRegistry meterRegistry) {
-      // Setup observation for RestClient as per
-      // https://docs.spring.io/spring-framework/reference/integration/observability.html#observability.http-client.restclient
-      final var observationRegistry = ObservationRegistry.create();
-      observationRegistry
-          .observationConfig()
-          .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
-
+    private RestClient restClient(final ObservationRegistry observationRegistry) {
       // The message converters are taken from the expected rest client in
       // AbstractRestClientOAuth2AccessTokenResponseClient
       return RestClient.builder()

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -802,18 +802,18 @@ public class WebSecurityConfig {
       final var oidcUserService = new OidcUserService();
       oidcUserService.setOauth2UserService(oauthUserService);
 
-      // see DefaultOauth2UserService#setRestOperations for the minimum handlers/converters required
-      final var restOperations = new RestTemplate();
-      restOperations.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
+      // see DefaultOAuth2UserService#setRestOperations for the minimum handlers/converters required
+      final var restTemplate = new RestTemplate();
+      restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
 
-      // instrument them so we can see additional external requests
-      restOperations.setObservationConvention(
+      // instrument user service requests so we can track them via metrics
+      restTemplate.setObservationConvention(
           new CustomDefaultClientRequestObservationConvention(
               CAMUNDA_AUTHENTICATION_OBSERVATION_NAME,
               CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS));
-      restOperations.setObservationRegistry(observationRegistry);
+      restTemplate.setObservationRegistry(observationRegistry);
 
-      oauthUserService.setRestOperations(restOperations);
+      oauthUserService.setRestOperations(restTemplate);
       return oidcUserService;
     }
 


### PR DESCRIPTION
## Description

Instrument OIDC `/userinfo` requests as well. This also switches us to use the injected `ObservationRegistry` instead of creating a new one every time.

Note that for whatever reason, the user info resolver does not use the templated URI requests, so I had to fetch the URI param slightly differently. But everything else works the same.

You get the following metrics during login:

```
# HELP camunda_authentication_external_requests_active_seconds  
# TYPE camunda_authentication_external_requests_active_seconds summary
camunda_authentication_external_requests_active_seconds_count{client_name="localhost",domain="identity",exception="none",method="GET",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 0
camunda_authentication_external_requests_active_seconds_sum{client_name="localhost",domain="identity",exception="none",method="GET",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 0.0
camunda_authentication_external_requests_active_seconds_count{client_name="localhost",domain="identity",exception="none",method="POST",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 0
camunda_authentication_external_requests_active_seconds_sum{client_name="localhost",domain="identity",exception="none",method="POST",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 0.0
# HELP camunda_authentication_external_requests_active_seconds_max  
# TYPE camunda_authentication_external_requests_active_seconds_max gauge
camunda_authentication_external_requests_active_seconds_max{client_name="localhost",domain="identity",exception="none",method="GET",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 0.0
camunda_authentication_external_requests_active_seconds_max{client_name="localhost",domain="identity",exception="none",method="POST",outcome="UNKNOWN",status="CLIENT_ERROR",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 0.0
# HELP camunda_authentication_external_requests_seconds  
# TYPE camunda_authentication_external_requests_seconds summary
camunda_authentication_external_requests_seconds_count{client_name="localhost",domain="identity",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 1
camunda_authentication_external_requests_seconds_sum{client_name="localhost",domain="identity",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 0.006067225
camunda_authentication_external_requests_seconds_count{client_name="localhost",domain="identity",error="none",exception="none",method="POST",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 1
camunda_authentication_external_requests_seconds_sum{client_name="localhost",domain="identity",error="none",exception="none",method="POST",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 0.112169558
# HELP camunda_authentication_external_requests_seconds_max  
# TYPE camunda_authentication_external_requests_seconds_max gauge
camunda_authentication_external_requests_seconds_max{client_name="localhost",domain="identity",error="none",exception="none",method="GET",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/userinfo"} 0.006067225
camunda_authentication_external_requests_seconds_max{client_name="localhost",domain="identity",error="none",exception="none",method="POST",outcome="SUCCESS",status="200",uri="/auth/realms/camunda-platform/protocol/openid-connect/token"} 0.112169558
```
