### PR TITLE
fix: prevent dot variable names from crashing

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
@@ -17,6 +17,9 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
@@ -7,7 +7,7 @@
  */
 
 const createVariableFieldName = (name: string) => {
-  return `#${name}`;
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The issue comes from React Final Form. So I'm escaping the variable name

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45136
