### PR TITLE
Delete decision instance data from ES/OS

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -71,7 +71,7 @@ public class HistoryDeletionJob implements BackgroundTask {
 
   /**
    * This deletes all entities in a given batch. A batch could contain different types of entities,
-   * such as process instances, or process definitions.
+   * such as process instances, process definitions, or decision instances.
    *
    * @param batch The batch of entities to delete
    * @return A future containing the amount of entities that were deleted

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -134,10 +134,10 @@ public class HistoryDeletionJob implements BackgroundTask {
    * @return A future containing the list of history-deletion IDs that were processed
    */
   private CompletionStage<List<String>> deleteProcessDefinitions(
-      final HistoryDeletionBatch batch, final List<String> processInstanceDeletionIds) {
+      final HistoryDeletionBatch batch, final List<String> deletedResourceIds) {
     final var processDefinitions = batch.getResourceKeys(HistoryDeletionType.PROCESS_DEFINITION);
     if (processDefinitions.isEmpty()) {
-      return CompletableFuture.completedFuture(processInstanceDeletionIds);
+      return CompletableFuture.completedFuture(deletedResourceIds);
     }
 
     return deleterRepository
@@ -146,7 +146,7 @@ public class HistoryDeletionJob implements BackgroundTask {
             processDefinitions.stream().map(Object::toString).toList())
         .thenApply(
             ignored -> {
-              final var ids = new ArrayList<>(processInstanceDeletionIds);
+              final var ids = new ArrayList<>(deletedResourceIds);
               ids.addAll(batch.getHistoryDeletionIds(HistoryDeletionType.PROCESS_DEFINITION));
               return ids;
             });

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -86,7 +86,7 @@ public class HistoryDeletionJob implements BackgroundTask {
 
     final var deleteProcessInstancesAndDefinitionsFuture =
         deleteProcessInstances(batch)
-            .thenCompose(ids -> deleteProcessDefinitions(batch, ids))
+            .thenCompose(ids -> deleteProcessDefinitions(batch, ids).exceptionally(ex -> ids))
             .exceptionally(ex -> List.of())
             .toCompletableFuture();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Decision instances that are marked for deletion should be handled by the `HistoryDeletionJob`. This job should ensure they eventually get removed from secondary storage.


I made one additional change in this PR as well. If a process instance is deleted successfully, but a process definition is not, we will still delete the process instances from the history deletion index. This makes it so the next deletion cycle won't encounter these same process instances again. As a result there'll be less chance of the deletion job getting blocked. An additional test case has been added for this as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #42401
closes #42402 
