### PR TITLE
feat: extend Interval class to support parametric inclusiveness and more methods

### DIFF
--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -153,6 +153,37 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>net.jqwik:jqwik</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -216,7 +216,8 @@ public record Interval<T extends Comparable<T>>(
 
   /**
    * Given a sorted collections of intervals where interval[n-1].end == interval[n].start, returns
-   * the smallest interval that covers all intervals in the collection.
+   * the smallest subset of contiguous intervals from the input that cover this interval's
+   * overlapping region.
    *
    * @param intervals the collection of contiguous intervals
    * @return the intervals that overlap with this interval

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -7,24 +7,110 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.SequencedCollection;
 import java.util.function.Function;
 
 /**
- * Represents a generic range with a start and end value.
+ * Represents a generic range with a start and end value, with configurable inclusiveness for each
+ * bound.
  *
  * @param <T> the type of the range values, must be comparable
- * @param start the first value in the range (inclusive)
- * @param end the last value in the range (inclusive)
+ * @param start the first value in the range
+ * @param startInclusive whether the start bound is inclusive
+ * @param end the last value in the range
+ * @param endInclusive whether the end bound is inclusive
  */
-public record Interval<T extends Comparable<T>>(T start, T end) {
+public record Interval<T extends Comparable<T>>(
+    T start, boolean startInclusive, T end, boolean endInclusive) {
+
+  /** For start bounds, inclusive is "before" exclusive when values are equal. */
+  private static final int START_INCLUSIVE_SIGN = -1;
+
+  /** For end bounds, inclusive is "after" exclusive when values are equal. */
+  private static final int END_INCLUSIVE_SIGN = 1;
+
+  public Interval {
+    Objects.requireNonNull(start, "start must not be null");
+    Objects.requireNonNull(end, "end must not be null");
+    final var comparison = start.compareTo(end);
+    if (comparison > 0) {
+      throw new IllegalArgumentException(
+          "Expected start <= end, but got start = %s, end = %s".formatted(start, end));
+    }
+    // For equal bounds, both must be inclusive or the interval is empty/invalid
+    if (comparison == 0 && (!startInclusive || !endInclusive)) {
+      throw new IllegalArgumentException(
+          "Interval with equal bounds must be inclusive on both sides, got %s%s, %s%s"
+              .formatted(startInclusive ? "[" : "(", start, end, endInclusive ? "]" : ")"));
+    }
+  }
+
+  /**
+   * Creates a closed interval [start, end] where both bounds are inclusive.
+   *
+   * @param start the first value in the range (inclusive)
+   * @param end the last value in the range (inclusive)
+   */
+  public Interval(final T start, final T end) {
+    this(start, true, end, true);
+  }
+
+  /**
+   * Creates a closed interval [start, end] where both bounds are inclusive.
+   *
+   * @param start the first value in the range (inclusive)
+   * @param end the last value in the range (inclusive)
+   * @return a new closed interval
+   */
+  public static <T extends Comparable<T>> Interval<T> closed(final T start, final T end) {
+    return new Interval<>(start, true, end, true);
+  }
+
+  /**
+   * Creates an open interval (start, end) where both bounds are exclusive.
+   *
+   * @param start the first value in the range (exclusive)
+   * @param end the last value in the range (exclusive)
+   * @return a new open interval
+   */
+  public static <T extends Comparable<T>> Interval<T> open(final T start, final T end) {
+    return new Interval<>(start, false, end, false);
+  }
+
+  /**
+   * Creates a half-open interval [start, end) where start is inclusive and end is exclusive.
+   *
+   * @param start the first value in the range (inclusive)
+   * @param end the last value in the range (exclusive)
+   * @return a new half-open interval
+   */
+  public static <T extends Comparable<T>> Interval<T> closedOpen(final T start, final T end) {
+    return new Interval<>(start, true, end, false);
+  }
+
+  /**
+   * Creates a half-open interval (start, end] where start is exclusive and end is inclusive.
+   *
+   * @param start the first value in the range (exclusive)
+   * @param end the last value in the range (inclusive)
+   * @return a new half-open interval
+   */
+  public static <T extends Comparable<T>> Interval<T> openClosed(final T start, final T end) {
+    return new Interval<>(start, false, end, true);
+  }
+
   /**
    * @param other interval to check
    * @return true if this interval completely covers the other interval
    */
   public boolean contains(final Interval<T> other) {
-    return start.compareTo(other.start) <= 0 && end.compareTo(other.end) >= 0;
+    return compareBound(
+                start, startInclusive, other.start, other.startInclusive, START_INCLUSIVE_SIGN)
+            <= 0
+        && compareBound(end, endInclusive, other.end, other.endInclusive, END_INCLUSIVE_SIGN) >= 0;
   }
 
   /**
@@ -32,7 +118,62 @@ public record Interval<T extends Comparable<T>>(T start, T end) {
    * @return true if the value is within this interval
    */
   public boolean contains(final T value) {
-    return value.compareTo(start) >= 0 && value.compareTo(end) <= 0;
+    final var startComparison = value.compareTo(start);
+    final var endComparison = value.compareTo(end);
+
+    final var afterStart = startInclusive ? startComparison >= 0 : startComparison > 0;
+    final var beforeEnd = endInclusive ? endComparison <= 0 : endComparison < 0;
+
+    return afterStart && beforeEnd;
+  }
+
+  /**
+   * @param other interval to check
+   * @return true if this interval overlaps with the other interval
+   */
+  public boolean overlapsWith(final Interval<T> other) {
+    // Two intervals overlap if neither is entirely before the other
+    // this.end vs other.start
+    final var thisEndVsOtherStart = end.compareTo(other.start);
+    final var noOverlapThisBefore =
+        thisEndVsOtherStart < 0
+            || (thisEndVsOtherStart == 0 && (!endInclusive || !other.startInclusive));
+
+    // other.end vs this.start
+    final var otherEndVsThisStart = other.end.compareTo(start);
+    final var noOverlapOtherBefore =
+        otherEndVsThisStart < 0
+            || (otherEndVsThisStart == 0 && (!other.endInclusive || !startInclusive));
+
+    return !noOverlapThisBefore && !noOverlapOtherBefore;
+  }
+
+  /**
+   * Given a sorted collections of intervals where interval[n-1].end == interval[n].start, returns
+   * the smallest interval that covers all intervals in the collection.
+   *
+   * @param intervals the collection of contiguous intervals
+   * @return the intervals that overlap with this interval
+   */
+  public SequencedCollection<Interval<T>> smallestCover(
+      final SequencedCollection<Interval<T>> intervals) {
+    if (intervals.isEmpty()) {
+      return List.of();
+    }
+    final var result = new ArrayList<Interval<T>>();
+    var i = 0;
+    for (final var interval : intervals) {
+      if (!result.isEmpty() && !areContiguous(result.getLast(), interval)) {
+        throw new IllegalArgumentException(
+            "Expected intervals to be contiguous, but interval at index %d is %s, interval at index %d is %s"
+                .formatted(i - 1, result.getLast(), i, interval));
+      }
+      if (interval.overlapsWith(this)) {
+        result.add(interval);
+      }
+      i++;
+    }
+    return result;
   }
 
   public SequencedCollection<T> values() {
@@ -48,6 +189,60 @@ public record Interval<T extends Comparable<T>>(T start, T end) {
    * @return a new interval with transformed values
    */
   public <U extends Comparable<U>> Interval<U> map(final Function<T, U> mapper) {
-    return new Interval<>(mapper.apply(start), mapper.apply(end));
+    return new Interval<>(mapper.apply(start), startInclusive, mapper.apply(end), endInclusive);
+  }
+
+  /**
+   * Returns the mathematical notation for this interval.
+   *
+   * @return string representation using [ ] for inclusive and ( ) for exclusive bounds
+   */
+  @Override
+  public String toString() {
+    return "%s%s, %s%s".formatted(startInclusive ? "[" : "(", start, end, endInclusive ? "]" : ")");
+  }
+
+  /**
+   * Compares bounds considering inclusiveness.
+   *
+   * @param thisBound this interval's bound value
+   * @param thisInclusive whether this bound is inclusive
+   * @param otherBound the other bound value
+   * @param otherInclusive whether the other bound is inclusive
+   * @param inclusiveSign -1 for start bounds (inclusive is "before"), +1 for end bounds (inclusive
+   *     is "after")
+   * @return negative if this bound is "before", positive if "after", 0 if equal
+   */
+  private int compareBound(
+      final T thisBound,
+      final boolean thisInclusive,
+      final T otherBound,
+      final boolean otherInclusive,
+      final int inclusiveSign) {
+    final var comparison = thisBound.compareTo(otherBound);
+    if (comparison != 0) {
+      return comparison;
+    }
+    if (thisInclusive == otherInclusive) {
+      return 0;
+    }
+    return thisInclusive ? inclusiveSign : -inclusiveSign;
+  }
+
+  /**
+   * Checks if two intervals are contiguous (share a boundary point).
+   *
+   * @return true if the intervals are contiguous
+   */
+  private static <T extends Comparable<T>> boolean areContiguous(
+      final Interval<T> first, final Interval<T> second) {
+    final var comparison = first.end.compareTo(second.start);
+    if (comparison != 0) {
+      return false;
+    }
+    // At the boundary, exactly one should be inclusive to avoid gaps or overlaps
+    // For contiguity: [a, b] and [b, c] or [a, b) and [b, c] or [a, b] and (b, c] are valid
+    // But [a, b) and (b, c] would have a gap at b
+    return first.endInclusive || second.startInclusive;
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+/**
+ * Property-based tests for {@link Interval} that verify mathematical properties hold for all valid
+ * intervals.
+ */
+final class IntervalPropertyTest {
+
+  // ==================== Arbitrary Providers ====================
+
+  @Provide
+  Arbitrary<Interval<Integer>> intervals() {
+    final var start = Arbitraries.integers().between(-1000, 1000);
+    final var length = Arbitraries.integers().between(0, 500);
+    final var startInclusive = Arbitraries.of(true, false);
+    final var endInclusive = Arbitraries.of(true, false);
+
+    return Combinators.combine(start, length, startInclusive, endInclusive)
+        .as(
+            (s, len, si, ei) -> {
+              final var end = s + len;
+              // For equal bounds, both must be inclusive
+              if (len == 0) {
+                return new Interval<>(s, true, end, true);
+              }
+              return new Interval<>(s, si, end, ei);
+            });
+  }
+
+  @Provide
+  Arbitrary<Integer> values() {
+    return Arbitraries.integers().between(-1500, 1500);
+  }
+
+  /**
+   * Generates a list of contiguous intervals that partition a range. Each interval in the list
+   * meets the next one at a boundary point without gaps.
+   *
+   * <p>Uses cumulative boundaries approach: generate sorted boundary points, then create intervals
+   * between consecutive points. This ensures contiguity is maintained even during shrinking.
+   */
+  @Provide
+  Arbitrary<List<Interval<Integer>>> contiguousIntervalLists() {
+    // Generate 2-9 unique sorted boundary points, then create intervals between them
+    return Arbitraries.integers()
+        .between(-500, 500)
+        .list()
+        .ofMinSize(2)
+        .ofMaxSize(9)
+        .map(
+            points -> {
+              // Sort and remove duplicates to get boundaries
+              final var boundaries = points.stream().distinct().sorted().toList();
+              if (boundaries.size() < 2) {
+                // Need at least 2 points for 1 interval
+                return List.of(Interval.closed(0, 1));
+              }
+
+              final var intervals = new ArrayList<Interval<Integer>>();
+              for (int i = 0; i < boundaries.size() - 1; i++) {
+                final var start = boundaries.get(i);
+                final var end = boundaries.get(i + 1);
+                // Use [start, end) for all but last, [start, end] for last
+                if (i < boundaries.size() - 2) {
+                  intervals.add(Interval.closedOpen(start, end));
+                } else {
+                  intervals.add(Interval.closed(start, end));
+                }
+              }
+              return intervals;
+            })
+        .filter(list -> !list.isEmpty());
+  }
+
+  // ==================== Equals and HashCode ====================
+
+  @Property(tries = 100)
+  void equalsIsReflexive(@ForAll("intervals") final Interval<Integer> a) {
+    assertThat(a).isEqualTo(a);
+  }
+
+  @Property(tries = 100)
+  void equalsIsSymmetric(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    assertThat(a.equals(b)).isEqualTo(b.equals(a));
+  }
+
+  @Property(tries = 100)
+  void hashCodeIsConsistentWithEquals(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    if (a.equals(b)) {
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+  }
+
+  // ==================== Contains Interval ====================
+
+  @Property(tries = 100)
+  void containsIntervalIsReflexive(@ForAll("intervals") final Interval<Integer> a) {
+    // Every interval contains itself
+    assertThat(a.contains(a)).isTrue();
+  }
+
+  @Property(tries = 100)
+  void containsIntervalIsAntisymmetric(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If a contains b and b contains a, they must be equal
+    if (a.contains(b) && b.contains(a)) {
+      assertThat(a).isEqualTo(b);
+    }
+  }
+
+  @Property(tries = 100)
+  void containsIntervalIsTransitive(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b,
+      @ForAll("intervals") final Interval<Integer> c) {
+    // If a contains b and b contains c, then a contains c
+    if (a.contains(b) && b.contains(c)) {
+      assertThat(a.contains(c)).isTrue();
+    }
+  }
+
+  // ==================== IsBefore and IsAfter ====================
+
+  @Property(tries = 100)
+  void isBeforeAndIsAfterAreInverses(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // a.isBefore(b) == b.isAfter(a)
+    assertThat(a.isBefore(b)).isEqualTo(b.isAfter(a));
+  }
+
+  @Property(tries = 100)
+  void isBeforeAndIsAfterAreMutuallyExclusive(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // Cannot be both before and after
+    assertThat(a.isBefore(b) && a.isAfter(b)).isFalse();
+  }
+
+  @Property(tries = 100)
+  void isBeforeIsIrreflexive(@ForAll("intervals") final Interval<Integer> a) {
+    // An interval is never before itself
+    assertThat(a.isBefore(a)).isFalse();
+  }
+
+  @Property(tries = 100)
+  void isAfterIsIrreflexive(@ForAll("intervals") final Interval<Integer> a) {
+    // An interval is never after itself
+    assertThat(a.isAfter(a)).isFalse();
+  }
+
+  @Property(tries = 100)
+  void isBeforeIsAsymmetric(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If a is before b, then b is not before a
+    if (a.isBefore(b)) {
+      assertThat(b.isBefore(a)).isFalse();
+    }
+  }
+
+  @Property(tries = 100)
+  void isBeforeIsTransitive(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b,
+      @ForAll("intervals") final Interval<Integer> c) {
+    // If a is before b and b is before c, then a is before c
+    if (a.isBefore(b) && b.isBefore(c)) {
+      assertThat(a.isBefore(c)).isTrue();
+    }
+  }
+
+  @Property(tries = 100)
+  void isAfterIsTransitive(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b,
+      @ForAll("intervals") final Interval<Integer> c) {
+    // If a is after b and b is after c, then a is after c
+    if (a.isAfter(b) && b.isAfter(c)) {
+      assertThat(a.isAfter(c)).isTrue();
+    }
+  }
+
+  // ==================== OverlapsWith ====================
+
+  @Property(tries = 100)
+  void overlapsWithIsCommutative(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // a.overlapsWith(b) == b.overlapsWith(a)
+    assertThat(a.overlapsWith(b)).isEqualTo(b.overlapsWith(a));
+  }
+
+  @Property(tries = 100)
+  void overlapsWithIsReflexive(@ForAll("intervals") final Interval<Integer> a) {
+    // Every interval overlaps with itself
+    assertThat(a.overlapsWith(a)).isTrue();
+  }
+
+  @Property(tries = 100)
+  void containmentImpliesOverlap(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If a contains b, then they overlap
+    if (a.contains(b)) {
+      assertThat(a.overlapsWith(b)).isTrue();
+    }
+  }
+
+  @Property(tries = 100)
+  void noOverlapMeansBeforeOrAfter(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If intervals don't overlap, one must be before or after the other
+    if (!a.overlapsWith(b)) {
+      assertThat(a.isBefore(b) || a.isAfter(b)).isTrue();
+    }
+  }
+
+  @Property(tries = 100)
+  void beforeOrAfterMeansNoOverlap(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If one is before/after the other, they don't overlap
+    if (a.isBefore(b) || a.isAfter(b)) {
+      assertThat(a.overlapsWith(b)).isFalse();
+    }
+  }
+
+  // ==================== Map ====================
+
+  @Property(tries = 100)
+  void mapWithIdentityPreservesInterval(@ForAll("intervals") final Interval<Integer> a) {
+    // Mapping with identity function should produce equal interval
+    assertThat(a.map(x -> x)).isEqualTo(a);
+  }
+
+  @Property(tries = 100)
+  void mapPreservesBoundBehavior(@ForAll("intervals") final Interval<Integer> a) {
+    // Mapping should preserve the bound behavior
+    final var mapped = a.map(x -> x * 2L);
+
+    // Start bound behavior preserved
+    assertThat(mapped.contains(mapped.start())).isEqualTo(a.startInclusive());
+    // End bound behavior preserved
+    assertThat(mapped.contains(mapped.end())).isEqualTo(a.endInclusive());
+  }
+
+  @Property(tries = 100)
+  void mapPreservesContainmentRelationship(
+      @ForAll("intervals") final Interval<Integer> a,
+      @ForAll("intervals") final Interval<Integer> b) {
+    // If a contains b, then map(a) contains map(b) for monotonic functions
+    final var mappedA = a.map(x -> x * 2L);
+    final var mappedB = b.map(x -> x * 2L);
+
+    if (a.contains(b)) {
+      assertThat(mappedA.contains(mappedB)).isTrue();
+    }
+  }
+
+  // ==================== Contains Value ====================
+
+  @Property(tries = 100)
+  void containsValueAtStartDependsOnInclusiveness(@ForAll("intervals") final Interval<Integer> a) {
+    assertThat(a.contains(a.start())).isEqualTo(a.startInclusive());
+  }
+
+  @Property(tries = 100)
+  void containsValueAtEndDependsOnInclusiveness(@ForAll("intervals") final Interval<Integer> a) {
+    assertThat(a.contains(a.end())).isEqualTo(a.endInclusive());
+  }
+
+  @Property(tries = 100)
+  void valuesOutsideIntervalAreNeverContained(
+      @ForAll("intervals") final Interval<Integer> a, @ForAll("values") final Integer value) {
+    if (value < a.start() || value > a.end()) {
+      assertThat(a.contains(value)).isFalse();
+    }
+  }
+
+  @Property(tries = 100)
+  void valuesStrictlyInsideIntervalAreAlwaysContained(
+      @ForAll("intervals") final Interval<Integer> a, @ForAll("values") final Integer value) {
+    if (value > a.start() && value < a.end()) {
+      assertThat(a.contains(value)).isTrue();
+    }
+  }
+
+  // ==================== SmallestCover ====================
+
+  @Property(tries = 100)
+  void smallestCoverOfEmptyListIsEmpty(@ForAll("intervals") final Interval<Integer> a) {
+    assertThat(a.smallestCover(List.of())).isEmpty();
+  }
+
+  @Property(tries = 100)
+  void smallestCoverReturnsOnlyOverlappingIntervals(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // All returned intervals must overlap with the query interval
+    final var result = query.smallestCover(intervals);
+
+    for (final var interval : result) {
+      assertThat(interval.overlapsWith(query))
+          .describedAs("Returned interval %s should overlap with query %s", interval, query)
+          .isTrue();
+    }
+  }
+
+  @Property(tries = 100)
+  void smallestCoverDoesNotExcludeOverlappingIntervals(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // All overlapping intervals from input must be in the result
+    final var result = query.smallestCover(intervals);
+
+    for (final var interval : intervals) {
+      if (interval.overlapsWith(query)) {
+        assertThat(result)
+            .describedAs("Overlapping interval %s should be in result", interval)
+            .contains(interval);
+      }
+    }
+  }
+
+  @Property(tries = 100)
+  void smallestCoverPreservesInputOrder(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // Result should be a subsequence of input (preserving order)
+    final var result = query.smallestCover(intervals);
+
+    var inputIndex = 0;
+    for (final var resultInterval : result) {
+      // Find this interval in the remaining input
+      while (inputIndex < intervals.size() && !intervals.get(inputIndex).equals(resultInterval)) {
+        inputIndex++;
+      }
+      assertThat(inputIndex)
+          .describedAs("Result interval %s should appear in input in order", resultInterval)
+          .isLessThan(intervals.size());
+      inputIndex++;
+    }
+  }
+
+  @Property(tries = 100)
+  void smallestCoverResultIsContiguous(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // Since input is contiguous and result is a subsequence, result should also be contiguous
+    // (because overlapping intervals from a contiguous list must be consecutive)
+    final var result = query.smallestCover(intervals);
+
+    if (result.size() > 1) {
+      final var resultList = new ArrayList<>(result);
+      for (int i = 0; i < resultList.size() - 1; i++) {
+        final var current = resultList.get(i);
+        final var next = resultList.get(i + 1);
+        // They should meet at a boundary
+        assertThat(current.end())
+            .describedAs("Interval %s should meet interval %s at boundary", current, next)
+            .isEqualTo(next.start());
+      }
+    }
+  }
+
+  @Property(tries = 100)
+  void smallestCoverUnionContainsQueryWhenFullyCovered(
+      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("contiguousIntervalLists") final List<Interval<Integer>> intervals) {
+    // If the query is fully covered by the input intervals, the result's union should contain query
+    if (intervals.isEmpty()) {
+      return;
+    }
+
+    final var inputStart = intervals.getFirst().start();
+    final var inputEnd = intervals.getLast().end();
+
+    // Check if query is within the range covered by input
+    if (query.start() >= inputStart && query.end() <= inputEnd) {
+      final var result = query.smallestCover(intervals);
+
+      if (!result.isEmpty()) {
+        final var resultList = new ArrayList<>(result);
+        final var resultStart = resultList.getFirst().start();
+        final var resultEnd = resultList.getLast().end();
+
+        // The result's union should cover the query
+        assertThat(resultStart)
+            .describedAs("Result union start should be <= query start")
+            .isLessThanOrEqualTo(query.start());
+        assertThat(resultEnd)
+            .describedAs("Result union end should be >= query end")
+            .isGreaterThanOrEqualTo(query.end());
+      }
+    }
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -122,6 +123,20 @@ public class IntervalTest {
 
       assertThat(interval.contains(1)).isFalse();
       assertThat(interval.contains(10)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, true", "true, false", "false, false"})
+    void shouldThrowExceptionWhenPointIntervalWithExtremesExcluded(
+        final boolean startInclusive, final boolean endInclusive) {
+      assertThatThrownBy(() -> new Interval<>(1, startInclusive, 1, endInclusive))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Interval with equal bounds must be inclusive on both sides");
+    }
+
+    @Test
+    void shouldAllowCreationOfClosedPointInterval() {
+      assertThatNoException().isThrownBy(() -> Interval.closed(1, 1));
     }
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
@@ -366,33 +366,6 @@ public class IntervalTest {
     }
 
     @Test
-    void shouldReturnSameIntervalForSingleElement() {
-      final var interval = Interval.closed(1, 10);
-
-      final var result = Interval.intersection(List.of(interval));
-
-      assertThat(result).contains(interval);
-    }
-
-    @Test
-    void shouldReturnIntersectionOfOverlappingIntervals() {
-      // [1, 10] ∩ [5, 15] = [5, 10]
-      final var result =
-          Interval.intersection(List.of(Interval.closed(1, 10), Interval.closed(5, 15)));
-
-      assertThat(result).contains(Interval.closed(5, 10));
-    }
-
-    @Test
-    void shouldReturnEmptyWhenIntervalsDoNotOverlap() {
-      // [1, 5] ∩ [7, 10] = ∅
-      final var result =
-          Interval.intersection(List.of(Interval.closed(1, 5), Interval.closed(7, 10)));
-
-      assertThat(result).isEmpty();
-    }
-
-    @Test
     void shouldReturnSinglePointWhenIntervalsMeetAtInclusiveBounds() {
       // [1, 5] ∩ [5, 10] = [5, 5]
       final var result =
@@ -417,26 +390,6 @@ public class IntervalTest {
           Interval.intersection(List.of(Interval.openClosed(1, 10), Interval.closedOpen(5, 15)));
 
       assertThat(result).contains(Interval.closed(5, 10));
-    }
-
-    @Test
-    void shouldHandleMultipleIntervals() {
-      // [1, 20] ∩ [5, 15] ∩ [8, 12] = [8, 12]
-      final var result =
-          Interval.intersection(
-              List.of(Interval.closed(1, 20), Interval.closed(5, 15), Interval.closed(8, 12)));
-
-      assertThat(result).contains(Interval.closed(8, 12));
-    }
-
-    @Test
-    void shouldReturnEmptyWhenOneIntervalDoesNotOverlapWithOthers() {
-      // [1, 10] ∩ [5, 15] ∩ [20, 25] = ∅
-      final var result =
-          Interval.intersection(
-              List.of(Interval.closed(1, 10), Interval.closed(5, 15), Interval.closed(20, 25)));
-
-      assertThat(result).isEmpty();
     }
 
     @ParameterizedTest

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
@@ -1,0 +1,530 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class IntervalTest {
+
+  static Stream<Arguments> inclusivenessVariants() {
+    return Stream.of(
+        Arguments.of(true, true),
+        Arguments.of(true, false),
+        Arguments.of(false, true),
+        Arguments.of(false, false));
+  }
+
+  private static Interval<Integer> createInterval(
+      final int start, final boolean startInclusive, final int end, final boolean endInclusive) {
+    return new Interval<>(start, startInclusive, end, endInclusive);
+  }
+
+  private static String expectedBracket(final boolean inclusive, final boolean isStart) {
+    if (isStart) {
+      return inclusive ? "[" : "(";
+    } else {
+      return inclusive ? "]" : ")";
+    }
+  }
+
+  @Nested
+  class Constructor {
+
+    @Test
+    void shouldNotCreateIntervalWithStartGreaterThanEnd() {
+      assertThatThrownBy(() -> new Interval<>(10, 5))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected start <= end");
+    }
+
+    @Test
+    void shouldCreateClosedIntervalWithEqualBounds() {
+      // when
+      final var interval = new Interval<>(5, 5);
+
+      // then
+      assertThat(interval.start()).isEqualTo(5);
+      assertThat(interval.end()).isEqualTo(5);
+      assertThat(interval.startInclusive()).isTrue();
+      assertThat(interval.endInclusive()).isTrue();
+    }
+
+    @Test
+    void shouldThrowWhenStartIsNull() {
+      assertThatThrownBy(() -> new Interval<>(null, 5))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("start must not be null");
+    }
+
+    @Test
+    void shouldThrowWhenEndIsNull() {
+      assertThatThrownBy(() -> new Interval<>(1, null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("end must not be null");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, true", "true, false", "false, false"})
+    void shouldThrowWhenEqualBoundsNotFullyInclusive(
+        final boolean startInclusive, final boolean endInclusive) {
+      assertThatThrownBy(() -> new Interval<>(5, startInclusive, 5, endInclusive))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Interval with equal bounds must be inclusive on both sides");
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldCreateIntervalWithCorrectInclusiveness(
+        final boolean startInclusive, final boolean endInclusive) {
+      // when
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // then
+      assertThat(interval.start()).isEqualTo(1);
+      assertThat(interval.end()).isEqualTo(10);
+      assertThat(interval.startInclusive()).isEqualTo(startInclusive);
+      assertThat(interval.endInclusive()).isEqualTo(endInclusive);
+    }
+
+    @Test
+    void shouldCreateClosedIntervalUsingFactoryMethod() {
+      final var interval = Interval.closed(1, 10);
+      assertThat(interval).isEqualTo(new Interval<>(1, true, 10, true));
+    }
+
+    @Test
+    void shouldCreateOpenIntervalUsingFactoryMethod() {
+      final var interval = Interval.open(1, 10);
+      assertThat(interval).isEqualTo(new Interval<>(1, false, 10, false));
+    }
+
+    @Test
+    void shouldCreateClosedOpenIntervalUsingFactoryMethod() {
+      final var interval = Interval.closedOpen(1, 10);
+      assertThat(interval).isEqualTo(new Interval<>(1, true, 10, false));
+    }
+
+    @Test
+    void shouldCreateOpenClosedIntervalUsingFactoryMethod() {
+      final var interval = Interval.openClosed(1, 10);
+      assertThat(interval).isEqualTo(new Interval<>(1, false, 10, true));
+    }
+  }
+
+  @Nested
+  class EqualsAndHashCode {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldBeEqualAndHaveSameHashCodeWhenIntervalsAreEqual(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval1 = createInterval(1, startInclusive, 10, endInclusive);
+      final var interval2 = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval1).isEqualTo(interval2);
+      assertThat(interval1.hashCode()).isEqualTo(interval2.hashCode());
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotBeEqualWhenIntervalsHaveDifferentStarts(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval1 = createInterval(1, startInclusive, 10, endInclusive);
+      final var interval2 = createInterval(2, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval1).isNotEqualTo(interval2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotBeEqualWhenIntervalsHaveDifferentEnds(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval1 = createInterval(1, startInclusive, 10, endInclusive);
+      final var interval2 = createInterval(1, startInclusive, 11, endInclusive);
+
+      // when/then
+      assertThat(interval1).isNotEqualTo(interval2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotBeEqualWhenIntervalsHaveDifferentInclusiveness(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval1 = createInterval(1, startInclusive, 10, endInclusive);
+      final var interval2 = createInterval(1, !startInclusive, 10, !endInclusive);
+
+      // when/then
+      assertThat(interval1).isNotEqualTo(interval2);
+      assertThat(interval1.hashCode()).isNotEqualTo(interval2.hashCode());
+    }
+  }
+
+  @Nested
+  class ContainsValue {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldContainValueInMiddleOfInterval(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(5)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldContainOrExcludeStartBasedOnInclusiveness(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(1)).isEqualTo(startInclusive);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldContainOrExcludeEndBasedOnInclusiveness(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(10)).isEqualTo(endInclusive);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotContainValueBeforeStart(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(0)).isFalse();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotContainValueAfterEnd(final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(11)).isFalse();
+    }
+  }
+
+  @Nested
+  class ContainsInterval {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldContainSmallerIntervalInside(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+      final var other = createInterval(3, startInclusive, 7, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(other)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldContainEqualInterval(final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+      final var other = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(other)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotContainLargerInterval(final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(3, startInclusive, 7, endInclusive);
+      final var other = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.contains(other)).isFalse();
+    }
+
+    @Test
+    void shouldContainOpenIntervalWhenClosedHasSameBounds() {
+      // [1, 10] contains (1, 10) because exclusive bounds are narrower
+      assertThat(Interval.closed(1, 10).contains(Interval.open(1, 10))).isTrue();
+    }
+
+    @Test
+    void shouldNotContainClosedIntervalWhenOpenHasSameBounds() {
+      // (1, 10) does not contain [1, 10] because inclusive bounds are wider
+      assertThat(Interval.open(1, 10).contains(Interval.closed(1, 10))).isFalse();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      // exclusive start does not contain inclusive start at same point
+      "false, true,  true, true,  false",
+      // exclusive end does not contain inclusive end at same point
+      "true, false,  true, true,  false",
+      // inclusive contains exclusive at same bounds
+      "true, true,   false, false, true",
+      // same inclusiveness is contained
+      "true, false,  true, false, true",
+      "false, true,  false, true, true"
+    })
+    void shouldRespectBoundInclusivenessWhenCheckingContainment(
+        final boolean outerStartIncl,
+        final boolean outerEndIncl,
+        final boolean innerStartIncl,
+        final boolean innerEndIncl,
+        final boolean expectedContains) {
+      // given
+      final var outer = createInterval(1, outerStartIncl, 10, outerEndIncl);
+      final var inner = createInterval(1, innerStartIncl, 10, innerEndIncl);
+
+      // when/then
+      assertThat(outer.contains(inner)).isEqualTo(expectedContains);
+    }
+  }
+
+  @Nested
+  class OverlapsWith {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldOverlapWhenIntervalsIntersect(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+      final var other = createInterval(5, startInclusive, 15, endInclusive);
+
+      // when/then
+      assertThat(interval.overlapsWith(other)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldOverlapWhenOneContainsOther(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+      final var other = createInterval(3, startInclusive, 7, endInclusive);
+
+      // when/then
+      assertThat(interval.overlapsWith(other)).isTrue();
+      assertThat(other.overlapsWith(interval)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldNotOverlapWhenIntervalsAreDisjoint(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 5, endInclusive);
+      final var other = createInterval(7, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.overlapsWith(other)).isFalse();
+    }
+
+    @Test
+    void shouldOverlapWhenBothBoundsInclusiveAtSamePoint() {
+      // [1, 10] and [10, 15] share point 10
+      assertThat(Interval.closed(1, 10).overlapsWith(Interval.closed(10, 15))).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      // [1, 10) and [10, 15] - first excludes 10
+      "true, false,  true, true,  false",
+      // [1, 10] and (10, 15] - second excludes 10
+      "true, true,   false, true, false",
+      // [1, 10) and (10, 15] - both exclude 10
+      "true, false,  false, true, false"
+    })
+    void shouldNotOverlapWhenBoundaryPointIsExcluded(
+        final boolean firstStartIncl,
+        final boolean firstEndIncl,
+        final boolean secondStartIncl,
+        final boolean secondEndIncl,
+        final boolean expectedOverlap) {
+      // given - intervals meeting at point 10
+      final var first = createInterval(1, firstStartIncl, 10, firstEndIncl);
+      final var second = createInterval(10, secondStartIncl, 15, secondEndIncl);
+
+      // when/then
+      assertThat(first.overlapsWith(second)).isEqualTo(expectedOverlap);
+    }
+  }
+
+  @Nested
+  class SmallestCover {
+
+    @Test
+    void shouldReturnEmptyListWhenCalledWithEmptyList() {
+      // given
+      final var interval = Interval.closed(1, 10);
+
+      // when
+      final var result = interval.smallestCover(List.of());
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOnlyOverlappingIntervals() {
+      // given - interval [5, 15] should overlap with [5, 10) and [10, 20], but not [1, 5)
+      final var interval = Interval.closed(5, 15);
+      final var intervals =
+          List.of(Interval.closedOpen(1, 5), Interval.closedOpen(5, 10), Interval.closed(10, 20));
+
+      // when
+      final var result = interval.smallestCover(intervals);
+
+      // then
+      assertThat(result).containsExactly(Interval.closedOpen(5, 10), Interval.closed(10, 20));
+    }
+
+    @Test
+    void shouldThrowWhenIntervalsAreNotContiguous() {
+      // given
+      final var interval = Interval.closed(1, 10);
+      final var intervals = List.of(Interval.closedOpen(1, 3), Interval.closed(5, 10));
+
+      // when/then
+      assertThatThrownBy(() -> interval.smallestCover(intervals))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected intervals to be contiguous");
+    }
+
+    @Test
+    void shouldAcceptContiguousIntervalsWithMatchingBoundaries() {
+      // given - [1, 5) and [5, 10] are contiguous
+      final var interval = Interval.closed(1, 10);
+      final var intervals = List.of(Interval.closedOpen(1, 5), Interval.closed(5, 10));
+
+      // when
+      final var result = interval.smallestCover(intervals);
+
+      // then
+      assertThat(result).containsExactly(Interval.closedOpen(1, 5), Interval.closed(5, 10));
+    }
+
+    @Test
+    void shouldAcceptContiguousClosedIntervals() {
+      // given - [1, 5] and [5, 10] share point 5
+      final var interval = Interval.closed(1, 10);
+      final var intervals = List.of(Interval.closed(1, 5), Interval.closed(5, 10));
+
+      // when
+      final var result = interval.smallestCover(intervals);
+
+      // then
+      assertThat(result).containsExactly(Interval.closed(1, 5), Interval.closed(5, 10));
+    }
+
+    @Test
+    void shouldThrowWhenIntervalsHaveGapDueToExclusiveBoundaries() {
+      // given - [1, 5) and (5, 10] have a gap at point 5
+      final var interval = Interval.closed(1, 10);
+      final var intervals = List.of(Interval.closedOpen(1, 5), Interval.openClosed(5, 10));
+
+      // when/then
+      assertThatThrownBy(() -> interval.smallestCover(intervals))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected intervals to be contiguous");
+    }
+  }
+
+  @Nested
+  class Values {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldReturnStartAndEnd(final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      assertThat(interval.values()).containsExactly(1, 10);
+    }
+  }
+
+  @Nested
+  class Map {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldMapIntervalValuesAndPreserveInclusiveness(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when
+      final var mapped = interval.map(i -> i * 2L);
+
+      // then
+      assertThat(mapped.start()).isEqualTo(2L);
+      assertThat(mapped.end()).isEqualTo(20L);
+      assertThat(mapped.startInclusive()).isEqualTo(startInclusive);
+      assertThat(mapped.endInclusive()).isEqualTo(endInclusive);
+    }
+
+    @Test
+    void shouldMapIntervalToStringType() {
+      // given
+      final var interval = Interval.closed(1, 5);
+
+      // when
+      final var mapped = interval.map(Object::toString);
+
+      // then
+      assertThat(mapped).isEqualTo(Interval.closed("1", "5"));
+    }
+  }
+
+  @Nested
+  class ToString {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.backup.api.IntervalTest#inclusivenessVariants")
+    void shouldFormatWithMathematicalNotation(
+        final boolean startInclusive, final boolean endInclusive) {
+      // given
+      final var interval = createInterval(1, startInclusive, 10, endInclusive);
+
+      // when/then
+      final var expected =
+          expectedBracket(startInclusive, true) + "1, 10" + expectedBracket(endInclusive, false);
+      assertThat(interval.toString()).isEqualTo(expected);
+    }
+  }
+}


### PR DESCRIPTION
## Description
Added inclusive/exclusive bound support to the Interval class with factory methods (closed(), open(), closedOpen(), openClosed()), isBefore()/isAfter() methods, and mathematical notation in toString() (e.g., [1, 10), (1, 10]).

Added method `smallestCover` that can be used to find the smallest covering subset of intervals given a given interval. This is necessary for correctly implementing #40232  and it's nicely tested by PBT.

Added property-based tests using jqwik that verify mathematical properties (reflexivity, symmetry, transitivity, commutativity) across all interval operations.

In the future we might even think about moving this class to a common package, but I didn't do it in this PR.
## Related issues

relates #40232 
