### PR TITLE
[Backport stable/8.6] fix: prevent dot variable names from crashing

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
@@ -17,6 +17,9 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
@@ -7,7 +7,7 @@
  */
 
 const createVariableFieldName = (name: string) => {
-  return `#${name}`;
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {


### PR DESCRIPTION
# Description
Backport of #45137 to `stable/8.6`.

relates to #45136