### PR TITLE
Introduce variable value type filtering

### DIFF
--- a/zeebe/exporter-filter/pom.xml
+++ b/zeebe/exporter-filter/pom.xml
@@ -29,6 +29,16 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -41,5 +41,9 @@ public interface FilterConfiguration {
     List<String> getVariableNameExclusionStartWith();
 
     List<String> getVariableNameExclusionEndWith();
+
+    List<String> getVariableValueTypeInclusion();
+
+    List<String> getVariableValueTypeExclusion();
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class VariableTypeFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(VariableTypeFilter.class);
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 9, 0, null, null);
+
+  private final ObjectMapper objectMapper;
+
+  private final Set<VariableValueType> allowedTypes;
+
+  public VariableTypeFilter(
+      final Set<VariableValueType> inclusion, final Set<VariableValueType> exclusion) {
+    this(new ObjectMapper(), inclusion, exclusion);
+  }
+
+  public VariableTypeFilter(
+      final ObjectMapper objectMapper,
+      final Set<VariableValueType> inclusion,
+      final Set<VariableValueType> exclusion) {
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+
+    final EnumSet<VariableValueType> allowed;
+    if (inclusion.isEmpty()) {
+      allowed = EnumSet.allOf(VariableValueType.class);
+      allowed.removeAll(exclusion);
+    } else {
+      allowed = EnumSet.copyOf(inclusion);
+      allowed.removeAll(exclusion);
+    }
+
+    allowedTypes = Collections.unmodifiableSet(allowed);
+  }
+
+  private static Set<VariableValueType> normalizeTypes(final Set<VariableValueType> rawTypes) {
+    if (rawTypes == null || rawTypes.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Set.copyOf(rawTypes);
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {
+      return true;
+    }
+    final VariableValueType inferredType = inferValueType(variableRecordValue.getValue());
+
+    return allowedTypes.contains(inferredType);
+  }
+
+  /**
+   * Infers a logical type from the JSON representation of the variable value, mirroring Optimize's
+   * ZeebeVariableImportService#getVariableTypeFromJsonNode:
+   *
+   * <p>NUMBER -> NUMBER BOOLEAN -> BOOLEAN STRING -> STRING OBJECT -> OBJECT ARRAY -> OBJECT
+   *
+   * <p>If parsing fails, falls back to UNKNOWN. Null raw value -> NULL.
+   */
+  private VariableValueType inferValueType(final String raw) {
+    if (raw == null) {
+      return VariableValueType.NULL;
+    }
+
+    try {
+      final JsonNode jsonNode = objectMapper.readTree(raw);
+      if (jsonNode == null) {
+        return VariableValueType.UNKNOWN;
+      }
+
+      return switch (jsonNode.getNodeType()) {
+        case NUMBER -> VariableValueType.NUMBER;
+        case BOOLEAN -> VariableValueType.BOOLEAN;
+        case STRING -> VariableValueType.STRING;
+        case OBJECT, ARRAY -> VariableValueType.OBJECT;
+        case NULL -> VariableValueType.NULL;
+        default -> VariableValueType.UNKNOWN;
+      };
+    } catch (final JsonProcessingException e) {
+      return VariableValueType.UNKNOWN;
+    }
+  }
+
+  public static Set<VariableValueType> parseTypes(final List<String> rawValues) {
+    if (rawValues == null || rawValues.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    final EnumSet<VariableValueType> result = EnumSet.noneOf(VariableValueType.class);
+
+    for (final String value : rawValues) {
+      if (value == null) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("parseTypes: skipping null value");
+        }
+        continue;
+      }
+
+      final String upper = value.trim().toUpperCase(Locale.ROOT);
+      if (upper.isEmpty()) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("parseTypes: skipping empty value after trim (original='{}')", value);
+        }
+        continue;
+      }
+
+      if (upper.equals(VariableValueType.UNKNOWN.name())) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("parseTypes: skipping explicit UNKNOWN type token (original='{}')", value);
+        }
+        continue;
+      }
+
+      try {
+        final VariableValueType parsed = VariableValueType.valueOf(upper);
+        result.add(parsed);
+      } catch (final IllegalArgumentException ex) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "parseTypes: unable to parse variable value type token '{}', skipping", value, ex);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+
+  /** Inferred variable value types (aligned with Optimize's JSON-node based mapping). */
+  public enum VariableValueType {
+    BOOLEAN,
+    NUMBER,
+    STRING,
+    OBJECT,
+    NULL,
+    UNKNOWN
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
@@ -56,13 +56,6 @@ public final class VariableTypeFilter implements ExporterRecordFilter, RecordVer
     allowedTypes = Collections.unmodifiableSet(allowed);
   }
 
-  private static Set<VariableValueType> normalizeTypes(final Set<VariableValueType> rawTypes) {
-    if (rawTypes == null || rawTypes.isEmpty()) {
-      return Collections.emptySet();
-    }
-    return Set.copyOf(rawTypes);
-  }
-
   @Override
   public boolean accept(final Record<?> record) {
     if (!(record.getValue() instanceof final VariableRecordValue variableRecordValue)) {

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/VariableTypeFilterTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.filter.VariableTypeFilter.VariableValueType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class VariableTypeFilterTest {
+
+  // ---------------------------------------------------------------------------
+  // accept(...) behavior
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptAllRecordsWhenInclusionAndExclusionEmpty() {
+    // given
+    final var filter = new VariableTypeFilter(/* inclusion */ Set.of(), /* exclusion */ Set.of());
+
+    final var variableRecord = variableRecord("true");
+    final var nonVariableRecord = nonVariableRecord();
+
+    // when / then
+    assertThat(filter.accept(variableRecord)).as("variable record should be accepted").isTrue();
+    assertThat(filter.accept(nonVariableRecord))
+        .as("non-variable record should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldFilterByInclusionOnly() {
+    // given
+    final var filter =
+        new VariableTypeFilter(
+            /* inclusion */ Set.of(VariableValueType.BOOLEAN, VariableValueType.STRING),
+            /* exclusion */ Set.of());
+
+    final var booleanVar = variableRecord("true");
+    final var stringVar = variableRecord("\"foo\"");
+    final var numberVar = variableRecord("42");
+
+    // when / then
+    assertThat(filter.accept(booleanVar)).isTrue();
+    assertThat(filter.accept(stringVar)).isTrue();
+    assertThat(filter.accept(numberVar)).isFalse();
+  }
+
+  @Test
+  void shouldFilterByExclusionOnly() {
+    // given
+    final var filter =
+        new VariableTypeFilter(
+            /* inclusion */ Set.of(),
+            /* exclusion */ Set.of(VariableValueType.BOOLEAN, VariableValueType.STRING));
+
+    final var booleanVar = variableRecord("false");
+    final var stringVar = variableRecord("\"bar\"");
+    final var numberVar = variableRecord("123.4");
+
+    // when / then
+    assertThat(filter.accept(booleanVar)).isFalse();
+    assertThat(filter.accept(stringVar)).isFalse();
+    assertThat(filter.accept(numberVar)).isTrue();
+  }
+
+  @Test
+  void shouldLetExclusionOverrideInclusionWhenBothPresent() {
+    // given
+    final var filter =
+        new VariableTypeFilter(
+            /* inclusion */ Set.of(VariableValueType.STRING, VariableValueType.OBJECT),
+            /* exclusion */ Set.of(VariableValueType.STRING));
+
+    final var stringVar = variableRecord("\"foo\"");
+    final var objectVar = variableRecord("{\"a\":1}");
+
+    // when / then
+    assertThat(filter.accept(stringVar))
+        .as("STRING is included but also excluded -> should be rejected")
+        .isFalse();
+    assertThat(filter.accept(objectVar)).as("OBJECT is only included -> accepted").isTrue();
+  }
+
+  @Test
+  void shouldSupportNullVariablesWhenExplicitlyIncluded() {
+    // given
+    final var filter =
+        new VariableTypeFilter(
+            /* inclusion */ Set.of(VariableValueType.NULL), /* exclusion */ Set.of());
+
+    final var nullVar = variableRecord(null);
+    final var nonNullVar = variableRecord("\"foo\"");
+
+    // when / then
+    assertThat(filter.accept(nullVar)).isTrue();
+    assertThat(filter.accept(nonNullVar)).isFalse();
+  }
+
+  @Test
+  void shouldInferJsonNullAsNullType() {
+    // Only allow NULL so we can detect that branch via accept()
+    final var filter =
+        new VariableTypeFilter(
+            EnumSet.of(VariableTypeFilter.VariableValueType.NULL), Collections.emptySet());
+
+    @SuppressWarnings("unchecked")
+    final Record<VariableRecordValue> record = (Record<VariableRecordValue>) mock(Record.class);
+    final var value = mock(VariableRecordValue.class);
+
+    when(record.getValue()).thenReturn(value);
+    // Jackson will parse this into a NullNode with nodeType == JsonNodeType.NULL
+    when(value.getValue()).thenReturn("null");
+
+    // when
+    final boolean accepted = filter.accept(record);
+
+    // then
+    assertThat(accepted)
+        .as("JSON literal 'null' should be inferred as VariableValueType.NULL")
+        .isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Type inference via accept(...)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldReturnEmptySetForNullOrEmptyRawTypes() {
+    assertThat(VariableTypeFilter.parseTypes(null)).isEmpty();
+    assertThat(VariableTypeFilter.parseTypes(List.of())).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // parseTypes(...)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldParseValidTypeTokensCaseInsensitively() {
+    // given
+    final var rawValues = List.of("boolean", "NUMBER", "String", "ObJeCt");
+
+    // when
+    final var types = VariableTypeFilter.parseTypes(rawValues);
+
+    // then
+    assertThat(types)
+        .containsExactlyInAnyOrder(
+            VariableValueType.BOOLEAN,
+            VariableValueType.NUMBER,
+            VariableValueType.STRING,
+            VariableValueType.OBJECT);
+  }
+
+  @Test
+  void shouldIgnoreUnknownEmptyAndNullTokens() {
+    // given
+    final var rawValues =
+        Arrays.asList(
+            "boolean",
+            "  ", // empty after trim
+            null, // allowed here
+            "unknown",
+            "does-not-exist",
+            "STRING");
+
+    // when
+    final var types = VariableTypeFilter.parseTypes(rawValues);
+
+    // then
+    assertThat(types)
+        .containsExactlyInAnyOrder(VariableValueType.BOOLEAN, VariableValueType.STRING);
+  }
+
+  @Test
+  void shouldExposeMinimumBrokerVersion() {
+    final var filter = new VariableTypeFilter(Set.of(), Set.of());
+
+    assertThat(filter.minRecordBrokerVersion()).isEqualTo(new SemanticVersion(8, 9, 0, null, null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Versioning
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static Record<?> variableRecord(final String value) {
+    final var variableValue = mock(VariableRecordValue.class);
+    when(variableValue.getValue()).thenReturn(value);
+
+    final var record = (Record<VariableRecordValue>) mock(Record.class);
+    when(record.getValue()).thenReturn(variableValue);
+
+    return record;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  private static Record<?> nonVariableRecord() {
+    @SuppressWarnings("unchecked")
+    final var record = (Record<RecordValue>) mock(Record.class);
+
+    final var someOtherValue = mock(RecordValue.class);
+    when(record.getValue()).thenReturn(someOtherValue);
+
+    return record;
+  }
+
+  @Nested
+  final class TypeInference {
+
+    private final VariableTypeFilter booleanOnlyFilter =
+        new VariableTypeFilter(Set.of(VariableValueType.BOOLEAN), Set.of());
+    private final VariableTypeFilter doubleOnlyFilter =
+        new VariableTypeFilter(Set.of(VariableValueType.NUMBER), Set.of());
+    private final VariableTypeFilter stringOnlyFilter =
+        new VariableTypeFilter(Set.of(VariableValueType.STRING), Set.of());
+    private final VariableTypeFilter objectOnlyFilter =
+        new VariableTypeFilter(Set.of(VariableValueType.OBJECT), Set.of());
+
+    @Test
+    void shouldInferBooleanFromJsonBoolean() {
+      assertThat(booleanOnlyFilter.accept(variableRecord("true"))).isTrue();
+      assertThat(booleanOnlyFilter.accept(variableRecord("false"))).isTrue();
+      assertThat(booleanOnlyFilter.accept(variableRecord("\"true\"")))
+          .as("JSON string '\"true\"' is STRING, not BOOLEAN")
+          .isFalse();
+    }
+
+    @Test
+    void shouldInferDoubleFromJsonNumber() {
+      assertThat(doubleOnlyFilter.accept(variableRecord("0"))).isTrue();
+      assertThat(doubleOnlyFilter.accept(variableRecord("1.23"))).isTrue();
+      assertThat(doubleOnlyFilter.accept(variableRecord("\"1.23\"")))
+          .as("JSON string '\"1.23\"' is STRING, not DOUBLE")
+          .isFalse();
+    }
+
+    @Test
+    void shouldInferStringFromJsonString() {
+      assertThat(stringOnlyFilter.accept(variableRecord("\"foo\""))).isTrue();
+    }
+
+    @Test
+    void shouldInferUnknownFromInvalidJson() {
+      assertThat(stringOnlyFilter.accept(variableRecord("foo")))
+          .as("invalid JSON treated as UNKNOWN")
+          .isFalse();
+    }
+
+    @Test
+    void shouldInferObjectFromJsonObjectOrArray() {
+      assertThat(objectOnlyFilter.accept(variableRecord("{\"a\":1}"))).isTrue();
+      assertThat(objectOnlyFilter.accept(variableRecord("[1,2,3]"))).isTrue();
+    }
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestConfiguration.java
@@ -47,11 +47,6 @@ public final class TestConfiguration implements FilterConfiguration {
     return this;
   }
 
-  /** Access to the underlying index config for tests that need to configure name rules. */
-  public TestIndexConfig testIndexConfig() {
-    return indexConfig;
-  }
-
   @Override
   public boolean shouldIndexValueType(final ValueType valueType) {
     return normalFlags.getOrDefault(valueType, false);
@@ -68,7 +63,7 @@ public final class TestConfiguration implements FilterConfiguration {
   }
 
   @Override
-  public IndexConfig filterIndexConfig() {
+  public TestIndexConfig filterIndexConfig() {
     return indexConfig;
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
@@ -26,6 +26,9 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   private List<String> exclusionStartWith = List.of();
   private List<String> exclusionEndWith = List.of();
 
+  private List<String> variableValueTypeInclusion = List.of();
+  private List<String> variableValueTypeExclusion = List.of();
+
   // --- fluent setters -------------------------------------------------------
 
   public TestIndexConfig withVariableNameInclusionExact(final List<String> names) {
@@ -55,6 +58,16 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
 
   public TestIndexConfig withVariableNameExclusionEndWith(final List<String> suffixes) {
     exclusionEndWith = suffixes != null ? suffixes : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableValueTypeInclusion(final List<String> typeInclusion) {
+    variableValueTypeInclusion = typeInclusion != null ? typeInclusion : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withVariableValueTypeExclusion(final List<String> typeExclusion) {
+    variableValueTypeExclusion = typeExclusion != null ? typeExclusion : List.of();
     return this;
   }
 
@@ -88,5 +101,15 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   @Override
   public List<String> getVariableNameExclusionEndWith() {
     return exclusionEndWith;
+  }
+
+  @Override
+  public List<String> getVariableValueTypeInclusion() {
+    return variableValueTypeInclusion;
+  }
+
+  @Override
+  public List<String> getVariableValueTypeExclusion() {
+    return variableValueTypeExclusion;
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -246,12 +246,16 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private int templatePriority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters
-    private final List<String> variableNameInclusionExact = new ArrayList<>();
-    private final List<String> variableNameInclusionStartWith = new ArrayList<>();
-    private final List<String> variableNameInclusionEndWith = new ArrayList<>();
-    private final List<String> variableNameExclusionExact = new ArrayList<>();
-    private final List<String> variableNameExclusionStartWith = new ArrayList<>();
-    private final List<String> variableNameExclusionEndWith = new ArrayList<>();
+    private List<String> variableNameInclusionExact = new ArrayList<>();
+    private List<String> variableNameInclusionStartWith = new ArrayList<>();
+    private List<String> variableNameInclusionEndWith = new ArrayList<>();
+    private List<String> variableNameExclusionExact = new ArrayList<>();
+    private List<String> variableNameExclusionStartWith = new ArrayList<>();
+    private List<String> variableNameExclusionEndWith = new ArrayList<>();
+
+    // variable value type filters
+    private List<String> variableValueTypeInclusion = new ArrayList<>();
+    private List<String> variableValueTypeExclusion = new ArrayList<>();
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -284,27 +288,71 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
     @Override
     public List<String> getVariableNameInclusionStartWith() {
-      return variableNameInclusionStartWith;
+      return List.copyOf(variableNameInclusionStartWith);
     }
 
     @Override
     public List<String> getVariableNameInclusionEndWith() {
-      return variableNameInclusionEndWith;
+      return List.copyOf(variableNameInclusionEndWith);
     }
 
     @Override
     public List<String> getVariableNameExclusionExact() {
-      return variableNameExclusionExact;
+      return List.copyOf(variableNameExclusionExact);
     }
 
     @Override
     public List<String> getVariableNameExclusionStartWith() {
-      return variableNameExclusionStartWith;
+      return List.copyOf(variableNameExclusionStartWith);
     }
 
     @Override
     public List<String> getVariableNameExclusionEndWith() {
-      return variableNameExclusionEndWith;
+      return List.copyOf(variableNameExclusionEndWith);
+    }
+
+    @Override
+    public List<String> getVariableValueTypeInclusion() {
+      return List.copyOf(variableValueTypeInclusion);
+    }
+
+    @Override
+    public List<String> getVariableValueTypeExclusion() {
+      return List.copyOf(variableValueTypeExclusion);
+    }
+
+    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
+      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    }
+
+    public void setVariableValueTypeInclusion(final List<String> variableValueTypeInclusion) {
+      this.variableValueTypeInclusion = variableValueTypeInclusion;
+    }
+
+    public void setVariableNameExclusionEndWith(final List<String> variableNameExclusionEndWith) {
+      this.variableNameExclusionEndWith = variableNameExclusionEndWith;
+    }
+
+    public void setVariableNameExclusionStartWith(
+        final List<String> variableNameExclusionStartWith) {
+      this.variableNameExclusionStartWith = variableNameExclusionStartWith;
+    }
+
+    public void setVariableNameExclusionExact(final List<String> variableNameExclusionExact) {
+      this.variableNameExclusionExact = variableNameExclusionExact;
+    }
+
+    public void setVariableNameInclusionEndWith(final List<String> variableNameInclusionEndWith) {
+      this.variableNameInclusionEndWith = variableNameInclusionEndWith;
+    }
+
+    public void setVariableNameInclusionStartWith(
+        final List<String> variableNameInclusionStartWith) {
+      this.variableNameInclusionStartWith = variableNameInclusionStartWith;
+    }
+
+    public void setVariableNameInclusionExact(final List<String> variableNameInclusionExact) {
+      this.variableNameInclusionExact = variableNameInclusionExact;
     }
 
     @Override
@@ -414,6 +462,10 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + variableNameExclusionStartWith
           + ", variableNameExclusionEndWith="
           + variableNameExclusionEndWith
+          + ", variableValueTypeInclusion="
+          + variableValueTypeInclusion
+          + ", variableValueTypeExclusion="
+          + variableValueTypeExclusion
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -237,12 +237,16 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters
-    private final List<String> variableNameInclusionExact = new ArrayList<>();
-    private final List<String> variableNameInclusionStartWith = new ArrayList<>();
-    private final List<String> variableNameInclusionEndWith = new ArrayList<>();
-    private final List<String> variableNameExclusionExact = new ArrayList<>();
-    private final List<String> variableNameExclusionStartWith = new ArrayList<>();
-    private final List<String> variableNameExclusionEndWith = new ArrayList<>();
+    private List<String> variableNameInclusionExact = new ArrayList<>();
+    private List<String> variableNameInclusionStartWith = new ArrayList<>();
+    private List<String> variableNameInclusionEndWith = new ArrayList<>();
+    private List<String> variableNameExclusionExact = new ArrayList<>();
+    private List<String> variableNameExclusionStartWith = new ArrayList<>();
+    private List<String> variableNameExclusionEndWith = new ArrayList<>();
+
+    // variable value type filters
+    private List<String> variableValueTypeInclusion = new ArrayList<>();
+    private List<String> variableValueTypeExclusion = new ArrayList<>();
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -275,27 +279,71 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
 
     @Override
     public List<String> getVariableNameInclusionStartWith() {
-      return variableNameInclusionStartWith;
+      return List.copyOf(variableNameInclusionStartWith);
     }
 
     @Override
     public List<String> getVariableNameInclusionEndWith() {
-      return variableNameInclusionEndWith;
+      return List.copyOf(variableNameInclusionEndWith);
     }
 
     @Override
     public List<String> getVariableNameExclusionExact() {
-      return variableNameExclusionExact;
+      return List.copyOf(variableNameExclusionExact);
     }
 
     @Override
     public List<String> getVariableNameExclusionStartWith() {
-      return variableNameExclusionStartWith;
+      return List.copyOf(variableNameExclusionStartWith);
     }
 
     @Override
     public List<String> getVariableNameExclusionEndWith() {
-      return variableNameExclusionEndWith;
+      return List.copyOf(variableNameExclusionEndWith);
+    }
+
+    @Override
+    public List<String> getVariableValueTypeInclusion() {
+      return List.copyOf(variableValueTypeInclusion);
+    }
+
+    @Override
+    public List<String> getVariableValueTypeExclusion() {
+      return List.copyOf(variableValueTypeExclusion);
+    }
+
+    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
+      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    }
+
+    public void setVariableValueTypeInclusion(final List<String> variableValueTypeInclusion) {
+      this.variableValueTypeInclusion = variableValueTypeInclusion;
+    }
+
+    public void setVariableNameExclusionEndWith(final List<String> variableNameExclusionEndWith) {
+      this.variableNameExclusionEndWith = variableNameExclusionEndWith;
+    }
+
+    public void setVariableNameExclusionStartWith(
+        final List<String> variableNameExclusionStartWith) {
+      this.variableNameExclusionStartWith = variableNameExclusionStartWith;
+    }
+
+    public void setVariableNameExclusionExact(final List<String> variableNameExclusionExact) {
+      this.variableNameExclusionExact = variableNameExclusionExact;
+    }
+
+    public void setVariableNameInclusionEndWith(final List<String> variableNameInclusionEndWith) {
+      this.variableNameInclusionEndWith = variableNameInclusionEndWith;
+    }
+
+    public void setVariableNameInclusionStartWith(
+        final List<String> variableNameInclusionStartWith) {
+      this.variableNameInclusionStartWith = variableNameInclusionStartWith;
+    }
+
+    public void setVariableNameInclusionExact(final List<String> variableNameInclusionExact) {
+      this.variableNameInclusionExact = variableNameInclusionExact;
     }
 
     @Override
@@ -403,6 +451,10 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + variableNameExclusionStartWith
           + ", variableNameExclusionEndWith="
           + variableNameExclusionEndWith
+          + ", variableValueTypeInclusion="
+          + variableValueTypeInclusion
+          + ", variableValueTypeExclusion="
+          + variableValueTypeExclusion
           + '}';
     }
   }


### PR DESCRIPTION
## Description

This PR introduces variable value type filtering to the exporter filter infrastructure so that variable records can be included or excluded based on their inferred JSON type (BOOLEAN, DOUBLE, STRING, OBJECT, NULL, UNKNOWN). This allows administrators to reduce the amount of variable data sent to Optimize and downstream consumers, improving export, ingestion, and analysis performance.

## Key changes

- New VariableTypeFilter
  - Infers a logical type from the variable’s JSON value:
    -  NUMBER → NUMBER, BOOLEAN → BOOLEAN, STRING → STRING, OBJECT/ARRAY → OBJECT, null → NULL, otherwise UNKNOWN.
  -  Applies configurable inclusion and exclusion sets of value types.
  -  Only applies to VARIABLE records; non-variable records are always accepted.

- DefaultRecordFilter now constructs:
  - VariableNameFilter (existing name-based filters).
  - VariableTypeFilter (new type-based filters).
  - Both run in the ExportRecordFilterChain for variable records.

By default (no inclusion/exclusion configured), variable records are not filtered by type, preserving existing behavior.

## Related issues

closes https://github.com/camunda/camunda/issues/44138
