### PR TITLE
docs: clarify focus of developer documentation site

### DIFF
--- a/docs/monorepo-docs/index.md
+++ b/docs/monorepo-docs/index.md
@@ -1,10 +1,15 @@
-# Camunda Platform Documentation
+# Camunda Platform Developer Documentation
 
 Welcome to the developer documentation for the Camunda platform and orchestration cluster.
 
-## Documentation
+## Documentation for developers of Camunda 8
 
-This site contains comprehensive documentation for the Camunda platform development and deployment:
+This site contains comprehensive documentation for developers of Camunda 8's development, CI, and release process:
+
+:::tip
+If you're looking for product documentation about Camunda 8, check out https://docs.camunda.io.
+There you'll find anything to get started using Camunda 8, best practices, and reference documentation.
+:::
 
 ### Collaboration
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Updated the title and content to focus on developer documentation for Camunda 8 rather than product documentation.

It should be clear to folks that reach this page that this is not product documentation and not meant for developers using Camunda 8 but rather for developers working on Camunda 8.

<img width="1046" height="565" alt="Screenshot 2026-02-05 at 08 51 49" src="https://github.com/user-attachments/assets/0311848b-f1f1-41fa-a499-862c83a2d3db" />

## Related issues

NA
