### PR TITLE
feat: add Mixpanel tracking events for batch operations

### DIFF
--- a/operate/client/src/App/BatchOperation/OperationActions.test.tsx
+++ b/operate/client/src/App/BatchOperation/OperationActions.test.tsx
@@ -30,6 +30,11 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
 
 const BATCH_OPERATION_KEY = 'migrate-operation-123';
 
+const defaultProps = {
+  batchOperationKey: BATCH_OPERATION_KEY,
+  batchOperationType: 'MODIFY_PROCESS_INSTANCE' as const,
+};
+
 describe('<OperationActions />', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,10 +45,7 @@ describe('<OperationActions />', () => {
 
   it('should render Suspend and Cancel actions for created state', () => {
     render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="CREATED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="CREATED" />,
       {wrapper: Wrapper},
     );
 
@@ -56,10 +58,7 @@ describe('<OperationActions />', () => {
     mockCancelBatchOperation().withSuccess(null, {mockResolverFn: cancelSpy});
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="CREATED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="CREATED" />,
       {wrapper: Wrapper},
     );
 
@@ -71,10 +70,7 @@ describe('<OperationActions />', () => {
 
   it('should render Suspend and Cancel actions for active state', () => {
     render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="ACTIVE"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="ACTIVE" />,
       {wrapper: Wrapper},
     );
 
@@ -92,10 +88,7 @@ describe('<OperationActions />', () => {
     });
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="ACTIVE"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="ACTIVE" />,
       {wrapper: Wrapper},
     );
 
@@ -108,10 +101,7 @@ describe('<OperationActions />', () => {
     mockSuspendBatchOperation().withServerError(500);
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="ACTIVE"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="ACTIVE" />,
       {wrapper: Wrapper},
     );
 
@@ -127,10 +117,7 @@ describe('<OperationActions />', () => {
 
   it('should render Resume and Cancel actions', () => {
     render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="SUSPENDED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="SUSPENDED" />,
       {wrapper: Wrapper},
     );
 
@@ -146,10 +133,7 @@ describe('<OperationActions />', () => {
     mockResumeBatchOperation().withSuccess(null, {mockResolverFn: resumeSpy});
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="SUSPENDED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="SUSPENDED" />,
       {wrapper: Wrapper},
     );
 
@@ -162,10 +146,7 @@ describe('<OperationActions />', () => {
     mockResumeBatchOperation().withServerError(500);
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="SUSPENDED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="SUSPENDED" />,
       {wrapper: Wrapper},
     );
 
@@ -184,10 +165,7 @@ describe('<OperationActions />', () => {
     mockCancelBatchOperation().withDelay(null);
 
     const {user} = render(
-      <OperationsActions
-        batchOperationKey={BATCH_OPERATION_KEY}
-        batchOperationState="SUSPENDED"
-      />,
+      <OperationsActions {...defaultProps} batchOperationState="SUSPENDED" />,
       {wrapper: Wrapper},
     );
 
@@ -211,10 +189,7 @@ describe('<OperationActions />', () => {
     'should not render any actions for %s state',
     (state) => {
       render(
-        <OperationsActions
-          batchOperationKey={BATCH_OPERATION_KEY}
-          batchOperationState={state}
-        />,
+        <OperationsActions {...defaultProps} batchOperationState={state} />,
         {wrapper: Wrapper},
       );
 

--- a/operate/client/src/App/BatchOperation/index.tsx
+++ b/operate/client/src/App/BatchOperation/index.tsx
@@ -24,6 +24,7 @@ import {useBatchOperation} from 'modules/queries/batch-operations/useBatchOperat
 import {BatchItemsCount} from 'App/BatchOperations/BatchItemsCount';
 import {formatOperationType} from 'modules/utils/formatOperationType';
 import {BatchStateIndicator} from 'App/BatchOperations/BatchStateIndicator';
+import {tracking} from 'modules/tracking';
 import {
   PageContainer,
   ContentContainer,
@@ -65,6 +66,19 @@ const BatchOperation: React.FC = () => {
   useEffect(() => {
     document.title = PAGE_TITLE.BATCH_OPERATION(operationType);
   }, [operationType]);
+
+  useEffect(() => {
+    if (batchOperationData) {
+      const {batchOperationType, state, operationsTotalCount} =
+        batchOperationData;
+      tracking.track({
+        eventName: 'batch-operation-details-loaded',
+        batchOperationType,
+        batchOperationState: state,
+        operationsTotalCount,
+      });
+    }
+  }, [batchOperationData]);
 
   useEffect(() => {
     if (error?.response?.status === 404 && batchOperationKey) {
@@ -143,10 +157,11 @@ const BatchOperation: React.FC = () => {
           isLoading,
           <Header>
             <h3>{operationType}</h3>
-            {state && (
+            {batchOperationData && (
               <OperationsActions
                 batchOperationKey={batchOperationKey}
-                batchOperationState={state}
+                batchOperationState={batchOperationData.state}
+                batchOperationType={batchOperationData.batchOperationType}
               />
             )}
           </Header>,

--- a/operate/client/src/App/BatchOperations/index.tsx
+++ b/operate/client/src/App/BatchOperations/index.tsx
@@ -11,6 +11,7 @@ import {useSearchParams, Link} from 'react-router-dom';
 import {Breadcrumb, BreadcrumbItem, Pagination} from '@carbon/react';
 import {Locations} from 'modules/Routes';
 import {PAGE_TITLE} from 'modules/constants';
+import {tracking} from 'modules/tracking';
 import {formatDate} from 'modules/utils/date';
 import {Forbidden} from 'modules/components/Forbidden';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
@@ -89,7 +90,16 @@ const BatchOperations: React.FC = () => {
       return {
         id: batchOperationKey,
         operationType: (
-          <Link to={batchOperationKey}>
+          <Link
+            to={batchOperationKey}
+            onClick={() => {
+              tracking.track({
+                eventName: 'batch-operation-details-opened',
+                batchOperationType,
+                batchOperationState: state,
+              });
+            }}
+          >
             {formatOperationType(batchOperationType)}
           </Link>
         ),
@@ -139,6 +149,17 @@ const BatchOperations: React.FC = () => {
               state={getTableState()}
               headerColumns={headers}
               rows={rows}
+              onSort={(sortKey) => {
+                const previousOrder = sort.find(
+                  (s) => s.field === sortKey,
+                )?.order;
+
+                tracking.track({
+                  eventName: 'batch-operations-sorted',
+                  sortBy: sortKey,
+                  sortOrder: previousOrder === 'desc' ? 'asc' : 'desc',
+                });
+              }}
               emptyMessage={{
                 message: 'No batch operations found',
                 additionalInfo:

--- a/operate/client/src/modules/components/SortableTable/index.tsx
+++ b/operate/client/src/modules/components/SortableTable/index.tsx
@@ -88,6 +88,7 @@ const SortableTable = <
   columnsWithNoContentPadding,
   batchOperationId,
   stickyHeader = false,
+  onSort,
 }: Props<RowType, ColTypes>) => {
   let scrollableContentRef = useRef<HTMLDivElement | null>(null);
 
@@ -166,6 +167,7 @@ const SortableTable = <
                         sortKey={headerColumns[index].sortKey ?? header.key}
                         isDefault={headerColumns[index].isDefault}
                         isDisabled={headerColumns[index].isDisabled}
+                        onSort={onSort}
                       />
                     );
                   })}

--- a/operate/client/src/modules/mutations/batchOperations/useCancelBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useCancelBatchOperation.ts
@@ -13,6 +13,7 @@ import type {RequestError} from 'modules/request';
 
 type CancelBatchOperationOptions = {
   onError?: (error: RequestError) => Promise<unknown> | unknown;
+  onSuccess?: () => Promise<unknown> | unknown;
 };
 
 function useCancelBatchOperation(options?: CancelBatchOperationOptions) {
@@ -32,6 +33,7 @@ function useCancelBatchOperation(options?: CancelBatchOperationOptions) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.batchOperations.get(batchOperationKey),
       });
+      options?.onSuccess?.();
     },
     onError: options?.onError,
   });

--- a/operate/client/src/modules/mutations/batchOperations/useResumeBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useResumeBatchOperation.ts
@@ -13,6 +13,7 @@ import type {RequestError} from 'modules/request';
 
 type ResumeBatchOperationOptions = {
   onError?: (error: RequestError) => Promise<unknown> | unknown;
+  onSuccess?: () => Promise<unknown> | unknown;
 };
 
 function useResumeBatchOperation(options?: ResumeBatchOperationOptions) {
@@ -32,6 +33,7 @@ function useResumeBatchOperation(options?: ResumeBatchOperationOptions) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.batchOperations.get(batchOperationKey),
       });
+      options?.onSuccess?.();
     },
     onError: options?.onError,
   });

--- a/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
+++ b/operate/client/src/modules/mutations/batchOperations/useSuspendBatchOperation.ts
@@ -13,6 +13,7 @@ import type {RequestError} from 'modules/request';
 
 type SuspendBatchOperationOptions = {
   onError?: (error: RequestError) => Promise<unknown> | unknown;
+  onSuccess?: () => Promise<unknown> | unknown;
 };
 
 function useSuspendBatchOperation(options?: SuspendBatchOperationOptions) {
@@ -32,6 +33,7 @@ function useSuspendBatchOperation(options?: SuspendBatchOperationOptions) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.batchOperations.get(batchOperationKey),
       });
+      options?.onSuccess?.();
     },
     onError: options?.onError,
   });

--- a/operate/client/src/modules/tracking/index.ts
+++ b/operate/client/src/modules/tracking/index.ts
@@ -12,7 +12,11 @@ import type {
   InstanceEntityState,
   OperationEntityType,
 } from 'modules/types/operate';
-import type {DecisionInstanceState} from '@camunda/camunda-api-zod-schemas/8.8';
+import type {
+  BatchOperationState,
+  BatchOperationType,
+  DecisionInstanceState,
+} from '@camunda/camunda-api-zod-schemas/8.8';
 
 const EVENT_PREFIX = 'operate:';
 
@@ -296,6 +300,43 @@ type Events =
   | {
       eventName: 'batch-move-modification-apply-button-clicked';
     }
+  /**
+   * Batch operations list and details
+   */
+  | {
+      eventName: 'batch-operations-sorted';
+      sortBy: string;
+      sortOrder: 'asc' | 'desc';
+    }
+  | {
+      eventName: 'batch-operation-details-opened';
+      batchOperationType: BatchOperationType;
+      batchOperationState: BatchOperationState;
+    }
+  | {
+      eventName: 'batch-operation-details-loaded';
+      batchOperationType: BatchOperationType;
+      batchOperationState: BatchOperationState;
+      operationsTotalCount: number;
+    }
+  | {
+      eventName: 'batch-operation-suspended';
+      batchOperationType: BatchOperationType;
+      batchOperationState: BatchOperationState;
+    }
+  | {
+      eventName: 'batch-operation-resumed';
+      batchOperationType: BatchOperationType;
+      batchOperationState: BatchOperationState;
+    }
+  | {
+      eventName: 'batch-operation-canceled';
+      batchOperationType: BatchOperationType;
+      batchOperationState: BatchOperationState;
+    }
+  /**
+   * audit logs
+   */
   | {
       eventName: 'audit-logs-loaded';
       filters: string[];


### PR DESCRIPTION
## Description

### Events Added

#### Batch Operations List Page
- **`batch-operations-sorted`** - Tracks column sorting to identify which columns are most valuable for user decision-making
- **`batch-operation-details-opened`** - Tracks navigation to detail view to understand which operation types and states draw user attention

#### Batch Operation Detail Page
- **`batch-operation-details-loaded`** - Tracks page loads to establish baseline usage patterns by operation type, state, and scale
- **`batch-operation-suspended`** - Tracks suspend actions to measure adoption and identify scenarios requiring pause capability
- **`batch-operation-resumed`** - Tracks resume actions to measure suspend-resume workflow completion rates
- **`batch-operation-canceled`** - Tracks cancel actions to identify problematic operation types with high cancellation rates


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #44241
