### PR TITLE
test: ensure PI modify moveAll works for MI subs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -458,23 +458,16 @@ public final class ProcessInstanceModificationModifyProcessor
     // collect terminate-by-id instructions, add key instructions to final list
     final var terminateInstructionIds = new HashSet<String>();
     final var terminateInstanceKeys = new HashSet<Long>();
-    terminateInstructionsInput.forEach(
-        instruction -> {
-          if (instruction.getElementInstanceKey() > 0) {
-            finalTerminateInstructions.add(instruction);
-            terminateInstanceKeys.add(instruction.getElementInstanceKey());
-          } else {
-            terminateInstructionIds.add(instruction.getElementId());
-          }
-        });
+    handleTerminateByKeyInstructions(
+        terminateInstructionsInput,
+        finalTerminateInstructions,
+        terminateInstanceKeys,
+        terminateInstructionIds);
 
     // iterate over all active element instances, including child instances
     // use a queue to iterate over the descendants, recursion might lead to StackOverflow
     if (!moveInstructions.isEmpty() || !terminateInstructionIds.isEmpty()) {
-      // track MI body + resolved ancestor scope pairs that have already generated an activate
-      // instruction, to avoid creating one activate per child when moving out of an MI sub-process
-      // while still allowing one activate per source scope when moving inside it
-      final var activatedMiBodyAncestorAndScopeKeys = new HashSet<String>();
+      final var activatedScopes = new HashSet<String>();
       final var elementInstances =
           new ArrayDeque<>(elementInstanceState.getChildren(processInstanceKey));
       while (!elementInstances.isEmpty()) {
@@ -486,25 +479,11 @@ public final class ProcessInstanceModificationModifyProcessor
           final var moveInstruction = moveInstructions.get(elementId);
           final var ancestorScopeKey =
               determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
-          // Check whether this element instance is inside a multi-instance body. If so, deduplicate
-          // only when the resolved target ancestor scope is identical.
-          final var miBodyAncestorKey = findMiBodyAncestorKey(elementInstance.getParentKey());
-          final boolean shouldActivate =
-              miBodyAncestorKey < 0
-                  || activatedMiBodyAncestorAndScopeKeys.add(
-                      miBodyAncestorKey + ":" + ancestorScopeKey);
+          final var shouldActivate =
+              shouldActivateElement(
+                  elementInstance, activatedScopes, ancestorScopeKey, moveInstruction);
           if (shouldActivate) {
-            final var activateInstruction =
-                new ProcessInstanceModificationActivateInstruction()
-                    .setElementId(moveInstruction.getTargetElementId())
-                    .setAncestorScopeKey(ancestorScopeKey);
-            moveInstruction
-                .getVariableInstructions()
-                .forEach(
-                    vi ->
-                        activateInstruction.addVariableInstruction(
-                            (ProcessInstanceModificationVariableInstruction) vi));
-            finalActivateInstructions.add(activateInstruction);
+            addActivateInstruction(finalActivateInstructions, moveInstruction, ancestorScopeKey);
           }
           // terminate source element instance
           finalTerminateInstructions.add(
@@ -531,6 +510,61 @@ public final class ProcessInstanceModificationModifyProcessor
     }
   }
 
+  private static void addActivateInstruction(
+      final List<ProcessInstanceModificationActivateInstructionValue> finalActivateInstructions,
+      final ProcessInstanceModificationMoveInstructionValue moveInstruction,
+      final long ancestorScopeKey) {
+    final var activateInstruction =
+        new ProcessInstanceModificationActivateInstruction()
+            .setElementId(moveInstruction.getTargetElementId())
+            .setAncestorScopeKey(ancestorScopeKey);
+    moveInstruction
+        .getVariableInstructions()
+        .forEach(
+            vi ->
+                activateInstruction.addVariableInstruction(
+                    (ProcessInstanceModificationVariableInstruction) vi));
+    finalActivateInstructions.add(activateInstruction);
+  }
+
+  /**
+   * Check whether this element instance is inside a multi-instance body. If so, activate only when
+   * the resolved target ancestor scope and the move instruction's source haven't been used yet.
+   *
+   * <p>This avoids creating one activate per child when moving out of an MI sub-process while still
+   * allowing one activate per source scope when moving inside it.
+   */
+  private boolean shouldActivateElement(
+      final ElementInstance elementInstance,
+      final HashSet<String> activatedMiBodyAncestorAndScopeKeys,
+      final long ancestorScopeKey,
+      final ProcessInstanceModificationMoveInstructionValue moveInstruction) {
+    final var miBodyAncestorKey = findMiBodyAncestorKey(elementInstance.getParentKey());
+    return miBodyAncestorKey < 0
+        || activatedMiBodyAncestorAndScopeKeys.add(
+            miBodyAncestorKey
+                + ":"
+                + ancestorScopeKey
+                + ":"
+                + moveInstruction.getSourceElementId());
+  }
+
+  private static void handleTerminateByKeyInstructions(
+      final List<ProcessInstanceModificationTerminateInstructionValue> terminateInstructionsInput,
+      final List<ProcessInstanceModificationTerminateInstructionValue> finalTerminateInstructions,
+      final HashSet<Long> terminateInstanceKeys,
+      final HashSet<String> terminateInstructionIds) {
+    terminateInstructionsInput.forEach(
+        instruction -> {
+          if (instruction.getElementInstanceKey() > 0) {
+            finalTerminateInstructions.add(instruction);
+            terminateInstanceKeys.add(instruction.getElementInstanceKey());
+          } else {
+            terminateInstructionIds.add(instruction.getElementId());
+          }
+        });
+  }
+
   private void mapMoveInstructionsByInstanceKey(
       final List<ProcessInstanceModificationMoveInstructionValue> moveInstructions,
       final List<ProcessInstanceModificationActivateInstructionValue> finalActivateInstructions,
@@ -543,17 +577,7 @@ public final class ProcessInstanceModificationModifyProcessor
       final var ancestorScopeKey =
           determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
 
-      final var activateInstruction =
-          new ProcessInstanceModificationActivateInstruction()
-              .setElementId(moveInstruction.getTargetElementId())
-              .setAncestorScopeKey(ancestorScopeKey);
-      moveInstruction
-          .getVariableInstructions()
-          .forEach(
-              vi ->
-                  activateInstruction.addVariableInstruction(
-                      (ProcessInstanceModificationVariableInstruction) vi));
-      finalActivateInstructions.add(activateInstruction);
+      addActivateInstruction(finalActivateInstructions, moveInstruction, ancestorScopeKey);
       // terminate source element instance
       finalTerminateInstructions.add(
           new ProcessInstanceModificationTerminateInstruction()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -471,6 +471,10 @@ public final class ProcessInstanceModificationModifyProcessor
     // iterate over all active element instances, including child instances
     // use a queue to iterate over the descendants, recursion might lead to StackOverflow
     if (!moveInstructions.isEmpty() || !terminateInstructionIds.isEmpty()) {
+      // track MI body + resolved ancestor scope pairs that have already generated an activate
+      // instruction, to avoid creating one activate per child when moving out of an MI sub-process
+      // while still allowing one activate per source scope when moving inside it
+      final var activatedMiBodyAncestorAndScopeKeys = new HashSet<String>();
       final var elementInstances =
           new ArrayDeque<>(elementInstanceState.getChildren(processInstanceKey));
       while (!elementInstances.isEmpty()) {
@@ -482,17 +486,26 @@ public final class ProcessInstanceModificationModifyProcessor
           final var moveInstruction = moveInstructions.get(elementId);
           final var ancestorScopeKey =
               determineAncestorScopeKey(moveInstruction, elementInstance.getParentKey(), process);
-          final var activateInstruction =
-              new ProcessInstanceModificationActivateInstruction()
-                  .setElementId(moveInstruction.getTargetElementId())
-                  .setAncestorScopeKey(ancestorScopeKey);
-          moveInstruction
-              .getVariableInstructions()
-              .forEach(
-                  vi ->
-                      activateInstruction.addVariableInstruction(
-                          (ProcessInstanceModificationVariableInstruction) vi));
-          finalActivateInstructions.add(activateInstruction);
+          // Check whether this element instance is inside a multi-instance body. If so, deduplicate
+          // only when the resolved target ancestor scope is identical.
+          final var miBodyAncestorKey = findMiBodyAncestorKey(elementInstance.getParentKey());
+          final boolean shouldActivate =
+              miBodyAncestorKey < 0
+                  || activatedMiBodyAncestorAndScopeKeys.add(
+                      miBodyAncestorKey + ":" + ancestorScopeKey);
+          if (shouldActivate) {
+            final var activateInstruction =
+                new ProcessInstanceModificationActivateInstruction()
+                    .setElementId(moveInstruction.getTargetElementId())
+                    .setAncestorScopeKey(ancestorScopeKey);
+            moveInstruction
+                .getVariableInstructions()
+                .forEach(
+                    vi ->
+                        activateInstruction.addVariableInstruction(
+                            (ProcessInstanceModificationVariableInstruction) vi));
+            finalActivateInstructions.add(activateInstruction);
+          }
           // terminate source element instance
           finalTerminateInstructions.add(
               new ProcessInstanceModificationTerminateInstruction()
@@ -647,6 +660,29 @@ public final class ProcessInstanceModificationModifyProcessor
     // No matching ancestor found - return -1 to let the activation logic handle it
     // (it will create new flow scope instances as needed)
     return ElementActivationBehavior.NO_ANCESTOR_SCOPE_KEY;
+  }
+
+  /**
+   * Walks up the ancestor chain from the given key and returns the key of the first ancestor whose
+   * element type is {@link BpmnElementType#MULTI_INSTANCE_BODY}, or {@code -1} if none is found.
+   *
+   * <p>This is used to deduplicate activate instructions when a source element lives inside a
+   * multi-instance sub-process: all sibling instances share the same MI body ancestor, so only one
+   * activate instruction should be produced for the whole group.
+   */
+  private long findMiBodyAncestorKey(final long startKey) {
+    var currentKey = startKey;
+    while (currentKey > 0) {
+      final var instance = elementInstanceState.getInstance(currentKey);
+      if (instance == null) {
+        break;
+      }
+      if (instance.getValue().getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+        return currentKey;
+      }
+      currentKey = instance.getParentKey();
+    }
+    return -1;
   }
 
   private Either<Rejection, ?> validateCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2424,6 +2424,260 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
+  public void shouldMoveAllOutsideOfMiSubprocessForDifferentTargets() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent("endA")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent("endB")
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to different target elements
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .moveElements("B", "D")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - both C and D should each be activated exactly once
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C and D are each activated exactly once despite 3 matching MI instances
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // C and D are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllOutsideOfMiSubprocessForSameTargetMultipleTimes() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent("endA")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent("endB")
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to different target elements
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .moveElements("B", "C")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - C should be activated twice (once for A and once for B), D should not be activated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C is activated twice despite 3 matching MI instances and two move instructions
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // All C's are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
+  public void shouldMoveAllInsideMiSubprocessForDifferentTargets() {
+    // given - a multi-instance sub-process with a parallel split inside, so tasks A and B are
+    // active simultaneously in each MI iteration
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("subProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..3 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .parallelGateway("fork")
+                .userTask("A")
+                .zeebeUserTask()
+                .userTask("C")
+                .zeebeUserTask()
+                .endEvent("endAC")
+                .moveToLastGateway()
+                .userTask("B")
+                .zeebeUserTask()
+                .userTask("D")
+                .zeebeUserTask()
+                .endEvent("endBD")
+                .subProcessDone()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - issue a single modification with two move instructions: A and B are different
+    // elements both inside the same MI body, moved to different target elements
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElementsWithSourceParentScope("A", "C")
+        .moveElementsWithSourceParentScope("B", "D")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then - C should be activated twice (once for A and once for B), D should not be activated
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B", "C", "D"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            // A and B are each activated three times during initial MI sub-process start
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // all three MI instances of A and B are terminated by the modification
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            // C and D are each activated 3 times, matching sibling MI instances
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            // C and D are terminated by the cancel
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "D", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
   public void shouldMoveElementInstanceBySourceElementInstanceKey() {
     // given
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2210,8 +2210,8 @@ public class ModifyProcessInstanceTest {
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementIdIn("A", "B")
-                .limitToProcessInstanceTerminated())
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B"))
         .extracting(
             r ->
                 tuple(
@@ -2278,8 +2278,8 @@ public class ModifyProcessInstanceTest {
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementIdIn("subProcess", "A", "B")
-                .limitToProcessInstanceTerminated())
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("subProcess", "A", "B"))
         .extracting(
             r ->
                 tuple(
@@ -2382,8 +2382,8 @@ public class ModifyProcessInstanceTest {
                     ProcessInstanceIntent.ELEMENT_TERMINATED,
                     ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementIdIn("A", "B")
-                .limitToProcessInstanceTerminated())
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("A", "B"))
         .extracting(
             r ->
                 tuple(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2338,6 +2338,136 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
+  public void shouldMoveAllMultiInstanceElementsOutOfNestedSubprocessByIds() {
+    // given a parent sub-process containing a multi-instance inner sub-process with a user task
+    // "A", followed by user task "B" inside the parent, and user task "C" outside the parent.
+    // The move goes from "A" to "C", two nesting layers up.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess("parentSubProcess")
+                .embeddedSubProcess()
+                .startEvent()
+                .subProcess("innerSubProcess")
+                .multiInstance(
+                    mi ->
+                        mi.parallel()
+                            .zeebeInputCollectionExpression("=for i in 1..5 return i")
+                            .multiInstanceDone())
+                .embeddedSubProcess()
+                .startEvent()
+                .userTask("A")
+                .zeebeUserTask()
+                .endEvent()
+                .subProcessDone()
+                .userTask("B")
+                .zeebeUserTask()
+                .endEvent()
+                .subProcessDone()
+                .userTask("C")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .moveElements("A", "C")
+        .modify();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then the multi-instance body and parent sub-process are terminated and a single "C" is
+    // activated at the process level
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withIntents(
+                    ProcessInstanceIntent.ELEMENT_TERMINATED,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated()
+                .withElementIdIn("parentSubProcess", "innerSubProcess", "A", "C"))
+        .extracting(
+            r ->
+                tuple(
+                    r.getValue().getBpmnElementType(), r.getValue().getElementId(), r.getIntent()))
+        .containsExactly(
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "parentSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.MULTI_INSTANCE_BODY,
+                "innerSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "parentSubProcess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.USER_TASK, "C", ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  @Test
   public void shouldMoveAllMultiInstanceParentElementsByIds() {
     // given a multi-instance with 5 elements
     ENGINE


### PR DESCRIPTION
## Description

Improves the handling of process instance modifications involving multi-instance (MI) elements. The main focus is to ensure that when moving elements out of or within MI sub-processes, activation instructions are deduplicated so that only one activation per MI body and ancestor scope is created, preventing redundant activations. The changes also introduce new tests to verify this behavior.

## Related issues

closes #44955 
