### PR TITLE
feat: startup script supports new restore options

### DIFF
--- a/zeebe/docker/utils/startup.sh
+++ b/zeebe/docker/utils/startup.sh
@@ -1,10 +1,15 @@
 #!/bin/sh -xeu
 
-
 if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
     exec /usr/local/zeebe/bin/gateway
 elif [ "$ZEEBE_RESTORE" = "true" ]; then
-    exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+  if [ "$ZEEBE_RESTORE_FROM_BACKUP_ID" ]; then
+    exec /usr/local/zeebe/bin/restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+  elif [ -z "$ZEEBE_RESTORE_TO_TIMESTAMP" ]; then
+    exec /usr/local/zeebe/bin/restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+  else
+    exec /usr/local/zeebe/bin/restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+  fi
 else
-    exec /usr/local/zeebe/bin/broker
+  exec /usr/local/zeebe/bin/broker
 fi


### PR DESCRIPTION
Updates the startup script to add new restore options. The script now supports restoring from a specific timestamp or a range between two timestamps, in addition to restoring from a backup ID.

closes #45011