### PR TITLE
[Backport stable/8.6] fix: variable form when variables have dots in the name

### DIFF
--- a/tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.test.tsx
+++ b/tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.test.tsx
@@ -17,6 +17,9 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.tsx
+++ b/tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.tsx
@@ -7,7 +7,7 @@
  */
 
 const createVariableFieldName = (name: string) => {
-  return `#${name}`;
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {

--- a/tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.test.tsx
+++ b/tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.test.tsx
@@ -15,6 +15,9 @@ describe('getVariableFieldName', () => {
   it('should get variable field name', () => {
     expect(getVariableFieldName('#someVariableName')).toBe('someVariableName');
   });
+  it('should decode variable field name with dots', () => {
+    expect(getVariableFieldName('#a%2Eb')).toBe('a.b');
+  });
   it('should get new variable prefix', () => {
     expect(getNewVariablePrefix('newVariables[0].name')).toBe(
       'newVariables[0]',

--- a/tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.tsx
+++ b/tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.tsx
@@ -7,7 +7,7 @@
  */
 
 const getVariableFieldName = (variableNameWithPrefix: string) => {
-  return variableNameWithPrefix.substring(1);
+  return decodeURIComponent(variableNameWithPrefix.substring(1));
 };
 
 const getNewVariablePrefix = (variableName: string) => {

--- a/tasklist/client/src/modules/mock-schema/mocks/variables.tsx
+++ b/tasklist/client/src/modules/mock-schema/mocks/variables.tsx
@@ -23,6 +23,20 @@ const variables: Variable[] = [
     previewValue: '"yes"',
     isValueTruncated: false,
   },
+  {
+    id: '0003',
+    name: 'a.b',
+    value: '"old"',
+    previewValue: '"old"',
+    isValueTruncated: false,
+  },
+  {
+    id: '0004',
+    name: 'a.b.c',
+    value: '"old"',
+    previewValue: '"old"',
+    isValueTruncated: false,
+  },
 ];
 
 const dynamicFormVariables: Variable[] = [


### PR DESCRIPTION
# Description
Backport of #45140 to `stable/8.6`.

relates to camunda/issues#683