### PR TITLE
[Backport stable/8.8] fix: client can keep access after permission removed by preventing cache expiration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -24,7 +24,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_FORM_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_PROCESS_CACHE_CAPACITY = 1000;
   public static final int DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY = 1000;
-  public static final Duration DEFAULT_AUTHORIZATIONS_CACHE_TTL = Duration.ofSeconds(30);
+  public static final Duration DEFAULT_AUTHORIZATIONS_CACHE_TTL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -77,7 +77,7 @@ public final class AuthorizationCheckBehavior {
 
     authorizationsCache =
         CacheBuilder.newBuilder()
-            .expireAfterAccess(config.getAuthorizationsCacheTtl())
+            .expireAfterWrite(config.getAuthorizationsCacheTtl())
             .maximumSize(config.getAuthorizationsCacheCapacity())
             .build(
                 new CacheLoader<>() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.AuthorizationDeletedApplier;
 import io.camunda.zeebe.engine.state.appliers.GroupCreatedApplier;
 import io.camunda.zeebe.engine.state.appliers.GroupEntityAddedApplier;
 import io.camunda.zeebe.engine.state.appliers.MappingRuleCreatedApplier;
@@ -50,6 +51,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +66,7 @@ final class AuthorizationCheckBehaviorTest {
   private UserCreatedApplier userCreatedApplier;
   private MappingRuleCreatedApplier mappingRuleCreatedApplier;
   private AuthorizationCreatedApplier authorizationCreatedApplier;
+  private AuthorizationDeletedApplier authorizationDeletedApplier;
   private GroupCreatedApplier groupCreatedApplier;
   private GroupEntityAddedApplier groupEntityAddedApplier;
   private RoleCreatedApplier roleCreatedApplier;
@@ -85,6 +88,8 @@ final class AuthorizationCheckBehaviorTest {
         new MappingRuleCreatedApplier(processingState.getMappingRuleState());
     authorizationCreatedApplier =
         new AuthorizationCreatedApplier(processingState.getAuthorizationState());
+    authorizationDeletedApplier =
+        new AuthorizationDeletedApplier(processingState.getAuthorizationState());
     groupCreatedApplier = new GroupCreatedApplier(processingState.getGroupState());
     groupEntityAddedApplier = new GroupEntityAddedApplier(processingState);
     roleCreatedApplier = new RoleCreatedApplier(processingState.getRoleState());
@@ -791,7 +796,7 @@ final class AuthorizationCheckBehaviorTest {
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
 
-    final var config = new EngineConfiguration().setAuthorizationsCacheTtl(Duration.ofMillis(1));
+    final var config = new EngineConfiguration().setAuthorizationsCacheTtl(Duration.ofSeconds(1));
     authorizationCheckBehavior =
         new AuthorizationCheckBehavior(processingState, securityConfig, config);
 
@@ -813,18 +818,34 @@ final class AuthorizationCheckBehaviorTest {
     assertThat(authorizationCheckBehavior.isAuthorized(request).isRight()).isFalse();
 
     // grant the required permission in state so a recompute should allow
-    addPermission(
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        AuthorizationScope.of(resourceId));
+    final var authorizationKey =
+        addPermission(
+            user.getUsername(),
+            AuthorizationOwnerType.USER,
+            resourceType,
+            permissionType,
+            AuthorizationScope.of(resourceId));
 
-    // Guava's expireAfterAccess is based on real time; wait past TTL to force cache reload
-    Thread.sleep(2);
+    // the request is still denied immediately after grant as the previous check cached a denial
+    assertThat(authorizationCheckBehavior.isAuthorized(request).isRight()).isFalse();
 
-    // then: subsequent check recomputes after TTL and succeeds
+    // Guava's expireAfterWrite is based on real time; wait past TTL to force cache reload
+    // cache re-computed with added permission after TTL expires.
+    // Because Awaitility polls every 100 millis, the test will fail with a timeout if the check can
+    // be artificially kept in the same result status by continuous calls in the TTL window.
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(100))
+        .until(() -> authorizationCheckBehavior.isAuthorized(request).isRight());
+
+    // the permission is removed and the request is still allowed due to caching
+    removePermission(authorizationKey);
     assertThat(authorizationCheckBehavior.isAuthorized(request).isRight()).isTrue();
+
+    // after the TTL expires again, the cache is re-computed to a denial as there is no permission
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .until(() -> authorizationCheckBehavior.isAuthorized(request).isLeft());
   }
 
   private TypedRecord<?> mockCommandWithMappingRule(
@@ -896,18 +917,32 @@ final class AuthorizationCheckBehaviorTest {
       final PermissionType permissionType,
       final AuthorizationScope... authorizationScopes) {
     for (final AuthorizationScope authorizationScope : authorizationScopes) {
-      final var authorizationKey = random.nextLong();
-      final var authorization =
-          new AuthorizationRecord()
-              .setAuthorizationKey(authorizationKey)
-              .setOwnerId(ownerId)
-              .setOwnerType(ownerType)
-              .setResourceMatcher(authorizationScope.getMatcher())
-              .setResourceId(authorizationScope.getResourceId())
-              .setResourceType(resourceType)
-              .setPermissionTypes(Set.of(permissionType));
-      authorizationCreatedApplier.applyState(authorizationKey, authorization);
+      addPermission(ownerId, ownerType, resourceType, permissionType, authorizationScope);
     }
+  }
+
+  private long addPermission(
+      final String ownerId,
+      final AuthorizationOwnerType ownerType,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final AuthorizationScope authorizationScope) {
+    final var authorizationKey = random.nextLong();
+    final var authorization =
+        new AuthorizationRecord()
+            .setAuthorizationKey(authorizationKey)
+            .setOwnerId(ownerId)
+            .setOwnerType(ownerType)
+            .setResourceMatcher(authorizationScope.getMatcher())
+            .setResourceId(authorizationScope.getResourceId())
+            .setResourceType(resourceType)
+            .setPermissionTypes(Set.of(permissionType));
+    authorizationCreatedApplier.applyState(authorizationKey, authorization);
+    return authorizationKey;
+  }
+
+  private void removePermission(final long authorizationKey) {
+    authorizationDeletedApplier.applyState(authorizationKey, null);
   }
 
   private TypedRecord<?> mockCommand(final String username) {


### PR DESCRIPTION
# Description
Backport of #45045 to `stable/8.8`.

relates to #44844