### PR TITLE
[Backport stable/8.8] fix: prevent dot variable names from crashing

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
@@ -662,6 +662,64 @@ describe('Edit variable', () => {
     ).toBeInTheDocument();
   });
 
+  it('should allow editing a variable with dots in modification mode', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstanceDeprecated().withSuccess(
+      mockProcessInstanceDeprecated,
+    );
+    mockFetchProcessDefinitionXml().withSuccess('');
+    processInstanceDetailsStore.setProcessInstance(instanceMock);
+
+    mockSearchVariables().withSuccess({
+      items: [
+        createvariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createvariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+      ],
+      page: {totalItems: 2},
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createvariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createvariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+      ],
+      page: {totalItems: 2},
+    });
+
+    const {user} = render(
+      <VariablePanel setListenerTabVisibility={vi.fn()} />,
+      {wrapper: getWrapper()},
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    act(() => {
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {id: 'flow_node_0', name: 'flow node 0'},
+          scopeId: 'random-scope-id-0',
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    const variableRow = await screen.findByTestId('variable-a.b');
+    const input = within(variableRow).getByTestId('edit-variable-value');
+    expect(input).toHaveValue('"old"');
+
+    await user.clear(input);
+    await user.type(input, '"new"');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('"new"');
+    });
+  });
+
   it('should not display edit button next to variables if instance is completed or canceled', async () => {
     mockFetchProcessInstance().withSuccess({
       ...mockProcessInstance,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.test.ts
@@ -17,6 +17,9 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
@@ -7,7 +7,7 @@
  */
 
 const createVariableFieldName = (name: string) => {
-  return `#${name}`;
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {


### PR DESCRIPTION
# Description
Backport of #45137 to `stable/8.8`.

relates to #45136