### PR TITLE
Introduce variable name filter

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
@@ -7,11 +7,17 @@
  */
 package io.camunda.zeebe.exporter.filter;
 
+import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.ENDS_WITH;
+import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.EXACT;
+import static io.camunda.zeebe.exporter.filter.NameFilterRule.Type.STARTS_WITH;
+import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
+
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class DefaultRecordFilter implements Context.RecordFilter {
 
@@ -21,8 +27,36 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
   public DefaultRecordFilter(final FilterConfiguration configuration) {
     this.configuration = configuration;
 
-    // The next PR will implement the filters to be added in the chain
-    exportRecordFilterChain = new ExportRecordFilterChain(Collections.emptyList());
+    exportRecordFilterChain = new ExportRecordFilterChain(createRecordFilters(configuration));
+  }
+
+  private static List<ExporterRecordFilter> createRecordFilters(
+      final FilterConfiguration configuration) {
+
+    final var index = configuration.filterIndexConfig();
+
+    final var nameInclusionRules = getVariableNameInclusionRules(index);
+    final var nameExclusionRules = getVariableNameExclusionRules(index);
+
+    return List.of(new VariableNameFilter(nameInclusionRules, nameExclusionRules));
+  }
+
+  private static List<NameFilterRule> getVariableNameInclusionRules(
+      final FilterConfiguration.IndexConfig index) {
+    final List<NameFilterRule> rules = new ArrayList<>();
+    rules.addAll(parseRules(index.getVariableNameInclusionExact(), EXACT));
+    rules.addAll(parseRules(index.getVariableNameInclusionStartWith(), STARTS_WITH));
+    rules.addAll(parseRules(index.getVariableNameInclusionEndWith(), ENDS_WITH));
+    return List.copyOf(rules);
+  }
+
+  private static List<NameFilterRule> getVariableNameExclusionRules(
+      final FilterConfiguration.IndexConfig index) {
+    final List<NameFilterRule> rules = new ArrayList<>();
+    rules.addAll(parseRules(index.getVariableNameExclusionExact(), EXACT));
+    rules.addAll(parseRules(index.getVariableNameExclusionStartWith(), STARTS_WITH));
+    rules.addAll(parseRules(index.getVariableNameExclusionEndWith(), ENDS_WITH));
+    return List.copyOf(rules);
   }
 
   @Override

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.filter;
 
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.List;
 
 /**
  * Configuration for exporter record filtering.
@@ -25,4 +26,20 @@ public interface FilterConfiguration {
   boolean shouldIndexRequiredValueType(ValueType valueType);
 
   boolean shouldIndexRecordType(RecordType recordType);
+
+  IndexConfig filterIndexConfig();
+
+  interface IndexConfig {
+    List<String> getVariableNameInclusionExact();
+
+    List<String> getVariableNameInclusionStartWith();
+
+    List<String> getVariableNameInclusionEndWith();
+
+    List<String> getVariableNameExclusionExact();
+
+    List<String> getVariableNameExclusionStartWith();
+
+    List<String> getVariableNameExclusionEndWith();
+  }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.exporter.filter.NameFilterRule.Type;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+final class NameFilter {
+
+  private final List<Predicate<String>> includePredicates;
+  private final List<Predicate<String>> excludePredicates;
+
+  NameFilter(final List<NameFilterRule> inclusionRules, final List<NameFilterRule> exclusionRules) {
+    includePredicates = toPredicates(inclusionRules);
+    excludePredicates = toPredicates(exclusionRules);
+  }
+
+  boolean accept(final String name) {
+    if (name == null) {
+      return true;
+    }
+
+    if (!includePredicates.isEmpty() && includePredicates.stream().noneMatch(p -> p.test(name))) {
+      return false;
+    }
+
+    return excludePredicates.isEmpty() || excludePredicates.stream().noneMatch(p -> p.test(name));
+  }
+
+  private static List<Predicate<String>> toPredicates(final List<NameFilterRule> rules) {
+    if (rules == null || rules.isEmpty()) {
+      return List.of();
+    }
+    return rules.stream().filter(Objects::nonNull).map(NameFilter::toPredicate).toList();
+  }
+
+  private static Predicate<String> toPredicate(final NameFilterRule rule) {
+    final String pattern = rule.pattern();
+
+    return switch (rule.type()) {
+      case Type.EXACT -> name -> name.equals(pattern);
+      case Type.STARTS_WITH -> name -> name.startsWith(pattern);
+      case Type.ENDS_WITH -> name -> name.endsWith(pattern);
+    };
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilterRule.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/NameFilterRule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import java.util.Objects;
+
+/**
+ * A single name filter rule.
+ *
+ * <p>Contract:
+ *
+ * <ul>
+ *   <li>{@code type} must not be {@code null}
+ *   <li>{@code pattern} must not be {@code null} or blank
+ * </ul>
+ */
+public record NameFilterRule(Type type, String pattern) {
+
+  public NameFilterRule {
+    Objects.requireNonNull(type, "type must not be null");
+
+    if (pattern == null || pattern.isBlank()) {
+      throw new IllegalArgumentException("pattern must not be null or blank");
+    }
+  }
+
+  public enum Type {
+    EXACT,
+    STARTS_WITH,
+    ENDS_WITH,
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class VariableNameFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_SEMANTIC_VERSION =
+      new SemanticVersion(8, 9, 0, null, null);
+
+  private final NameFilter nameFilter;
+
+  public VariableNameFilter(
+      final List<NameFilterRule> inclusionRules, final List<NameFilterRule> exclusionRules) {
+    nameFilter = new NameFilter(inclusionRules, exclusionRules);
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+
+    return nameFilter.accept(variableRecordValue.getName());
+  }
+
+  public static List<NameFilterRule> parseRules(
+      final List<String> rawList, final NameFilterRule.Type type) {
+
+    if (rawList == null || rawList.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return rawList.stream()
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(pattern -> new NameFilterRule(type, pattern))
+        .toList();
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_SEMANTIC_VERSION;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -9,11 +9,14 @@ package io.camunda.zeebe.exporter.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.exporter.filter.config.TestConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 final class DefaultRecordFilterTest {
@@ -82,5 +85,160 @@ final class DefaultRecordFilterTest {
 
     // then
     assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldApplyVariableNameInclusionRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.testIndexConfig().withVariableNameInclusionExact(List.of("included"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    final var included = variableRecord("included");
+    final var other = variableRecord("other");
+
+    // when / then
+    assertThat(filter.acceptRecord(included)).isTrue();
+    assertThat(filter.acceptRecord(other)).isFalse();
+  }
+
+  @Test
+  void shouldApplyVariableNameExclusionRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    // No inclusion rules -> all variable names are included by default,
+    // but we explicitly exclude the exact name "excluded".
+    configuration.testIndexConfig().withVariableNameExclusionExact(List.of("excluded"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    final var excluded = variableRecord("excluded");
+    final var other = variableRecord("other");
+
+    // when / then
+    assertThat(filter.acceptRecord(excluded))
+        .as("name 'excluded' should be rejected by exclusion rules")
+        .isFalse();
+    assertThat(filter.acceptRecord(other))
+        .as("name 'other' is not excluded and should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldApplyVariableNameInclusionStartWithRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.testIndexConfig().withVariableNameInclusionStartWith(List.of("incl"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    final var included = variableRecord("includeMe");
+    final var other = variableRecord("other");
+
+    // when / then
+    assertThat(filter.acceptRecord(included)).isTrue();
+    assertThat(filter.acceptRecord(other)).isFalse();
+  }
+
+  @Test
+  void shouldApplyVariableNameInclusionEndWithRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration.testIndexConfig().withVariableNameInclusionEndWith(List.of("_suffix"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    final var included = variableRecord("name_suffix");
+    final var other = variableRecord("name_other");
+
+    // when / then
+    assertThat(filter.acceptRecord(included)).isTrue();
+    assertThat(filter.acceptRecord(other)).isFalse();
+  }
+
+  @Test
+  void shouldApplyVariableNameExclusionStartWithRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    // No inclusion rules -> all variable names are included by default,
+    // but we explicitly exclude names starting with "secret_".
+    configuration.testIndexConfig().withVariableNameExclusionStartWith(List.of("secret_"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    final var excluded = variableRecord("secret_token");
+    final var other = variableRecord("public_value");
+
+    // when / then
+    assertThat(filter.acceptRecord(excluded))
+        .as("names starting with 'secret_' should be rejected by exclusion rules")
+        .isFalse();
+    assertThat(filter.acceptRecord(other))
+        .as("name 'public_value' does not start with 'secret_' and should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldApplyVariableNameExclusionEndWithRulesFromTestConfiguration() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    // No inclusion rules -> all variable names are included by default,
+    // but we explicitly exclude names ending with "_tmp".
+    configuration.testIndexConfig().withVariableNameExclusionEndWith(List.of("_tmp"));
+
+    final var excluded = variableRecord("value_tmp");
+    final var other = variableRecord("value");
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // when / then
+    assertThat(filter.acceptRecord(excluded))
+        .as("names ending with '_tmp' should be rejected by exclusion rules")
+        .isFalse();
+    assertThat(filter.acceptRecord(other))
+        .as("name 'value' does not end with '_tmp' and should be accepted")
+        .isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> variableRecord(final String name) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(record.getBrokerVersion()).thenReturn("8.9.0"); // satisfies VariableNameFilterRecord
+    when(record.getValue()).thenReturn(value);
+    when(value.getName()).thenReturn(name);
+
+    return record;
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/NameFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/NameFilterTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class NameFilterTest {
+
+  @Test
+  void shouldAcceptAllNamesWhenNoRules() {
+    // given
+    final var filter = new NameFilter(List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept("foo")).isTrue();
+    assertThat(filter.accept("bar")).isTrue();
+    assertThat(filter.accept("any_name")).isTrue();
+  }
+
+  @Test
+  void shouldAcceptOnlyNamesMatchingExactInclusion() {
+    // given
+    final var inclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.EXACT, "foo"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.accept("foo")).isTrue();
+    assertThat(filter.accept("bar")).isFalse();
+    assertThat(filter.accept("foobar")).isFalse();
+  }
+
+  @Test
+  void shouldApplyStartsWithInclusionRule() {
+    // given
+    final var inclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.STARTS_WITH, "foo"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.accept("foo")).isTrue();
+    assertThat(filter.accept("fooVar")).isTrue();
+    assertThat(filter.accept("foobar")).isTrue();
+
+    assertThat(filter.accept("barfoo")).isFalse();
+    assertThat(filter.accept("other")).isFalse();
+  }
+
+  @Test
+  void shouldApplyEndsWithInclusionRule() {
+    // given
+    final var inclusionRules =
+        List.of(new NameFilterRule(NameFilterRule.Type.ENDS_WITH, "_suffix"));
+    final var filter = new NameFilter(inclusionRules, List.of());
+
+    // when / then
+    assertThat(filter.accept("var_suffix")).isTrue();
+    assertThat(filter.accept("foo_suffix")).isTrue();
+
+    assertThat(filter.accept("suffix_foo")).isFalse();
+    assertThat(filter.accept("foo")).isFalse();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingExactExclusionOnly() {
+    // given: no inclusion, only exclusion
+    final var exclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.EXACT, "secret"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("secret")).isFalse();
+    assertThat(filter.accept("public")).isTrue();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingStartsWithExclusionOnly() {
+    // given
+    final var exclusionRules =
+        List.of(new NameFilterRule(NameFilterRule.Type.STARTS_WITH, "debug_"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("debug_var")).isFalse();
+    assertThat(filter.accept("debug_foo")).isFalse();
+
+    assertThat(filter.accept("nodebug")).isTrue();
+    assertThat(filter.accept("prod_var")).isTrue();
+  }
+
+  @Test
+  void shouldRejectNamesMatchingEndsWithExclusionOnly() {
+    // given
+    final var exclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.ENDS_WITH, "_tmp"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("var_tmp")).isFalse();
+    assertThat(filter.accept("foo_tmp")).isFalse();
+
+    assertThat(filter.accept("tmp_var")).isTrue();
+    assertThat(filter.accept("var")).isTrue();
+  }
+
+  @Test
+  void shouldApplyInclusionThenExclusion() {
+    // given: name must start with "foo", but anything ending with "_debug" is excluded
+    final var inclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.STARTS_WITH, "foo"));
+    final var exclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.ENDS_WITH, "_debug"));
+
+    final var filter = new NameFilter(inclusionRules, exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("fooVar")).isTrue(); // included, not excluded
+    assertThat(filter.accept("foo_debug")).isFalse(); // included AND excluded -> rejected
+    assertThat(filter.accept("barVar")).isFalse(); // not included -> rejected early
+  }
+
+  @Test
+  void shouldShortCircuitOnFailedInclusionEvenIfExclusionWouldAllow() {
+    // given: include EXACT "foo"; exclude EXACT "bar"
+    final var inclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.EXACT, "foo"));
+    final var exclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.EXACT, "bar"));
+
+    final var filter = new NameFilter(inclusionRules, exclusionRules);
+
+    // when / then
+    // "baz" does not match inclusion -> immediately false, regardless of exclusion
+    assertThat(filter.accept("baz")).isFalse();
+  }
+
+  @Test
+  void shouldAllowWhenInclusionEmptyAndNotExcluded() {
+    // given: no inclusion rules, only one exclusion
+    final var exclusionRules = List.of(new NameFilterRule(NameFilterRule.Type.EXACT, "forbidden"));
+    final var filter = new NameFilter(List.of(), exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("allowed")).isTrue();
+    assertThat(filter.accept("forbidden")).isFalse();
+  }
+
+  // ------- null-handling tests -------
+
+  @Test
+  void shouldAcceptNullName() {
+    // given
+    final var filter = new NameFilter(List.of(), List.of());
+
+    // when / then
+    assertThat(filter.accept(null)).isTrue();
+  }
+
+  @Test
+  void shouldHandleNullInclusionAndExclusionLists() {
+    // given
+    final var filter = new NameFilter(null, null);
+
+    // when / then
+    // With no rules at all, non-null names are accepted
+    assertThat(filter.accept("foo")).isTrue();
+    assertThat(filter.accept("bar")).isTrue();
+  }
+
+  @Test
+  void shouldIgnoreNullRulesInLists() {
+    // given: lists containing null entries must not cause NPE
+    final var validRule = new NameFilterRule(NameFilterRule.Type.EXACT, "foo");
+    final var inclusionRules = Arrays.asList(null, validRule);
+    final var exclusionRules = Collections.singletonList((NameFilterRule) null);
+
+    final var filter = new NameFilter(inclusionRules, exclusionRules);
+
+    // when / then
+    assertThat(filter.accept("foo")).isTrue();
+    assertThat(filter.accept("bar")).isFalse();
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableNameFilterTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static io.camunda.zeebe.exporter.filter.VariableNameFilter.parseRules;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.filter.NameFilterRule.Type;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class VariableNameFilterTest {
+
+  // ---------------------------------------------------------------------------
+  // Record-type behavior
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptNonVariableRecords() {
+    // given
+    final var filter = new VariableNameFilter(List.of(), List.of());
+    final Record<ProcessInstanceRecordValue> record = nonVariableRecord();
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  @Test
+  void shouldAcceptVariableRecordWithNullName() {
+    // given
+    final var filter = new VariableNameFilter(List.of(), List.of());
+    final Record<VariableRecordValue> recordWithNullName = variableRecord(null);
+
+    // when
+    final boolean accepted = filter.accept(recordWithNullName);
+
+    // then
+    assertThat(accepted).isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inclusion/Exclusion rules
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldFilterVariableNamesUsingInclusionRules() {
+    // given: only variables with exact name "foo" are allowed
+    final var inclusionRules = parseRules(List.of("foo"), Type.EXACT);
+    final var filter = new VariableNameFilter(inclusionRules, List.of());
+
+    final Record<VariableRecordValue> matchingRecord = variableRecord("foo");
+    final Record<VariableRecordValue> nonMatchingRecord = variableRecord("bar");
+
+    // when
+    final boolean matchingAccepted = filter.accept(matchingRecord);
+    final boolean nonMatchingAccepted = filter.accept(nonMatchingRecord);
+
+    // then
+    assertThat(matchingAccepted).isTrue();
+    assertThat(nonMatchingAccepted).isFalse();
+  }
+
+  @Test
+  void shouldApplyInclusionAndExclusionRulesTogether() {
+    // given:
+    //  - include names starting with "biz_"
+    //  - exclude exact name "biz_debug"
+    final var inclusionRules = parseRules(List.of("biz_"), Type.STARTS_WITH);
+    final var exclusionRules = parseRules(List.of("biz_debug"), Type.EXACT);
+
+    final var filter = new VariableNameFilter(inclusionRules, exclusionRules);
+
+    final Record<VariableRecordValue> allowed = variableRecord("biz_total");
+    final Record<VariableRecordValue> excluded = variableRecord("biz_debug");
+    final Record<VariableRecordValue> notIncluded = variableRecord("other");
+
+    // when
+    final boolean allowedAccepted = filter.accept(allowed);
+    final boolean excludedAccepted = filter.accept(excluded);
+    final boolean notIncludedAccepted = filter.accept(notIncluded);
+
+    // then
+    assertThat(allowedAccepted).as("name matches inclusion and not exclusion").isTrue();
+    assertThat(excludedAccepted)
+        .as("name matches both inclusion and exclusion -> excluded")
+        .isFalse();
+    assertThat(notIncludedAccepted).as("name does not match inclusion -> rejected").isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // parseRules behavior
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void parseRulesShouldReturnEmptyListForNull() {
+    // when
+    final var rules = parseRules(null, Type.EXACT);
+
+    // then
+    assertThat(rules).isEmpty();
+  }
+
+  @Test
+  void parseRulesShouldTrimAndIgnoreEmptyEntries() {
+    // given
+    final var raw = List.of("  foo ", " ", "", "bar");
+
+    // when
+    final var rules = parseRules(raw, Type.EXACT);
+
+    // then
+    assertThat(rules).hasSize(2).allSatisfy(rule -> assertThat(rule.type()).isEqualTo(Type.EXACT));
+    assertThat(rules.get(0).pattern()).isEqualTo("foo");
+    assertThat(rules.get(1).pattern()).isEqualTo("bar");
+  }
+
+  @Test
+  void parseRulesShouldIgnoreNullEntries() {
+    // given
+    final var raw = Arrays.asList(null, "foo", " ", null, "bar");
+
+    // when
+    final var rules = parseRules(raw, Type.EXACT);
+
+    // then
+    assertThat(rules).hasSize(2);
+    assertThat(rules.get(0).pattern()).isEqualTo("foo");
+    assertThat(rules.get(1).pattern()).isEqualTo("bar");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Version constraint
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExposeMinRecordBrokerVersion() {
+    final var filter = new VariableNameFilter(List.of(), List.of());
+
+    assertThat(filter.minRecordBrokerVersion().toString()).isEqualTo("8.9.0");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> nonVariableRecord() {
+    final var record = (Record<ProcessInstanceRecordValue>) mock(Record.class);
+    final var value = mock(ProcessInstanceRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    return record;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<VariableRecordValue> variableRecord(final String name) {
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+    when(record.getValue()).thenReturn(value);
+    when(value.getName()).thenReturn(name);
+    return record;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
@@ -27,6 +27,8 @@ public final class TestConfiguration implements FilterConfiguration {
   private final Map<ValueType, Boolean> requiredFlags = new EnumMap<>(ValueType.class);
   private final Map<RecordType, Boolean> recordTypeFlags = new EnumMap<>(RecordType.class);
 
+  private final TestIndexConfig indexConfig = new TestIndexConfig();
+
   /** Mark a {@link ValueType} as normally indexed. */
   public TestConfiguration withIndexedValueType(final ValueType valueType) {
     normalFlags.put(valueType, true);
@@ -45,6 +47,11 @@ public final class TestConfiguration implements FilterConfiguration {
     return this;
   }
 
+  /** Access to the underlying index config for tests that need to configure name rules. */
+  public TestIndexConfig testIndexConfig() {
+    return indexConfig;
+  }
+
   @Override
   public boolean shouldIndexValueType(final ValueType valueType) {
     return normalFlags.getOrDefault(valueType, false);
@@ -58,5 +65,10 @@ public final class TestConfiguration implements FilterConfiguration {
   @Override
   public boolean shouldIndexRecordType(final RecordType recordType) {
     return recordTypeFlags.getOrDefault(recordType, false);
+  }
+
+  @Override
+  public IndexConfig filterIndexConfig() {
+    return indexConfig;
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter.config;
+
+import io.camunda.zeebe.exporter.filter.FilterConfiguration;
+import java.util.List;
+
+/**
+ * Minimal {@link FilterConfiguration.IndexConfig} implementation for tests.
+ *
+ * <p>By default, all lists are empty (no name-based rules). Tests can override individual lists via
+ * the fluent setters.
+ */
+public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
+
+  private List<String> inclusionExact = List.of();
+  private List<String> inclusionStartWith = List.of();
+  private List<String> inclusionEndWith = List.of();
+
+  private List<String> exclusionExact = List.of();
+  private List<String> exclusionStartWith = List.of();
+  private List<String> exclusionEndWith = List.of();
+
+  // --- fluent setters -------------------------------------------------------
+
+  public TestIndexConfig withVariableNameInclusionExact(final List<String> names) {
+    inclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableNameInclusionStartWith(final List<String> prefixes) {
+    inclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableNameInclusionEndWith(final List<String> suffixes) {
+    inclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableNameExclusionExact(final List<String> names) {
+    exclusionExact = names != null ? names : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableNameExclusionStartWith(final List<String> prefixes) {
+    exclusionStartWith = prefixes != null ? prefixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableNameExclusionEndWith(final List<String> suffixes) {
+    exclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  // --- FilterConfiguration.IndexConfig -------------------------------------
+
+  @Override
+  public List<String> getVariableNameInclusionExact() {
+    return inclusionExact;
+  }
+
+  @Override
+  public List<String> getVariableNameInclusionStartWith() {
+    return inclusionStartWith;
+  }
+
+  @Override
+  public List<String> getVariableNameInclusionEndWith() {
+    return inclusionEndWith;
+  }
+
+  @Override
+  public List<String> getVariableNameExclusionExact() {
+    return exclusionExact;
+  }
+
+  @Override
+  public List<String> getVariableNameExclusionStartWith() {
+    return exclusionStartWith;
+  }
+
+  @Override
+  public List<String> getVariableNameExclusionEndWith() {
+    return exclusionEndWith;
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -145,6 +145,11 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     };
   }
 
+  @Override
+  public IndexConfig filterIndexConfig() {
+    return index;
+  }
+
   public boolean getIsIncludeEnabledRecords() {
     return includeEnabledRecords;
   }
@@ -153,7 +158,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     this.includeEnabledRecords = includeEnabledRecords;
   }
 
-  public static class IndexConfiguration {
+  public static class IndexConfiguration implements IndexConfig {
 
     private static final int DEFAULT_INDEX_TEMPLATE_PRIORITY = 20;
     // prefix for index and templates
@@ -240,6 +245,14 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private Integer numberOfReplicas = null;
     private int templatePriority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
+    // variable name filters
+    private final List<String> variableNameInclusionExact = new ArrayList<>();
+    private final List<String> variableNameInclusionStartWith = new ArrayList<>();
+    private final List<String> variableNameInclusionEndWith = new ArrayList<>();
+    private final List<String> variableNameExclusionExact = new ArrayList<>();
+    private final List<String> variableNameExclusionStartWith = new ArrayList<>();
+    private final List<String> variableNameExclusionEndWith = new ArrayList<>();
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -262,6 +275,36 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
     public void setTemplatePriority(final int templatePriority) {
       this.templatePriority = templatePriority;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionExact() {
+      return variableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionStartWith() {
+      return variableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionEndWith() {
+      return variableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionExact() {
+      return variableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionStartWith() {
+      return variableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionEndWith() {
+      return variableNameExclusionEndWith;
     }
 
     @Override
@@ -358,6 +401,19 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + conditionalSubscription
           + ", conditionalEvaluation="
           + conditionalEvaluation
+          // variable name filters
+          + ", variableNameInclusionExact="
+          + variableNameInclusionExact
+          + ", variableNameInclusionStartWith="
+          + variableNameInclusionStartWith
+          + ", variableNameInclusionEndWith="
+          + variableNameInclusionEndWith
+          + ", variableNameExclusionExact="
+          + variableNameExclusionExact
+          + ", variableNameExclusionStartWith="
+          + variableNameExclusionStartWith
+          + ", variableNameExclusionEndWith="
+          + variableNameExclusionEndWith
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -144,6 +144,11 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     };
   }
 
+  @Override
+  public IndexConfig filterIndexConfig() {
+    return index;
+  }
+
   public boolean getIsIncludeEnabledRecords() {
     return includeEnabledRecords;
   }
@@ -152,7 +157,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     this.includeEnabledRecords = includeEnabledRecords;
   }
 
-  public static class IndexConfiguration {
+  public static class IndexConfiguration implements IndexConfig {
 
     public static final int DEFAULT_INDEX_TEMPLATE_PRIORITY = 20;
     // prefix for index and templates
@@ -231,6 +236,14 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private Integer numberOfReplicas = null;
     private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
+    // variable name filters
+    private final List<String> variableNameInclusionExact = new ArrayList<>();
+    private final List<String> variableNameInclusionStartWith = new ArrayList<>();
+    private final List<String> variableNameInclusionEndWith = new ArrayList<>();
+    private final List<String> variableNameExclusionExact = new ArrayList<>();
+    private final List<String> variableNameExclusionStartWith = new ArrayList<>();
+    private final List<String> variableNameExclusionEndWith = new ArrayList<>();
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -253,6 +266,36 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
 
     public void setPriority(final int priority) {
       this.priority = priority;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionExact() {
+      return variableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionStartWith() {
+      return variableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getVariableNameInclusionEndWith() {
+      return variableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionExact() {
+      return variableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionStartWith() {
+      return variableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getVariableNameExclusionEndWith() {
+      return variableNameExclusionEndWith;
     }
 
     @Override
@@ -347,6 +390,19 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + conditionalSubscription
           + ", conditionalEvaluation="
           + conditionalEvaluation
+          // variable name filters
+          + ", variableNameInclusionExact="
+          + variableNameInclusionExact
+          + ", variableNameInclusionStartWith="
+          + variableNameInclusionStartWith
+          + ", variableNameInclusionEndWith="
+          + variableNameInclusionEndWith
+          + ", variableNameExclusionExact="
+          + variableNameExclusionExact
+          + ", variableNameExclusionStartWith="
+          + variableNameExclusionStartWith
+          + ", variableNameExclusionEndWith="
+          + variableNameExclusionEndWith
           + '}';
     }
   }


### PR DESCRIPTION
## Description

This PR introduces configurable name-based exporter filters.

 It adds six new configuration properties per search database (Elasticsearch/OpenSearch)—three inclusion lists and three exclusion lists, each using a different matching mode (exact, starts-with, ends-with). 

These lists are used to build a VariableNameFilter that decides which variable records are exported. 

This lays the groundwork for administrators to selectively limit which variables (and, in follow-up work, specific flow nodes and BPMN processes) are exported to Optimize, significantly reducing data volume. 

Smaller, more targeted exports improve performance across the pipeline: faster export generation, quicker ingestion into Optimize, reduced memory and storage consumption, and more efficient analysis.

## Related issues

closes https://github.com/camunda/camunda/issues/44137
