### PR TITLE
feat: validate wheter Optimize pom was updated with the previous version

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -165,22 +165,41 @@ jobs:
       #   has been set correctly based on the current release version.
       # - For GA minor releases (e.g., 8.9.0), previousVersion should be set to the
       #   previous minor version (e.g., 8.8.0).
+      # - For new alpha releases (e.g., 8.9.0-alpha1), previousVersion should also be validated
+      #   to ensure main branch was properly updated after stable branch creation.
       # - Long-term, this manual step should disappear once
       #   https://github.com/camunda/camunda/issues/40258 is implemented and
       #   the backend no longer depends on project.previousVersion.
       - name: Validate Optimize Previous Version
-        if: ${{ inputs.includeOptimize && !inputs.dryRun && !contains(inputs.releaseVersion, '-') && endsWith(inputs.releaseVersion, '.0') }}
+        if: ${{ inputs.includeOptimize && !inputs.dryRun && ((!contains(inputs.releaseVersion, '-') && endsWith(inputs.releaseVersion, '.0')) || (contains(inputs.releaseVersion, '-alpha1') && endsWith(split(inputs.releaseVersion, '-')[0], '.0'))) }}
         run: |
           set -euo pipefail
           
           echo "=== Validating Optimize project.previousVersion ==="
           
-          # Extract current release version components (e.g., 8.9.0 -> major=8, minor=9)
           RELEASE_VERSION="${{ inputs.releaseVersion }}"
-          if ! [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
-            echo "❌ FAILED: Release version '${RELEASE_VERSION}' does not match expected pattern X.Y.0"
-            echo "This should not happen due to workflow conditionals. Please check the release version format."
-            exit 1
+          
+          # Determine if this is an alpha release or GA release
+          if [[ "${RELEASE_VERSION}" == *"-alpha"* ]]; then
+            # Alpha release - extract base version (e.g., 8.9.0-alpha1 -> 8.9.0)
+            BASE_VERSION="${RELEASE_VERSION%%-alpha*}"
+            echo "Validating alpha release: ${RELEASE_VERSION} (base version: ${BASE_VERSION})"
+            
+            # Validate base version format
+            if ! [[ "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
+              echo "❌ FAILED: Alpha release base version '${BASE_VERSION}' does not match expected pattern X.Y.0"
+              exit 1
+            fi
+          else
+            # GA release - use release version directly
+            BASE_VERSION="${RELEASE_VERSION}"
+            echo "Validating GA release: ${RELEASE_VERSION}"
+            
+            # Validate GA version format
+            if ! [[ "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
+              echo "❌ FAILED: GA release version '${BASE_VERSION}' does not match expected pattern X.Y.0"
+              exit 1
+            fi
           fi
           
           MAJOR="${BASH_REMATCH[1]}"
@@ -189,7 +208,7 @@ jobs:
           # Handle edge case for X.0.0 releases
           if [[ "${MINOR}" -eq 0 ]]; then
             echo "❌ FAILED: Cannot validate previousVersion for X.0.0 releases"
-            echo "Release version '${RELEASE_VERSION}' is a major release (X.0.0)"
+            echo "Release version '${BASE_VERSION}' is a major release (X.0.0)"
             echo "There is no previous minor version to validate against."
             echo "This validation only applies to minor releases (X.Y.0 where Y > 0)."
             exit 1

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -177,10 +177,23 @@ jobs:
           
           # Extract current release version components (e.g., 8.9.0 -> major=8, minor=9)
           RELEASE_VERSION="${{ inputs.releaseVersion }}"
-          [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]
+          if ! [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
+            echo "❌ FAILED: Release version '${RELEASE_VERSION}' does not match expected pattern X.Y.0"
+            echo "This should not happen due to workflow conditionals. Please check the release version format."
+            exit 1
+          fi
           
           MAJOR="${BASH_REMATCH[1]}"
           MINOR="${BASH_REMATCH[2]}"
+          
+          # Handle edge case for X.0.0 releases
+          if [[ "${MINOR}" -eq 0 ]]; then
+            echo "❌ FAILED: Cannot validate previousVersion for X.0.0 releases"
+            echo "Release version '${RELEASE_VERSION}' is a major release (X.0.0)"
+            echo "There is no previous minor version to validate against."
+            echo "This validation only applies to minor releases (X.Y.0 where Y > 0)."
+            exit 1
+          fi
           
           # Calculate expected previous version (e.g., 8.9.0 -> expected previous is 8.8.0)
           EXPECTED_PREVIOUS_MINOR=$((MINOR - 1))

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -160,6 +160,51 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # NOTE:
+      # - This step validates that Optimize's project.previousVersion in optimize/pom.xml
+      #   has been set correctly based on the current release version.
+      # - For GA minor releases (e.g., 8.9.0), previousVersion should be set to the
+      #   previous minor version (e.g., 8.8.0).
+      # - Long-term, this manual step should disappear once
+      #   https://github.com/camunda/camunda/issues/40258 is implemented and
+      #   the backend no longer depends on project.previousVersion.
+      - name: Validate Optimize Previous Version
+        if: ${{ inputs.includeOptimize && !inputs.dryRun && !contains(inputs.releaseVersion, '-') && endsWith(inputs.releaseVersion, '.0') }}
+        run: |
+          set -euo pipefail
+          
+          echo "=== Validating Optimize project.previousVersion ==="
+          
+          # Extract current release version components (e.g., 8.9.0 -> major=8, minor=9)
+          RELEASE_VERSION="${{ inputs.releaseVersion }}"
+          [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0$ ]]
+          
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          
+          # Calculate expected previous version (e.g., 8.9.0 -> expected previous is 8.8.0)
+          EXPECTED_PREVIOUS_MINOR=$((MINOR - 1))
+          EXPECTED_PREVIOUS_VERSION="${MAJOR}.${EXPECTED_PREVIOUS_MINOR}.0"
+          
+          # Extract actual previous version from optimize/pom.xml
+          ACTUAL_PREVIOUS_VERSION=$(./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.previousVersion -q -DforceStdout 2>/dev/null || echo "")
+          
+          # Validation checks
+          if [[ -z "${ACTUAL_PREVIOUS_VERSION}" ]]; then
+            echo "❌ FAILED: project.previousVersion missing from optimize/pom.xml"
+            echo "Update it before release. See: https://github.com/camunda/camunda/issues/40258"
+            exit 1
+          fi
+          
+          if [[ "${ACTUAL_PREVIOUS_VERSION}" != "${EXPECTED_PREVIOUS_VERSION}" ]]; then
+            echo "❌ FAILED: project.previousVersion not set correctly"
+            echo "Expected: ${EXPECTED_PREVIOUS_VERSION}"
+            echo "Actual:   ${ACTUAL_PREVIOUS_VERSION}"
+            echo "Update it before release. See: https://github.com/camunda/camunda/issues/40258"
+            exit 1
+          fi
+          
+          echo "✅ PASSED: project.previousVersion correctly set to ${ACTUAL_PREVIOUS_VERSION}"
       - name: Maven Prepare Release
         id: maven-prepare-release
         run: |

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -171,7 +171,7 @@ jobs:
       #   https://github.com/camunda/camunda/issues/40258 is implemented and
       #   the backend no longer depends on project.previousVersion.
       - name: Validate Optimize Previous Version
-        if: ${{ inputs.includeOptimize && !inputs.dryRun && ((!contains(inputs.releaseVersion, '-') && endsWith(inputs.releaseVersion, '.0')) || (contains(inputs.releaseVersion, '-alpha1') && endsWith(split(inputs.releaseVersion, '-')[0], '.0'))) }}
+        if: ${{ inputs.includeOptimize && !inputs.dryRun && ((!contains(inputs.releaseVersion, '-') && endsWith(inputs.releaseVersion, '.0')) || contains(inputs.releaseVersion, '.0-alpha1')) }}
         run: |
           set -euo pipefail
           

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -190,6 +190,9 @@ jobs:
               echo "❌ FAILED: Alpha release base version '${BASE_VERSION}' does not match expected pattern X.Y.0"
               exit 1
             fi
+            
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
           else
             # GA release - use release version directly
             BASE_VERSION="${RELEASE_VERSION}"
@@ -200,10 +203,10 @@ jobs:
               echo "❌ FAILED: GA release version '${BASE_VERSION}' does not match expected pattern X.Y.0"
               exit 1
             fi
+            
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
           fi
-          
-          MAJOR="${BASH_REMATCH[1]}"
-          MINOR="${BASH_REMATCH[2]}"
           
           # Handle edge case for X.0.0 releases
           if [[ "${MINOR}" -eq 0 ]]; then
@@ -221,13 +224,7 @@ jobs:
           # Extract actual previous version from optimize/pom.xml
           ACTUAL_PREVIOUS_VERSION=$(./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.previousVersion -q -DforceStdout 2>/dev/null || echo "")
           
-          # Validation checks
-          if [[ -z "${ACTUAL_PREVIOUS_VERSION}" ]]; then
-            echo "❌ FAILED: project.previousVersion missing from optimize/pom.xml"
-            echo "Update it before release. See: https://github.com/camunda/camunda/issues/40258"
-            exit 1
-          fi
-          
+          # Validation check
           if [[ "${ACTUAL_PREVIOUS_VERSION}" != "${EXPECTED_PREVIOUS_VERSION}" ]]; then
             echo "❌ FAILED: project.previousVersion not set correctly"
             echo "Expected: ${EXPECTED_PREVIOUS_VERSION}"

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -325,8 +325,8 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 
 > [!WARNING]
 > - **Manual Step Required:** Two manual updates are needed:
-> 1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
-> 2. After cutting the stable branch, bump `project.previousVersion` on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
+> 1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
+> 2. After cutting the stable branch, bump `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
 > - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
 > - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -320,6 +320,11 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 - **Change of source branch**
   - For 8.8 minor release the source branch `stable/8.8` based on `release-8.8.0-alpha8`
   - Currently  an automated script decides the source branch for the release type, in case of change in future release process, the code needs to be adjusted [here](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/decide_dev_version_and_is_latest_for_release.bpmn#L39)
+- **Optimize Previous Version Management (8.9+)**
+  - Starting with 8.9, Optimize is included in the monorepo release process (`includeOptimize=true`).
+  - **Manual Step Required:** Before performing a minor release that includes Optimize, the `project.previousVersion` property in `optimize/pom.xml` must be manually updated to reflect the previous minor version (e.g., for 8.9.0 release, set `project.previousVersion` to `8.8.0`).
+  - The release workflow includes validation to catch incorrect or missing `project.previousVersion` values, but the initial update must be done manually.
+  - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
 
 ## Troubleshooting
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -322,9 +322,13 @@ In addition to the standard steps above, recent minor releases have surfaced sev
   - Currently  an automated script decides the source branch for the release type, in case of change in future release process, the code needs to be adjusted [here](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/decide_dev_version_and_is_latest_for_release.bpmn#L39)
 - **Optimize Previous Version Management (8.9+)**
   - Starting with 8.9, Optimize is included in the monorepo release process (`includeOptimize=true`).
-  - **Manual Step Required:** Before performing a minor release that includes Optimize, the `project.previousVersion` property in `optimize/pom.xml` must be manually updated to reflect the previous minor version (e.g., for 8.9.0 release, set `project.previousVersion` to `8.8.0`).
-  - The release workflow includes validation to catch incorrect or missing `project.previousVersion` values, but the initial update must be done manually.
-  - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
+
+> [!WARNING]
+> - **Manual Step Required:** Two manual updates are needed:
+    1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
+    2. After cutting the stable branch, bump `project.previousVersion` on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
+>  - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
+> - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
 
 ## Troubleshooting
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -325,9 +325,9 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 
 > [!WARNING]
 > - **Manual Step Required:** Two manual updates are needed:
-    1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
-    2. After cutting the stable branch, bump `project.previousVersion` on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
->  - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
+> 1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
+> 2. After cutting the stable branch, bump `project.previousVersion` on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
+> - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
 > - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
 
 ## Troubleshooting


### PR DESCRIPTION
## Description
The unified camunda-platform-release.yml workflow does not update project.previousVersion in optimize/pom.xml anymore. However, [Optimize’s current upgrade logic still relies on this value to generate correct upgrade plans and upgrade artifacts. ](https://github.com/camunda/camunda/pull/41961#issuecomment-3632726914) If project.previousVersion is stale when we cut a GA minor/major release, we risk producing invalid or incomplete upgrade paths. In order to complete step 4 of https://github.com/camunda/camunda/issues/40184?reload=1, while https://github.com/camunda/camunda/issues/40258 isn't completed and to avoid issues during the minor release we are introducing a validation step.

What this PR does:

- Adds a read‑only validation step in camunda-platform-release.yml that:
- Runs only when includeOptimize == true and the release is a GA major/minor or the first alpha.
- Reads project.previousVersion from optimize/pom.xml.
- Fails early if the property is missing or obviously invalid (e.g. equal to the current releaseVersion, wrong major, etc.).
- The step does not mutate the POM; it only enforces that the value has been updated before the release.

Ownership and dependency on Optimize:

- This PR makes explicit that updating `project.previousVersion` remains the responsibility of the Optimize team for upcoming GA minor/major releases.
- The validation step is a temporary safety net until the Optimize improvement in https://github.com/camunda/camunda/issues/40258 is implemented and the backend no longer depends on this POM property.

Once #40258 (or a related change) removes that dependency, we can:

- Drop this validation from `camunda-platform-release.yml.`
- Remove the manual instruction to update `project.previousVersion` from the Optimize release process.

Release notes
For upcoming minor releases, we did also add a short entry in the release notes to document that this is a temporary constraint while we transition to the automated/streamlined upgrade process described in [#40258](https://github.com/camunda/camunda/issues/40258).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
