### PR TITLE
fix: do not spread key prop

### DIFF
--- a/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
+++ b/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
@@ -59,11 +59,15 @@ const PartiallyExpandableDataTable: React.FC<Props> = ({
             <TableHead>
               <TableRow>
                 <TableExpandHeader {...getExpandHeaderProps()} />
-                {headers.map((header) => (
-                  <TableHeader {...getHeaderProps({header})}>
-                    {header.header}
-                  </TableHeader>
-                ))}
+                {headers.map((header) => {
+                  const {key, ...props} = getHeaderProps({header});
+
+                  return (
+                    <TableHeader key={key} {...props}>
+                      {header.header}
+                    </TableHeader>
+                  );
+                })}
               </TableRow>
             </TableHead>
             <TableBody>

--- a/operate/client/src/App/Dashboard/v2/PartiallyExpandableDataTable/index.tsx
+++ b/operate/client/src/App/Dashboard/v2/PartiallyExpandableDataTable/index.tsx
@@ -59,11 +59,15 @@ const PartiallyExpandableDataTable: React.FC<Props> = ({
             <TableHead>
               <TableRow>
                 <TableExpandHeader {...getExpandHeaderProps()} />
-                {headers.map((header) => (
-                  <TableHeader {...getHeaderProps({header})}>
-                    {header.header}
-                  </TableHeader>
-                ))}
+                {headers.map((header) => {
+                  const {key, ...props} = getHeaderProps({header});
+
+                  return (
+                    <TableHeader key={key} {...props}>
+                      {header.header}
+                    </TableHeader>
+                  );
+                })}
               </TableRow>
             </TableHead>
             <TableBody>


### PR DESCRIPTION
## Description

Remove warning below

```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, sortDirection: ..., isSortable: ..., isSortHeader: ..., slug: ..., decorator: ..., onClick: ..., children: ...};
```
