### PR TITLE
Propagate business id during process instance creation

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -129,7 +129,7 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
 
   @Override
   public String getBusinessId() {
-    return "";
+    return ""; // not used in Optimize
   }
 
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -127,6 +127,11 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     return -1L; // not used in Optimize
   }
 
+  @Override
+  public String getBusinessId() {
+    return "";
+  }
+
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {
     this.parentElementInstanceKey = parentElementInstanceKey;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -63,13 +63,13 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   }
 
   @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKey;
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
   }
 
   @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKey;
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
   }
 
   @Override
@@ -147,12 +147,12 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     this.elementId = elementId;
   }
 
-  public void setProcessInstanceKey(final long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
   public void setProcessDefinitionKey(final long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
   }
 
   public void setVersion(final int version) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -98,7 +98,7 @@ public final class ProcessInstanceCreationCreateProcessor
 
     final var processInstance =
         helper.initProcessInstanceRecord(
-            process, processInstanceKey, record.getTags(), record.getBusinessId());
+            process, processInstanceKey, record.getTags(), record.getBusinessIdBuffer());
 
     helper.setVariablesFromDocument(processInstance, record.getVariablesBuffer());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -97,7 +97,8 @@ public final class ProcessInstanceCreationCreateProcessor
     final var record = command.getValue();
 
     final var processInstance =
-        helper.initProcessInstanceRecord(process, processInstanceKey, record.getTags());
+        helper.initProcessInstanceRecord(
+            process, processInstanceKey, record.getTags(), record.getBusinessId());
 
     helper.setVariablesFromDocument(processInstance, record.getVariablesBuffer());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -102,7 +102,7 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
 
     final var processInstance =
         helper.initProcessInstanceRecord(
-            process, processInstanceKey, record.getTags(), record.getBusinessId());
+            process, processInstanceKey, record.getTags(), record.getBusinessIdBuffer());
 
     helper.setVariablesFromDocument(processInstance, record.getVariablesBuffer());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -101,7 +101,8 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
     final var record = command.getValue();
 
     final var processInstance =
-        helper.initProcessInstanceRecord(process, processInstanceKey, record.getTags());
+        helper.initProcessInstanceRecord(
+            process, processInstanceKey, record.getTags(), record.getBusinessId());
 
     helper.setVariablesFromDocument(processInstance, record.getVariablesBuffer());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -95,7 +95,7 @@ public class ProcessInstanceCreationHelper {
       final DeployedProcess process,
       final long processInstanceKey,
       final Set<String> tags,
-      final String businessId) {
+      final DirectBuffer businessId) {
     return new ProcessInstanceRecord()
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -92,7 +92,10 @@ public class ProcessInstanceCreationHelper {
   }
 
   public ProcessInstanceRecord initProcessInstanceRecord(
-      final DeployedProcess process, final long processInstanceKey, final Set<String> tags) {
+      final DeployedProcess process,
+      final long processInstanceKey,
+      final Set<String> tags,
+      final String businessId) {
     return new ProcessInstanceRecord()
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
@@ -103,7 +106,8 @@ public class ProcessInstanceCreationHelper {
         .setElementId(process.getProcess().getId())
         .setFlowScopeKey(-1)
         .setTenantId(process.getTenantId())
-        .setTags(tags);
+        .setTags(tags)
+        .setBusinessId(businessId);
   }
 
   private Either<Rejection, DeployedProcess> getProcess(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -74,6 +74,37 @@ public class CreateProcessInstanceAnywhereTest {
   }
 
   @Test
+  public void shouldActivateSingleElementWithBusinessId() {
+    // Given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent("end").done())
+        .deploy();
+
+    final String businessId = "biz-123";
+
+    // When
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction("end")
+            .withBusinessId(businessId)
+            .create();
+
+    // Then
+    final var processActivated =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    Assertions.assertThat(processActivated.getValue().getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
   public void shouldActivateMultipleElements() {
     // Given
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -270,6 +270,31 @@ public final class CreateProcessInstanceTest {
   }
 
   @Test
+  public void shouldCreateProcessInstanceWithBusinessId() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess("process").startEvent().endEvent().done())
+        .deploy();
+
+    final String businessId = "biz-123";
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withBusinessId(businessId).create();
+
+    // then
+    final Record<ProcessInstanceRecordValue> processActivated =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    assertThat(processActivated.getValue().getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
   public void shouldActivateNoneStartEvent() {
     // given
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -112,6 +112,11 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public ProcessInstanceCreationClient withBusinessId(final String businessId) {
+      processInstanceCreationRecord.setBusinessId(businessId);
+      return this;
+    }
+
     public ProcessInstanceCreationClient withVariables(final Map<String, Object> variables) {
       processInstanceCreationRecord.setVariables(MsgPackUtil.asMsgPack(variables));
       return this;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -59,6 +59,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -66,6 +66,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -59,6 +59,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -66,6 +66,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -47,6 +47,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue TAGS_KEY = new StringValue("tags");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -70,9 +71,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(11);
+    super(12);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -83,7 +85,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(runtimeInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(businessIdProperty);
   }
 
   @Override
@@ -159,6 +162,21 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setRootProcessInstanceKey(
       final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceCreationRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProperty.setValue(businessId);
     return this;
   }
 
@@ -261,5 +279,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProperty.getValue();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -58,6 +58,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
+  public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -96,8 +97,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
 
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+
   public ProcessInstanceRecord() {
-    super(16);
+    super(17);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -113,7 +116,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(processDefinitionPathProp)
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -129,6 +133,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    businessIdProp.setValue(record.getBusinessId());
   }
 
   @JsonIgnore
@@ -278,6 +283,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessInstanceRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -158,18 +158,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKeyProp.getValue();
-  }
-
-  @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
   }
 
-  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
   }
 
   @Override
@@ -312,6 +307,11 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1720,6 +1720,7 @@ final class JsonSerializableToJsonTest {
               final int version = 1;
               final long instanceKey = 2L;
               final long rootProcessInstanceKey = 3L;
+              final String businessId = "business-id-456";
 
               return new ProcessInstanceCreationRecord()
                   .setBpmnProcessId(processId)
@@ -1733,7 +1734,8 @@ final class JsonSerializableToJsonTest {
                       new ProcessInstanceCreationStartInstruction().setElementId("element"))
                   .setProcessInstanceKey(instanceKey)
                   .setTags(Set.of("tag1", "tag2"))
-                  .setRootProcessInstanceKey(rootProcessInstanceKey);
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setBusinessId(businessId);
             },
         """
                 {
@@ -1753,7 +1755,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "test-tenant",
                   "runtimeInstructions": [],
                   "tags": ["tag1", "tag2"],
-                  "rootProcessInstanceKey": 3
+                  "rootProcessInstanceKey": 3,
+                  "businessId": "business-id-456"
                 }
                 """
       },
@@ -1777,7 +1780,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "runtimeInstructions": [],
                   "tags": [],
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "businessId": ""
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1911,6 +1911,7 @@ final class JsonSerializableToJsonTest {
               final var processDefinitionPath = List.of(101L, 102L);
               final var callingElementPath = List.of(12345, 67890);
               final var rootProcessInstanceKey = 9999L;
+              final var businessId = "business-id-123";
 
               return new ProcessInstanceRecord()
                   .setElementId(elementId)
@@ -1927,7 +1928,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionPath(processDefinitionPath)
                   .setCallingElementPath(callingElementPath)
                   .setTags(Set.of("tag1", "tag2"))
-                  .setRootProcessInstanceKey(rootProcessInstanceKey);
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setBusinessId(businessId);
             },
         """
                 {
@@ -1946,7 +1948,8 @@ final class JsonSerializableToJsonTest {
                   "processDefinitionPath": [101, 102],
                   "callingElementPath": [12345, 67890],
                   "tags": ["tag1", "tag2"],
-                  "rootProcessInstanceKey": 9999
+                  "rootProcessInstanceKey": 9999,
+                  "businessId": "business-id-123"
                 }
                 """
       },
@@ -1976,7 +1979,8 @@ final class JsonSerializableToJsonTest {
                   "processDefinitionPath": [],
                   "callingElementPath": [],
                   "tags": [],
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "businessId": ""
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -47,6 +47,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue TAGS_KEY = new StringValue("tags");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -70,9 +71,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(11);
+    super(12);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -83,7 +85,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(runtimeInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(businessIdProperty);
   }
 
   @Override
@@ -159,6 +162,21 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setRootProcessInstanceKey(
       final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceCreationRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProperty.setValue(businessId);
     return this;
   }
 
@@ -261,5 +279,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProperty.getValue();
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
@@ -58,6 +58,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
+  public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -96,8 +97,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
 
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
+
   public ProcessInstanceRecord() {
-    super(16);
+    super(17);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -113,7 +116,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(processDefinitionPathProp)
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -129,6 +133,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    businessIdProp.setValue(record.getBusinessId());
   }
 
   @JsonIgnore
@@ -362,6 +367,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessInstanceRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -73,6 +73,7 @@ public interface ProcessInstanceCreationRecordValue
    * with the same business id already exists, the creation will be rejected.
    *
    * @return the business id, or an empty string if not set
+   * @since 8.9
    */
   String getBusinessId();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -38,6 +38,7 @@ public interface ProcessInstanceCreationRecordValue
   /**
    * @return the unique key of the BPMN process definition to create a process from
    */
+  @Override
   long getProcessDefinitionKey();
 
   /** Returns a list of start instructions (if available), or an empty list. */
@@ -61,6 +62,19 @@ public interface ProcessInstanceCreationRecordValue
    * @return the key of the root process instance, or {@code -1} if not set
    */
   long getRootProcessInstanceKey();
+
+  /**
+   * Returns the business id for the process instance to be created. The business id is an
+   * immutable, user-defined string identifier that uniquely identifies a process instance within
+   * the scope of a process definition.
+   *
+   * <p>If provided, the engine will enforce uniqueness: only one active process instance with a
+   * given business id can exist per process definition (scoped by tenant). If a process instance
+   * with the same business id already exists, the creation will be rejected.
+   *
+   * @return the business id, or an empty string if not set
+   */
+  String getBusinessId();
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableProcessInstanceCreationStartInstructionValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -206,6 +206,7 @@ public interface ProcessInstanceRecordValue
    * <p>It can be used to enforce idempotency when creating process instances.
    *
    * @return the business id, or an empty string if not set
+   * @since 8.9
    */
   String getBusinessId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -199,8 +199,11 @@ public interface ProcessInstanceRecordValue
    * user-defined string identifier that can be used to identify a process instance within the scope
    * of a process definition.
    *
-   * <p>The business id is set only on root process instances and remains immutable throughout the
-   * instance's lifecycle. It can be used to enforce idempotency when creating process instances.
+   * <p>The business id is set only on elements of type PROCESS.
+   *
+   * <p>Once set, it remains immutable throughout the instance's lifecycle.
+   *
+   * <p>It can be used to enforce idempotency when creating process instances.
    *
    * @return the business id, or an empty string if not set
    */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -196,8 +196,8 @@ public interface ProcessInstanceRecordValue
 
   /**
    * Returns the business id associated with this process instance. The business id is an immutable,
-   * user-defined string identifier that can be used to uniquely identify a process instance within
-   * the scope of a process definition.
+   * user-defined string identifier that can be used to identify a process instance within the scope
+   * of a process definition.
    *
    * <p>The business id is set only on root process instances and remains immutable throughout the
    * instance's lifecycle. It can be used to enforce idempotency when creating process instances.

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -42,15 +42,16 @@ public interface ProcessInstanceRecordValue
   int getVersion();
 
   /**
-   * @return the key of the deployed process this instance belongs to.
-   */
-  long getProcessDefinitionKey();
-
-  /**
    * @return the key of the process instance
    */
   @Override
   long getProcessInstanceKey();
+
+  /**
+   * @return the key of the deployed process this instance belongs to.
+   */
+  @Override
+  long getProcessDefinitionKey();
 
   /**
    * @return the id of the current process element, or empty if the id is not specified.

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -193,4 +193,16 @@ public interface ProcessInstanceRecordValue
    * @return the key of the root process instance, or {@code -1} if not set
    */
   long getRootProcessInstanceKey();
+
+  /**
+   * Returns the business id associated with this process instance. The business id is an immutable,
+   * user-defined string identifier that can be used to uniquely identify a process instance within
+   * the scope of a process definition.
+   *
+   * <p>The business id is set only on root process instances and remains immutable throughout the
+   * instance's lifecycle. It can be used to enforce idempotency when creating process instances.
+   *
+   * @return the business id, or an empty string if not set
+   */
+  String getBusinessId();
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,11 +159,11 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 448]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 460]");
   }
 
   @Test
-  void shouldReturnFalseIfRecordSizeDoesReachSizelimit() {
+  void shouldReturnFalseIfRecordSizeDoesReachSizeLimit() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> size < 100);
 
@@ -175,7 +175,7 @@ class RecordBatchTest {
   }
 
   @Test
-  void shouldReturnTrueIfRecordSizeDoesntReachSizelimit() {
+  void shouldReturnTrueIfRecordSizeDoesntReachSizeLimit() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> size < 100);
 
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 449);
+    final var recordBatch = new RecordBatch((count, size) -> size < 461);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);


### PR DESCRIPTION
## Description

This PR propagates the `businessId` during process instance creation (engine-internal only).

It introduces `businessId` as a first-class attribute on:
- `ProcessInstanceCreationRecord` (to carry the value through the engine’s creation flow), and
- `ProcessInstanceRecord` (to persist it on the created process instance),

and wires the propagation from the creation record to the resulting process instance record when creating process instances.

Additionally, it updates the documentation around `businessId` semantics/constraints (e.g. optional + immutable, not necessarily unique unless idempotency is enforced, applicability to child instances created via call activities, and version introduction).

> Note: this PR does **not** expose `businessId` via any external API yet; it’s only internal plumbing in the engine.

## Testing

Protocol / record serialization coverage was updated for the new `businessId` field (JSON serialization + golden records, plus dependent batching tests).

Engine-level tests were added to verify that:
- a process instance can be created with a `businessId`, and the value is propagated to the **`PROCESS_INSTANCE` `ELEMENT_ACTIVATED`** event
- the same holds when starting the instance “anywhere”

To enable the above, the test process instance client was extended to support setting `businessId` during instance creation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45178