### PR TITLE
feat: extend audit log API and client/java with related entity and description fields 

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AuditLogFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AuditLogFilter.java
@@ -435,4 +435,53 @@ public interface AuditLogFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   AuditLogFilter resourceKey(final Consumer<BasicStringProperty> fn);
+
+  /**
+   * Filter audit logs by the related entity key
+   *
+   * @param relatedEntityKey the related entity key
+   * @return the updated filter
+   */
+  AuditLogFilter relatedEntityKey(final String relatedEntityKey);
+
+  /**
+   * Filter audit logs by the related entity key using {@link BasicStringProperty} consumer
+   *
+   * @param fn the related entity key filter consumer
+   * @return the updated filter
+   */
+  AuditLogFilter relatedEntityKey(final Consumer<BasicStringProperty> fn);
+
+  /**
+   * Filter audit logs by the related entity type
+   *
+   * @param relatedEntityType the related entity type
+   * @return the updated filter
+   */
+  AuditLogFilter relatedEntityType(final AuditLogEntityTypeEnum relatedEntityType);
+
+  /**
+   * Filter audit logs by the related entity type using {@link AuditLogEntityTypeFilterProperty}
+   * consumer
+   *
+   * @param fn the related entity type filter consumer
+   * @return the updated filter
+   */
+  AuditLogFilter relatedEntityType(final Consumer<AuditLogEntityTypeFilterProperty> fn);
+
+  /**
+   * Filter audit logs by the entity description
+   *
+   * @param entityDescription the entity description
+   * @return the updated filter
+   */
+  AuditLogFilter entityDescription(final String entityDescription);
+
+  /**
+   * Filter audit logs by the entity description using {@link StringProperty} consumer
+   *
+   * @param fn the entity description filter consumer
+   * @return the updated filter
+   */
+  AuditLogFilter entityDescription(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AuditLogResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AuditLogResult.java
@@ -76,4 +76,10 @@ public interface AuditLogResult {
   String getFormKey();
 
   String getResourceKey();
+
+  String getRelatedEntityKey();
+
+  AuditLogEntityTypeEnum getRelatedEntityType();
+
+  String getEntityDescription();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuditLogFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AuditLogFilterImpl.java
@@ -381,6 +381,45 @@ public class AuditLogFilterImpl
   }
 
   @Override
+  public AuditLogFilter relatedEntityKey(final String relatedEntityKey) {
+    return relatedEntityKey(b -> b.eq(relatedEntityKey));
+  }
+
+  @Override
+  public AuditLogFilter relatedEntityKey(final Consumer<BasicStringProperty> fn) {
+    final BasicStringProperty property = new BasicStringPropertyImpl();
+    fn.accept(property);
+    filter.setRelatedEntityKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AuditLogFilter relatedEntityType(final AuditLogEntityTypeEnum relatedEntityType) {
+    return relatedEntityType(b -> b.eq(relatedEntityType));
+  }
+
+  @Override
+  public AuditLogFilter relatedEntityType(final Consumer<AuditLogEntityTypeFilterProperty> fn) {
+    final AuditLogEntityTypeFilterProperty property = new AuditLogEntityTypeFilterPropertyImpl();
+    fn.accept(property);
+    filter.setRelatedEntityType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AuditLogFilter entityDescription(final String entityDescription) {
+    return entityDescription(b -> b.eq(entityDescription));
+  }
+
+  @Override
+  public AuditLogFilter entityDescription(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setEntityDescription(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.AuditLogFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AuditLogResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AuditLogResultImpl.java
@@ -53,6 +53,9 @@ public class AuditLogResultImpl implements AuditLogResult {
   private String deploymentKey;
   private String formKey;
   private String resourceKey;
+  private String relatedEntityKey;
+  private AuditLogEntityTypeEnum relatedEntityType;
+  private String entityDescription;
 
   public AuditLogResultImpl(final io.camunda.client.protocol.rest.AuditLogResult item) {
     auditLogKey = item.getAuditLogKey();
@@ -82,6 +85,9 @@ public class AuditLogResultImpl implements AuditLogResult {
     deploymentKey = item.getDeploymentKey();
     formKey = item.getFormKey();
     resourceKey = item.getResourceKey();
+    relatedEntityKey = item.getRelatedEntityKey();
+    relatedEntityType = EnumUtil.convert(item.getRelatedEntityType(), AuditLogEntityTypeEnum.class);
+    entityDescription = item.getEntityDescription();
   }
 
   @Override
@@ -317,6 +323,33 @@ public class AuditLogResultImpl implements AuditLogResult {
 
   public void setResourceKey(final String resourceKey) {
     this.resourceKey = resourceKey;
+  }
+
+  @Override
+  public String getRelatedEntityKey() {
+    return relatedEntityKey;
+  }
+
+  public void setRelatedEntityKey(final String relatedEntityKey) {
+    this.relatedEntityKey = relatedEntityKey;
+  }
+
+  @Override
+  public AuditLogEntityTypeEnum getRelatedEntityType() {
+    return relatedEntityType;
+  }
+
+  public void setRelatedEntityType(final AuditLogEntityTypeEnum relatedEntityType) {
+    this.relatedEntityType = relatedEntityType;
+  }
+
+  @Override
+  public String getEntityDescription() {
+    return entityDescription;
+  }
+
+  public void setEntityDescription(final String entityDescription) {
+    this.entityDescription = entityDescription;
   }
 
   public void setTenantId(final String tenantId) {

--- a/clients/java/src/test/java/io/camunda/client/auditlog/SearchAuditLogTest.java
+++ b/clients/java/src/test/java/io/camunda/client/auditlog/SearchAuditLogTest.java
@@ -101,7 +101,10 @@ public class SearchAuditLogTest extends ClientRestTest {
                     .decisionRequirementsKey("decisionRequirementsKey")
                     .decisionDefinitionId("decisionDefinitionId")
                     .decisionDefinitionKey("decisionDefinitionKey")
-                    .decisionEvaluationKey("decisionEvaluationKey"))
+                    .decisionEvaluationKey("decisionEvaluationKey")
+                    .relatedEntityKey("relatedEntityKey")
+                    .relatedEntityType(AuditLogEntityTypeEnum.USER)
+                    .entityDescription("entityDescription"))
         .send()
         .join();
 
@@ -134,6 +137,9 @@ public class SearchAuditLogTest extends ClientRestTest {
     assertThat(filter.getDeploymentKey().get$Eq()).isEqualTo("deploymentKey");
     assertThat(filter.getFormKey().get$Eq()).isEqualTo("formKey");
     assertThat(filter.getResourceKey().get$Eq()).isEqualTo("resourceKey");
+    assertThat(filter.getRelatedEntityKey().get$Eq()).isEqualTo("relatedEntityKey");
+    assertThat(filter.getRelatedEntityType().get$Eq().getValue()).isEqualTo("USER");
+    assertThat(filter.getEntityDescription().get$Eq()).isEqualTo("entityDescription");
   }
 
   @Test
@@ -166,7 +172,10 @@ public class SearchAuditLogTest extends ClientRestTest {
                     .decisionRequirementsKey(f -> f.notIn("decisionRequirementsKey"))
                     .decisionDefinitionId(f -> f.eq("decisionDefinitionId"))
                     .decisionDefinitionKey(f -> f.eq("decisionDefinitionKey"))
-                    .decisionEvaluationKey(f -> f.eq("decisionEvaluationKey")))
+                    .decisionEvaluationKey(f -> f.eq("decisionEvaluationKey"))
+                    .relatedEntityKey(f -> f.eq("relatedEntityKey"))
+                    .relatedEntityType(f -> f.eq(AuditLogEntityTypeEnum.USER))
+                    .entityDescription(f -> f.eq("entityDescription")))
         .send()
         .join();
 
@@ -199,6 +208,9 @@ public class SearchAuditLogTest extends ClientRestTest {
     assertThat(filter.getDeploymentKey().get$Eq()).isEqualTo("deploymentKey");
     assertThat(filter.getFormKey().get$Eq()).isEqualTo("formKey");
     assertThat(filter.getResourceKey().get$Eq()).isEqualTo("resourceKey");
+    assertThat(filter.getRelatedEntityKey().get$Eq()).isEqualTo("relatedEntityKey");
+    assertThat(filter.getRelatedEntityType().get$Eq().getValue()).isEqualTo("USER");
+    assertThat(filter.getEntityDescription().get$Eq()).isEqualTo("entityDescription");
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1023,6 +1023,15 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getDecisionEvaluationKey())
         .map(mapToOperations(Long.class))
         .ifPresent(builder::decisionEvaluationKeyOperations);
+    ofNullable(filter.getRelatedEntityKey())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::relatedEntityKeyOperations);
+    ofNullable(filter.getRelatedEntityType())
+        .map(mapToOperations(String.class, new AuditLogEntityTypeConverter()))
+        .ifPresent(builder::relatedEntityTypeOperations);
+    ofNullable(filter.getEntityDescription())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::entityDescriptionOperations);
     return builder.build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1437,7 +1437,14 @@ public final class SearchQueryResponseMapper {
         .decisionEvaluationKey(KeyUtil.keyToString(auditLog.decisionEvaluationKey()))
         .deploymentKey(KeyUtil.keyToString(auditLog.deploymentKey()))
         .formKey(KeyUtil.keyToString(auditLog.formKey()))
-        .resourceKey(KeyUtil.keyToString(auditLog.resourceKey()));
+        .resourceKey(KeyUtil.keyToString(auditLog.resourceKey()))
+        .relatedEntityKey(auditLog.relatedEntityKey())
+        .relatedEntityType(
+            ofNullable(auditLog.relatedEntityType())
+                .map(Enum::name)
+                .map(AuditLogEntityTypeEnum::fromValue)
+                .orElse(null))
+        .entityDescription(auditLog.entityDescription());
   }
 
   private static ProcessInstanceStateEnum toProtocolState(

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -169,15 +169,20 @@ components:
         relatedEntityKey:
           allOf:
             - $ref: '#/components/schemas/AuditLogEntityKey'
-          description: The key of the related entity.
+          description: |
+            The key of the related entity. The content depends on the operation type and entity type.
+            For example, for authorization operations, this will contain the ID of the owner (e.g., user or group) the authorization belongs to.
         relatedEntityType:
           allOf:
             - $ref: '#/components/schemas/AuditLogEntityTypeEnum'
-          description: The type of the related entity.
+          description: |
+            The type of the related entity. The content depends on the operation type and entity type.
+            For example, for authorization operations, this will contain the type of the owner (e.g., USER or GROUP) the authorization belongs to.
         entityDescription:
           type: string
-          description: Additional description of the entity affected by the operation.
-
+          description: |
+            Additional description of the entity affected by the operation.
+            For example, for variable operations, this will contain the variable name.
     AuditLogSearchQuerySortRequest:
       type: object
       additionalProperties: false

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -166,6 +166,17 @@ components:
           allOf:
             - $ref: 'deployments.yaml#/components/schemas/ResourceKey'
           description: The system-assigned key for this resource.
+        relatedEntityKey:
+          allOf:
+            - $ref: '#/components/schemas/AuditLogEntityKey'
+          description: The key of the related entity.
+        relatedEntityType:
+          allOf:
+            - $ref: '#/components/schemas/AuditLogEntityTypeEnum'
+          description: The type of the related entity.
+        entityDescription:
+          type: string
+          description: Additional description of the entity affected by the operation.
 
     AuditLogSearchQuerySortRequest:
       type: object
@@ -325,6 +336,18 @@ components:
           description: The decision evaluation key search filter.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKeyFilterProperty'
+        relatedEntityKey:
+          description: The related entity key search filter.
+          allOf:
+            - $ref: '#/components/schemas/AuditLogEntityKeyFilterProperty'
+        relatedEntityType:
+          description: The related entity type search filter.
+          allOf:
+            - $ref: '#/components/schemas/EntityTypeFilterProperty'
+        entityDescription:
+          description: The entity description filter.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 
     AuditLogSearchQueryResult:
       description: Audit log search response.


### PR DESCRIPTION
## Description

- Add related entity and description filtering options to client/java
- Add related entity and description fields to HTTP search mappers
- Extend audit log schema with related entity and description fields

## Related issues

related to https://github.com/camunda/camunda/issues/44945
