### PR TITLE
Remove the breakdown sections from the epic templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
+++ b/.github/ISSUE_TEMPLATE/4. epic breakdown.yml
@@ -42,40 +42,6 @@ body:
     validations:
       required: false
   - type: textarea
-    id: breakdown
-    attributes:
-      label: Breakdown
-      description:
-    validations:
-      required: false
-  - type: textarea
-    id: backend
-    attributes:
-      label: Backend
-      description: Add all related backend issues here.
-      value: |
-        - [ ] #<issue-number>
-        - [ ] ...
-    validations:
-      required: false
-  - type: textarea
-    id: frontend
-    attributes:
-      label: Frontend
-      description: Add all related frontend issues here.
-      value: |
-        - [ ] #<issue-number>
-        - [ ] ...
-    validations:
-      required: false
-  - type: textarea
-    id: documentation
-    attributes:
-      label: Documentation
-      description: Tasks that require writing / modifying documentation
-    validations:
-      required: false
-  - type: textarea
     id: additional
     attributes:
       label: Additional information


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Github supports adding sub-issues which are superior to manual lists like these in many ways. As a result, these breakdown sections are not really needed in the template anymore.

As raised in slack [here](https://camunda.slack.com/archives/C08F5RD5X8B/p1770217809764439)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

N/A
