### PR TITLE
Add AuditLogProcessInstanceRelated interface and implement required methods

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -121,6 +121,7 @@
       <column name="TENANT_ID" type="VARCHAR(${userCharColumnSize})"/>
       <column name="IS_PREVIEW" type="BOOLEAN"/>
       <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
     </createTable>
 
     <createIndex tableName="${prefix}VARIABLE" indexName="${prefix}IDX_VARIABLE_PROCESS_INSTANCE_KEY">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -31,7 +31,8 @@ public record VariableDbModel(
     Long rootProcessInstanceKey,
     String processDefinitionId,
     String tenantId,
-    int partitionId)
+    int partitionId,
+    Long elementInstanceKey)
     implements Copyable<VariableDbModel> {
 
   @Override
@@ -90,7 +91,8 @@ public record VariableDbModel(
         rootProcessInstanceKey,
         processDefinitionId,
         tenantId,
-        partitionId);
+        partitionId,
+        elementInstanceKey);
   }
 
   public static class VariableDbModelBuilder implements ObjectBuilder<VariableDbModel> {
@@ -104,6 +106,7 @@ public record VariableDbModel(
     private String processDefinitionId;
     private String tenantId;
     private int partitionId;
+    private Long elementInstanceKey;
 
     public VariableDbModelBuilder() {}
 
@@ -152,6 +155,11 @@ public record VariableDbModel(
       return this;
     }
 
+    public VariableDbModelBuilder elementInstanceKey(final Long elementInstanceKey) {
+      this.elementInstanceKey = elementInstanceKey;
+      return this;
+    }
+
     // Build method to create the record
     @Override
     public VariableDbModel build() {
@@ -179,7 +187,8 @@ public record VariableDbModel(
           rootProcessInstanceKey,
           processDefinitionId,
           tenantId,
-          partitionId);
+          partitionId,
+          elementInstanceKey);
     }
 
     private VariableDbModel getLongModel() {
@@ -197,7 +206,8 @@ public record VariableDbModel(
           rootProcessInstanceKey,
           processDefinitionId,
           tenantId,
-          partitionId);
+          partitionId,
+          elementInstanceKey);
     }
 
     private VariableDbModel getDoubleModel() {
@@ -215,7 +225,8 @@ public record VariableDbModel(
           rootProcessInstanceKey,
           processDefinitionId,
           tenantId,
-          partitionId);
+          partitionId,
+          elementInstanceKey);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -141,11 +141,11 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
                                    LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW,
-                                   PARTITION_ID)
+                                   PARTITION_ID, ELEMENT_INSTANCE_KEY)
     VALUES
     <foreach collection="dbModels" item="variable" separator=",">
       (#{variable.variableKey}, #{variable.processInstanceKey}, #{variable.rootProcessInstanceKey}, #{variable.processDefinitionId}, #{variable.scopeKey}, #{variable.type}, #{variable.name}, #{variable.doubleValue, jdbcType=DOUBLE},
-       #{variable.longValue, jdbcType=NUMERIC}, #{variable.value}, #{variable.fullValue}, #{variable.tenantId}, #{variable.isPreview}, #{variable.partitionId})
+       #{variable.longValue, jdbcType=NUMERIC}, #{variable.value}, #{variable.fullValue}, #{variable.tenantId}, #{variable.isPreview}, #{variable.partitionId}, #{variable.elementInstanceKey})
     </foreach>
   </insert>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
@@ -30,6 +30,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build();
 
     // then
@@ -45,6 +46,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -63,6 +65,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build();
 
     // then
@@ -78,6 +81,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -96,6 +100,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build();
 
     // then
@@ -111,6 +116,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -129,6 +135,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build();
 
     // then
@@ -144,6 +151,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -162,6 +170,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build();
 
     // then
@@ -177,6 +186,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -197,6 +207,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build()
             .truncateValue(variableSizeThreshold, null);
 
@@ -213,6 +224,7 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 
   @Test
@@ -234,6 +246,7 @@ public class VariableDbModelTest {
             .processInstanceKey(3L)
             .rootProcessInstanceKey(4L)
             .tenantId("tenant1")
+            .elementInstanceKey(5L)
             .build()
             .truncateValue(variableSizeThreshold, maxBytesThreshold);
 
@@ -250,5 +263,6 @@ public class VariableDbModelTest {
     assertThat(model.processInstanceKey()).isEqualTo(3L);
     assertThat(model.rootProcessInstanceKey()).isEqualTo(4L);
     assertThat(model.tenantId()).isEqualTo("tenant1");
+    assertThat(model.elementInstanceKey()).isEqualTo(5L);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/BatchInsertMergerTest.java
@@ -53,7 +53,8 @@ class BatchInsertMergerTest {
             200L,
             "process1",
             "tenant1",
-            1);
+            1,
+            -1L);
 
     final var variable2 =
         new VariableDbModel(
@@ -70,7 +71,8 @@ class BatchInsertMergerTest {
             201L,
             "process1",
             "tenant1",
-            1);
+            1,
+            -1L);
 
     final var merger = new InsertVariableMerger(variable2, 50);
     final var parameter = new BatchInsertDto<>(List.of(variable1));
@@ -208,7 +210,8 @@ class BatchInsertMergerTest {
             200L,
             "process1",
             "tenant1",
-            1);
+            1,
+            -1L);
 
     final var merger = new InsertVariableMerger(variable, 2); // Max batch size of 2
 
@@ -237,7 +240,8 @@ class BatchInsertMergerTest {
             200L,
             "process1",
             "tenant1",
-            1);
+            1,
+            -1L);
 
     final var merger = new InsertVariableMerger(variable, 1); // Max batch size of 1
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -65,6 +65,11 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
   }
 
   @Override
+  public long getElementInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bpmnProcessId;
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -228,7 +228,7 @@ public class AuditLogProcessOperationsIT {
         AuditLogOperationTypeEnum.MODIFY,
         processInstanceKey,
         processInstance.getProcessDefinitionKey(),
-        null);
+        SERVICE_TASKS_PROCESS_ID);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -192,7 +192,7 @@ public class AuditLogProcessOperationsIT {
         AuditLogOperationTypeEnum.MIGRATE,
         processInstanceKey,
         targetProcess.getProcessDefinitionKey(),
-        null);
+        PROCESS_V1_ID);
   }
 
   @Test

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -84,7 +85,8 @@ final class ImmutableProtocolArchTest {
   private DescribedPredicate<JavaClass> getExcludedClasses() {
     return Predicates.equivalentTo(ProcessInstanceRelated.class)
         .or(Predicates.equivalentTo(BatchOperationRelated.class))
-        .or(Predicates.equivalentTo(TenantOwned.class));
+        .or(Predicates.equivalentTo(TenantOwned.class))
+        .or(Predicates.equivalentTo(AuditLogProcessInstanceRelated.class));
   }
 
   private static final class BuilderCondition extends ArchCondition<JavaClass> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -198,6 +198,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     value.setTenantId(processInstanceRecord.getTenantId());
     value.setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
     value.setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey());
+    value.setBpmnProcessId(processInstanceRecord.getBpmnProcessId());
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
     responseWriter.writeEventOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -337,7 +337,8 @@ public final class ProcessInstanceModificationModifyProcessor
         .setProcessInstanceKey(value.getProcessInstanceKey())
         .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
         .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey())
-        .setTenantId(processInstanceRecord.getTenantId());
+        .setTenantId(processInstanceRecord.getTenantId())
+        .setBpmnProcessId(processInstanceRecord.getBpmnProcessId());
 
     final var requiredKeysForActivation =
         activateInstructions.stream()

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogTenant;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.util.DateUtil;
@@ -371,6 +372,8 @@ public class AuditLogEntry {
             .setBatchOperationKey(getBatchOperationKey(record))
             .setProcessInstanceKey(getProcessInstanceKey(record))
             .setProcessDefinitionKey(getProcessDefinitionKey(record))
+            .setElementInstanceKey(getElementInstanceKey(record))
+            .setProcessDefinitionId(getProcessDefinitionId(record))
             .setEntityVersion(record.getRecordVersion())
             .setEntityValueType(record.getValueType().value())
             .setEntityOperationIntent(record.getIntent().value())
@@ -381,30 +384,41 @@ public class AuditLogEntry {
 
   private static <R extends RecordValue> Long getProcessInstanceKey(final Record<R> record) {
     final var value = record.getValue();
-
     if (value instanceof ProcessInstanceRelated) {
       return ((ProcessInstanceRelated) value).getProcessInstanceKey();
-    } else {
-      return null;
     }
+    return null;
   }
 
   private static <R extends RecordValue> Long getProcessDefinitionKey(final Record<R> record) {
     final var value = record.getValue();
-
     if (value instanceof ProcessInstanceRelated) {
       return ((ProcessInstanceRelated) value).getProcessDefinitionKey();
-    } else {
-      return null;
     }
+    return null;
   }
 
   private static <R extends RecordValue> Long getBatchOperationKey(final Record<R> record) {
     final var batchOperationKey = record.getBatchOperationReference();
     if (RecordMetadataDecoder.batchOperationReferenceNullValue() != batchOperationKey) {
       return batchOperationKey;
-    } else {
-      return null;
     }
+    return null;
+  }
+
+  private static <R extends RecordValue> Long getElementInstanceKey(final Record<R> record) {
+    final var value = record.getValue();
+    if (value instanceof AuditLogProcessInstanceRelated) {
+      return ((AuditLogProcessInstanceRelated) value).getElementInstanceKey();
+    }
+    return null;
+  }
+
+  private static <R extends RecordValue> String getProcessDefinitionId(final Record<R> record) {
+    final var value = record.getValue();
+    if (value instanceof AuditLogProcessInstanceRelated) {
+      return ((AuditLogProcessInstanceRelated) value).getBpmnProcessId();
+    }
+    return null;
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/IncidentResolutionAuditLogTransformer.java
@@ -22,11 +22,7 @@ public class IncidentResolutionAuditLogTransformer
   @Override
   public void transform(final Record<IncidentRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setProcessDefinitionId(value.getBpmnProcessId())
-        .setProcessDefinitionKey(value.getProcessDefinitionKey())
-        .setProcessInstanceKey(value.getProcessInstanceKey())
-        .setElementInstanceKey(value.getElementInstanceKey())
-        .setJobKey(value.getJobKey());
+    log.setJobKey(value.getJobKey());
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCancelAuditLogTransformer.java
@@ -23,10 +23,6 @@ public class ProcessInstanceCancelAuditLogTransformer
 
   @Override
   public void transform(final Record<ProcessInstanceRecordValue> record, final AuditLogEntry log) {
-    final var value = record.getValue();
-    log.setProcessDefinitionId(record.getValue().getBpmnProcessId())
-        .setProcessDefinitionKey(value.getProcessDefinitionKey())
-        .setProcessInstanceKey(value.getProcessInstanceKey());
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceCreationAuditLogTransformer.java
@@ -22,10 +22,6 @@ public class ProcessInstanceCreationAuditLogTransformer
   @Override
   public void transform(
       final Record<ProcessInstanceCreationRecordValue> record, final AuditLogEntry log) {
-    final var value = record.getValue();
-    log.setProcessInstanceKey(value.getProcessInstanceKey())
-        .setProcessDefinitionId(value.getBpmnProcessId())
-        .setProcessDefinitionKey(value.getProcessDefinitionKey());
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceMigrationAuditLogTransformer.java
@@ -25,9 +25,8 @@ public class ProcessInstanceMigrationAuditLogTransformer
   public void transform(
       final Record<ProcessInstanceMigrationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setProcessDefinitionKey(value.getTargetProcessDefinitionKey())
-        .setProcessInstanceKey(value.getProcessInstanceKey());
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    log.setProcessDefinitionKey(value.getTargetProcessDefinitionKey());
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);
     }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformer.java
@@ -24,8 +24,6 @@ public class ProcessInstanceModificationAuditLogTransformer
   @Override
   public void transform(
       final Record<ProcessInstanceModificationRecordValue> record, final AuditLogEntry log) {
-    final var value = record.getValue();
-    log.setProcessInstanceKey(value.getProcessInstanceKey());
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
@@ -21,11 +21,6 @@ public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTask
   @Override
   public void transform(final Record<UserTaskRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setProcessDefinitionId(value.getBpmnProcessId())
-        .setProcessDefinitionKey(value.getProcessDefinitionKey())
-        .setProcessInstanceKey(value.getProcessInstanceKey())
-        .setElementInstanceKey(value.getElementInstanceKey())
-        .setUserTaskKey(value.getUserTaskKey())
-        .setEntityKey(String.valueOf(value.getUserTaskKey()));
+    log.setUserTaskKey(value.getUserTaskKey()).setEntityKey(String.valueOf(value.getUserTaskKey()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
-import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 
 public class VariableAddUpdateAuditLogTransformer
@@ -17,14 +15,5 @@ public class VariableAddUpdateAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.VARIABLE_ADD_UPDATE_CONFIG;
-  }
-
-  @Override
-  public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
-    final var value = record.getValue();
-    log.setProcessInstanceKey(value.getProcessInstanceKey())
-        .setProcessDefinitionId(value.getBpmnProcessId())
-        .setProcessDefinitionKey(value.getProcessDefinitionKey())
-        .setElementInstanceKey(value.getScopeKey());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntryTest.java
@@ -67,6 +67,7 @@ class AuditLogEntryTest {
 
     assertThat(entry.getBatchOperationKey()).isEqualTo(123L); // no batch operation in this record
     assertThat(entry.getProcessInstanceKey()).isEqualTo(value.getProcessInstanceKey());
+    assertThat(entry.getProcessDefinitionId()).isEqualTo(value.getBpmnProcessId());
     assertThat(entry.getProcessDefinitionKey()).isEqualTo(value.getProcessDefinitionKey());
     assertThat(entry.getEntityVersion()).isEqualTo(record.getRecordVersion());
     assertThat(entry.getEntityValueType())
@@ -76,13 +77,12 @@ class AuditLogEntryTest {
     assertThat(entry.getTimestamp())
         .isEqualTo(
             OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC));
+    assertThat(entry.getElementInstanceKey()).isEqualTo(-1L);
 
     // Verify fields that are NOT set by AuditLogEntry.of() are null/empty
     assertThat(entry.getBatchOperationType()).isNull();
     assertThat(entry.getResult()).isNull();
     assertThat(entry.getAnnotation()).isNull();
-    assertThat(entry.getProcessDefinitionId()).isNull();
-    assertThat(entry.getElementInstanceKey()).isNull();
     assertThat(entry.getJobKey()).isNull();
     assertThat(entry.getUserTaskKey()).isNull();
     assertThat(entry.getDecisionEvaluationKey()).isNull();

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceModificationAuditLogTransformerTest.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.jupiter.api.Test;
 
-class ProcessInstanceModifiedAuditLogTransformerTest {
+class ProcessInstanceModificationAuditLogTransformerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final ProcessInstanceModificationAuditLogTransformer transformer =
@@ -32,7 +32,9 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
         ImmutableProcessInstanceModificationRecordValue.builder()
             .from(factory.generateObject(ProcessInstanceModificationRecordValue.class))
             .withProcessInstanceKey(123L)
+            .withProcessDefinitionKey(234L)
             .withTenantId("tenant-1")
+            .withBpmnProcessId("bpmnProcessId")
             .build();
 
     final Record<ProcessInstanceModificationRecordValue> record =
@@ -46,6 +48,8 @@ class ProcessInstanceModifiedAuditLogTransformerTest {
 
     // then
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
+    assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmnProcessId");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(234L);
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.MODIFY);
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
@@ -47,6 +47,7 @@ class UserTaskAuditLogTransformerTest {
 
     // then
     assertThat(entity.getUserTaskKey()).isEqualTo(123L);
+    assertThat(entity.getEntityKey()).isEqualTo("123");
     assertThat(entity.getProcessInstanceKey()).isEqualTo(456L);
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(789L);
     assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -62,6 +62,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -43,6 +43,12 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -100,6 +100,12 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -71,7 +71,7 @@
               "type": "keyword"
             },
             "elementInstanceKey": {
-              "type": "long"
+              "enabled": "false"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -69,6 +69,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -43,6 +43,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -62,6 +62,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-migration-template.json
@@ -43,6 +43,12 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -100,6 +100,12 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -71,7 +71,7 @@
               "type": "keyword"
             },
             "elementInstanceKey": {
-              "type": "long"
+              "enabled": "false"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -69,6 +69,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -43,6 +43,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "elementInstanceKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
@@ -52,6 +52,7 @@ public class VariableExportHandler implements RdbmsExportHandler<VariableRecordV
         .rootProcessInstanceKey(value.getRootProcessInstanceKey())
         .processDefinitionId(value.getBpmnProcessId())
         .tenantId(value.getTenantId())
+        .elementInstanceKey(value.getElementInstanceKey())
         .partitionId(record.getPartitionId())
         .build();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -33,6 +33,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -48,15 +49,17 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceMigrationRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(processDefinitionKeyProperty);
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
   }
 
   @Override
@@ -118,6 +121,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   public ProcessInstanceMigrationRecord setRootProcessInstanceKey(
       final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -39,6 +39,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -46,6 +47,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
       terminateInstructionsProperty =
@@ -64,7 +66,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceModificationRecord() {
-    super(8);
+    super(9);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -72,7 +74,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(activatedElementInstanceKeys)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(processDefinitionKeyProperty);
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
   }
 
   /**
@@ -216,6 +219,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   public ProcessInstanceModificationRecord setProcessDefinitionKey(
       final long processDefinitionKey) {
     processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceModificationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1756,7 +1756,8 @@ final class JsonSerializableToJsonTest {
                   "runtimeInstructions": [],
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 3,
-                  "businessId": "business-id-456"
+                  "businessId": "business-id-456",
+                  "elementInstanceKey": -1
                 }
                 """
       },
@@ -1781,7 +1782,8 @@ final class JsonSerializableToJsonTest {
                   "runtimeInstructions": [],
                   "tags": [],
                   "rootProcessInstanceKey": -1,
-                  "businessId": ""
+                  "businessId": "",
+                  "elementInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2961,7 +2961,8 @@ final class JsonSerializableToJsonTest {
                         new ProcessInstanceMigrationMappingInstruction()
                             .setTargetElementId("targetId3"))
                     .setRootProcessInstanceKey(321L)
-                    .setProcessDefinitionKey(234L),
+                    .setProcessDefinitionKey(234L)
+                    .setBpmnProcessId("bpmnProcessId"),
         """
                 {
                   "tenantId": "tenantId",
@@ -2978,7 +2979,9 @@ final class JsonSerializableToJsonTest {
                     "targetElementId": "targetId3"
                   }],
                   "rootProcessInstanceKey": 321,
-                  "processDefinitionKey": 234
+                  "processDefinitionKey": 234,
+                  "bpmnProcessId": "bpmnProcessId",
+                  "elementInstanceKey": -1
                 }
                 """
       },
@@ -3002,7 +3005,9 @@ final class JsonSerializableToJsonTest {
                   "targetProcessDefinitionKey": 456,
                   "mappingInstructions": [],
                   "rootProcessInstanceKey": -1,
-                  "processDefinitionKey": -1
+                  "processDefinitionKey": -1,
+                  "bpmnProcessId": "",
+                  "elementInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1806,6 +1806,7 @@ final class JsonSerializableToJsonTest {
               final var variableInstructionElementId = "sub-process";
               final var rootProcessInstanceKey = 4L;
               final var processDefinitionKey = 5L;
+              final var bpmnProcessId = "bpmnProcessId";
 
               return new ProcessInstanceModificationRecord()
                   .setProcessInstanceKey(key)
@@ -1834,7 +1835,8 @@ final class JsonSerializableToJsonTest {
                                   .setElementId(variableInstructionElementId))
                           .addAncestorScopeKeys(Set.of(key, ancestorScopeKey)))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
-                  .setProcessDefinitionKey(processDefinitionKey);
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setBpmnProcessId(bpmnProcessId);
             },
         """
                 {
@@ -1871,7 +1873,9 @@ final class JsonSerializableToJsonTest {
                   "ancestorScopeKeys": [1,3],
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 4,
-                  "processDefinitionKey": 5
+                  "processDefinitionKey": 5,
+                  "bpmnProcessId": "bpmnProcessId",
+                  "elementInstanceKey": -1
                 }
                 """
       },
@@ -1894,7 +1898,9 @@ final class JsonSerializableToJsonTest {
                   "ancestorScopeKeys": [],
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
-                  "processDefinitionKey": -1
+                  "processDefinitionKey": -1,
+                  "bpmnProcessId": "",
+                  "elementInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1963,7 +1963,8 @@ final class JsonSerializableToJsonTest {
                   "callingElementPath": [12345, 67890],
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 9999,
-                  "businessId": "business-id-123"
+                  "businessId": "business-id-123",
+                  "elementInstanceKey": -1
                 }
                 """
       },
@@ -1994,7 +1995,8 @@ final class JsonSerializableToJsonTest {
                   "callingElementPath": [],
                   "tags": [],
                   "rootProcessInstanceKey": -1,
-                  "businessId": ""
+                  "businessId": "",
+                  "elementInstanceKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1612,7 +1612,8 @@ final class JsonSerializableToJsonTest {
                   "name": "x",
                   "value": "1",
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": 5
+                  "rootProcessInstanceKey": 5,
+                  "elementInstanceKey": 3
                 }
                 """
       },
@@ -1649,7 +1650,8 @@ final class JsonSerializableToJsonTest {
                   "name": "x",
                   "value": "1",
                   "tenantId": "tenant-test",
-                  "rootProcessInstanceKey": 5
+                  "rootProcessInstanceKey": 5,
+                  "elementInstanceKey": 3
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
@@ -33,6 +33,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -48,15 +49,17 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceMigrationRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(processDefinitionKeyProperty);
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
   }
 
   @Override
@@ -140,6 +143,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
@@ -39,6 +39,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -46,6 +47,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
       terminateInstructionsProperty =
@@ -64,7 +66,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceModificationRecord() {
-    super(8);
+    super(9);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -72,7 +74,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(activatedElementInstanceKeys)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(processDefinitionKeyProperty);
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
   }
 
   /**
@@ -216,6 +219,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   public ProcessInstanceModificationRecord setProcessDefinitionKey(
       final long processDefinitionKey) {
     processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceModificationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuditLogProcessInstanceRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuditLogProcessInstanceRelated.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public interface AuditLogProcessInstanceRelated {
+
+  /**
+   * @return the key of the related element instance, or -1 if not applicable
+   */
+  default long getElementInstanceKey() {
+    return -1L;
+  }
+
+  /**
+   * @return the BPMN process id of the corresponding process definition
+   */
+  String getBpmnProcessId();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -28,7 +28,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableIncidentRecordValue.Builder.class)
-public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated, TenantOwned {
+public interface IncidentRecordValue
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
   /**
    * @return the type of error this incident is caused by. Can be <code>UNKNOWN</code> if the
    *     incident record is part of a {@link IncidentIntent#RESOLVE} command.
@@ -42,23 +43,18 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
   String getErrorMessage();
 
   /**
-   * @return the BPMN process id this incident belongs to. Can be empty if the incident record is
-   *     part of a {@link IncidentIntent#RESOLVE} command.
-   */
-  String getBpmnProcessId();
-
-  /**
-   * @return the key of the process this incident belongs to. Can be <code>-1</code> if the incident
-   *     record is part of a {@link IncidentIntent#RESOLVE} command.
-   */
-  long getProcessDefinitionKey();
-
-  /**
    * @return the key of the process instance this incident belongs to. Can be <code>-1</code> if the
    *     incident record is part of a {@link IncidentIntent#RESOLVE} command.
    */
   @Override
   long getProcessInstanceKey();
+
+  /**
+   * @return the key of the process this incident belongs to. Can be <code>-1</code> if the incident
+   *     record is part of a {@link IncidentIntent#RESOLVE} command.
+   */
+  @Override
+  long getProcessDefinitionKey();
 
   /**
    * @return the id of the element this incident belongs to. Can be empty if incident record is part
@@ -70,7 +66,15 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    * @return the key of the element instance this incident belongs to. Can be <code>-1</code> if the
    *     incident record is part of a {@link IncidentIntent#RESOLVE} command.
    */
+  @Override
   long getElementInstanceKey();
+
+  /**
+   * @return the BPMN process id this incident belongs to. Can be empty if the incident record is
+   *     part of a {@link IncidentIntent#RESOLVE} command.
+   */
+  @Override
+  String getBpmnProcessId();
 
   /**
    * @return the key of the job this incident belongs to. Can be <code>-1</code> if the incident

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -24,10 +24,14 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceCreationRecordValue.Builder.class)
 public interface ProcessInstanceCreationRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        TenantOwned {
   /**
    * @return the BPMN process id to create a process from
    */
+  @Override
   String getBpmnProcessId();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceMigrationRecordValue.Builder.class)
 public interface ProcessInstanceMigrationRecordValue
-    extends RecordValue, ProcessInstanceRelated, TenantOwned {
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
 
   /**
    * @return the key of the process definition to migrate to

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceModificationRecordValue.Builder.class)
 public interface ProcessInstanceModificationRecordValue
-    extends RecordValue, ProcessInstanceRelated, TenantOwned {
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
 
   /** Returns a list of terminate instructions (if available), or an empty list. */
   List<ProcessInstanceModificationTerminateInstructionValue> getTerminateInstructions();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -30,10 +30,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceRecordValue.Builder.class)
 public interface ProcessInstanceRecordValue
-    extends RecordValue, ProcessInstanceRelated, TenantOwned {
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
   /**
    * @return the BPMN process id this process instance belongs to.
    */
+  @Override
   String getBpmnProcessId();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -31,7 +31,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableUserTaskRecordValue.Builder.class)
 public interface UserTaskRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        TenantOwned {
 
   long getUserTaskKey();
 
@@ -65,11 +68,13 @@ public interface UserTaskRecordValue
   /**
    * @return the element instance key of the corresponding user task
    */
+  @Override
   long getElementInstanceKey();
 
   /**
    * @return the bpmn process id of the corresponding process definition
    */
+  @Override
   String getBpmnProcessId();
 
   /**
@@ -80,6 +85,7 @@ public interface UserTaskRecordValue
   /**
    * @return the process key of the corresponding process definition
    */
+  @Override
   long getProcessDefinitionKey();
 
   int getPriority();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -27,7 +27,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableVariableRecordValue.Builder.class)
-public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated, TenantOwned {
+public interface VariableRecordValue
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
 
   /**
    * @return the name of the variable.
@@ -53,11 +54,21 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
   /**
    * @return the key of the process the variable belongs to
    */
+  @Override
   long getProcessDefinitionKey();
+
+  /**
+   * @return the element instance key of the scope the variable belongs to.
+   */
+  @Override
+  default long getElementInstanceKey() {
+    return getScopeKey();
+  }
 
   /**
    * @return the BPMN process id this process instance belongs to.
    */
+  @Override
   String getBpmnProcessId();
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds an `AuditLogProcessInstanceRelated` interface to records that both implement the `ProcessInstanceRelated` interface and is being transformed into an audit log.

## Checklist

- [x] Create AuditLogProcessInstanceRelated interface and use it in `AuditLogEntry`
- [x] Add AuditLogProcessInstanceRelated interface to the following items:
- - [x] IncidentRecordValue
- - [x] ProcessInstanceRecordValue
- - [x] ProcessInstanceCreationRecordValue
- - [x] ProcessInstanceMigrationRecordValue
- - [x] ProcessInstanceModificationRecordValue
- - [x] UserTaskRecordValue
- - [x] VariableRecordValue

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43760 and #43757 
