### PR TITLE
feat: add MCP panel to Core Features board

### DIFF
--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -2633,7 +2633,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Highest-requested API endpoints based on request rate",
+          "description": "Highest-requested MCP endpoints based on request rate",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2925,7 +2925,7 @@
               "refId": "Latency (avg)"
             }
           ],
-          "title": "Search Latency MCP (top 10)",
+          "title": "Average Latency MCP (top 10)",
           "transformations": [
             {
               "id": "organize",

--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -8315,5 +8315,5 @@
   "timezone": "browser",
   "title": "Core Features Overview",
   "uid": "core-features-overview",
-  "version": 2
+  "version": 3
 }

--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -389,7 +389,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2449
+            "y": 3949
           },
           "id": 1,
           "options": {
@@ -512,7 +512,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 11
+            "y": 19
           },
           "id": 4,
           "options": {
@@ -538,7 +538,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "# 1. GET requests, excluding license and topology\nsum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    method=\"GET\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n  }[$__rate_interval]) != 0\n)",
+              "expr": "# 1. GET requests, excluding license and topology\nsum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    method=\"GET\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n  }[$__rate_interval]) != 0\n)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{method}} {{uri}}",
@@ -554,7 +554,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "# 2. POST requests to /search or /statistics\nsum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    method=\"POST\",\n    uri=~\".*/search.*|.*/statistics.*\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n  }[$__rate_interval]) != 0\n)",
+              "expr": "# 2. POST requests to /search or /statistics\nsum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    method=\"POST\",\n    uri=~\".*/search.*|.*/statistics.*\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n  }[$__rate_interval]) != 0\n)",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -627,7 +627,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 11
+            "y": 19
           },
           "id": 17,
           "options": {
@@ -644,7 +644,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10, (sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\nor\nsum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )))",
+              "expr": "topk(10, (sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )\nor\nsum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )))",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -747,7 +747,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 11
+            "y": 19
           },
           "id": 49,
           "options": {
@@ -773,7 +773,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\",\n    uri!~\".*/search.*|.*/statistics.*\",\n  }[$__rate_interval]) != 0\n)\n",
+              "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri=~\"$uri\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\",\n    uri!~\".*/search.*|.*/statistics.*\",\n  }[$__rate_interval]) != 0\n)\n",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{method}} {{uri}}",
@@ -845,7 +845,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 11
+            "y": 19
           },
           "id": 50,
           "options": {
@@ -862,7 +862,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10, sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\",\n    uri!~\".*/search.*|.*/statistics.*\",\n  }[4h])\n))",
+              "expr": "topk(10, sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\",\n    uri!~\".*/search.*|.*/statistics.*\",\n  }[4h])\n))",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -960,7 +960,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1143
+            "y": 51
           },
           "id": 6,
           "options": {
@@ -985,7 +985,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
+              "expr": "  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
               "hide": false,
               "instant": false,
               "legendFormat": "{{method}} {{uri}}",
@@ -999,7 +999,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",      \n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
+              "expr": "  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",      \n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
               "hide": false,
               "instant": false,
               "legendFormat": "{{method}} {{uri}}",
@@ -1071,7 +1071,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1143
+            "y": 51
           },
           "id": 13,
           "options": {
@@ -1087,7 +1087,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10,\n  ((sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  )) or\n    ((sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  ))\n  )\n))",
+              "expr": "topk(10,\n  ((sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"GET\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[4h])\n  )) or\n    ((sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method=\"POST\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri=~\".*/search.*|.*/statistics.*\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\"\n    }[4h])\n  ))\n  )\n))",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1181,7 +1181,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 1143
+            "y": 51
           },
           "id": 51,
           "options": {
@@ -1206,7 +1206,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[$__rate_interval])\n  )\n",
+              "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[$__rate_interval])\n  )\n",
               "hide": false,
               "instant": false,
               "legendFormat": "{{method}} {{uri}}",
@@ -1278,7 +1278,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 1143
+            "y": 51
           },
           "id": 52,
           "options": {
@@ -1294,7 +1294,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10,\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[4h])\n  )\n)\n",
+              "expr": "topk(10,\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      method!~\"GET|OPTIONS|HEAD\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*|/v2/jobs/activation\",\n      uri!~\".*/search.*|.*/statistics.*\",\n    }[4h])\n  )\n)\n",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1388,7 +1388,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1151
+            "y": 59
           },
           "id": 5,
           "options": {
@@ -1413,7 +1413,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n))\n",
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[$__rate_interval])\n  )\n))\n",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1489,7 +1489,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1151
+            "y": 59
           },
           "id": 14,
           "options": {
@@ -1506,7 +1506,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n))\n",
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )\n))\n",
               "format": "table",
               "fullMetaSearch": false,
               "hide": false,
@@ -1603,7 +1603,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 1151
+            "y": 59
           },
           "id": 15,
           "options": {
@@ -1628,7 +1628,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n",
+              "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[$__rate_interval])\n  )\n",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1704,7 +1704,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 1151
+            "y": 59
           },
           "id": 16,
           "options": {
@@ -1721,7 +1721,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n))\n",
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\"\n    }[4h])\n  )\n))\n",
               "format": "table",
               "fullMetaSearch": false,
               "hide": false,
@@ -1833,7 +1833,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1159
+            "y": 67
           },
           "id": 9,
           "options": {
@@ -1927,7 +1927,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1159
+            "y": 67
           },
           "id": 18,
           "options": {
@@ -2048,7 +2048,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 1159
+            "y": 67
           },
           "id": 8,
           "options": {
@@ -2143,7 +2143,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 1159
+            "y": 67
           },
           "id": 19,
           "options": {
@@ -2262,7 +2262,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1167
+            "y": 75
           },
           "id": 10,
           "options": {
@@ -2362,7 +2362,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1167
+            "y": 75
           },
           "id": 20,
           "options": {
@@ -2446,7 +2446,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1167
+            "y": 75
           },
           "id": 11,
           "options": {
@@ -2516,6 +2516,875 @@
         "x": 0,
         "y": 11
       },
+      "id": 105,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Highest-requested MCP endpoints based on request rate",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": []
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    uri=~\".*/mcp.*\"\n  }[$__rate_interval]) != 0\n)",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": true,
+              "refId": "Requests per second",
+              "useBackend": false
+            }
+          ],
+          "title": "Request Rate MCP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Highest-requested API endpoints based on request rate",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "decimals": 3,
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "uri"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/core-features-rest/api?orgId=1&from=now-15m&to=now&timezone=browser&${region:queryparam}&${namespace:queryparam}&${container:queryparam}&var-uri=${__value.raw}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 107,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(10, \n  (\n    sum by(uri, method) (\n      rate(http_server_requests_seconds_count{\n        camunda_region=~\"$region\",\n        container=~\"$container\",\n        namespace=~\"$namespace\",\n        uri=~\".*/mcp.*\"\n      }[4h])\n    )\n  )\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Requests per second",
+              "useBackend": false
+            }
+          ],
+          "title": "Request Rate MCP (top 10)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Time": "",
+                  "Value": "Rate (req/s)",
+                  "uri": ""
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest average request duration.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.3
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval])\n  )\n",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": true,
+              "refId": "Latency (avg)"
+            }
+          ],
+          "title": "Average Latency MCP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest average request duration.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.3
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "uri"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Show details",
+                        "url": "/d/core-features-rest/api?orgId=1&from=now-15m&to=now&timezone=browser&var-uri=${__value.raw}&${region:queryparam}&${container:queryparam}&${namespace:queryparam}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 109,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(10,\n  (\n    (\n      sum by(uri, method) (\n        rate(http_server_requests_seconds_sum{\n          camunda_region=~\"$region\",\n          container=~\"$container\",\n          namespace=~\"$namespace\",\n          uri=~\".*/mcp.*\"\n        }[4h])\n      )\n      /\n      sum by(uri, method) (\n        rate(http_server_requests_seconds_count{\n          camunda_region=~\"$region\",\n          container=~\"$container\",\n          namespace=~\"$namespace\",\n          uri=~\".*/mcp.*\"\n        }[4h])\n      )\n    )\n  )\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": false,
+              "refId": "Latency (avg)"
+            }
+          ],
+          "title": "Search Latency MCP (top 10)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Avg Response Time (s)"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest proportion of server-side errors (5xx), useful for spotting failing API routes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 36
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval])\n  )\n))\n",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": true,
+              "refId": "Error rate",
+              "useBackend": false
+            }
+          ],
+          "title": "Server error rate MCP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest proportion of server-side errors (5xx), useful for spotting failing API routes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "uri"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/core-features-rest/api?orgId=1&from=now-15m&to=now&timezone=browser&var-uri=${__value.raw}&${region:queryparam}&${container:queryparam}&${namespace:queryparam}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 36
+          },
+          "id": 111,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      uri=~\".*/mcp.*\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[4h])\n  )\n))\n",
+              "format": "table",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": false,
+              "refId": "Error rate",
+              "useBackend": false
+            }
+          ],
+          "title": "Server error rate MCP (top 10)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Server Error Rate (%)"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest proportion of client-side errors (4xx), useful for spotting failing API routes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 36
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval]) != 0\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[$__rate_interval])\n  )\n",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": true,
+              "refId": "Error rate",
+              "useBackend": false
+            }
+          ],
+          "title": "Client error rate MCP",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Endpoints with the highest proportion of client-side errors (4xx).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "uri"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/core-features-rest/api?orgId=1&from=now-15m&to=now&timezone=browser&var-uri=${__value.raw}&${region:queryparam}&${container:queryparam}&${namespace:queryparam}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "id": 113,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      uri=~\".*/mcp.*\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      uri=~\".*/mcp.*\"\n    }[4h])\n  )\n))\n",
+              "format": "table",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "{{method}} {{uri}}",
+              "range": false,
+              "refId": "Error rate",
+              "useBackend": false
+            }
+          ],
+          "title": "Client error rate MCP (top 10)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Client Error Rate (%)"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "MCP",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
       "id": 21,
       "panels": [
         {
@@ -2544,7 +3413,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 12
+            "y": 1512
           },
           "id": 25,
           "options": {
@@ -2692,7 +3561,7 @@
             "h": 8,
             "w": 8,
             "x": 6,
-            "y": 12
+            "y": 1512
           },
           "id": 23,
           "options": {
@@ -2857,7 +3726,7 @@
             "h": 8,
             "w": 8,
             "x": 14,
-            "y": 12
+            "y": 1512
           },
           "id": 30,
           "options": {
@@ -2948,7 +3817,7 @@
             "h": 8,
             "w": 2,
             "x": 22,
-            "y": 12
+            "y": 1512
           },
           "id": 104,
           "options": {
@@ -3035,7 +3904,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152
+            "y": 1652
           },
           "id": 76,
           "options": {
@@ -3137,7 +4006,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152
+            "y": 1652
           },
           "id": 32,
           "options": {
@@ -3260,7 +4129,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 1660
           },
           "id": 29,
           "options": {
@@ -3318,7 +4187,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 1660
           },
           "id": 46,
           "options": {
@@ -3446,7 +4315,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 1668
           },
           "id": 34,
           "options": {
@@ -3506,7 +4375,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 1668
           },
           "id": 45,
           "options": {
@@ -3650,7 +4519,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 1676
           },
           "id": 31,
           "options": {
@@ -3752,7 +4621,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 1676
           },
           "id": 44,
           "options": {
@@ -3835,7 +4704,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 63,
       "panels": [
@@ -3920,7 +4789,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 433
+            "y": 1933
           },
           "id": 79,
           "interval": "1s",
@@ -4039,7 +4908,7 @@
             "h": 9,
             "w": 9,
             "x": 6,
-            "y": 433
+            "y": 1933
           },
           "id": 71,
           "options": {
@@ -4141,7 +5010,7 @@
             "h": 9,
             "w": 9,
             "x": 15,
-            "y": 433
+            "y": 1933
           },
           "id": 70,
           "options": {
@@ -4244,7 +5113,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 522
+            "y": 2022
           },
           "id": 72,
           "options": {
@@ -4343,7 +5212,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 522
+            "y": 2022
           },
           "id": 73,
           "options": {
@@ -4442,7 +5311,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 522
+            "y": 2022
           },
           "id": 74,
           "options": {
@@ -4541,7 +5410,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 531
+            "y": 2031
           },
           "id": 75,
           "options": {
@@ -4640,7 +5509,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 531
+            "y": 2031
           },
           "id": 77,
           "options": {
@@ -4693,7 +5562,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 62,
       "panels": [
@@ -4764,7 +5633,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 1514
           },
           "id": 64,
           "options": {
@@ -4865,7 +5734,7 @@
             "h": 10,
             "w": 6,
             "x": 12,
-            "y": 14
+            "y": 1514
           },
           "id": 66,
           "options": {
@@ -4975,7 +5844,7 @@
             "h": 10,
             "w": 6,
             "x": 18,
-            "y": 14
+            "y": 1514
           },
           "id": 67,
           "options": {
@@ -5085,7 +5954,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 1584
           },
           "id": 87,
           "options": {
@@ -5185,7 +6054,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 1584
           },
           "id": 86,
           "options": {
@@ -5244,7 +6113,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 1593
           },
           "id": 85,
           "options": {
@@ -5379,7 +6248,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 1593
           },
           "id": 83,
           "options": {
@@ -5478,7 +6347,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 102
+            "y": 1602
           },
           "id": 68,
           "options": {
@@ -5553,7 +6422,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 1602
           },
           "id": 84,
           "options": {
@@ -5635,7 +6504,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 1611
           },
           "id": 69,
           "options": {
@@ -5708,7 +6577,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 101,
       "panels": [
@@ -5777,7 +6646,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 1515
           },
           "id": 82,
           "options": {
@@ -5820,7 +6689,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 100,
       "panels": [
@@ -5891,7 +6760,7 @@
             "h": 8,
             "w": 11,
             "x": 0,
-            "y": 16
+            "y": 1516
           },
           "id": 96,
           "maxDataPoints": 100,
@@ -6002,7 +6871,7 @@
             "h": 8,
             "w": 11,
             "x": 11,
-            "y": 16
+            "y": 1516
           },
           "id": 90,
           "options": {
@@ -6045,7 +6914,7 @@
             "h": 8,
             "w": 2,
             "x": 22,
-            "y": 16
+            "y": 1516
           },
           "id": 98,
           "options": {
@@ -6154,7 +7023,7 @@
             "h": 8,
             "w": 11,
             "x": 0,
-            "y": 24
+            "y": 1524
           },
           "id": 97,
           "options": {
@@ -6288,7 +7157,7 @@
             "h": 8,
             "w": 11,
             "x": 11,
-            "y": 24
+            "y": 1524
           },
           "id": 91,
           "options": {
@@ -6331,7 +7200,7 @@
             "h": 2,
             "w": 24,
             "x": 0,
-            "y": 32
+            "y": 1532
           },
           "id": 102,
           "options": {
@@ -6411,7 +7280,7 @@
             "h": 8,
             "w": 11,
             "x": 0,
-            "y": 34
+            "y": 1534
           },
           "id": 94,
           "options": {
@@ -6460,7 +7329,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 47,
       "panels": [
@@ -6535,7 +7404,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 207
+            "y": 1707
           },
           "id": 60,
           "options": {
@@ -6643,7 +7512,7 @@
             "h": 10,
             "w": 11,
             "x": 11,
-            "y": 207
+            "y": 1707
           },
           "id": 61,
           "options": {
@@ -6686,7 +7555,7 @@
             "h": 10,
             "w": 2,
             "x": 22,
-            "y": 207
+            "y": 1707
           },
           "id": 80,
           "options": {
@@ -6795,7 +7664,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 217
+            "y": 1717
           },
           "id": 27,
           "options": {
@@ -6873,7 +7742,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 217
+            "y": 1717
           },
           "id": 26,
           "options": {
@@ -6987,7 +7856,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 217
+            "y": 1717
           },
           "id": 24,
           "options": {


### PR DESCRIPTION
## Description

Adds a new row with panels for MCP gateway requests to the Core Features Overview board.
Excludes MCP requests from REST panels.

<img width="1382" height="949" alt="image" src="https://github.com/user-attachments/assets/1b1e85f8-c6ab-4b08-b417-b670d3c2511c" />


## Related issues

closes #45015 