### PR TITLE
fix: add the CLUSTER_VARIABLE resource type, this was forgotten

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -48,9 +48,7 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
     final var authorizedResourceIds =
         resourceAccessChecks
             .getAuthorizedResourceIdsByType()
-            // FIXME: change resource type to CLUSTER_VARIABLE once available
-            //  (see https://github.com/camunda/camunda/issues/39054)
-            .getOrDefault(AuthorizationResourceType.UNSPECIFIED.name(), List.of());
+            .getOrDefault(AuthorizationResourceType.CLUSTER_VARIABLE.name(), List.of());
     final var dbPage = convertPaging(dbSort, query.page());
     dbQueryBuilder
         .filter(query.filter())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -75,9 +75,7 @@ public class ClusterVariableIT {
             .getGloballyScopedClusterVariable(
                 randomizedVariable.name(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
-                    // FIXME: change resource type to CLUSTER_VARIABLE once available
-                    //  (see https://github.com/camunda/camunda/issues/39054)
-                    AuthorizationResourceType.UNSPECIFIED, randomizedVariable.name()));
+                    AuthorizationResourceType.CLUSTER_VARIABLE, randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertVariableDbModelEqualToEntity(randomizedVariable, instance);
@@ -102,9 +100,7 @@ public class ClusterVariableIT {
                 randomizedVariable.name(),
                 randomizedVariable.tenantId(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
-                    // FIXME: change resource type to CLUSTER_VARIABLE once available
-                    //  (see https://github.com/camunda/camunda/issues/39054)
-                    AuthorizationResourceType.UNSPECIFIED, randomizedVariable.name()));
+                    AuthorizationResourceType.CLUSTER_VARIABLE, randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertThat(instance.isPreview()).isTrue();
@@ -128,9 +124,7 @@ public class ClusterVariableIT {
             .getGloballyScopedClusterVariable(
                 randomizedVariable.name(),
                 CommonFixtures.resourceAccessChecksFromResourceIds(
-                    // FIXME: change resource type to CLUSTER_VARIABLE once available
-                    //  (see https://github.com/camunda/camunda/issues/39054)
-                    AuthorizationResourceType.UNSPECIFIED, randomizedVariable.name()));
+                    AuthorizationResourceType.CLUSTER_VARIABLE, randomizedVariable.name()));
 
     assertThat(instance).isNotNull();
     assertThat(instance.isPreview()).isTrue();


### PR DESCRIPTION
This pull request updates the codebase to use the correct `CLUSTER_VARIABLE` authorization resource type instead of the placeholder `UNSPECIFIED` type. This change affects both the implementation and the related acceptance tests, ensuring that resource access checks are now performed against the appropriate resource type.

**Authorization resource type updates:**

* Updated `ClusterVariableDbReader` to use `AuthorizationResourceType.CLUSTER_VARIABLE` when retrieving authorized resource IDs, replacing the previous use of `UNSPECIFIED`.

**Test updates:**

* Updated all relevant test cases in `ClusterVariableIT.java` to use `AuthorizationResourceType.CLUSTER_VARIABLE` instead of `UNSPECIFIED` for resource access checks:
  - `shouldSaveAndFindGlobalClusterVariableByNameAndResource`
  - `shouldSaveAndFindBigTenantClusterVariableByNameAndResource`
  - `shouldSaveAndFindBigGlobalClusterVariableByNameAndResource`