### PR TITLE
feat: add decision instances deletion to CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -47,6 +47,7 @@ import io.camunda.client.api.command.CreateRoleCommandStep1;
 import io.camunda.client.api.command.CreateTenantCommandStep1;
 import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
+import io.camunda.client.api.command.DeleteDecisionInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
@@ -880,7 +881,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  .send();
    * </pre>
    *
-   * @param decisionDefinitionKey the key of the process definition
+   * @param processDefinitionKey the key of the process definition
    * @return a builder for the request to get the XML of a process definition
    */
   ProcessDefinitionGetXmlRequest newProcessDefinitionGetXmlRequest(long processDefinitionKey);
@@ -1215,6 +1216,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a decision instance
    */
   DecisionInstanceGetRequest newDecisionInstanceGetRequest(String decisionInstanceId);
+
+  /**
+   * Command to delete a decision instance history.
+   *
+   * <pre>
+   * camundaClient
+   *  .newDeleteDecisionInstanceCommand(decisionInstanceKey)
+   *  .send();
+   * </pre>
+   *
+   * @param decisionInstanceKey the key which identifies the corresponding decision instance
+   * @return a builder for the command
+   */
+  DeleteDecisionInstanceCommandStep1 newDeleteDecisionInstanceCommand(long decisionInstanceKey);
 
   /**
    * Executes a search request to query incidents.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -410,14 +410,14 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newDeleteInstanceCommand(processInstanceKey)
+   *  .newDeleteProcessInstanceCommand(processInstanceKey)
    *  .send();
    * </pre>
    *
    * @param processInstanceKey the key which identifies the corresponding process instance
    * @return a builder for the command
    */
-  DeleteProcessInstanceCommandStep1 newDeleteInstanceCommand(long processInstanceKey);
+  DeleteProcessInstanceCommandStep1 newDeleteProcessInstanceCommand(long processInstanceKey);
 
   /**
    * Command to set and/or update the variables of a given flow element (e.g. process instance,

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -35,7 +35,7 @@ public interface CreateBatchOperationCommandStep1 {
    *
    * @return the builder for this command
    */
-  CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceDelete();
+  CreateBatchOperationCommandStep2<ProcessInstanceFilter> deleteProcessInstance();
 
   /**
    * Defines the type of the batch operation to resolve incidents.
@@ -63,7 +63,7 @@ public interface CreateBatchOperationCommandStep1 {
    *
    * @return the builder for this command
    */
-  CreateBatchOperationCommandStep2<DecisionInstanceFilter> decisionInstanceDelete();
+  CreateBatchOperationCommandStep2<DecisionInstanceFilter> deleteDecisionInstance();
 
   interface CreateBatchOperationCommandStep2<E extends SearchRequestFilter> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -56,6 +57,13 @@ public interface CreateBatchOperationCommandStep1 {
    * @return the builder for this command
    */
   ProcessInstanceModificationStep<ProcessInstanceFilter> modifyProcessInstance();
+
+  /**
+   * Defines the type of the batch operation to delete decision instances.
+   *
+   * @return the builder for this command
+   */
+  CreateBatchOperationCommandStep2<DecisionInstanceFilter> decisionInstanceDelete();
 
   interface CreateBatchOperationCommandStep2<E extends SearchRequestFilter> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteDecisionInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteDecisionInstanceCommandStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteDecisionInstanceResponse;
+
+public interface DeleteDecisionInstanceCommandStep1
+    extends CommandWithOperationReferenceStep<DeleteDecisionInstanceCommandStep1>,
+        FinalCommandStep<DeleteDecisionInstanceResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteDecisionInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteDecisionInstanceResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface DeleteDecisionInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -55,6 +55,7 @@ import io.camunda.client.api.command.CreateRoleCommandStep1;
 import io.camunda.client.api.command.CreateTenantCommandStep1;
 import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
+import io.camunda.client.api.command.DeleteDecisionInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
@@ -222,6 +223,7 @@ import io.camunda.client.impl.command.CreateRoleCommandImpl;
 import io.camunda.client.impl.command.CreateTenantCommandImpl;
 import io.camunda.client.impl.command.CreateUserCommandImpl;
 import io.camunda.client.impl.command.DeleteAuthorizationCommandImpl;
+import io.camunda.client.impl.command.DeleteDecisionInstanceCommandImpl;
 import io.camunda.client.impl.command.DeleteDocumentCommandImpl;
 import io.camunda.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.client.impl.command.DeleteMappingRuleCommandImpl;
@@ -986,6 +988,13 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public DecisionInstanceGetRequest newDecisionInstanceGetRequest(final String decisionInstanceId) {
     return new DecisionInstanceGetRequestImpl(httpClient, jsonMapper, decisionInstanceId);
+  }
+
+  @Override
+  public DeleteDecisionInstanceCommandStep1 newDeleteDecisionInstanceCommand(
+      final long decisionInstanceKey) {
+    return new DeleteDecisionInstanceCommandImpl(
+        decisionInstanceKey, config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -707,7 +707,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public DeleteProcessInstanceCommandStep1 newDeleteInstanceCommand(final long processInstanceKey) {
+  public DeleteProcessInstanceCommandStep1 newDeleteProcessInstanceCommand(
+      final long processInstanceKey) {
     return new DeleteProcessInstanceCommandImpl(processInstanceKey, config, httpClient, jsonMapper);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -229,7 +229,7 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     }
 
     @Override
-    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceDelete() {
+    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> deleteProcessInstance() {
       return new CreateBatchOperationCommandImpl<>(
           httpClient,
           jsonMapper,
@@ -265,7 +265,7 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     }
 
     @Override
-    public CreateBatchOperationCommandStep2<DecisionInstanceFilter> decisionInstanceDelete() {
+    public CreateBatchOperationCommandStep2<DecisionInstanceFilter> deleteDecisionInstance() {
       return new CreateBatchOperationCommandImpl<>(
           httpClient,
           jsonMapper,

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.command.CreateBatchOperationCommandStep1.ProcessIns
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.request.SearchRequestBuilders;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
@@ -35,6 +36,7 @@ import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateBatchOperationResponseImpl;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.DecisionInstanceDeletionBatchOperationRequest;
 import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCancellationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceDeletionBatchOperationRequest;
@@ -134,6 +136,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
         return "/process-instances/cancellation";
       case DELETE_PROCESS_INSTANCE:
         return "/process-instances/deletion";
+      case DELETE_DECISION_INSTANCE:
+        return "/decision-instances/deletion";
       case RESOLVE_INCIDENT:
         return "/process-instances/incident-resolution";
       case MIGRATE_PROCESS_INSTANCE:
@@ -160,6 +164,9 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
             .filter(provideSearchRequestProperty(filter));
       case DELETE_PROCESS_INSTANCE:
         return new ProcessInstanceDeletionBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      case DELETE_DECISION_INSTANCE:
+        return new DecisionInstanceDeletionBatchOperationRequest()
             .filter(provideSearchRequestProperty(filter));
       case RESOLVE_INCIDENT:
         return new ProcessInstanceIncidentResolutionBatchOperationRequest()
@@ -255,6 +262,15 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
           jsonMapper,
           BatchOperationTypeEnum.MODIFY_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
+    }
+
+    @Override
+    public CreateBatchOperationCommandStep2<DecisionInstanceFilter> decisionInstanceDelete() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.DELETE_DECISION_INSTANCE,
+          SearchRequestBuilders::decisionInstanceFilter);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDecisionInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteDecisionInstanceCommandImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.DeleteDecisionInstanceCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteDecisionInstanceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteDecisionInstanceResponseImpl;
+import io.camunda.client.protocol.rest.DeleteDecisionInstanceRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteDecisionInstanceCommandImpl implements DeleteDecisionInstanceCommandStep1 {
+
+  private final long decisionInstanceKey;
+  private final DeleteDecisionInstanceRequest httpRequestObject;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteDecisionInstanceCommandImpl(
+      final long decisionInstanceKey,
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
+    this.decisionInstanceKey = decisionInstanceKey;
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new DeleteDecisionInstanceRequest();
+    requestTimeout(config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public DeleteDecisionInstanceCommandStep1 operationReference(final long operationReference) {
+    httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<DeleteDecisionInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteDecisionInstanceResponse> send() {
+    final HttpCamundaFuture<DeleteDecisionInstanceResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/decision-instances/" + decisionInstanceKey + "/deletion",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        DeleteDecisionInstanceResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteDecisionInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteDecisionInstanceResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.DeleteDecisionInstanceResponse;
+
+public class DeleteDecisionInstanceResponseImpl implements DeleteDecisionInstanceResponse {
+
+  public DeleteDecisionInstanceResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -93,7 +93,7 @@ public final class CreateBatchOperationTest extends ClientRestTest {
     // when
     client
         .newCreateBatchOperationCommand()
-        .processInstanceDelete()
+        .deleteProcessInstance()
         .filter(filter -> filter.processDefinitionId("test-01"))
         .send()
         .join();
@@ -210,7 +210,7 @@ public final class CreateBatchOperationTest extends ClientRestTest {
     // when
     client
         .newCreateBatchOperationCommand()
-        .decisionInstanceDelete()
+        .deleteDecisionInstance()
         .filter(filter -> filter.decisionDefinitionId("test-d-01"))
         .send()
         .join();

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.DecisionInstanceDeletionBatchOperationRequest;
 import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceCancellationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceDeletionBatchOperationRequest;
@@ -198,5 +199,29 @@ public final class CreateBatchOperationTest extends ClientRestTest {
     final ProcessInstanceIncidentResolutionBatchOperationRequest lastRequest =
         gatewayService.getLastRequest(ProcessInstanceIncidentResolutionBatchOperationRequest.class);
     assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+  }
+
+  @Test
+  public void shouldSendDecisionInstanceDeleteCommandWithFilter() {
+    // given
+    gatewayService.onDeleteDecisionInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .decisionInstanceDelete()
+        .filter(filter -> filter.decisionDefinitionId("test-d-01"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/decision-instances/deletion");
+
+    final DecisionInstanceDeletionBatchOperationRequest lastRequest =
+        gatewayService.getLastRequest(DecisionInstanceDeletionBatchOperationRequest.class);
+    assertThat(lastRequest.getFilter().getDecisionDefinitionId()).isEqualTo("test-d-01");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/process/rest/DeleteDecisionInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/DeleteDecisionInstanceRestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.DeleteDecisionInstanceRequest;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public class DeleteDecisionInstanceRestTest extends ClientRestTest {
+
+  private static final long DECISION_INSTANCE_KEY = 123L;
+
+  @Test
+  public void shouldSendDeleteCommand() {
+    // when
+    client.newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY).send().join();
+
+    // then
+    final DeleteDecisionInstanceRequest request =
+        gatewayService.getLastRequest(DeleteDecisionInstanceRequest.class);
+    assertThat(request).isNotNull();
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getDeleteDecisionInstanceUrl(DECISION_INSTANCE_KEY),
+        () -> new ProblemDetail().title("Invalid request").status(400));
+
+    assertThatThrownBy(
+            () -> client.newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client
+        .newDeleteDecisionInstanceCommand(DECISION_INSTANCE_KEY)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final DeleteDecisionInstanceRequest request =
+        gatewayService.getLastRequest(DeleteDecisionInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
@@ -32,7 +32,7 @@ public class DeleteProcessInstanceRestTest extends ClientRestTest {
   @Test
   public void shouldSendDeleteCommand() {
     // when
-    client.newDeleteInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
+    client.newDeleteProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
 
     // then
     final DeleteProcessInstanceRequest request =
@@ -47,7 +47,8 @@ public class DeleteProcessInstanceRestTest extends ClientRestTest {
         RestGatewayPaths.getDeleteProcessInstanceUrl(PROCESS_INSTANCE_KEY),
         () -> new ProblemDetail().title("Invalid request").status(400));
 
-    assertThatThrownBy(() -> client.newDeleteInstanceCommand(PROCESS_INSTANCE_KEY).send().join())
+    assertThatThrownBy(
+            () -> client.newDeleteProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
@@ -59,7 +60,7 @@ public class DeleteProcessInstanceRestTest extends ClientRestTest {
 
     // when
     client
-        .newDeleteInstanceCommand(PROCESS_INSTANCE_KEY)
+        .newDeleteProcessInstanceCommand(PROCESS_INSTANCE_KEY)
         .operationReference(operationReference)
         .execute();
 

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -48,6 +48,8 @@ public class RestGatewayPaths {
   private static final String URL_DECISION_INSTANCE = REST_API_PATH + "/decision-instances/%s";
   private static final String URL_DECISION_REQUIREMENTS =
       REST_API_PATH + "/decision-requirements/%s";
+  private static final String URL_DECISION_INSTANCES_DELETION =
+      REST_API_PATH + "/decision-instances/deletion";
   private static final String URL_DEPLOYMENTS = REST_API_PATH + "/deployments";
   private static final String URL_ELEMENT_INSTANCE = REST_API_PATH + "/element-instances/%s";
   private static final String URL_EXPRESSION_EVALUATION = REST_API_PATH + "/expression/evaluation";
@@ -297,6 +299,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstancesDeletionUrl() {
     return URL_PROCESS_INSTANCES_DELETION;
+  }
+
+  public static String getDecisionInstancesDeletionUrl() {
+    return URL_DECISION_INSTANCES_DELETION;
   }
 
   public static String getProcessInstancesIncidentResolutionUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -48,6 +48,8 @@ public class RestGatewayPaths {
   private static final String URL_DECISION_INSTANCE = REST_API_PATH + "/decision-instances/%s";
   private static final String URL_DECISION_REQUIREMENTS =
       REST_API_PATH + "/decision-requirements/%s";
+  private static final String URL_DECISION_INSTANCE_DELETION =
+      REST_API_PATH + "/decision-instances/%s/deletion";
   private static final String URL_DECISION_INSTANCES_DELETION =
       REST_API_PATH + "/decision-instances/deletion";
   private static final String URL_DEPLOYMENTS = REST_API_PATH + "/deployments";
@@ -339,6 +341,10 @@ public class RestGatewayPaths {
 
   public static String getDecisionInstanceUrl(final String decisionInstanceId) {
     return String.format(URL_DECISION_INSTANCE, decisionInstanceId);
+  }
+
+  public static String getDeleteDecisionInstanceUrl(final long decisionInstanceKey) {
+    return String.format(URL_DECISION_INSTANCE_DELETION, decisionInstanceKey);
   }
 
   public static String getUserTaskFormUrl(final long userTaskKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -294,6 +294,10 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesModifyUrl(), response);
   }
 
+  public void onDeleteDecisionInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getDecisionInstancesDeletionUrl(), response);
+  }
+
   public void onCreateAuthorizationRequest(final AuthorizationCreateResult response) {
     registerPost(RestGatewayPaths.getAuthorizationsUrl(), response);
   }

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -71,6 +71,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-xml-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-dmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryAuthorizationIT.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.historydeletion;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.DELETE_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_DECISION_INSTANCE;
+import static io.camunda.client.api.search.enums.ResourceType.BATCH;
+import static io.camunda.client.api.search.enums.ResourceType.DECISION_DEFINITION;
+import static io.camunda.it.util.DmnBuilderHelper.getDmnModelInstance;
+import static io.camunda.it.util.TestHelper.deployDmnModel;
+import static io.camunda.it.util.TestHelper.evaluateDecision;
+import static io.camunda.it.util.TestHelper.waitForDecisionInstanceCount;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Decision;
+import io.camunda.configuration.HistoryDeletion;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DeleteDecisionInstanceHistoryAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withDataConfig(
+              config -> {
+                final var historyDeletionConfig = new HistoryDeletion();
+                historyDeletionConfig.setDelayBetweenRuns(Duration.ofMillis(100));
+                historyDeletionConfig.setMaxDelayBetweenRuns(Duration.ofMillis(100));
+                config.setHistoryDeletion(historyDeletionConfig);
+              });
+
+  private static final String SINGLE_AUTHORIZED_USER = "singleAuthorizedUser";
+  private static final String BATCH_AUTHORIZED_USER = "batchAuthorizedUser";
+  private static final String UNAUTHORIZED_USER = "unauthorizedUser";
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER_DEF =
+      new TestUser(
+          UNAUTHORIZED_USER,
+          "password",
+          List.of(new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser BATCH_ONLY_USER_DEF =
+      new TestUser(
+          BATCH_AUTHORIZED_USER,
+          "password",
+          List.of(
+              new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*")),
+              new Permissions(
+                  BATCH, CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser DELETE_ONLY_USER_DEF =
+      new TestUser(
+          SINGLE_AUTHORIZED_USER,
+          "password",
+          List.of(
+              new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*")),
+              new Permissions(DECISION_DEFINITION, DELETE_DECISION_INSTANCE, List.of("*"))));
+
+  private static final String DMN_DECISION_ID = "testDecisionDefinition";
+  private static long decisionKey;
+
+  @BeforeAll
+  static void setUp(@Authenticated final CamundaClient adminClient) {
+    final var dmnModel = getDmnModelInstance(DMN_DECISION_ID);
+    final Decision decision = deployDmnModel(adminClient, dmnModel, DMN_DECISION_ID);
+    decisionKey = decision.getDecisionKey();
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteDecisionInstanceHistoryWithAuthorizedUser(
+      @Authenticated(SINGLE_AUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    // given
+    final var decisionInstanceKey =
+        evaluateDecision(adminClient, decisionKey, "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionInstanceKey(decisionInstanceKey), 1);
+
+    // when
+    final var result =
+        camundaClient.newDeleteDecisionInstanceCommand(decisionInstanceKey).send().join();
+
+    // then - should not throw an exception
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToDeleteDecisionInstanceHistoryWithoutPermissions(
+      @Authenticated(UNAUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    // given
+    final var decisionInstanceKey =
+        evaluateDecision(adminClient, decisionKey, "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionInstanceKey(decisionInstanceKey), 1);
+
+    // when
+    final ThrowingCallable executeDelete =
+        () -> camundaClient.newDeleteDecisionInstanceCommand(decisionInstanceKey).send().join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeDelete).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .contains("Insufficient permissions to perform operation 'DELETE_DECISION_INSTANCE'");
+  }
+
+  @Test
+  void shouldBeUnauthorizedToDeleteSingleDecisionInstanceHistoryWithOnlyBatchPermissions(
+      @Authenticated(BATCH_AUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    // given
+    final var decisionInstanceKey =
+        evaluateDecision(adminClient, decisionKey, "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionInstanceKey(decisionInstanceKey), 1);
+
+    // when
+    final ThrowingCallable executeDelete =
+        () -> camundaClient.newDeleteDecisionInstanceCommand(decisionInstanceKey).send().join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeDelete).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .contains("Insufficient permissions to perform operation 'DELETE_DECISION_INSTANCE'");
+  }
+
+  @Test
+  void shouldBeAuthorizedToBatchDeleteDecisionInstanceHistoryWithAuthorizedUser(
+      @Authenticated(BATCH_AUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    // given
+    final String dmnId = "batchSuccessTestDecisionId";
+    final var dmnModelBatch = getDmnModelInstance(dmnId);
+    final Decision decisionBatch = deployDmnModel(adminClient, dmnModelBatch, dmnId);
+    evaluateDecision(adminClient, decisionBatch.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    evaluateDecision(adminClient, decisionBatch.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionDefinitionId(dmnId), 2);
+
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .deleteDecisionInstance()
+            .filter(f -> f.decisionDefinitionId(dmnId))
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToBatchDeleteDecisionInstanceHistoryWithoutBatchPermissions(
+      @Authenticated(UNAUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    // given
+    final String dmnId = "batchUnauthorizedId";
+    final var dmnModelBatch = getDmnModelInstance(dmnId);
+    final Decision decisionBatch = deployDmnModel(adminClient, dmnModelBatch, dmnId);
+    evaluateDecision(adminClient, decisionBatch.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionDefinitionId(dmnId), 1);
+
+    // when
+    final ThrowingCallable executeDelete =
+        () ->
+            camundaClient
+                .newCreateBatchOperationCommand()
+                .deleteDecisionInstance()
+                .filter(f -> f.decisionDefinitionId(dmnId))
+                .send()
+                .join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeDelete).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .contains(
+            "Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE'");
+  }
+
+  @Test
+  void shouldBeUnauthorizedToBatchDeleteDecisionInstanceHistoryWithOnlySinglePermissions(
+      @Authenticated(SINGLE_AUTHORIZED_USER) final CamundaClient camundaClient,
+      @Authenticated final CamundaClient adminClient) {
+    final String dmnId = "batchOnlySingleUnauthorizedId";
+    final var dmnModelBatch = getDmnModelInstance(dmnId);
+    final Decision decisionBatch = deployDmnModel(adminClient, dmnModelBatch, dmnId);
+    evaluateDecision(adminClient, decisionBatch.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(adminClient, f -> f.decisionDefinitionId(dmnId), 1);
+
+    // when
+    final ThrowingCallable executeDelete =
+        () ->
+            camundaClient
+                .newCreateBatchOperationCommand()
+                .deleteDecisionInstance()
+                .filter(f -> f.decisionDefinitionId(dmnId))
+                .send()
+                .join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeDelete).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .contains(
+            "Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryIT.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.historydeletion;
+
+import static io.camunda.it.util.TestHelper.deployDmnModel;
+import static io.camunda.it.util.TestHelper.evaluateDecision;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Decision;
+import io.camunda.client.api.response.DeleteDecisionInstanceResponse;
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
+import io.camunda.configuration.HistoryDeletion;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.camunda.bpm.model.dmn.Dmn;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.dmn.instance.DecisionTable;
+import org.camunda.bpm.model.dmn.instance.Definitions;
+import org.camunda.bpm.model.dmn.instance.Input;
+import org.camunda.bpm.model.dmn.instance.InputExpression;
+import org.camunda.bpm.model.dmn.instance.Output;
+import org.camunda.bpm.model.dmn.instance.Text;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DeleteDecisionInstanceHistoryIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withProcessingConfig(
+              config ->
+                  config
+                      .getEngine()
+                      .getBatchOperations()
+                      .setSchedulerInterval(Duration.ofMillis(100)))
+          .withDataConfig(
+              config -> {
+                final var historyDeletionConfig = new HistoryDeletion();
+                historyDeletionConfig.setDelayBetweenRuns(Duration.ofMillis(100));
+                historyDeletionConfig.setMaxDelayBetweenRuns(Duration.ofMillis(100));
+                config.setHistoryDeletion(historyDeletionConfig);
+              });
+
+  private static final Duration DELETION_TIMEOUT = Duration.ofSeconds(30);
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldDeleteTwoDecisionInstancesByIdUsingBatchOperation() {
+    // given
+    final var dmnModel = getDmnModelInstance(Strings.newRandomValidBpmnId());
+    final Decision decision =
+        deployDmnModel(camundaClient, dmnModel, dmnModel.getModel().getModelName());
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 2);
+
+    // when
+    final var batchResult =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .decisionInstanceDelete()
+            .filter(f -> f.decisionDefinitionId(decision.getDmnDecisionId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(batchResult).isNotNull();
+    assertThat(batchResult.getBatchOperationKey()).isNotNull();
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchResult.getBatchOperationKey(), 2);
+    waitForBatchOperationCompleted(camundaClient, batchResult.getBatchOperationKey(), 2, 0);
+
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 0);
+  }
+
+  @Test
+  void shouldDeleteOneOfTwoDecisionInstancesByKeyUsingBatchOperation() {
+    // given
+    final var dmnModel = getDmnModelInstance(Strings.newRandomValidBpmnId());
+    final Decision decision =
+        deployDmnModel(camundaClient, dmnModel, dmnModel.getModel().getModelName());
+    final long instanceToDeleteKey =
+        evaluateDecision(camundaClient, decision.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    final long instanceToKeepKey =
+        evaluateDecision(camundaClient, decision.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 2);
+
+    // when
+    final var batchResult =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .decisionInstanceDelete()
+            .filter(f -> f.decisionInstanceKey(instanceToDeleteKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(batchResult).isNotNull();
+    assertThat(batchResult.getBatchOperationKey()).isNotNull();
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchResult.getBatchOperationKey(), 1);
+    waitForBatchOperationCompleted(camundaClient, batchResult.getBatchOperationKey(), 1, 0);
+
+    waitForDecisionInstanceCount(f -> f.decisionInstanceKey(instanceToDeleteKey), 0);
+    waitForDecisionInstanceCount(f -> f.decisionInstanceKey(instanceToKeepKey), 1);
+  }
+
+  @Test
+  void shouldDeleteDecisionInstanceByKeyUsingSingleOperation() {
+    // given
+    final var dmnModel = getDmnModelInstance(Strings.newRandomValidBpmnId());
+    final Decision decision =
+        deployDmnModel(camundaClient, dmnModel, dmnModel.getModel().getModelName());
+    final long instanceToDeleteKey =
+        evaluateDecision(camundaClient, decision.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 1);
+
+    // when
+    final DeleteDecisionInstanceResponse response =
+        camundaClient.newDeleteDecisionInstanceCommand(instanceToDeleteKey).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 0);
+  }
+
+  @Test
+  void shouldDeleteOneOfTwoDecisionInstancesByKeyUsingSingleOperation() {
+    // given
+    final var dmnModel = getDmnModelInstance(Strings.newRandomValidBpmnId());
+    final Decision decision =
+        deployDmnModel(camundaClient, dmnModel, dmnModel.getModel().getModelName());
+    final long instanceToDeleteKey =
+        evaluateDecision(camundaClient, decision.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    final long instanceToKeepKey =
+        evaluateDecision(camundaClient, decision.getDecisionKey(), "{}").getDecisionEvaluationKey();
+    waitForDecisionInstanceCount(f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 2);
+
+    // when
+    final DeleteDecisionInstanceResponse response =
+        camundaClient.newDeleteDecisionInstanceCommand(instanceToDeleteKey).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    waitForDecisionInstanceCount(f -> f.decisionInstanceKey(instanceToDeleteKey), 0);
+    waitForDecisionInstanceCount(f -> f.decisionInstanceKey(instanceToKeepKey), 1);
+  }
+
+  @Test
+  void shouldReturnNotFoundForNonExistingDecisionInstanceWithSingularDeletion() {
+    // given - non-existing decision instance key
+    final long nonExistingKey = 99999L;
+
+    // when/then - try to delete non-existing decision instance should throw not found exception
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () -> camundaClient.newDeleteDecisionInstanceCommand(nonExistingKey).send().join())
+        .satisfies(
+            exception -> {
+              assertThat(exception.code()).isEqualTo(404);
+              assertThat(exception.details().getDetail())
+                  .containsIgnoringCase("decision instance")
+                  .containsIgnoringCase("not found");
+            });
+  }
+
+  private void waitForDecisionInstanceCount(
+      final Consumer<DecisionInstanceFilter> filter, final int expectedResultCount) {
+    Awaitility.await("Expected amount of decision instances in secondary storage")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newDecisionInstanceSearchRequest()
+                          .filter(filter)
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(expectedResultCount);
+            });
+  }
+
+  private DmnModelInstance getDmnModelInstance(final String decisionId) {
+    // Create an empty DMN model
+    final DmnModelInstance modelInstance = Dmn.createEmptyModel();
+
+    // Create and configure the definitions element
+    final Definitions definitions = modelInstance.newInstance(Definitions.class);
+    definitions.setName("DRD");
+    definitions.setNamespace("http://camunda.org/schema/1.0/dmn");
+    modelInstance.setDefinitions(definitions);
+
+    // Create the decision element
+    final org.camunda.bpm.model.dmn.instance.Decision decision =
+        modelInstance.newInstance(org.camunda.bpm.model.dmn.instance.Decision.class);
+    decision.setId(decisionId);
+    decision.setName("Decision 1");
+    definitions.addChildElement(decision);
+
+    // Create the decision table
+    final DecisionTable decisionTable = modelInstance.newInstance(DecisionTable.class);
+    decision.addChildElement(decisionTable);
+
+    // Add input clauses
+    final Input inputExperience = modelInstance.newInstance(Input.class);
+    final InputExpression inputExpressionExperience =
+        modelInstance.newInstance(InputExpression.class);
+    final Text textExperience = modelInstance.newInstance(Text.class);
+    textExperience.setTextContent("experience");
+    inputExpressionExperience.setText(textExperience);
+    inputExperience.setInputExpression(inputExpressionExperience);
+    decisionTable.addChildElement(inputExperience);
+
+    final Input inputType = modelInstance.newInstance(Input.class);
+    final InputExpression inputExpressionType = modelInstance.newInstance(InputExpression.class);
+    final Text textElementType = modelInstance.newInstance(Text.class);
+    textElementType.setTextContent("type");
+    inputExpressionType.setText(textElementType);
+    inputType.setInputExpression(inputExpressionType);
+    decisionTable.addChildElement(inputType);
+
+    // Add output clauses
+    final Output outputCode = modelInstance.newInstance(Output.class);
+    outputCode.setName("code");
+    decisionTable.addChildElement(outputCode);
+
+    final Output outputDescription = modelInstance.newInstance(Output.class);
+    outputDescription.setName("description");
+    decisionTable.addChildElement(outputDescription);
+    return modelInstance;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionInstanceHistoryIT.java
@@ -76,7 +76,7 @@ public class DeleteDecisionInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .decisionInstanceDelete()
+            .deleteDecisionInstance()
             .filter(f -> f.decisionDefinitionId(decision.getDmnDecisionId()))
             .send()
             .join();
@@ -107,7 +107,7 @@ public class DeleteDecisionInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .decisionInstanceDelete()
+            .deleteDecisionInstance()
             .filter(f -> f.decisionInstanceKey(instanceToDeleteKey))
             .send()
             .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryAuthorizationIT.java
@@ -107,7 +107,8 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
         adminClient, f -> f.processInstanceKey(processInstanceKey), 1);
 
     // when
-    final var result = camundaClient.newDeleteInstanceCommand(processInstanceKey).send().join();
+    final var result =
+        camundaClient.newDeleteProcessInstanceCommand(processInstanceKey).send().join();
 
     // then - should not throw an exception
     assertThat(result).isNotNull();
@@ -125,7 +126,7 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
 
     // when
     final ThrowingCallable executeDelete =
-        () -> camundaClient.newDeleteInstanceCommand(processInstanceKey).send().join();
+        () -> camundaClient.newDeleteProcessInstanceCommand(processInstanceKey).send().join();
 
     // then
     final var problemException =
@@ -147,7 +148,7 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
 
     // when
     final ThrowingCallable executeDelete =
-        () -> camundaClient.newDeleteInstanceCommand(processInstanceKey).send().join();
+        () -> camundaClient.newDeleteProcessInstanceCommand(processInstanceKey).send().join();
 
     // then
     final var problemException =
@@ -172,7 +173,7 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
     final var result =
         camundaClient
             .newCreateBatchOperationCommand()
-            .processInstanceDelete()
+            .deleteProcessInstance()
             .filter(f -> f.variables(getScopedVariables(scopeId)))
             .send()
             .join();
@@ -197,7 +198,7 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
         () ->
             camundaClient
                 .newCreateBatchOperationCommand()
-                .processInstanceDelete()
+                .deleteProcessInstance()
                 .filter(f -> f.variables(getScopedVariables(scopeId)))
                 .send()
                 .join();
@@ -227,7 +228,7 @@ public class DeleteProcessInstanceHistoryAuthorizationIT {
         () ->
             camundaClient
                 .newCreateBatchOperationCommand()
-                .processInstanceDelete()
+                .deleteProcessInstance()
                 .filter(f -> f.variables(getScopedVariables(scopeId)))
                 .send()
                 .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
@@ -78,7 +78,7 @@ public class DeleteProcessInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .processInstanceDelete()
+            .deleteProcessInstance()
             .filter(f -> f.processDefinitionId(processId))
             .send()
             .join();
@@ -131,7 +131,7 @@ public class DeleteProcessInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .processInstanceDelete()
+            .deleteProcessInstance()
             .filter(f -> f.processDefinitionId(subProcessId))
             .send()
             .join();
@@ -164,7 +164,7 @@ public class DeleteProcessInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .processInstanceDelete()
+            .deleteProcessInstance()
             .filter(f -> f.processInstanceKey(piKey1))
             .send()
             .join();
@@ -202,7 +202,7 @@ public class DeleteProcessInstanceHistoryIT {
     final var batchResult =
         camundaClient
             .newCreateBatchOperationCommand()
-            .processInstanceDelete()
+            .deleteProcessInstance()
             .filter(f -> f.processInstanceKey(piKey))
             .send()
             .join();
@@ -245,7 +245,7 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when - delete using singular deletion
     final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey).send().join();
+        camundaClient.newDeleteProcessInstanceCommand(piKey).send().join();
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
@@ -266,7 +266,7 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when - delete only one by key
     final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey1).send().join();
+        camundaClient.newDeleteProcessInstanceCommand(piKey1).send().join();
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
@@ -293,7 +293,7 @@ public class DeleteProcessInstanceHistoryIT {
     waitForProcessInstances(camundaClient, f -> f.processInstanceKey(piKey), 1);
 
     // when
-    final var resultFuture = camundaClient.newDeleteInstanceCommand(piKey).send();
+    final var resultFuture = camundaClient.newDeleteProcessInstanceCommand(piKey).send();
 
     // then
     assertThatExceptionOfType(ProblemException.class)
@@ -327,7 +327,7 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when - delete using singular deletion
     final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey).send().join();
+        camundaClient.newDeleteProcessInstanceCommand(piKey).send().join();
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
@@ -356,7 +356,7 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when - delete using singular deletion
     final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey).send().join();
+        camundaClient.newDeleteProcessInstanceCommand(piKey).send().join();
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
@@ -380,7 +380,7 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when - delete using singular deletion
     final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey).send().join();
+        camundaClient.newDeleteProcessInstanceCommand(piKey).send().join();
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
@@ -394,7 +394,8 @@ public class DeleteProcessInstanceHistoryIT {
 
     // when/then - try to delete non-existing process instance should throw not found exception
     assertThatExceptionOfType(ProblemException.class)
-        .isThrownBy(() -> camundaClient.newDeleteInstanceCommand(nonExistingKey).send().join())
+        .isThrownBy(
+            () -> camundaClient.newDeleteProcessInstanceCommand(nonExistingKey).send().join())
         .satisfies(
             exception -> {
               assertThat(exception.code()).isEqualTo(404);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/DmnBuilderHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/DmnBuilderHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.util;
+
+import org.camunda.bpm.model.dmn.Dmn;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.dmn.instance.Decision;
+import org.camunda.bpm.model.dmn.instance.DecisionTable;
+import org.camunda.bpm.model.dmn.instance.Definitions;
+import org.camunda.bpm.model.dmn.instance.Input;
+import org.camunda.bpm.model.dmn.instance.InputExpression;
+import org.camunda.bpm.model.dmn.instance.Output;
+import org.camunda.bpm.model.dmn.instance.Text;
+
+/** Helper class to build simple DMN models for testing purposes. */
+public class DmnBuilderHelper {
+
+  public static DmnModelInstance getDmnModelInstance(final String decisionId) {
+    // Create an empty DMN model
+    final DmnModelInstance modelInstance = Dmn.createEmptyModel();
+
+    // Create and configure the definitions element
+    final Definitions definitions = modelInstance.newInstance(Definitions.class);
+    definitions.setName("DRD");
+    definitions.setNamespace("http://camunda.org/schema/1.0/dmn");
+    modelInstance.setDefinitions(definitions);
+
+    // Create the decision element
+    final Decision decision = modelInstance.newInstance(Decision.class);
+    decision.setId(decisionId);
+    decision.setName("Decision 1");
+    definitions.addChildElement(decision);
+
+    // Create the decision table
+    final DecisionTable decisionTable = modelInstance.newInstance(DecisionTable.class);
+    decision.addChildElement(decisionTable);
+
+    // Add input clauses
+    final Input inputExperience = modelInstance.newInstance(Input.class);
+    final InputExpression inputExpressionExperience =
+        modelInstance.newInstance(InputExpression.class);
+    final Text textExperience = modelInstance.newInstance(Text.class);
+    textExperience.setTextContent("experience");
+    inputExpressionExperience.setText(textExperience);
+    inputExperience.setInputExpression(inputExpressionExperience);
+    decisionTable.addChildElement(inputExperience);
+
+    // Add output clauses
+    final Output outputCode = modelInstance.newInstance(Output.class);
+    outputCode.setName("code");
+    decisionTable.addChildElement(outputCode);
+
+    return modelInstance;
+  }
+}

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -122,9 +123,10 @@ public final class DecisionInstanceServices
                 q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey))));
 
     if (searchResult.items().isEmpty()) {
-      throw new CamundaSearchException(
-          ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted("Decision Instance", decisionInstanceKey),
-          CamundaSearchException.Reason.NOT_FOUND);
+      throw ErrorMapper.mapSearchError(
+          new CamundaSearchException(
+              ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted("Decision Instance", decisionInstanceKey),
+              CamundaSearchException.Reason.NOT_FOUND));
     }
 
     final var decisionInstance = searchResult.items().getFirst();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds both single operation and batch operation decision instance deletion to the CamundaClient, plus ITs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/42466 and https://github.com/camunda/camunda/issues/42467
