### PR TITLE
feat: eliminate ancestor selection requirement and refactor related logic

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -420,13 +420,6 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
           return;
         }
 
-        if (modificationsStore.state.status === 'requires-ancestor-selection') {
-          return modificationsStore.setAncestorFlowNodeKeyForMoveOperation({
-            instanceKey: scopeKey,
-            flowNodeId: elementId,
-          });
-        }
-
         if (modificationsStore.state.status === 'adding-token') {
           modificationsStore.finishAddingToken(
             businessObjects,
@@ -610,13 +603,6 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
 
         if (modificationsStore.state.status === 'moving-token') {
           return;
-        }
-
-        if (modificationsStore.state.status === 'requires-ancestor-selection') {
-          return modificationsStore.setAncestorFlowNodeKeyForMoveOperation({
-            instanceKey: scopeKey,
-            flowNodeId: elementId,
-          });
         }
 
         if (modificationsStore.state.status === 'adding-token') {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -52,7 +52,6 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
-import * as modificationsUtils from 'modules/utils/modifications';
 
 const mockIncidents = {
   page: {totalItems: 1},
@@ -609,11 +608,6 @@ describe('TopPanel', () => {
       },
     });
 
-    const finishMovingTokenSpy = vi.spyOn(
-      modificationsUtils,
-      'finishMovingToken',
-    );
-
     const {user} = render(<TopPanel />, {
       wrapper: getWrapper(),
     });
@@ -634,16 +628,12 @@ describe('TopPanel', () => {
 
     await user.click(await screen.findByTestId('task-2'));
 
-    expect(finishMovingTokenSpy).toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Object),
-      expect.any(String),
-      'task-2',
-      'sourceParent',
-    );
-
-    finishMovingTokenSpy.mockRestore();
+    const modifications = modificationsStore.state.modifications;
+    expect(modifications).toHaveLength(1);
+    expect(modifications[0].payload).toMatchObject({
+      operation: 'MOVE_TOKEN',
+      ancestorScopeType: 'sourceParent',
+    });
   });
 
   /* eslint-disable vitest/no-standalone-expect -- eslint doesn't understand dynamically skipped tests */

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -52,6 +52,7 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
+import * as modificationsUtils from 'modules/utils/modifications';
 
 const mockIncidents = {
   page: {totalItems: 1},
@@ -567,7 +568,7 @@ describe('TopPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should render modification info banner when move modification requires an ancestor', async () => {
+  it('should pass the ancestor type if move modification requires an ancestor', async () => {
     mockFetchProcessDefinitionXml().withSuccess(
       open('subprocessInsideMultiInstance.bpmn'),
     );
@@ -608,6 +609,11 @@ describe('TopPanel', () => {
       },
     });
 
+    const finishMovingTokenSpy = vi.spyOn(
+      modificationsUtils,
+      'finishMovingToken',
+    );
+
     const {user} = render(<TopPanel />, {
       wrapper: getWrapper(),
     });
@@ -628,11 +634,16 @@ describe('TopPanel', () => {
 
     await user.click(await screen.findByTestId('task-2'));
 
-    expect(
-      await screen.findByText(
-        /Target flow node has multiple parent scopes. Please select parent node from Instance History to move./i,
-      ),
-    ).toBeInTheDocument();
+    expect(finishMovingTokenSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Object),
+      expect.any(String),
+      'task-2',
+      'sourceParent',
+    );
+
+    finishMovingTokenSpy.mockRestore();
   });
 
   /* eslint-disable vitest/no-standalone-expect -- eslint doesn't understand dynamically skipped tests */

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -77,7 +77,7 @@ import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {isInstanceRunning} from 'modules/utils/instance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
-import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
+import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram';
 
 const OVERLAY_TYPE_STATE = 'flowNodeState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
@@ -350,10 +350,6 @@ const TopPanel: React.FC = observer(() => {
           isOpen={isIncidentBarOpen}
         />
       )}
-
-      {modificationsStore.state.status === 'requires-ancestor-selection' && (
-        <ModificationInfoBanner text="Target flow node has multiple parent scopes. Please select parent node from Instance History to move." />
-      )}
       {modificationsStore.state.status === 'moving-token' &&
         businessObjects && (
           <ModificationInfoBanner
@@ -425,8 +421,10 @@ const TopPanel: React.FC = observer(() => {
                 }}
                 onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
                   if (modificationsStore.state.status === 'moving-token') {
-                    const ancestorSelectionRequired = hasMultipleScopes(
-                      businessObjects[flowNodeId ?? ''],
+                    const ancestorScopeType = getAncestorScopeType(
+                      businessObjects,
+                      sourceFlowNodeIdForMoveOperation ?? '',
+                      flowNodeId ?? '',
                       totalRunningInstancesByFlowNode,
                     );
 
@@ -441,7 +439,7 @@ const TopPanel: React.FC = observer(() => {
                       businessObjects,
                       processInstance?.processDefinitionId,
                       flowNodeId,
-                      ancestorSelectionRequired,
+                      ancestorScopeType,
                     );
                   } else {
                     if (modificationsStore.state.status !== 'adding-token') {

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -104,11 +104,6 @@ const useModifiableFlowNodes = () => {
   const appendableFlowNodes = useAppendableFlowNodes();
   const cancellableFlowNodes = useCancellableFlowNodes();
 
-  // disable all flownodes while ancestor selection is required
-  if (modificationsStore.state.status === 'requires-ancestor-selection') {
-    return [];
-  }
-
   if (modificationsStore.state.status === 'moving-token') {
     return appendableFlowNodes.filter(
       (flowNodeId) =>

--- a/operate/client/src/modules/utils/instanceHistoryModification.ts
+++ b/operate/client/src/modules/utils/instanceHistoryModification.ts
@@ -103,6 +103,7 @@ const getParentInstanceIdForPlaceholder = (
   }
 
   if (
+    'ancestorElement' in modificationPayload &&
     modificationPayload.ancestorElement !== undefined &&
     parentFlowNodeId === modificationPayload.ancestorElement.flowNodeId
   ) {

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -12,7 +12,10 @@ import {modificationsStore} from 'modules/stores/modifications';
 import {tracking} from 'modules/tracking';
 import {generateUniqueID} from './generateUniqueID';
 import {TOKEN_OPERATIONS} from 'modules/constants';
-import {getFlowNodeParents} from './processInstanceDetailsDiagram';
+import {
+  getFlowNodeParents,
+  type AncestorScopeType,
+} from './processInstanceDetailsDiagram';
 
 const cancelAllTokens = (
   flowNodeId: string,
@@ -34,7 +37,7 @@ const finishMovingToken = (
   businessObjects: BusinessObjects,
   bpmnProcessId?: string,
   targetFlowNodeId?: string,
-  ancestorSelectionRequired?: boolean,
+  ancestorScopeType?: AncestorScopeType,
 ) => {
   tracking.track({
     eventName: 'move-token',
@@ -69,14 +72,11 @@ const finishMovingToken = (
       newScopeCount,
       businessObjects,
       bpmnProcessId,
+      ancestorScopeType,
     });
   }
 
-  if (ancestorSelectionRequired) {
-    modificationsStore.setStatus('requires-ancestor-selection');
-  } else {
-    modificationsStore.setStatus('enabled');
-  }
+  modificationsStore.setStatus('enabled');
   modificationsStore.setSourceFlowNodeIdForMoveOperation(null);
   modificationsStore.setSourceFlowNodeInstanceKeyForMoveOperation(null);
 };

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -8,14 +8,14 @@
 
 import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
-import {modificationsStore} from 'modules/stores/modifications';
+import {
+  modificationsStore,
+  type AncestorScopeType,
+} from 'modules/stores/modifications';
 import {tracking} from 'modules/tracking';
 import {generateUniqueID} from './generateUniqueID';
 import {TOKEN_OPERATIONS} from 'modules/constants';
-import {
-  getFlowNodeParents,
-  type AncestorScopeType,
-} from './processInstanceDetailsDiagram';
+import {getFlowNodeParents} from './processInstanceDetailsDiagram';
 
 const cancelAllTokens = (
   flowNodeId: string,

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
@@ -6,8 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {hasMultipleScopes} from './processInstanceDetailsDiagram';
-import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {
+  hasMultipleScopes,
+  areInSameRunningScope,
+  getAncestorScopeType,
+} from './processInstanceDetailsDiagram';
+import type {
+  BusinessObject,
+  BusinessObjects,
+} from 'bpmn-js/lib/NavigatedViewer';
 
 describe('hasMultipleScopes', () => {
   it('should return false if parentFlowNode is undefined', () => {
@@ -206,5 +213,376 @@ describe('hasMultipleScopes', () => {
       totalRunningInstancesByFlowNode,
     );
     expect(result).toBe(true);
+  });
+});
+
+describe('areInSameRunningScope', () => {
+  it('should return false if source flow node does not exist', () => {
+    const businessObjects: BusinessObjects = {
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+      },
+    };
+
+    const result = areInSameRunningScope(businessObjects, 'node1', 'node2', {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false if target flow node does not exist', () => {
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+      },
+    };
+
+    const result = areInSameRunningScope(businessObjects, 'node1', 'node2', {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false if source flow node has no parent', () => {
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: undefined,
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: {
+          id: 'process',
+          name: 'Process',
+          $type: 'bpmn:Process',
+        },
+      },
+    };
+
+    const result = areInSameRunningScope(businessObjects, 'node1', 'node2', {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false if target flow node has no parent', () => {
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: {
+          id: 'process',
+          name: 'Process',
+          $type: 'bpmn:Process',
+        },
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: undefined,
+      },
+    };
+
+    const result = areInSameRunningScope(businessObjects, 'node1', 'node2', {});
+    expect(result).toBe(false);
+  });
+
+  it('should return true if nodes share the same parent and it has running instances', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      process: parentProcess,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      process: 1,
+    };
+
+    const result = areInSameRunningScope(
+      businessObjects,
+      'node1',
+      'node2',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return false if nodes share the same parent but it has no running instances', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      process: parentProcess,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      process: 0,
+    };
+
+    const result = areInSameRunningScope(
+      businessObjects,
+      'node1',
+      'node2',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return false if nodes have different parents', () => {
+    const process1: BusinessObject = {
+      id: 'process1',
+      name: 'Process 1',
+      $type: 'bpmn:Process',
+    };
+
+    const process2: BusinessObject = {
+      id: 'process2',
+      name: 'Process 2',
+      $type: 'bpmn:Process',
+    };
+
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: process1,
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: process2,
+      },
+      process1,
+      process2,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      process1: 1,
+      process2: 1,
+    };
+
+    const result = areInSameRunningScope(
+      businessObjects,
+      'node1',
+      'node2',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return false when totalRunningInstancesByFlowNode is undefined', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const businessObjects: BusinessObjects = {
+      node1: {
+        id: 'node1',
+        name: 'Node 1',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      node2: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      process: parentProcess,
+    };
+
+    const result = areInSameRunningScope(
+      businessObjects,
+      'node1',
+      'node2',
+      undefined,
+    );
+    expect(result).toBe(false);
+  });
+});
+
+describe('getAncestorScopeType', () => {
+  it('should return undefined when target does not have multiple scopes', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const targetFlowNode: BusinessObject = {
+      id: 'task-1',
+      name: 'Task 1',
+      $type: 'bpmn:ServiceTask',
+      $parent: parentProcess,
+    };
+
+    const businessObjects: BusinessObjects = {
+      'task-1': targetFlowNode,
+      'task-2': {
+        id: 'task-2',
+        name: 'Task 2',
+        $type: 'bpmn:ServiceTask',
+        $parent: parentProcess,
+      },
+      process: parentProcess,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      process: 1,
+    };
+
+    const result = getAncestorScopeType(
+      businessObjects,
+      'task-2',
+      'task-1',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('should return "sourceParent" when target has multiple scopes and nodes are in same running scope', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const subprocess: BusinessObject = {
+      id: 'subprocess',
+      name: 'Subprocess',
+      $type: 'bpmn:SubProcess',
+      $parent: parentProcess,
+    };
+
+    const targetFlowNode: BusinessObject = {
+      id: 'task-1',
+      name: 'Task 1',
+      $type: 'bpmn:ServiceTask',
+      $parent: subprocess,
+    };
+
+    const sourceFlowNode: BusinessObject = {
+      id: 'task-2',
+      name: 'Task 2',
+      $type: 'bpmn:ServiceTask',
+      $parent: subprocess,
+    };
+
+    const businessObjects: BusinessObjects = {
+      'task-1': targetFlowNode,
+      'task-2': sourceFlowNode,
+      subprocess,
+      process: parentProcess,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      subprocess: 2,
+      process: 1,
+    };
+
+    const result = getAncestorScopeType(
+      businessObjects,
+      'task-2',
+      'task-1',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe('sourceParent');
+  });
+
+  it('should return "inferred" when target has multiple scopes but nodes are not in same running scope', () => {
+    const parentProcess: BusinessObject = {
+      id: 'process',
+      name: 'Process',
+      $type: 'bpmn:Process',
+    };
+
+    const subprocess1: BusinessObject = {
+      id: 'subprocess1',
+      name: 'Subprocess 1',
+      $type: 'bpmn:SubProcess',
+      $parent: parentProcess,
+    };
+
+    const subprocess2: BusinessObject = {
+      id: 'subprocess2',
+      name: 'Subprocess 2',
+      $type: 'bpmn:SubProcess',
+      $parent: parentProcess,
+    };
+
+    const targetFlowNode: BusinessObject = {
+      id: 'task-1',
+      name: 'Task 1',
+      $type: 'bpmn:ServiceTask',
+      $parent: subprocess1,
+    };
+
+    const sourceFlowNode: BusinessObject = {
+      id: 'task-2',
+      name: 'Task 2',
+      $type: 'bpmn:ServiceTask',
+      $parent: subprocess2,
+    };
+
+    const businessObjects: BusinessObjects = {
+      'task-1': targetFlowNode,
+      'task-2': sourceFlowNode,
+      subprocess1,
+      subprocess2,
+      process: parentProcess,
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      subprocess1: 2,
+      subprocess2: 1,
+      process: 1,
+    };
+
+    const result = getAncestorScopeType(
+      businessObjects,
+      'task-2',
+      'task-1',
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe('inferred');
   });
 });

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -158,5 +158,3 @@ export {
   areInSameRunningScope,
   getAncestorScopeType,
 };
-
-export type {AncestorScopeType};

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -12,6 +12,7 @@ import type {
 } from 'bpmn-js/lib/NavigatedViewer';
 import {isAdHocSubProcess} from 'modules/bpmn-js/utils/isAdHocSubProcess';
 import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
+import type {AncestorScopeType} from 'modules/stores/modifications';
 
 const checkScope = (
   parentFlowNode: BusinessObject | undefined,
@@ -98,9 +99,64 @@ const getFlowNodeParents = (
   return getFlowNodesInBetween(businessObjects, flowNodeId, bpmnProcessId);
 };
 
+const areInSameRunningScope = (
+  businessObjects: BusinessObjects,
+  sourceFlowNodeId: string,
+  targetFlowNodeId: string,
+  totalRunningInstancesByFlowNode?: Record<string, number>,
+): boolean => {
+  const sourceFlowNode = businessObjects[sourceFlowNodeId];
+  const targetFlowNode = businessObjects[targetFlowNodeId];
+
+  if (!sourceFlowNode || !targetFlowNode) {
+    return false;
+  }
+
+  const sourceParent = sourceFlowNode.$parent;
+  const targetParent = targetFlowNode.$parent;
+
+  if (!sourceParent || !targetParent) {
+    return false;
+  }
+
+  if (sourceParent.id === targetParent.id) {
+    const runningCount =
+      totalRunningInstancesByFlowNode?.[sourceParent.id] ?? 0;
+    return runningCount > 0;
+  }
+
+  return false;
+};
+
+const getAncestorScopeType = (
+  businessObjects: BusinessObjects,
+  sourceFlowNodeId: string,
+  targetFlowNodeId: string,
+  totalRunningInstancesByFlowNode?: Record<string, number>,
+): AncestorScopeType => {
+  const targetFlowNode = businessObjects[targetFlowNodeId];
+
+  if (!hasMultipleScopes(targetFlowNode, totalRunningInstancesByFlowNode)) {
+    return;
+  }
+
+  const inSameScope = areInSameRunningScope(
+    businessObjects,
+    sourceFlowNodeId,
+    targetFlowNodeId,
+    totalRunningInstancesByFlowNode,
+  );
+
+  return inSameScope ? 'sourceParent' : 'inferred';
+};
+
 export {
   getFlowNodeParents,
   hasMultipleScopes,
   hasSingleScope,
   getFlowNodesInBetween,
+  areInSameRunningScope,
+  getAncestorScopeType,
 };
+
+export type {AncestorScopeType};


### PR DESCRIPTION
## Description
This PR eliminates the manual ancestor scope selection step when moving tokens between flow nodes in a multi-instance scenarios. 

To do that, the API request for move modification is adjusted from the `ancestorType: direct` option to the following:
* `sourceParent`: The backend will use the source flow node parent scope. We use it when source and target flow nodes share the same running scope (efficient)
* `inferred`: Let the backend automatically infer the scope (less efficient option)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #41859
