### PR TITLE
fix: checkpoint scheduler should reliably handle errors

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -91,7 +91,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
 
   private CompletableActorFuture<ScheduleInstruction> checkpointIfNeeded(
       final ScheduleInstruction instruction) {
-    final var now = ActorClock.current().instant();
+    final var now = ActorClock.currentInstant();
     final CompletableActorFuture<ScheduleInstruction> future = new CompletableActorFuture<>();
     if (instruction.checkpointTime.isBefore(now) || instruction.checkpointTime.equals(now)) {
       backupRequestHandler
@@ -100,7 +100,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
           .thenApplyAsync(
               id -> {
                 LOG.debug("Checkpoint {} triggered with id {}", instruction.type, id);
-                final var currentClock = ActorClock.current().instant();
+                final var currentClock = ActorClock.currentInstant();
                 // The instructions checkpoint timestamp might be in the past leading to an
                 // instant execution of the schedule. However, for the next interval we want to
                 // readjust the schedule to account for that drift.
@@ -153,7 +153,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
 
   private Instant minFromState(
       final Set<PartitionCheckpointState> states, final Schedule schedule) {
-    final var now = ActorClock.current().instant();
+    final var now = ActorClock.currentInstant();
     return states.stream()
         .min(Comparator.comparingLong(PartitionCheckpointState::checkpointId))
         .map(PartitionCheckpointState::checkpointTimestamp)

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -124,10 +124,9 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
     final var delay =
         instruction.checkpointTaken
             ? determineDelayFromSchedules(currentState)
-            : instruction.checkpointTime.toEpochMilli()
-                - ActorClock.current().instant().toEpochMilli();
+            : instruction.checkpointTime.toEpochMilli() - ActorClock.currentTimeMillis();
 
-    return Math.abs(delay);
+    return Math.max(0, delay);
   }
 
   /**
@@ -196,7 +195,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
   }
 
   private long determineDelayFromSchedules(final CheckpointState state) {
-    final var now = ActorClock.current().instant();
+    final var now = ActorClock.currentTimeMillis();
     final Instant next;
 
     if (backupSchedule != null && checkpointSchedule != null) {
@@ -212,7 +211,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
       next = nextExecution(backupSchedule, state.lastBackup);
       metrics.recordNextExecution(next, CheckpointType.SCHEDULED_BACKUP);
     }
-    return next.toEpochMilli() - now.toEpochMilli();
+    return next.toEpochMilli() - now;
   }
 
   private long backOffOnError(final Throwable error) {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -427,6 +427,39 @@ public class CheckpointScheduleTest {
     verify(backupRequestHandler).checkpoint(CheckpointType.MARKER);
   }
 
+  @Test
+  void shouldRetryWhenCheckpointingFailed() {
+    // given
+    final var now = actorScheduler.getClock().getCurrentTime();
+    checkpointScheduler =
+        createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(60)), null);
+
+    // Provide a state where last checkpoint was long ago
+    when(backupRequestHandler.getCheckpointState())
+        .thenReturn(
+            CompletableFuture.completedStage(
+                checkpointState(now.minus(Duration.ofHours(1)).toEpochMilli(), 0L)));
+
+    // First checkpoint call fails
+    doAnswer(invocation -> CompletableFuture.failedStage(new RuntimeException("Checkpoint failed")))
+        .when(backupRequestHandler)
+        .checkpoint(any());
+
+    // when
+    actorScheduler.submitActor(checkpointScheduler);
+    actorScheduler.workUntilDone(); // Should handle checkpoint error and schedule backoff
+
+    // then
+    verify(backupRequestHandler, times(1)).checkpoint(any());
+
+    // Move clock past initial backoff (1s)
+    actorScheduler.updateClock(Duration.ofSeconds(2));
+    actorScheduler.workUntilDone();
+
+    // Should have retried (starts by acquiring state again)
+    verify(backupRequestHandler, times(2)).getCheckpointState();
+  }
+
   private CheckpointStateResponse checkpointState(
       final long checkpointTimestamp, final long backupTimestamp) {
     final var response = new CheckpointStateResponse();

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
@@ -30,6 +30,11 @@ public interface ActorClock extends InstantSource {
     return clock != null ? clock.getTimeMillis() : System.currentTimeMillis();
   }
 
+  static Instant currentInstant() {
+    final ActorClock clock = current();
+    return clock != null ? clock.instant() : Instant.now();
+  }
+
   @Override
   default Instant instant() {
     return Instant.ofEpochMilli(getTimeMillis());


### PR DESCRIPTION
This fixes a couple of cases where the checkpoint scheduler would not run as expected, especially when it encounters errors.