### PR TITLE
feat: renamed bom, created deprecated bom and migrated to new bom

### DIFF
--- a/bom-deprecated/README.md
+++ b/bom-deprecated/README.md
@@ -1,0 +1,4 @@
+# Zeebe BOM
+
+Deprecated, please use Camunda BOM.
+

--- a/bom-deprecated/pom.xml
+++ b/bom-deprecated/pom.xml
@@ -4,16 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.camunda</groupId>
-    <artifactId>camunda-release-parent</artifactId>
-    <version>4.1.1</version>
-    <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath/>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-bom</artifactId>
+    <version>8.9.0-SNAPSHOT</version>
+    <relativePath>../bom/pom.xml</relativePath>
   </parent>
 
-  <groupId>io.camunda</groupId>
   <artifactId>zeebe-bom</artifactId>
-  <version>8.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe BOM</name>

--- a/bom-deprecated/pom.xml
+++ b/bom-deprecated/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda</groupId>
+    <artifactId>camunda-release-parent</artifactId>
+    <version>4.1.1</version>
+    <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
+    <relativePath/>
+  </parent>
+
+  <groupId>io.camunda</groupId>
+  <artifactId>zeebe-bom</artifactId>
+  <version>8.9.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Zeebe BOM</name>
+  <description>${project.name}</description>
+  <url>http://zeebe.io/</url>
+  <inceptionYear>2017</inceptionYear>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-bom</artifactId>
+    </relocation>
+  </distributionManagement>
+</project>

--- a/bom/README.md
+++ b/bom/README.md
@@ -1,12 +1,11 @@
-# Zeebe BOM
+# Camunda BOM
 
-The Bill of Materials (BOM) is the recommended way for third-party projects to import Zeebe
+The Bill of Materials (BOM) is the recommended way for third-party projects to import Camunda
 dependencies. It bundles dependencies that we consider consumable.
 
 These dependencies receive special attention from the team when it comes to backwards compatibility.
 The team will try to maintain backwards compatibility for these libraries, but this does not mean
-that we guarantee it. For our official backwards compatibility guarantees, please refer to the
-[Public API documentation](https://docs.camunda.io/docs/apis-clients/public-api/).
+that we guarantee it.
 
 ## Usage
 
@@ -18,7 +17,7 @@ section of your pom.
     <dependencies>
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-bom</artifactId>
+        <artifactId>camunda-bom</artifactId>
         <version>X.Y.Z</version>
         <scope>import</scope>
         <type>pom</type>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -12,14 +12,14 @@
   </parent>
 
   <groupId>io.camunda</groupId>
-  <artifactId>zeebe-bom</artifactId>
+  <artifactId>camunda-bom</artifactId>
   <version>8.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Zeebe BOM</name>
+  <name>Camunda BOM</name>
   <description>${project.name}</description>
-  <url>http://zeebe.io/</url>
-  <inceptionYear>2017</inceptionYear>
+  <url>http://camunda.com/</url>
+  <inceptionYear>2025</inceptionYear>
 
   <scm>
     <connection>scm:git:git@github.com:camunda/camunda.git</connection>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <!-- We can't reference zeebe parent as parent otherwise we will have a circle dependency -->
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-bom</artifactId>
+    <artifactId>camunda-bom</artifactId>
     <version>8.9.0-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-bom</artifactId>
+    <artifactId>camunda-bom</artifactId>
     <version>8.9.0-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
   <modules>
     <module>bom</module>
+    <module>bom-deprecated</module>
     <module>parent</module>
     <module>library-parent</module>
     <module>dist</module>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR renames the bom from `io.camunda:zeebe-bom` to `io.camunda:camunda-bom`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #22058 
