### PR TITLE
fix: global variable modification not allowed with element-selection v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
@@ -20,7 +20,6 @@ import {
   useIsPlaceholderSelected,
   useIsRootNodeSelected,
 } from 'modules/hooks/flowNodeSelection';
-import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {IS_ELEMENT_SELECTION_V2} from 'modules/feature-flags';
 import {hasPendingAddOrMoveModification} from 'modules/utils/modifications';
 
@@ -38,18 +37,15 @@ const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
 
     const {isModificationModeEnabled} = modificationsStore;
 
-    const {selectedElementId} = useProcessInstanceElementSelection();
-
     const isVariableModificationAllowed = computed(() => {
-      if (!isModificationModeEnabled || selectedElementId === null) {
-        return false;
+      switch (true) {
+        case !isModificationModeEnabled:
+          return false;
+        case isRootNodeSelected:
+          return hasPendingAddOrMoveModification();
+        default:
+          return isPlaceholderSelected;
       }
-
-      if (isRootNodeSelected) {
-        return hasPendingAddOrMoveModification();
-      }
-
-      return isPlaceholderSelected;
     });
 
     const isVariableModificationAllowedV1 = computed(() => {


### PR DESCRIPTION
## Description

I noticed that it is never possible to add/modify global variables when `IS_ELEMENT_SELECTION_V2` is enabled. This PR fixes it.

**Aside:** Defining a MobX `computed` on every render seems _weird_. Is there some benefit to continue using `computed` once we remove `IS_ELEMENT_SELECTION_V2`? `hasPendingAddOrMoveModification` and `isModificationModeEnabled` access the `modificationsStore`.

## Related issues

relates #41143, #40425
