### PR TITLE
refactor: revert default PI retention mode to PI_HIERARCHY

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -18,9 +18,8 @@ public class DocumentBasedHistory {
   public static final Duration DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS = Duration.ofMillis(60000);
   private static final Duration DEFAULT_HISTORY_DELAY_BETWEEN_RUNS = Duration.ofMillis(2000);
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
-  // TODO once all entities are set with rootProcessInstanceKey, set the default to PI_HIERARCHY
   private static final ProcessInstanceRetentionMode
-      DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI;
+      DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI_HIERARCHY;
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
@@ -14,14 +14,10 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.worker.JobWorker;
-import io.camunda.exporter.CamundaExporter;
-import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.HistoryMultiDbTest;
-import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -44,21 +40,6 @@ import org.slf4j.LoggerFactory;
 // of https://github.com/camunda/camunda/issues/41683
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class ProcessInstanceHistoryCleanupIT {
-
-  // TODO remove this once default retention mode is PI_HIERARCHY
-  @MultiDbTestApplication
-  static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker()
-          .withExporterMutator(
-              CamundaExporter.class.getSimpleName().toLowerCase(),
-              args -> {
-                final Map<String, Object> history =
-                    new HashMap<>((Map<String, Object>) args.get("history"));
-                history.put(
-                    "processInstanceRetentionMode",
-                    ProcessInstanceRetentionMode.PI_HIERARCHY.name());
-                args.put("history", history);
-              });
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProcessInstanceHistoryCleanupIT.class);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -221,9 +221,8 @@ public class ExporterConfiguration {
 
   public static class HistoryConfiguration {
     private boolean processInstanceEnabled = true;
-    // TODO once all entities are set with rootProcessInstanceKey, set the default to PI_HIERARCHY
     private ProcessInstanceRetentionMode processInstanceRetentionMode =
-        ProcessInstanceRetentionMode.PI;
+        ProcessInstanceRetentionMode.PI_HIERARCHY;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`PI_HIERARCHY` will be the default PI retention mode in 8.9

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

reverts https://github.com/camunda/camunda/pull/44419
