### PR TITLE
feat: delete decision instance data from RDBMS

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -382,6 +382,11 @@
     </createIndex>
 
     <createIndex tableName="${prefix}DECISION_INSTANCE"
+      indexName="${prefix}IDX_DECISION_INSTANCE_KEY">
+      <column name="DECISION_INSTANCE_KEY"/>
+    </createIndex>
+
+    <createIndex tableName="${prefix}DECISION_INSTANCE"
       indexName="${prefix}IDX_DECISION_INSTANCE_DD_KEY">
       <column name="DECISION_DEFINITION_KEY"/>
     </createIndex>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReader.java
@@ -8,8 +8,7 @@
 package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
-import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
-import java.util.List;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,10 +21,11 @@ public class HistoryDeletionDbReader {
     this.historyDeletionMapper = historyDeletionMapper;
   }
 
-  public List<HistoryDeletionDbModel> getNextBatch(final int partitionId, final int limit) {
+  public HistoryDeletionBatch getNextBatch(final int partitionId, final int limit) {
     LOG.trace(
         "[RDBMS DB] Fetch first {} history deletion records from partition {}", limit, partitionId);
 
-    return historyDeletionMapper.getHistoryDeletionBatch(partitionId, limit);
+    return new HistoryDeletionBatch(
+        historyDeletionMapper.getHistoryDeletionBatch(partitionId, limit));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
@@ -29,4 +29,6 @@ public interface DecisionInstanceMapper extends RootProcessInstanceDependantMapp
   List<DecisionInstanceDbModel.EvaluatedOutput> loadOutputs(List<String> decisionInstanceIds);
 
   int cleanupHistory(HistoryCleanupMapper.CleanupHistoryDto dto);
+
+  int deleteByKeys(List<Long> decisionInstanceKeys);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionBatch.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionBatch.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Represents a batch of db models to be deleted from the history.
+ *
+ * @param historyDeletionModels List of entities marked for deletion
+ */
+public record HistoryDeletionBatch(List<HistoryDeletionDbModel> historyDeletionModels) {
+
+  /**
+   * Gets resource keys filtered by resource type.
+   *
+   * @param historyDeletionType The type of resource to filter by
+   * @return List of resource keys matching the type
+   */
+  public List<Long> getResourceKeys(final HistoryDeletionTypeDbModel historyDeletionType) {
+    return getResourceKeys(historyDeletionType, model -> true);
+  }
+
+  /**
+   * Gets resource keys filtered by resource type and an additional predicate.
+   *
+   * @param historyDeletionType The type of resource to filter by
+   * @param additionalFilter Additional predicate to filter the models
+   * @return List of resource keys matching both the type and the additional filter
+   */
+  public List<Long> getResourceKeys(
+      final HistoryDeletionTypeDbModel historyDeletionType,
+      final Predicate<HistoryDeletionDbModel> additionalFilter) {
+    return historyDeletionModels.stream()
+        .filter(model -> model.resourceType().equals(historyDeletionType))
+        .filter(additionalFilter)
+        .map(HistoryDeletionDbModel::resourceKey)
+        .toList();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 public class DecisionInstanceWriter extends RootProcessInstanceDependant implements RdbmsWriter {
 
@@ -91,5 +92,9 @@ public class DecisionInstanceWriter extends RootProcessInstanceDependant impleme
       final int partitionId, final OffsetDateTime cleanupDate, final int limit) {
     return mapper.cleanupHistory(
         new HistoryCleanupMapper.CleanupHistoryDto(partitionId, cleanupDate, limit));
+  }
+
+  public int deleteByKeys(final List<Long> decisionInstanceKeys) {
+    return mapper.deleteByKeys(decisionInstanceKeys);
   }
 }

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -328,4 +328,12 @@
     <bind name="primaryKeyColumn" value="'DECISION_INSTANCE_ID'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
+
+  <delete id="deleteByKeys">
+    DELETE FROM ${prefix}DECISION_INSTANCE
+    WHERE DECISION_INSTANCE_KEY IN
+    <foreach collection="decisionInstanceKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+  </delete>
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/HistoryDeletionDbReaderTest.java
@@ -21,6 +21,6 @@ class HistoryDeletionDbReaderTest {
   @Test
   void shouldReturnEmptyList() {
     final var nextBatch = historyDeletionDbReader.getNextBatch(0, 1);
-    assertThat(nextBatch).isEmpty();
+    assertThat(nextBatch.historyDeletionModels()).isEmpty();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionIT.java
@@ -62,7 +62,7 @@ public class HistoryDeletionIT {
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
 
     // then
-    assertThat(actual).containsExactly(model);
+    assertThat(actual.historyDeletionModels()).containsExactly(model);
   }
 
   @TestTemplate
@@ -71,7 +71,7 @@ public class HistoryDeletionIT {
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 1);
 
     // then
-    assertThat(actual).isEmpty();
+    assertThat(actual.historyDeletionModels()).isEmpty();
   }
 
   @TestTemplate
@@ -99,7 +99,7 @@ public class HistoryDeletionIT {
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 10);
 
     // then
-    assertThat(actual).containsExactlyInAnyOrder(model1, model2);
+    assertThat(actual.historyDeletionModels()).containsExactlyInAnyOrder(model1, model2);
   }
 
   @TestTemplate
@@ -128,8 +128,8 @@ public class HistoryDeletionIT {
     final var actualPartition1 = historyDeletionReader.getNextBatch(1, 10);
 
     // then
-    assertThat(actualPartition0).containsExactly(modelPartition0);
-    assertThat(actualPartition1).containsExactly(modelPartition1);
+    assertThat(actualPartition0.historyDeletionModels()).containsExactly(modelPartition0);
+    assertThat(actualPartition1.historyDeletionModels()).containsExactly(modelPartition1);
   }
 
   @TestTemplate
@@ -165,7 +165,7 @@ public class HistoryDeletionIT {
     final var actual = historyDeletionReader.getNextBatch(PARTITION_ID, 10);
 
     // then
-    assertThat(actual)
+    assertThat(actual.historyDeletionModels())
         .containsExactly(
             modelC, // batchOperationKey=9, resourceKey=3
             modelB, // batchOperationKey=10, resourceKey=1
@@ -181,13 +181,15 @@ public class HistoryDeletionIT {
             RESOURCE_KEY, PROCESS_INSTANCE, BATCH_OPERATION_KEY, PARTITION_ID);
     historyDeletionWriter.create(model);
     rdbmsWriters.flush();
-    assertThat(historyDeletionReader.getNextBatch(PARTITION_ID, 1)).isNotEmpty();
+    assertThat(historyDeletionReader.getNextBatch(PARTITION_ID, 1).historyDeletionModels())
+        .isNotEmpty();
 
     // when
     historyDeletionWriter.delete(RESOURCE_KEY, BATCH_OPERATION_KEY);
     rdbmsWriters.flush();
 
     // then
-    assertThat(historyDeletionReader.getNextBatch(PARTITION_ID, 1)).isEmpty();
+    assertThat(historyDeletionReader.getNextBatch(PARTITION_ID, 1).historyDeletionModels())
+        .isEmpty();
   }
 }


### PR DESCRIPTION
## Description

Decision instances that are marked for deletion should be handled by the `RdbmsExporter#currentHistoryDeletionTask` which calls `HistoryDeletionService`. This task should ensure they eventually get removed from secondary storage.

Synced with ES/OS implementation ([ref](https://github.com/camunda/camunda/pull/45127))

## Related issues

closes #42403
