### PR TITLE
Don't fail exporting when updating with script on batch operation or list view index

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/BatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/BatchRequest.java
@@ -30,6 +30,16 @@ public interface BatchRequest {
 
   BatchRequest update(String index, String id, ExporterEntity entity) throws PersistenceException;
 
+  /**
+   * Updates the document with the given id in the given index using the provided script and
+   * parameters.
+   *
+   * <p>Warning! If the document with the given id does not exist in the given index, this update
+   * will fail exceptionally, resulting in a blocked exporter until the document is restored. For
+   * some indices this exception will be swallowed. The list of these indices can be found in {@link
+   * io.camunda.exporter.DefaultExporterResourceProvider#init}. See also <a
+   * href="https://github.com/camunda/camunda/issues/44356">https://github.com/camunda/camunda/issues/44356</a>
+   */
   BatchRequest updateWithScript(
       String index, String id, String script, Map<String, Object> parameters)
       throws PersistenceException;

--- a/operate/schema/src/main/java/io/camunda/operate/store/OperationStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/OperationStore.java
@@ -26,6 +26,16 @@ public interface OperationStore {
 
   void update(OperationEntity operation, boolean refreshImmediately) throws PersistenceException;
 
+  /**
+   * Updates the document with the given id in the given index using the provided script and
+   * parameters.
+   *
+   * <p>Warning! If the document with the given id does not exist in the given index, this update
+   * will fail exceptionally, resulting in a blocked exporter until the document is restored. For
+   * some indices this exception will be swallowed. The list of these indices can be found in {@link
+   * io.camunda.exporter.DefaultExporterResourceProvider#init}. See also <a
+   * href="https://github.com/camunda/camunda/issues/44356">https://github.com/camunda/camunda/issues/44356</a>
+   */
   void updateWithScript(
       String index, String batchOperationId, String script, Map<String, Object> parameters);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -386,6 +386,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     indicesWithCustomErrorHandlers =
         Map.of(
             indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
+            ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST,
+            indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName(),
+            ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST,
+            indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In some handlers we updated the list view or batch operation using a script. If the document does not exist, this will
fail exceptionally, blocking the exporter entirely. For this reason we normally use upsert in other places.
When we do a script update we don't have the proper document available. This makes upserting in this case impossible.
At the same time, if the document doesn't exist we don't have anything to update. Either the document is archived
(and immutable) or deleted entirely. Either way, we can ignore the update.

It would be awesome to have a better solution than this, but this is a quick-fix. Other solutions are described in
https://github.com/camunda/camunda/issues/44356.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #44356 
