### PR TITLE
test: move tests related to identity into their own jobs

### DIFF
--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -22,6 +22,12 @@ inputs:
     history-matrix-output-result:
       description: 'Matrix output for history tests'
       required: true
+    identity-tests-result:
+      description: 'Result of the identity tests job'
+      required: true
+    identity-matrix-output-result:
+      description: 'Matrix output for identity tests'
+      required: true
     rdbms-tests-result:
         description: 'Result of the RDBMS integration tests job'
         required: true
@@ -76,6 +82,7 @@ runs:
         # Collect from matrix jobs
         collect_from_matrix_job "history-tests" "${{ inputs.history-tests-result }}" '${{ inputs.history-matrix-output-result }}'
         collect_from_matrix_job "database-integration-tests" "${{ inputs.database-integration-tests-result }}" '${{ inputs.database-matrix-output-result }}'
+        collect_from_matrix_job "identity-tests" "${{ inputs.identity-tests-result }}" '${{ inputs.identity-matrix-output-result }}'
         collect_from_matrix_job "zeebe-unit-tests" "${{ inputs.zeebe-tests-result }}" '${{ inputs.zeebe-matrix-output-result }}'
         collect_from_matrix_job "integration-tests" "${{ inputs.integration-tests-result }}" '${{ inputs.integration-matrix-output-result }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,25 @@ jobs:
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
 
+  identity-tests:
+    name: "Identity Integration Tests / ${{ matrix.name }}"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    strategy:
+      fail-fast: false
+      matrix: *database-matrix
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "${{ matrix.database-type }}"
+      database-container: "${{ matrix.database-container }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      database-name: "${{ matrix.database-name }}"
+      it-database-type: "${{ matrix.it-database-type }}"
+      maven-profiles: "identity-tests"
+      test-type: "identity-tests"
+      test-type-label: "Identity"
+
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1152,6 +1152,7 @@ jobs:
       - docker-checks
       - general-unit-tests
       - history-tests
+      - identity-tests
       - integration-tests
       - rdbms-integration-tests
       - zeebe-unit-tests
@@ -1182,6 +1183,11 @@ jobs:
         id: history-matrix-read
         with:
           matrix-step-name: history-tests
+      - name: Read identity tests matrix outputs
+        uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: identity-matrix-read
+        with:
+          matrix-step-name: identity-tests
       - name: Collect flaky test results
         id: collect-results
         uses: ./.github/actions/collect-flaky-tests
@@ -1192,6 +1198,8 @@ jobs:
           database-matrix-output-result: ${{ steps.database-integration-matrix-read.outputs.result }}
           history-tests-result: ${{ needs.history-tests.result }}
           history-matrix-output-result: ${{ steps.history-matrix-read.outputs.result }}
+          identity-tests-result: ${{ needs.identity-tests.result }}
+          identity-matrix-output-result: ${{ steps.identity-matrix-read.outputs.result }}
           rdbms-tests-result: ${{ needs.rdbms-integration-tests.result }}
           rdbms-tests-flaky: ${{ needs.rdbms-integration-tests.outputs.flakyTests }}
           docker-checks-result: ${{ needs.docker-checks.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1461,6 +1461,7 @@ jobs:
       - general-unit-tests
       - history-tests
       - identity-frontend-tests
+      - identity-tests
       - integration-tests
       - java-checks
       - maven-spotless-linter

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
+      matrix: &database-matrix
         include:
           # PostgreSQL - Supported versions: 14, 15, 16, 17, 18
           - database-name: "Postgres 14"
@@ -95,4 +95,45 @@ jobs:
       database-image-version: ${{ matrix.database-image-version }}
       database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
+      notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+
+  rdbms-history-tests:
+    name: "RDBMS History Tests / ${{ matrix.database-name }}"
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: *database-matrix
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: ${{ matrix.database-type }}
+      database-image-version: ${{ matrix.database-image-version }}
+      database-name: ${{ matrix.database-name }}
+      it-database-type: "${{ matrix.it-database-type }}"
+      maven-profiles: "history"
+      test-type: "history-tests"
+      test-type-label: "History"
+      runs-on: "gcp-perf-core-8-default"
+      notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+
+  rdbms-identity-tests:
+    name: "RDBMS Identity Tests / ${{ matrix.database-name }}"
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: *database-matrix
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: ${{ matrix.database-type }}
+      database-image-version: ${{ matrix.database-image-version }}
+      database-name: ${{ matrix.database-name }}
+      it-database-type: "${{ matrix.it-database-type }}"
+      maven-profiles: "identity-tests"
+      test-type: "identity-tests"
+      test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
+      matrix: &database-matrix
         include:
           # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.11 (max)
           - database-name: "Elasticsearch 8.19.0"
@@ -83,4 +83,47 @@ jobs:
       database-image-version: ${{ matrix.database-image-version }}
       database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
+      notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+
+  search-history-tests:
+    name: "Search History Tests / ${{ matrix.database-name }}"
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: *database-matrix
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "${{ matrix.database-type }}"
+      database-container: "${{ matrix.database-container }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      database-name: "${{ matrix.database-name }}"
+      it-database-type: "${{ matrix.it-database-type }}"
+      maven-profiles: "history"
+      test-type: "history-tests"
+      test-type-label: "History"
+      runs-on: "gcp-perf-core-8-default"
+      notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+
+  search-identity-tests:
+    name: "Search Identity Tests / ${{ matrix.database-name }}"
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: *database-matrix
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "${{ matrix.database-type }}"
+      database-container: "${{ matrix.database-container }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      database-name: "${{ matrix.database-name }}"
+      it-database-type: "${{ matrix.it-database-type }}"
+      maven-profiles: "identity-tests"
+      test-type: "identity-tests"
+      test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -726,6 +726,7 @@
               <excludedGroups>rdbms, history</excludedGroups>
               <excludes>
                 <exclude>${identity-packages}</exclude>
+                <exclude>**/*$*.java</exclude>
               </excludes>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -22,6 +22,7 @@
   <name>Camunda QA Acceptance Tests</name>
   <properties>
     <version.maven-surefire-junit5-tree-reporter>1.5.1</version.maven-surefire-junit5-tree-reporter>
+    <identity-packages>io/camunda/it/auth/*,io/camunda/it/identity/*,io/camunda/it/csrf/*,io/camunda/it/logout/*,io/camunda/it/oidc/*</identity-packages>
   </properties>
 
   <dependencies>
@@ -723,6 +724,40 @@
               <failIfNoTests>false</failIfNoTests>
               <groups>multi-db-test</groups>
               <excludedGroups>rdbms, history</excludedGroups>
+              <excludes>
+                <exclude>${identity-packages}</exclude>
+              </excludes>
+              <systemPropertyVariables>
+                <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+    This profile will run all tests annotated with @Tag("multiDbTest") for the identity related packages.
+    The profile is mainly used to run tests, that can be executed against multiple different
+    databases.
+
+    For example against:
+    Elasticsearch, OpenSearch, AWS OpenSearch, PostGreSQL, etc.
+    -->
+    <profile>
+      <id>identity-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>multi-db-test</groups>
+              <excludedGroups>rdbms, history</excludedGroups>
+              <includes>
+                <include>${identity-packages}</include>
+              </includes>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
               </systemPropertyVariables>


### PR DESCRIPTION
to help reduce how long the main database tests takes.

Overall this probably knocks another minute or so off the main DB tests.

## Related issues

refs #38904
