### PR TITLE
Add contextual data to rejection commands records

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -233,7 +233,6 @@ public final class ProcessInstanceModificationModifyProcessor
 
     if (processInstance == null) {
       final String reason = String.format(ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND, eventKey);
-      // No enrichment possible - process instance doesn't exist in state
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandHelper.enrichCommandForRejection;
 
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
@@ -62,6 +63,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command) {
     return commandChecker
         .checkUserTaskExists(command)
+        .flatMap(userTask -> enrichCommandForRejection(command, userTask))
         .flatMap(userTask -> checkAuthorization(command, userTask))
         .flatMap(userTask -> commandChecker.checkLifecycleState(command, userTask));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandHelper.enrichCommandForRejection;
 
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
@@ -65,6 +66,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command) {
     return commandChecker
         .checkUserTaskExists(command)
+        .flatMap(userTask -> enrichCommandForRejection(command, userTask))
         .flatMap(userTask -> checkAuthorization(command, userTask))
         .flatMap(userTask -> commandChecker.checkLifecycleState(command, userTask))
         .flatMap(userTask -> checkClaim(command, userTask));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask.processors;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+
+final class UserTaskCommandHelper {
+  private UserTaskCommandHelper() {}
+
+  /**
+   * Enriches the command with fields from the persisted user task record. This ensures that if any
+   * subsequent validation fails and a rejection is written, it will have the proper context to be
+   * exported for audit log purposes.
+   */
+  static Either<Rejection, UserTaskRecord> enrichCommandForRejection(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord persistedUserTask) {
+    command.getValue().setTenantId(persistedUserTask.getTenantId());
+    command.getValue().setRootProcessInstanceKey(persistedUserTask.getRootProcessInstanceKey());
+    return Either.right(persistedUserTask);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandHelper.enrichCommandForRejection;
 
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
@@ -74,6 +75,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
       final TypedRecord<UserTaskRecord> command) {
     return commandChecker
         .checkUserTaskExists(command)
+        .flatMap(userTask -> enrichCommandForRejection(command, userTask))
         .flatMap(userTask -> checkAuthorization(command, userTask))
         .flatMap(userTask -> commandChecker.checkLifecycleState(command, userTask));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionUpdateUserTaskRequest;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
+import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandHelper.enrichCommandForRejection;
 
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
@@ -72,6 +73,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command) {
     return commandChecker
         .checkUserTaskExists(command)
+        .flatMap(userTask -> enrichCommandForRejection(command, userTask))
         .flatMap(userTask -> checkAuthorization(command, userTask))
         .flatMap(userTask -> commandChecker.checkLifecycleState(command, userTask));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IncidentResolveRejectionCommandTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(
+              config -> {
+                config.getMultiTenancy().setChecksEnabled(true);
+              });
+
+  private static final String TENANT = "custom-tenant";
+  private static final String USERNAME = "tenant-user";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @BeforeClass
+  public static void setUp() {
+    final var user = ENGINE.user().newUser(USERNAME).create().getValue();
+    final var createdUsername = user.getUsername();
+    ENGINE.tenant().newTenant().withTenantId(TENANT).create().getValue().getTenantKey();
+    ENGINE
+        .tenant()
+        .addEntity(TENANT)
+        .withEntityType(EntityType.USER)
+        .withEntityId(createdUsername)
+        .add();
+  }
+
+  @Test
+  public void shouldEnrichRejectionCommandWhenNoRetriesLeft() {
+    // given - create a process instance with a job incident (no retries left)
+    final String processId = Strings.newRandomValidBpmnId();
+    final String jobType = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    // Wait for job creation and activate it
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.jobs().withType(jobType).withTenantId(TENANT).activate(USERNAME);
+
+    // Fail the job with no retries
+    final var failedEvent =
+        ENGINE.job().withType(jobType).ofInstance(processInstanceKey).withRetries(0).fail(USERNAME);
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withJobKey(failedEvent.getKey())
+            .getFirst();
+
+    // when - try to resolve the incident without updating retries
+    final var rejectionRecord =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .expectRejection()
+            .resolve(USERNAME);
+
+    // then - verify the rejection record is enriched
+    assertThat(rejectionRecord)
+        .hasIntent(IncidentIntent.RESOLVE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The elementInstancePath should be set from the incident record
+    Assertions.assertThat(rejectionRecord.getValue().getElementInstancePath())
+        .describedAs("Rejection record should have elementInstancePath set")
+        .isNotEmpty();
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionCommandForChildProcess() {
+    // given - parent process with call activity that creates an incident
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+    final String jobType = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .serviceTask("childTask", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("callActivity", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).withTenantId(TENANT).create();
+
+    // Wait for the child process instance to be created
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withBpmnProcessId(childProcessId)
+            .getFirst();
+
+    final var childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for job creation in child process and activate it
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(childProcessInstanceKey)
+        .await();
+    ENGINE.jobs().withType(jobType).withTenantId(TENANT).activate(USERNAME);
+
+    // Fail the job with no retries
+    ENGINE
+        .job()
+        .withType(jobType)
+        .ofInstance(childProcessInstanceKey)
+        .withRetries(0)
+        .fail(USERNAME);
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstanceKey)
+            .getFirst();
+
+    // when - try to resolve the incident without updating retries
+    final var rejectionRecord =
+        ENGINE
+            .incident()
+            .ofInstance(childProcessInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .expectRejection()
+            .resolve(USERNAME);
+
+    // then - verify the rejection record has elementInstancePath with call hierarchy
+    assertThat(rejectionRecord)
+        .hasIntent(IncidentIntent.RESOLVE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The elementInstancePath should contain the call hierarchy from the incident
+    final var elementInstancePath = rejectionRecord.getValue().getElementInstancePath();
+    Assertions.assertThat(elementInstancePath)
+        .describedAs("Rejection record should have elementInstancePath set with call hierarchy")
+        .isNotEmpty();
+
+    // There should be multiple levels in the path (parent and child)
+    Assertions.assertThat(elementInstancePath.size())
+        .describedAs("Element instance path should contain multiple levels for nested process")
+        .isGreaterThan(1);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldNotEnrichRejectionWhenIncidentNotFound() {
+    // given - create a valid process instance first to work with the engine
+    final String processId = Strings.newRandomValidBpmnId();
+    final String jobType = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    // Wait for the process to start
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // Create an incident first so we have a valid key range
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.jobs().withType(jobType).withTenantId(TENANT).activate(USERNAME);
+    ENGINE.job().withType(jobType).ofInstance(processInstanceKey).withRetries(0).fail(USERNAME);
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // Resolve the incident first by updating retries
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(jobType)
+        .withRetries(1)
+        .updateRetries(USERNAME);
+    ENGINE
+        .incident()
+        .ofInstance(processInstanceKey)
+        .withKey(incidentCreated.getKey())
+        .resolve(USERNAME);
+
+    // Wait for incident to be resolved
+    RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withRecordKey(incidentCreated.getKey())
+        .await();
+
+    // when - try to resolve the already resolved incident again (NOT_FOUND scenario)
+    final var rejectionRecord =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreated.getKey())
+            .expectRejection()
+            .resolve(USERNAME);
+
+    // then - the rejection should still be written but without enrichment
+    // (since the incident doesn't exist anymore, we can't look up elementInstancePath)
+    assertThat(rejectionRecord)
+        .hasIntent(IncidentIntent.RESOLVE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // elementInstancePath should be empty (default) since we couldn't look it up
+    Assertions.assertThat(rejectionRecord.getValue().getElementInstancePath())
+        .describedAs(
+            "Rejection record should have empty elementInstancePath when incident not found")
+        .isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelRejectionCommandTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ProcessInstanceCancelRejectionCommandTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String TENANT = "custom-tenant";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEnrichRejectionWhenTryingToCancelChildProcess() {
+    // given - parent process with call activity
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .userTask("childTask")
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("callActivity", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).withTenantId(TENANT).create();
+
+    // Wait for the child process instance to be created
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withBpmnProcessId(childProcessId)
+            .getFirst();
+
+    final var childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for child task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(childProcessInstanceKey)
+        .withElementId("childTask")
+        .await();
+
+    // when - try to cancel the child process instance (should fail)
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(childProcessInstanceKey)
+            .expectRejection()
+            .cancel();
+
+    // then - verify the rejection record is enriched
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceIntent.CANCEL)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be set to the parent (root) process instance key
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have rootProcessInstanceKey set to the parent process instance")
+        .isEqualTo(parentProcessInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionWhenTryingToCancelDeeplyNestedChildProcess() {
+    // given - parent -> child -> grandchild process hierarchy
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+    final String grandchildProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(grandchildProcessId)
+                .startEvent()
+                .userTask("grandchildTask")
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .callActivity("callGrandchild", ca -> ca.zeebeProcessId(grandchildProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("callChild", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).withTenantId(TENANT).create();
+
+    // Wait for the grandchild process instance to be created
+    final var grandchildProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withBpmnProcessId(grandchildProcessId)
+            .filter(r -> r.getValue().getRootProcessInstanceKey() == rootProcessInstanceKey)
+            .getFirst();
+
+    final var grandchildProcessInstanceKey =
+        grandchildProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for grandchild task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(grandchildProcessInstanceKey)
+        .withElementId("grandchildTask")
+        .await();
+
+    // when - try to cancel the grandchild process instance (should fail)
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(grandchildProcessInstanceKey)
+            .expectRejection()
+            .cancel();
+
+    // then - verify the rejection record is enriched with the ROOT process instance key
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceIntent.CANCEL)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be the root (parent) process instance key, not intermediate
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set to the ROOT process")
+        .isEqualTo(rootProcessInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldNotEnrichRejectionWhenProcessInstanceNotFound() {
+    // when - try to cancel a non-existing process instance
+    final var rejectionRecord =
+        ENGINE.processInstance().withInstanceKey(-1).onPartition(1).expectRejection().cancel();
+
+    // then - verify the rejection is written but without enrichment
+    // (since the process instance doesn't exist, we can't look up rootProcessInstanceKey)
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceIntent.CANCEL)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // rootProcessInstanceKey should be the default value (not set) since we couldn't look it up
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when process instance not found")
+        .isEqualTo(-1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationRejectionCommandTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ProcessInstanceModificationRejectionCommandTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @ClassRule
+  public static final BrokerClassRuleHelper CLASS_RULE_HELPER = new BrokerClassRuleHelper();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TENANT = "custom-tenant";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEnrichRejectionCommandWhenElementNotFound() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("A").endEvent().done())
+        .withTenantId(TENANT)
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when - try to activate a non-existing element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("NON_EXISTING_ELEMENT")
+        .expectRejection()
+        .modify();
+
+    // then - verify the rejection record is enriched with rootProcessInstanceKey
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    // The rootProcessInstanceKey should be set to processInstanceKey for a non-nested process
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionCommandWhenTerminateElementNotFound() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("A").endEvent().done())
+        .withTenantId(TENANT)
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+    final var userTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+
+    // when - try to terminate a non-existing element instance
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .terminateElement(userTaskActivated.getKey())
+        .terminateElement(99999L) // non-existing
+        .expectRejection()
+        .modify();
+
+    // then - verify the rejection record is enriched
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionCommandForChildProcess() {
+    // given - parent process with call activity
+    final var childProcessId = "childProcess";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .userTask("childTask")
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("callActivity", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+
+    // Get the child process instance
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withBpmnProcessId(childProcessId)
+            .getFirst();
+    final var childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for the child task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(childProcessInstanceKey)
+        .withElementId("childTask")
+        .await();
+
+    // when - try to modify the child process with invalid element
+    ENGINE
+        .processInstance()
+        .withInstanceKey(childProcessInstanceKey)
+        .modification()
+        .activateElement("NON_EXISTING_ELEMENT")
+        .expectRejection()
+        .modify();
+
+    // then - verify the rejection record has the ROOT process instance key (parent), not the child
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords()
+            .onlyCommandRejections()
+            .withProcessInstanceKey(childProcessInstanceKey)
+            .getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    // The rootProcessInstanceKey should be the parent (root) process instance key
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have rootProcessInstanceKey set to the parent process instance")
+        .isEqualTo(parentProcessInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionWhenAncestorScopeKeyNotFound() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("A").endEvent().done())
+        .withTenantId(TENANT)
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when - try to activate with a non-existing ancestor scope key
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("A", 12345L) // non-existing ancestor
+        .expectRejection()
+        .modify();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionWhenVariableScopeNotFound() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("A")
+                .userTask("B")
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when - try to set variables on a non-existing scope
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .withVariables("NON_EXISTING_SCOPE", java.util.Map.of("var", "value"))
+        .expectRejection()
+        .modify();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldNotSetRootProcessInstanceKeyWhenProcessInstanceNotFound() {
+    // given - no process deployed, just use a random key
+    final long unknownKey = 12345L;
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(unknownKey)
+        .modification()
+        .activateElement("A")
+        .expectRejection()
+        .modify();
+
+    // then - the rejection should still be written but without enrichment
+    // (since the process instance doesn't exist, we can't look up rootProcessInstanceKey)
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasKey(unknownKey);
+
+    // rootProcessInstanceKey should be the default value (not set) since we couldn't look it up
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when process instance not found")
+        .isEqualTo(-1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationRejectionCommandTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ProcessInstanceMigrationRejectionCommandTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String TENANT = "custom-tenant";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEnrichRejectionCommandWhenActiveElementNotMapped() {
+    // given - deploy source and target processes
+    final String sourceProcessId = Strings.newRandomValidBpmnId();
+    final String targetProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(sourceProcessId)
+                .startEvent()
+                .serviceTask("A", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var targetDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("B", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .done())
+            .withTenantId(TENANT)
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        targetDeployment.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).withTenantId(TENANT).create();
+
+    // Wait for the service task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when - try to migrate without providing mapping for active element
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .expectRejection()
+            .migrate();
+
+    // then - verify the rejection record is enriched
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be set (for a non-nested process, it equals the process
+    // instance key)
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionCommandForChildProcess() {
+    // given - parent process with call activity
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+    final String targetChildProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .serviceTask("childTask", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("callActivity", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var targetDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetChildProcessId)
+                    .startEvent()
+                    .serviceTask("differentTask", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .done())
+            .withTenantId(TENANT)
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        targetDeployment.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).withTenantId(TENANT).create();
+
+    // Wait for the child process instance to be created
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withBpmnProcessId(childProcessId)
+            .getFirst();
+
+    final var childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for the child task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(childProcessInstanceKey)
+        .withElementId("childTask")
+        .await();
+
+    // when - try to migrate the child process with invalid mapping (no mapping for active element)
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(childProcessInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .expectRejection()
+            .migrate();
+
+    // then - verify the rejection record has the ROOT process instance key (parent), not the child
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be the parent (root) process instance key
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have rootProcessInstanceKey set to the parent process instance")
+        .isEqualTo(parentProcessInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionWhenTargetProcessDefinitionNotFound() {
+    // given
+    final String sourceProcessId = Strings.newRandomValidBpmnId();
+    final String tenantId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(sourceProcessId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .withTenantId(tenantId)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).withTenantId(tenantId).create();
+
+    // Wait for the service task to be activated
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    final long unknownTargetKey = 99999L;
+
+    // when - try to migrate to unknown target process definition
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(unknownTargetKey)
+            .expectRejection()
+            .migrate();
+
+    // then - verify the rejection record is enriched
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // The rootProcessInstanceKey should still be set since we found the source process instance
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(tenantId);
+  }
+
+  @Test
+  public void shouldNotEnrichRejectionWhenProcessInstanceNotFound() {
+    // given - no source process instance exists
+    final long unknownProcessInstanceKey = 12345L;
+
+    // when - try to migrate a non-existing process instance
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(unknownProcessInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(1L)
+            .expectRejection()
+            .migrate();
+
+    // then - verify the rejection is written but without enrichment
+    // (since the process instance doesn't exist, we can't look up rootProcessInstanceKey)
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // rootProcessInstanceKey should be the default value (not set) since we couldn't look it up
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when process instance not found")
+        .isEqualTo(-1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class UserTaskRejectionCommandTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(
+              config -> {
+                config.getMultiTenancy().setChecksEnabled(true);
+              });
+
+  private static final String TENANT = "custom-tenant";
+  private static final String USERNAME = "tenant-user";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @BeforeClass
+  public static void setUp() {
+    final var user = ENGINE.user().newUser(USERNAME).create().getValue();
+    final var createdUsername = user.getUsername();
+    ENGINE.tenant().newTenant().withTenantId(TENANT).create().getValue().getTenantKey();
+    ENGINE
+        .tenant()
+        .addEntity(TENANT)
+        .withEntityType(EntityType.USER)
+        .withEntityId(createdUsername)
+        .add();
+  }
+
+  @Test
+  public void shouldNotEnrichCompleteRejectionWhenUserTaskAlreadyCompleted() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // Complete the user task
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).complete(USERNAME);
+
+    // Wait for the task to be completed
+    RecordingExporter.userTaskRecords(UserTaskIntent.COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - try to complete the already completed user task
+    final var rejectionRecord =
+        ENGINE.userTask().withKey(userTaskCreated.getKey()).expectRejection().complete(USERNAME);
+
+    // then - verify the rejection is written but without enrichment
+    // (since the user task no longer exists after completion, we can't look up context)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.COMPLETE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // When user task is not found, rootProcessInstanceKey defaults to -1
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when task not found")
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldEnrichClaimRejectionWhenUserTaskAlreadyClaimed() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // Claim the user task with user1
+    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("user1").claim(USERNAME);
+
+    // Wait for the task to be claimed
+    RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - try to claim the already claimed user task with user2
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAssignee("user2")
+            .expectRejection()
+            .claim(USERNAME);
+
+    // then - verify the rejection record is enriched
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.CLAIM)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be set since the task exists
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichRejectionWithRootProcessInstanceKeyForChildProcess() {
+    // given - parent process with call activity
+    final String parentProcessId = Strings.newRandomValidBpmnId();
+    final String childProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .userTask("childTask")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity("callActivity", ca -> ca.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).withTenantId(TENANT).create();
+
+    // Wait for the child process instance to be created
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withBpmnProcessId(childProcessId)
+            .getFirst();
+
+    final var childProcessInstanceKey = childProcessInstance.getValue().getProcessInstanceKey();
+
+    // Wait for the child user task to be created
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstanceKey)
+            .getFirst();
+
+    // Claim the user task with user1
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee("user1").claim(USERNAME);
+
+    // Wait for the task to be claimed
+    RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+        .withProcessInstanceKey(childProcessInstanceKey)
+        .await();
+
+    // when - try to claim the already claimed user task
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskCreated.getKey())
+            .withAssignee("user2")
+            .expectRejection()
+            .claim(USERNAME);
+
+    // then - verify the rejection record has the ROOT process instance key (parent), not the child
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.CLAIM)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be the parent (root) process instance key
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have rootProcessInstanceKey set to the parent process instance")
+        .isEqualTo(parentProcessInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldNotEnrichRejectionWhenUserTaskNotFound() {
+    // given - non-existing user task key
+    final long unknownUserTaskKey = 12345L;
+
+    // when - try to complete a non-existing user task
+    final var rejectionRecord =
+        ENGINE.userTask().withKey(unknownUserTaskKey).expectRejection().complete();
+
+    // then - verify the rejection is written but without enrichment
+    // (since the user task doesn't exist, we can't look up rootProcessInstanceKey)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.COMPLETE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // rootProcessInstanceKey should be the default value (not set) since we couldn't look it up
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when user task not found")
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldNotEnrichAssignRejectionWhenUserTaskDoesNotExist() {
+    // given - non-existing user task key
+    final long unknownUserTaskKey = 12345L;
+
+    // when - try to assign a non-existing user task
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .withKey(unknownUserTaskKey)
+            .withAssignee("user1")
+            .expectRejection()
+            .assign();
+
+    // then - verify the rejection is written but without enrichment
+    // (since the user task doesn't exist, we can't look up context)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.ASSIGN)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // rootProcessInstanceKey should be the default value
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when user task not found")
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldNotEnrichUpdateRejectionWhenUserTaskAlreadyCompleted() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // Complete the user task
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).complete(USERNAME);
+
+    // Wait for the task to be completed
+    RecordingExporter.userTaskRecords(UserTaskIntent.COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - try to update the already completed user task
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskCreated.getKey())
+            .withCandidateUsers("newUser")
+            .expectRejection()
+            .update(USERNAME);
+
+    // then - verify the rejection is written but without enrichment
+    // (since the user task no longer exists after completion, we can't look up context)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.UPDATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+
+    // When user task is not found, rootProcessInstanceKey defaults to -1
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs(
+            "Rejection record should have default rootProcessInstanceKey when task not found")
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldEnrichClaimRejectionWhenUserTaskAlreadyClaimedByDifferentUser() {
+    // given - create a user task and claim it
+    final String processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // Claim the user task first with user1
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee("user1").claim(USERNAME);
+
+    // Wait for the task to be claimed
+    RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - try to claim the already claimed task with a different user (user2)
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskCreated.getKey())
+            .withAssignee("user2")
+            .expectRejection()
+            .claim(USERNAME);
+
+    // then - verify the rejection record is enriched (task exists, just can't be claimed again)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.CLAIM)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be set since the task exists
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+
+  @Test
+  public void shouldEnrichClaimRejectionWhenAssigneeIsEmpty() {
+    // given - create a user task
+    final String processId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .withTenantId(TENANT)
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withTenantId(TENANT).create();
+
+    final var userTaskCreated =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when - try to claim with empty assignee (should be rejected)
+    final var rejectionRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskCreated.getKey())
+            .withAssignee("")
+            .expectRejection()
+            .claim(USERNAME);
+
+    // then - verify the rejection record is enriched (task exists, but assignee is empty)
+    assertThat(rejectionRecord)
+        .hasIntent(UserTaskIntent.CLAIM)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The rootProcessInstanceKey should be set since the task exists
+    Assertions.assertThat(rejectionRecord.getValue().getRootProcessInstanceKey())
+        .describedAs("Rejection record should have rootProcessInstanceKey set")
+        .isEqualTo(processInstanceKey);
+
+    Assertions.assertThat(rejectionRecord.getValue().getTenantId())
+        .describedAs("Rejection record should have tenantId set")
+        .isEqualTo(TENANT);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Enriching command records with additional context before writing rejection responses, to add relevant data in these  to be exported as part of audit logs and batch operations items (for now just tenantId and rootProcessInstanceKey are added).

**Changes**

* `IncidentResolveProcessor`: Added enrichment of rejection records with elementInstancePath and tenantId from the incident record when resolving incidents fails
* `ProcessInstanceCancelProcessor`: Added rootProcessInstanceKey and tenantId enrichment for rejected cancel commands
* `ProcessInstanceMigrationMigrateProcessor`: Added rootProcessInstanceKey and tenantId enrichment for rejected migration commands
* `ProcessInstanceModificationModifyProcessor`: Added rootProcessInstanceKey and tenantId enrichment for rejected modification commands
* UserTask processors (Assign, Claim, Complete, Update): Added rootProcessInstanceKey and tenantId enrichment via shared UserTaskCommandHelper utility

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44130
