### PR TITLE
[Backport stable/8.8] fix: variable form when variables have dots in the name

### DIFF
--- a/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.test.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.test.tsx
@@ -17,6 +17,7 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+<<<<<<< HEAD:tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.test.tsx
 
   it('should escape dots in variable names', () => {
     expect(createVariableFieldName('some.variable.name')).toBe(
@@ -24,6 +25,11 @@ describe('createVariableFieldName', () => {
     );
   });
 
+=======
+  it('should encode variable field name with dots', () => {
+    expect(createVariableFieldName('a.b')).toBe('#a%2Eb');
+  });
+>>>>>>> c857b356 (fix: variable form when variables have dots in the name):tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.test.tsx
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.tsx
@@ -9,8 +9,12 @@
 import {VARIABLE_NAME_DOT_ESCAPE_CHAR} from './constants';
 
 const createVariableFieldName = (name: string) => {
+<<<<<<< HEAD:tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.tsx
   const escapedName = name.replaceAll('.', VARIABLE_NAME_DOT_ESCAPE_CHAR);
   return `#${escapedName}`;
+=======
+  return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
+>>>>>>> c857b356 (fix: variable form when variables have dots in the name):tasklist/client/src/Tasks/Task/Variables/createVariableFieldName.tsx
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {

--- a/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.test.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.test.tsx
@@ -15,6 +15,7 @@ describe('getVariableFieldName', () => {
   it('should get variable field name', () => {
     expect(getVariableFieldName('#someVariableName')).toBe('someVariableName');
   });
+<<<<<<< HEAD:tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.test.tsx
 
   it('should unescape dots in variable names', () => {
     expect(getVariableFieldName('#some___DOT___variable___DOT___name')).toBe(
@@ -22,6 +23,11 @@ describe('getVariableFieldName', () => {
     );
   });
 
+=======
+  it('should decode variable field name with dots', () => {
+    expect(getVariableFieldName('#a%2Eb')).toBe('a.b');
+  });
+>>>>>>> c857b356 (fix: variable form when variables have dots in the name):tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.test.tsx
   it('should get new variable prefix', () => {
     expect(getNewVariablePrefix('newVariables[0].name')).toBe(
       'newVariables[0]',

--- a/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.tsx
@@ -9,8 +9,12 @@
 import {VARIABLE_NAME_DOT_ESCAPE_CHAR} from './constants';
 
 const getVariableFieldName = (variableNameWithPrefix: string) => {
+<<<<<<< HEAD:tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.tsx
   const nameWithoutPrefix = variableNameWithPrefix.substring(1);
   return nameWithoutPrefix.replaceAll(VARIABLE_NAME_DOT_ESCAPE_CHAR, '.');
+=======
+  return decodeURIComponent(variableNameWithPrefix.substring(1));
+>>>>>>> c857b356 (fix: variable form when variables have dots in the name):tasklist/client/src/Tasks/Task/Variables/getVariableFieldName.tsx
 };
 
 const getNewVariablePrefix = (variableName: string) => {

--- a/tasklist/client/src/v1/TaskDetails/Variables/index.test.tsx
+++ b/tasklist/client/src/v1/TaskDetails/Variables/index.test.tsx
@@ -36,7 +36,7 @@ const getWrapper = () => {
 };
 
 function isRequestingAllVariables(req: VariableSearchRequestBody) {
-  return req.variableNames !== undefined && req.variableNames.length == 0;
+  return req.variableNames !== undefined && req.variableNames.length === 0;
 }
 
 describe('<Variables />', () => {
@@ -216,6 +216,56 @@ describe('<Variables />', () => {
     await user.type(screen.getByLabelText('myVar'), newVariableValue);
 
     expect(screen.getByDisplayValue(newVariableValue)).toBeInTheDocument();
+
+    vi.runOnlyPendingTimers();
+
+    await waitFor(() =>
+      expect(screen.getByText(/complete task/i)).toBeEnabled(),
+    );
+  });
+
+  it('should edit variables with dots in names', async () => {
+    nodeMockServer.use(
+      http.post<never, VariableSearchRequestBody>(
+        '/v1/tasks/:taskId/variables/search',
+        async ({request}) => {
+          if (isRequestingAllVariables(await request.json())) {
+            return HttpResponse.json(variableMocks.variables);
+          }
+
+          return HttpResponse.json(
+            [
+              {
+                message: 'Invalid variables',
+              },
+            ],
+            {
+              status: 400,
+            },
+          );
+        },
+      ),
+    );
+
+    const {user} = render(
+      <Variables
+        task={taskMocks.assignedTask()}
+        user={currentUser}
+        onSubmit={() => Promise.resolve()}
+        onSubmitFailure={noop}
+        onSubmitSuccess={noop}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    const dotVariableInput = await screen.findByLabelText('a.b');
+    expect(dotVariableInput).toHaveValue('"old"');
+    await user.clear(dotVariableInput);
+    await user.type(dotVariableInput, '"new"');
+
+    expect(dotVariableInput).toHaveValue('"new"');
 
     vi.runOnlyPendingTimers();
 

--- a/tasklist/client/src/v1/mocks/variables.tsx
+++ b/tasklist/client/src/v1/mocks/variables.tsx
@@ -23,6 +23,20 @@ const variables: Variable[] = [
     previewValue: '"yes"',
     isValueTruncated: false,
   },
+  {
+    id: '0003',
+    name: 'a.b',
+    value: '"old"',
+    previewValue: '"old"',
+    isValueTruncated: false,
+  },
+  {
+    id: '0004',
+    name: 'a.b.c',
+    value: '"old"',
+    previewValue: '"old"',
+    isValueTruncated: false,
+  },
 ];
 
 const dynamicFormVariables: Variable[] = [


### PR DESCRIPTION
# Description
Backport of #45140 to `stable/8.8`.

relates to camunda/issues#683