### PR TITLE
fix: calculate modification menu entries based on resolved element instance

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -60,7 +60,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       clearSelection,
     } = useProcessInstanceElementSelection();
     const {data: businessObjects} = useBusinessObjects();
-    const {data: selectedElementRunningInstancesCount} =
+    const {data: totalRunningInstancesCount} =
       useTotalRunningInstancesForFlowNode(selectedElementId ?? undefined);
     const {data: totalRunningInstancesVisible} =
       useTotalRunningInstancesVisibleForFlowNode(
@@ -68,13 +68,20 @@ const ModificationDropdown: React.FC<Props> = observer(
       );
     const {data: totalRunningInstancesByFlowNode} =
       useTotalRunningInstancesByFlowNode();
+    const selectedElementRunningInstancesCount =
+      resolvedElementInstance === null ? totalRunningInstancesCount : 1;
+
+    const resolvedElementInstanceKey =
+      resolvedElementInstance?.elementInstanceKey;
 
     const availableModifications = useAvailableModifications({
       runningElementInstanceCount: selectedElementRunningInstancesCount ?? 0,
       elementId: selectedElementId ?? undefined,
       elementInstanceKey: selectedElementInstanceKey ?? undefined,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
-      isElementInstanceResolved: resolvedElementInstance !== null,
+      isElementInstanceResolved:
+        selectedElementInstanceKey !== null ||
+        resolvedElementInstanceKey !== undefined,
     });
     const canBeModified = useCanBeModified(selectedElementId ?? undefined);
     const {data: processInstance} = useProcessInstance();
@@ -185,7 +192,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                       )}
 
                     {availableModifications.includes('cancel-instance') &&
-                      !isNil(selectedElementInstanceKey) &&
+                      !isNil(resolvedElementInstanceKey) &&
                       businessObjects && (
                         <Button
                           kind="ghost"
@@ -200,7 +207,7 @@ const ModificationDropdown: React.FC<Props> = observer(
 
                             modificationsStore.cancelToken(
                               selectedElementId,
-                              selectedElementInstanceKey,
+                              resolvedElementInstanceKey,
                               businessObjects,
                             );
                             clearSelection();
@@ -237,7 +244,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                       )}
 
                     {availableModifications.includes('move-instance') &&
-                      !isNil(selectedElementInstanceKey) && (
+                      !isNil(resolvedElementInstanceKey) && (
                         <Button
                           kind="ghost"
                           title="Move selected instance in this flow node to another target"
@@ -247,7 +254,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                           onClick={() => {
                             modificationsStore.startMovingToken(
                               selectedElementId,
-                              selectedElementInstanceKey,
+                              resolvedElementInstanceKey,
                             );
                             clearSelection();
                           }}

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -77,7 +77,7 @@ const ModificationDropdown: React.FC<Props> = observer(
     const availableModifications = useAvailableModifications({
       runningElementInstanceCount: selectedElementRunningInstancesCount ?? 0,
       elementId: selectedElementId ?? undefined,
-      elementInstanceKey: selectedElementInstanceKey ?? undefined,
+      isSpecificElementInstanceSelected: selectedElementInstanceKey !== null,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
       isElementInstanceKeyAvailable:
         selectedElementInstanceKey !== null ||

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -79,7 +79,7 @@ const ModificationDropdown: React.FC<Props> = observer(
       elementId: selectedElementId ?? undefined,
       elementInstanceKey: selectedElementInstanceKey ?? undefined,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
-      isElementInstanceResolved:
+      isElementInstanceKeyAvailable:
         selectedElementInstanceKey !== null ||
         resolvedElementInstanceKey !== undefined,
     });

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
@@ -79,8 +79,9 @@ const ModificationDropdown: React.FC<Props> = observer(
     const availableModifications = useAvailableModifications({
       runningElementInstanceCount: selectedRunningInstanceCount,
       elementId: flowNodeId,
-      elementInstanceKey:
-        flowNodeSelectionStore.state.selection?.flowNodeInstanceId,
+      isSpecificElementInstanceSelected:
+        flowNodeSelectionStore.state.selection?.flowNodeInstanceId !==
+        undefined,
       isMultiInstanceBody:
         flowNodeSelectionStore.state.selection?.isMultiInstance,
       isElementInstanceKeyAvailable: !isNil(

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/indexV1.tsx
@@ -83,7 +83,7 @@ const ModificationDropdown: React.FC<Props> = observer(
         flowNodeSelectionStore.state.selection?.flowNodeInstanceId,
       isMultiInstanceBody:
         flowNodeSelectionStore.state.selection?.isMultiInstance,
-      isElementInstanceResolved: !isNil(
+      isElementInstanceKeyAvailable: !isNil(
         flowNodeSelectionStore.selectedFlowNodeInstanceId,
       ),
     });

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -481,7 +481,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            elementInstanceKey: '23894723897402320',
+            isSpecificElementInstanceSelected: true,
             isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -435,7 +435,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'StartEvent_1',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -451,7 +451,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -466,7 +466,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_0ruokei',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -481,7 +481,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -507,7 +507,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );
@@ -565,7 +565,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_0ruokei',
-            isElementInstanceResolved: true,
+            isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},
       );

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -481,6 +481,7 @@ describe('modifications hooks', () => {
           useAvailableModifications({
             runningElementInstanceCount: 1,
             elementId: 'ServiceTask_1daop2o',
+            elementInstanceKey: '23894723897402320',
             isElementInstanceKeyAvailable: true,
           }),
         {wrapper: getWrapper()},

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -14,13 +14,17 @@ import {
   useModificationsByFlowNode,
   useWillAllFlowNodesBeCanceled,
   useNewScopeKeyForElement,
+  useAvailableModifications,
 } from './modifications';
 import {modificationsStore} from 'modules/stores/modifications';
 import {type GetProcessInstanceStatisticsResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {
+  mockProcessWithInputOutputMappingsXML,
+  eventSubProcess,
+} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -411,6 +415,163 @@ describe('modifications hooks', () => {
       });
 
       expect(result.current).toBeNull();
+    });
+  });
+
+  describe('useAvailableModifications', () => {
+    beforeEach(() => {
+      mockFetchProcessInstance().withSuccess(mockProcessInstance);
+      mockFetchProcessDefinitionXml().withSuccess(eventSubProcess);
+      mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
+    });
+
+    afterEach(() => {
+      modificationsStore.reset();
+    });
+
+    it('should return empty array if element cannot be modified', async () => {
+      const {result: resultNonModifiable} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'StartEvent_1',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => {
+        expect(resultNonModifiable.current).toEqual([]);
+      });
+    });
+
+    it('should return only add when no active instances in statistics', async () => {
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'ServiceTask_1daop2o',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => expect(result.current.length).toBeGreaterThan(0));
+      expect(result.current).toEqual(['add']);
+    });
+
+    it('should return only add for subprocess when no active instances', async () => {
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'ServiceTask_0ruokei',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => expect(result.current.length).toBeGreaterThan(0));
+      expect(result.current).toEqual(['add']);
+    });
+
+    it('should not include add option if elementInstanceKey is provided', () => {
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'ServiceTask_1daop2o',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      expect(result.current).not.toContain('add');
+    });
+
+    it('should include add, cancel-instance, and move-instance with single active instance', async () => {
+      mockFetchFlownodeInstancesStatistics().withSuccess({
+        items: [
+          {
+            elementId: 'ServiceTask_1daop2o',
+            active: 1,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+        ],
+      });
+
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'ServiceTask_1daop2o',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => expect(result.current.length).toBe(3));
+
+      expect(result.current).toEqual([
+        'add',
+        'cancel-instance',
+        'move-instance',
+      ]);
+    });
+
+    it('should include add, cancel-all, and move-all with multiple active instances', async () => {
+      mockFetchFlownodeInstancesStatistics().withSuccess({
+        items: [
+          {
+            elementId: 'ServiceTask_1daop2o',
+            active: 5,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+        ],
+      });
+
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 5,
+            elementId: 'ServiceTask_1daop2o',
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => expect(result.current.length).toBe(3));
+      expect(result.current).toEqual(['add', 'cancel-all', 'move-all']);
+    });
+
+    it('should not include move options for subprocess even with active instances', async () => {
+      mockFetchFlownodeInstancesStatistics().withSuccess({
+        items: [
+          {
+            elementId: 'ServiceTask_0ruokei',
+            active: 1,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+        ],
+      });
+
+      const {result} = renderHook(
+        () =>
+          useAvailableModifications({
+            runningElementInstanceCount: 1,
+            elementId: 'ServiceTask_0ruokei',
+            isElementInstanceResolved: true,
+          }),
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => expect(result.current.length).toBe(2));
+      expect(result.current).toEqual(['add', 'cancel-all']);
     });
   });
 });

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -262,7 +262,7 @@ const useCanBeModified = (elementId?: string) => {
 type UseAvailableModificationsParams = {
   runningElementInstanceCount: number;
   elementId?: string;
-  elementInstanceKey?: string;
+  isSpecificElementInstanceSelected?: boolean;
   isMultiInstanceBody?: boolean;
   isElementInstanceKeyAvailable?: boolean;
 };
@@ -270,7 +270,7 @@ type UseAvailableModificationsParams = {
 const useAvailableModifications = ({
   runningElementInstanceCount,
   elementId,
-  elementInstanceKey,
+  isSpecificElementInstanceSelected,
   isMultiInstanceBody,
   isElementInstanceKeyAvailable,
 }: UseAvailableModificationsParams) => {
@@ -290,7 +290,7 @@ const useAvailableModifications = ({
   if (
     appendableFlowNodes.includes(elementId) &&
     !(isMultiInstance(businessObjects?.[elementId]) && !isMultiInstanceBody) &&
-    elementInstanceKey === undefined
+    !isSpecificElementInstanceSelected
   ) {
     options.push('add');
   }

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -264,7 +264,7 @@ type UseAvailableModificationsParams = {
   elementId?: string;
   elementInstanceKey?: string;
   isMultiInstanceBody?: boolean;
-  isElementInstanceResolved?: boolean;
+  isElementInstanceKeyAvailable?: boolean;
 };
 
 const useAvailableModifications = ({
@@ -272,7 +272,7 @@ const useAvailableModifications = ({
   elementId,
   elementInstanceKey,
   isMultiInstanceBody,
-  isElementInstanceResolved,
+  isElementInstanceKeyAvailable,
 }: UseAvailableModificationsParams) => {
   const options: ModificationOption[] = [];
   const appendableFlowNodes = useAppendableFlowNodes();
@@ -300,7 +300,7 @@ const useAvailableModifications = ({
   }
 
   const isSingleOperationAllowed =
-    isElementInstanceResolved &&
+    isElementInstanceKeyAvailable &&
     runningElementInstanceCount === 1 &&
     !isSubProcess(businessObjects?.[elementId]);
 


### PR DESCRIPTION
## Description

- fix wrong modification dropdown menu entries
- add test coverage for `useAvailableModifications` hook

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44553 
