### PR TITLE
fix: client can keep access after permission removed by preventing cache expiration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -24,7 +24,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_FORM_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_PROCESS_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY = 1000;
-  public static final Duration DEFAULT_AUTHORIZATIONS_CACHE_TTL = Duration.ofSeconds(30);
+  public static final Duration DEFAULT_AUTHORIZATIONS_CACHE_TTL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -90,7 +90,7 @@ public final class AuthorizationCheckBehavior {
 
     authorizationsCache =
         CacheBuilder.newBuilder()
-            .expireAfterAccess(config.getAuthorizationsCacheTtl())
+            .expireAfterWrite(config.getAuthorizationsCacheTtl())
             .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(
                 new CacheLoader<>() {


### PR DESCRIPTION
## Description

* Cache expiration method switched from `expireAfterAccess()` to `expireAfterWrite()` - clients and users were able to keep revoked access by continuously interacting with protected resources and thus moving the cache sliding window as the cache is read on each request.
* Authorization cache default TTL reduced from 30 to 10 seconds
* Test improved to reduce flakiness and to make sure that simply accessing the cache does not keep it alive.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44844 
