### PR TITLE
Handle restart of RestoreApp after a successful retry when dynamic node id is configured

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -204,11 +204,11 @@ public class RestoreApp implements ApplicationRunner {
     return backupId != null && backupId.length > 0;
   }
 
-  private long getRestoreId() {
+  private String getRestoreId() {
     if (hasBackupId()) {
-      return Arrays.hashCode(backupId);
+      return String.valueOf(Arrays.hashCode(backupId));
     } else if (hasTimeRange()) {
-      return Objects.hash(from, to);
+      return String.valueOf(Objects.hash(from, to));
     } else {
       throw new IllegalStateException("No valid restore parameters provided");
     }
@@ -216,10 +216,10 @@ public class RestoreApp implements ApplicationRunner {
 
   public record PreRestoreActionResult(boolean skipRestore, String message) {}
 
-  public record PostRestoreActionContext(long restoreId, int nodeId, boolean skippedRestore) {}
+  public record PostRestoreActionContext(String restoreId, int nodeId, boolean skippedRestore) {}
 
   public interface PreRestoreAction {
-    PreRestoreActionResult beforeRestore(final long restoreId, int nodeId)
+    PreRestoreActionResult beforeRestore(final String restoreId, int nodeId)
         throws InterruptedException;
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
@@ -77,7 +77,7 @@ public class RestoreNodeIdProviderConfiguration {
               "PreRestoreAction configured to use S3: missing s3 node id repository");
         }
         final var restoreStatusManager = new RestoreStatusManager(nodeIdRepository.get());
-        yield ((restoreId, nodeId) -> restoreStatusManager.initializeRestore());
+        yield ((restoreId, nodeId) -> restoreStatusManager.initializeRestore(restoreId));
       }
     };
   }
@@ -93,8 +93,9 @@ public class RestoreNodeIdProviderConfiguration {
         }
         final var restoreStatusManager = new RestoreStatusManager(nodeIdRepository.get());
         yield ((restoreId, nodeId) -> {
-          restoreStatusManager.markNodeRestored(nodeId);
-          restoreStatusManager.waitForAllNodesRestored(cluster.getSize(), Duration.ofSeconds(10));
+          restoreStatusManager.markNodeRestored(restoreId, nodeId);
+          restoreStatusManager.waitForAllNodesRestored(
+              restoreId, cluster.getSize(), Duration.ofSeconds(10));
         });
       }
     };

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.dynamic.nodeid.fs.VersionedNodeIdBasedDataDirectoryProvi
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
 import io.camunda.zeebe.restore.RestoreApp.PostRestoreAction;
+import io.camunda.zeebe.restore.RestoreApp.PostRestoreActionContext;
 import io.camunda.zeebe.restore.RestoreApp.PreRestoreAction;
 import io.camunda.zeebe.restore.RestoreApp.PreRestoreActionResult;
 import java.nio.file.Path;
@@ -71,7 +72,7 @@ public class RestoreNodeIdProviderConfiguration {
   @Bean
   public PreRestoreAction preRestoreAction(final Optional<NodeIdRepository> nodeIdRepository) {
     return switch (cluster.getNodeIdProvider().getType()) {
-      case FIXED -> (restoreId, ignore) -> new PreRestoreActionResult(true, "");
+      case FIXED -> (restoreId, ignore) -> new PreRestoreActionResult(false, "");
       case S3 -> {
         if (nodeIdRepository.isEmpty()) {
           throw new IllegalStateException(
@@ -82,9 +83,9 @@ public class RestoreNodeIdProviderConfiguration {
           final var restoreStatus = restoreStatusManager.initializeRestore(restoreId);
           if (restoreStatus.isNodeRestored(nodeId)) {
             return new PreRestoreActionResult(
-                false, "Node " + nodeId + " has already been restored for restore id " + restoreId);
+                true, "Node " + nodeId + " has already been restored for restore id " + restoreId);
           } else {
-            return new PreRestoreActionResult(true, "");
+            return new PreRestoreActionResult(false, "");
           }
         });
       }
@@ -92,22 +93,50 @@ public class RestoreNodeIdProviderConfiguration {
   }
 
   @Bean
-  public PostRestoreAction postRestoreAction(final Optional<NodeIdRepository> nodeIdRepository) {
+  public PostRestoreAction postRestoreAction(
+      final Optional<NodeIdRepository> nodeIdRepository, final BrokerBasedProperties brokerCfg) {
     return switch (cluster.getNodeIdProvider().getType()) {
-      case FIXED -> (restoreId, ignore) -> {};
+      case FIXED -> (context) -> validateAfterRestore(brokerCfg, context);
       case S3 -> {
         if (nodeIdRepository.isEmpty()) {
           throw new IllegalStateException(
               "PostRestoreAction configured to use S3: missing s3 node id repository");
         }
         final var restoreStatusManager = new RestoreStatusManager(nodeIdRepository.get());
-        yield ((restoreId, nodeId) -> {
-          restoreStatusManager.markNodeRestored(restoreId, nodeId);
+        yield (context -> {
+          final var restoreId = context.restoreId();
+          final var nodeId = context.nodeId();
+          if (!context.skippedRestore()) {
+            restoreStatusManager.markNodeRestored(restoreId, nodeId);
+          }
+          // Validate even if we skipped in case the restore was retried with empty disk, but the s3
+          // object was not deleted.
+          validateAfterRestore(brokerCfg, context);
+
           restoreStatusManager.waitForAllNodesRestored(
               restoreId, cluster.getSize(), Duration.ofSeconds(10));
         });
       }
     };
+  }
+
+  private static void validateAfterRestore(
+      final BrokerBasedProperties brokerCfg, final PostRestoreActionContext context) {
+    if (!RestoreValidator.validate(brokerCfg)) {
+      final String message;
+      if (context.skippedRestore()) {
+        message =
+            String.format(
+                "Expected to find restored data on node %d, but validation failed. Possible root cause: Restore is skipped because node is marked as restored in the s3 bucket, but node started with empty directory. Try restoring the cluster after deleting the s3 bucket configured for node id provider.",
+                context.nodeId());
+      } else {
+        message =
+            String.format(
+                "Expected to find restored data on node %d, but validation failed.",
+                context.nodeId());
+      }
+      throw new IllegalStateException(message);
+    }
   }
 
   @Bean

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning.startup;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionConfig;
@@ -39,10 +40,7 @@ public final class RaftPartitionFactory {
   public RaftPartition createRaftPartition(
       final PartitionMetadata partitionMetadata, final MeterRegistry partitionMeterRegistry) {
     final var partitionDirectory =
-        Paths.get(brokerCfg.getData().getDirectory())
-            .resolve(GROUP_NAME)
-            .resolve("partitions")
-            .resolve(partitionMetadata.id().id().toString());
+        getPartitionDirectory(partitionMetadata.id(), brokerCfg.getData().getDirectory());
     try {
       if (FileUtil.isEmpty(partitionDirectory)) {
         LOG.info(
@@ -56,6 +54,14 @@ public final class RaftPartitionFactory {
       throw new UncheckedIOException(e);
     }
     return createRaftPartition(partitionMetadata, partitionDirectory, partitionMeterRegistry);
+  }
+
+  public static Path getPartitionDirectory(
+      final PartitionId partitionId, final String dataDirectory) {
+    return Paths.get(dataDirectory)
+        .resolve(GROUP_NAME)
+        .resolve("partitions")
+        .resolve(partitionId.id().toString());
   }
 
   public RaftPartition createRaftPartition(

--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>apache-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
     <!--  TEST   -->
     <dependency>
       <groupId>org.assertj</groupId>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreIdMismatchException.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreIdMismatchException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.nodeid;
+
+public class RestoreIdMismatchException extends RuntimeException {
+
+  public RestoreIdMismatchException(final long expectedRestoreId, final long actualRestoreId) {
+    super(
+        String.format(
+            "Restore ID mismatch: expected %d but got %d", expectedRestoreId, actualRestoreId));
+  }
+}

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreIdMismatchException.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreIdMismatchException.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.dynamic.nodeid;
 
 public class RestoreIdMismatchException extends RuntimeException {
 
-  public RestoreIdMismatchException(final long expectedRestoreId, final long actualRestoreId) {
+  public RestoreIdMismatchException(final String expectedRestoreId, final String actualRestoreId) {
     super(
         String.format(
-            "Restore ID mismatch: expected %d but got %d", expectedRestoreId, actualRestoreId));
+            "Restore ID mismatch: expected %s but got %s", expectedRestoreId, actualRestoreId));
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
@@ -34,12 +34,12 @@ public class RestoreStatusManager {
    * @param restoreId the restore ID to initialize
    * @return the initialized or existing restore status
    */
-  public RestoreStatus initializeRestore(final long restoreId) throws InterruptedException {
+  public RestoreStatus initializeRestore(final String restoreId) throws InterruptedException {
     while (true) {
       try {
         final var existingStatus = repository.getRestoreStatus(restoreId);
         if (existingStatus != null) {
-          if (existingStatus.restoreStatus().restoreId() != restoreId) {
+          if (!existingStatus.restoreStatus().restoreId().equals(restoreId)) {
             throw new RestoreIdMismatchException(
                 restoreId, existingStatus.restoreStatus().restoreId());
           }
@@ -70,7 +70,8 @@ public class RestoreStatusManager {
    * @param restoreId the restore ID to update
    * @param nodeId the node ID that completed restore
    */
-  public void markNodeRestored(final long restoreId, final int nodeId) throws InterruptedException {
+  public void markNodeRestored(final String restoreId, final int nodeId)
+      throws InterruptedException {
 
     // retry forever
     while (true) {
@@ -82,7 +83,7 @@ public class RestoreStatusManager {
 
         final var currentStatus = storedStatus.restoreStatus();
 
-        if (currentStatus.restoreId() != restoreId) {
+        if (!currentStatus.restoreId().equals(restoreId)) {
           throw new RestoreIdMismatchException(restoreId, currentStatus.restoreId());
         }
 
@@ -113,7 +114,7 @@ public class RestoreStatusManager {
    * @throws IllegalStateException if timeout is reached or restore status is not initialized
    */
   public void waitForAllNodesRestored(
-      final long restoreId, final int clusterSize, final Duration pollInterval)
+      final String restoreId, final int clusterSize, final Duration pollInterval)
       throws InterruptedException {
     final var expectedNodeIds = IntStream.range(0, clusterSize).boxed().collect(Collectors.toSet());
 
@@ -125,7 +126,7 @@ public class RestoreStatusManager {
 
       final var currentStatus = storedStatus.restoreStatus();
 
-      if (currentStatus.restoreId() != restoreId) {
+      if (!currentStatus.restoreId().equals(restoreId)) {
         throw new RestoreIdMismatchException(restoreId, currentStatus.restoreId());
       }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManager.java
@@ -11,7 +11,6 @@ package io.camunda.zeebe.dynamic.nodeid;
 import io.camunda.zeebe.dynamic.nodeid.StoredRestoreStatus.RestoreStatus;
 import io.camunda.zeebe.dynamic.nodeid.repository.NodeIdRepository;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -92,10 +91,7 @@ public class RestoreStatusManager {
           return;
         }
 
-        final var updatedCompletedNodes = new HashSet<>(currentStatus.restoredNodes());
-        updatedCompletedNodes.add(nodeId);
-
-        final var updatedStatus = new RestoreStatus(restoreId, updatedCompletedNodes);
+        final var updatedStatus = currentStatus.markNodeRestored(nodeId);
 
         repository.updateRestoreStatus(updatedStatus, storedStatus.etag());
         LOG.info("Marked node {} as restored", nodeId);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * A record that holds the restore status. The etag is used for conflict detection during updates.
  */
 public record StoredRestoreStatus(RestoreStatus restoreStatus, String etag) {
-  public record RestoreStatus(Set<Integer> restoredNodes) {
+  public record RestoreStatus(long restoreId, Set<Integer> restoredNodes) {
 
     public byte[] toJsonBytes(final ObjectMapper objectMapper) {
       try {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
@@ -18,6 +18,10 @@ import java.util.Set;
 public record StoredRestoreStatus(RestoreStatus restoreStatus, String etag) {
   public record RestoreStatus(long restoreId, Set<Integer> restoredNodes) {
 
+    public boolean isNodeRestored(final int nodeId) {
+      return restoredNodes != null && restoredNodes.contains(nodeId);
+    }
+
     public byte[] toJsonBytes(final ObjectMapper objectMapper) {
       try {
         return objectMapper.writeValueAsBytes(this);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
@@ -18,9 +18,9 @@ import java.util.Set;
  * A record that holds the restore status. The etag is used for conflict detection during updates.
  */
 public record StoredRestoreStatus(RestoreStatus restoreStatus, String etag) {
-  public record RestoreStatus(long restoreId, Set<Integer> restoredNodes) {
+  public record RestoreStatus(String restoreId, Set<Integer> restoredNodes) {
 
-    public RestoreStatus(final long restoreId, final Set<Integer> restoredNodes) {
+    public RestoreStatus(final String restoreId, final Set<Integer> restoredNodes) {
       this.restoreId = restoreId;
       this.restoredNodes =
           restoredNodes == null ? ImmutableSet.of() : ImmutableSet.copyOf(restoredNodes);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/StoredRestoreStatus.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.dynamic.nodeid;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -18,8 +20,20 @@ import java.util.Set;
 public record StoredRestoreStatus(RestoreStatus restoreStatus, String etag) {
   public record RestoreStatus(long restoreId, Set<Integer> restoredNodes) {
 
+    public RestoreStatus(final long restoreId, final Set<Integer> restoredNodes) {
+      this.restoreId = restoreId;
+      this.restoredNodes =
+          restoredNodes == null ? ImmutableSet.of() : ImmutableSet.copyOf(restoredNodes);
+    }
+
     public boolean isNodeRestored(final int nodeId) {
       return restoredNodes != null && restoredNodes.contains(nodeId);
+    }
+
+    public RestoreStatus markNodeRestored(final int nodeId) {
+      final var updatedCompletedNodes = new HashSet<>(restoredNodes());
+      updatedCompletedNodes.add(nodeId);
+      return new RestoreStatus(restoreId, updatedCompletedNodes);
     }
 
     public byte[] toJsonBytes(final ObjectMapper objectMapper) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -68,7 +68,7 @@ public interface NodeIdRepository extends AutoCloseable {
    *
    * @return the current restore status, or null if none exists
    */
-  StoredRestoreStatus getRestoreStatus(final long restoreId);
+  StoredRestoreStatus getRestoreStatus(final String restoreId);
 
   /**
    * A StoredLease represents the Lease stored in a Repository such as S3. It can be

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -68,7 +68,7 @@ public interface NodeIdRepository extends AutoCloseable {
    *
    * @return the current restore status, or null if none exists
    */
-  StoredRestoreStatus getRestoreStatus();
+  StoredRestoreStatus getRestoreStatus(final long restoreId);
 
   /**
    * A StoredLease represents the Lease stored in a Repository such as S3. It can be

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -134,7 +134,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
     final PutObjectRequest.Builder putRequestBuilder =
         PutObjectRequest.builder()
             .bucket(config.bucketName)
-            .key("restore")
+            .key(getRestoreStatusKey(restoreStatus.restoreId()))
             .contentType("application/json");
 
     if (etag == null || etag.isEmpty()) {
@@ -158,8 +158,12 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   @Override
-  public StoredRestoreStatus getRestoreStatus() {
-    final var request = GetObjectRequest.builder().bucket(config.bucketName).key("restore").build();
+  public StoredRestoreStatus getRestoreStatus(final long restoreId) {
+    final var request =
+        GetObjectRequest.builder()
+            .bucket(config.bucketName)
+            .key(getRestoreStatusKey(restoreId))
+            .build();
     try {
       final var response = client.getObject(request);
       final var bytes = response.readAllBytes();
@@ -179,6 +183,10 @@ public class S3NodeIdRepository implements NodeIdRepository {
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private String getRestoreStatusKey(final long restoreId) {
+    return "restore/%d".formatted(restoreId);
   }
 
   public void initializeForNode(final int nodeId) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -158,7 +158,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   @Override
-  public StoredRestoreStatus getRestoreStatus(final long restoreId) {
+  public StoredRestoreStatus getRestoreStatus(final String restoreId) {
     final var request =
         GetObjectRequest.builder()
             .bucket(config.bucketName)
@@ -185,8 +185,8 @@ public class S3NodeIdRepository implements NodeIdRepository {
     }
   }
 
-  private String getRestoreStatusKey(final long restoreId) {
-    return "restore/%d".formatted(restoreId);
+  private String getRestoreStatusKey(final String restoreId) {
+    return "restore/%s".formatted(restoreId);
   }
 
   public void initializeForNode(final int nodeId) {

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
@@ -31,7 +31,7 @@ public class RestoreStatusManagerTest {
   private NodeIdRepository repository;
 
   private RestoreStatusManager restoreStatusManager;
-  private final long restoreId = 123L;
+  private final String restoreId = "123";
 
   @BeforeEach
   void setUp() {

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RestoreStatusManagerTest.java
@@ -31,6 +31,7 @@ public class RestoreStatusManagerTest {
   private NodeIdRepository repository;
 
   private RestoreStatusManager restoreStatusManager;
+  private final long restoreId = 123L;
 
   @BeforeEach
   void setUp() {
@@ -41,23 +42,24 @@ public class RestoreStatusManagerTest {
   @Test
   void shouldInitializeRestoreWhenNoExistingStatus() throws InterruptedException {
     // given
-    when(repository.getRestoreStatus()).thenReturn(null);
+    when(repository.getRestoreStatus(restoreId)).thenReturn(null);
 
     // when
-    restoreStatusManager.initializeRestore();
+    restoreStatusManager.initializeRestore(restoreId);
 
     // then
-    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of())), isNull());
+    verify(repository).updateRestoreStatus(eq(new RestoreStatus(restoreId, Set.of())), isNull());
   }
 
   @Test
   void shouldNotInitializeRestoreWhenStatusAlreadyExists() throws InterruptedException {
     // given
-    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
-    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+    final var existingStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of()), "etag123");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(existingStatus);
 
     // when
-    restoreStatusManager.initializeRestore();
+    restoreStatusManager.initializeRestore(restoreId);
 
     // then
     verify(repository, never()).updateRestoreStatus(any(), any());
@@ -67,21 +69,21 @@ public class RestoreStatusManagerTest {
   void shouldRetryInitializeRestoreOnConcurrentUpdateConflict() throws InterruptedException {
     // given
     final var callCount = new AtomicInteger(0);
-    when(repository.getRestoreStatus())
+    when(repository.getRestoreStatus(restoreId))
         .thenAnswer(
             inv -> {
               if (callCount.getAndIncrement() == 0) {
                 return null;
               }
               // After first attempt, return existing status to stop retry loop
-              return new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag");
+              return new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of()), "etag");
             });
     doThrow(new RuntimeException("Concurrent update"))
         .when(repository)
         .updateRestoreStatus(any(), isNull());
 
     // when
-    restoreStatusManager.initializeRestore();
+    restoreStatusManager.initializeRestore(restoreId);
 
     // then
     verify(repository, times(1)).updateRestoreStatus(any(), isNull());
@@ -90,24 +92,27 @@ public class RestoreStatusManagerTest {
   @Test
   void shouldMarkNodeAsRestored() throws InterruptedException {
     // given
-    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
-    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+    final var existingStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of()), "etag123");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(existingStatus);
 
     // when
-    restoreStatusManager.markNodeRestored(0);
+    restoreStatusManager.markNodeRestored(restoreId, 0);
 
     // then
-    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of(0))), eq("etag123"));
+    verify(repository)
+        .updateRestoreStatus(eq(new RestoreStatus(restoreId, Set.of(0))), eq("etag123"));
   }
 
   @Test
   void shouldNotMarkNodeAsRestoredWhenAlreadyMarked() throws InterruptedException {
     // given
-    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1)), "etag123");
-    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+    final var existingStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0, 1)), "etag123");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(existingStatus);
 
     // when
-    restoreStatusManager.markNodeRestored(0);
+    restoreStatusManager.markNodeRestored(restoreId, 0);
 
     // then
     verify(repository, never()).updateRestoreStatus(any(), any());
@@ -116,10 +121,11 @@ public class RestoreStatusManagerTest {
   @Test
   void shouldRetryMarkNodeRestoredOnConcurrentUpdateConflict() throws InterruptedException {
     // given
-    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of()), "etag123");
+    final var existingStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of()), "etag123");
 
     // Both calls return status without node 0 marked (simulating that another node updated etag)
-    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+    when(repository.getRestoreStatus(restoreId)).thenReturn(existingStatus);
 
     // First call throws exception (concurrent update), second call succeeds
     doThrow(new RuntimeException("Concurrent update"))
@@ -128,46 +134,50 @@ public class RestoreStatusManagerTest {
         .updateRestoreStatus(any(), any());
 
     // when
-    restoreStatusManager.markNodeRestored(0);
+    restoreStatusManager.markNodeRestored(restoreId, 0);
 
     // then
-    verify(repository, times(2)).getRestoreStatus();
+    verify(repository, times(2)).getRestoreStatus(restoreId);
     verify(repository, times(2)).updateRestoreStatus(any(), any());
   }
 
   @Test
   void shouldAddNodeToExistingRestoredNodes() throws InterruptedException {
     // given
-    final var existingStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 2)), "etag123");
-    when(repository.getRestoreStatus()).thenReturn(existingStatus);
+    final var existingStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0, 2)), "etag123");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(existingStatus);
 
     // when
-    restoreStatusManager.markNodeRestored(1);
+    restoreStatusManager.markNodeRestored(restoreId, 1);
 
     // then
-    verify(repository).updateRestoreStatus(eq(new RestoreStatus(Set.of(0, 1, 2))), eq("etag123"));
+    verify(repository)
+        .updateRestoreStatus(eq(new RestoreStatus(restoreId, Set.of(0, 1, 2))), eq("etag123"));
   }
 
   @Test
   void shouldReturnImmediatelyWhenAllNodesAlreadyRestored() throws InterruptedException {
     // given
-    final var completeStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1, 2)), "etag");
-    when(repository.getRestoreStatus()).thenReturn(completeStatus);
+    final var completeStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0, 1, 2)), "etag");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(completeStatus);
 
     // when
-    restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10));
+    restoreStatusManager.waitForAllNodesRestored(restoreId, 3, Duration.ofMillis(10));
 
     // then
-    verify(repository, times(1)).getRestoreStatus();
+    verify(repository, times(1)).getRestoreStatus(restoreId);
   }
 
   @Test
   void shouldThrowWhenWaitingAndRestoreStatusNotInitialized() {
     // given
-    when(repository.getRestoreStatus()).thenReturn(null);
+    when(repository.getRestoreStatus(restoreId)).thenReturn(null);
 
     // when/then
-    assertThatThrownBy(() -> restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10)))
+    assertThatThrownBy(
+            () -> restoreStatusManager.waitForAllNodesRestored(restoreId, 3, Duration.ofMillis(10)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Restore status not initialized");
   }
@@ -175,29 +185,32 @@ public class RestoreStatusManagerTest {
   @Test
   void shouldWaitForSingleNodeCluster() throws InterruptedException {
     // given
-    final var completeStatus = new StoredRestoreStatus(new RestoreStatus(Set.of(0)), "etag");
-    when(repository.getRestoreStatus()).thenReturn(completeStatus);
+    final var completeStatus =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0)), "etag");
+    when(repository.getRestoreStatus(restoreId)).thenReturn(completeStatus);
 
     // when
-    restoreStatusManager.waitForAllNodesRestored(1, Duration.ofMillis(10));
+    restoreStatusManager.waitForAllNodesRestored(restoreId, 1, Duration.ofMillis(10));
 
     // then
-    verify(repository, times(1)).getRestoreStatus();
+    verify(repository, times(1)).getRestoreStatus(restoreId);
   }
 
   @Test
   void shouldContinuePollingUntilAllNodesRestored() throws InterruptedException {
     // given
-    final var status1 = new StoredRestoreStatus(new RestoreStatus(Set.of(0)), "etag1");
-    final var status2 = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1)), "etag2");
-    final var status3 = new StoredRestoreStatus(new RestoreStatus(Set.of(0, 1, 2)), "etag3");
+    final var status1 = new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0)), "etag1");
+    final var status2 =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0, 1)), "etag2");
+    final var status3 =
+        new StoredRestoreStatus(new RestoreStatus(restoreId, Set.of(0, 1, 2)), "etag3");
 
-    when(repository.getRestoreStatus()).thenReturn(status1, status2, status3);
+    when(repository.getRestoreStatus(restoreId)).thenReturn(status1, status2, status3);
 
     // when
-    restoreStatusManager.waitForAllNodesRestored(3, Duration.ofMillis(10));
+    restoreStatusManager.waitForAllNodesRestored(restoreId, 3, Duration.ofMillis(10));
 
     // then
-    verify(repository, times(3)).getRestoreStatus();
+    verify(repository, times(3)).getRestoreStatus(restoreId);
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -226,7 +226,7 @@ class S3NodeIdRepositoryIT {
   @Test
   void shouldReturnNullWhenRestoreStatusNotInitialized() {
     // given
-    final long restoreId = 123L;
+    final String restoreId = "123";
     repository = fixed(Clock.systemUTC().millis());
 
     // when
@@ -239,7 +239,7 @@ class S3NodeIdRepositoryIT {
   @Test
   void shouldUpdateAndGetRestoreStatus() {
     // given
-    final long restoreId = 123L;
+    final String restoreId = "123";
     repository = fixed(Clock.systemUTC().millis());
     final var restoreStatus = new RestoreStatus(restoreId, Set.of());
 
@@ -256,7 +256,7 @@ class S3NodeIdRepositoryIT {
   @Test
   void shouldUpdateRestoreStatusWithRestoredNodes() {
     // given
-    final long restoreId = 123L;
+    final String restoreId = "test-id";
     repository = fixed(Clock.systemUTC().millis());
     final var initialStatus = new RestoreStatus(restoreId, Set.of());
     repository.updateRestoreStatus(initialStatus, null);
@@ -276,7 +276,7 @@ class S3NodeIdRepositoryIT {
   @Test
   void shouldFailToUpdateRestoreStatusWhenEtagMismatch() {
     // given
-    final long restoreId = 123L;
+    final String restoreId = "test-id";
     repository = fixed(Clock.systemUTC().millis());
     final var initialStatus = new RestoreStatus(restoreId, Set.of());
     repository.updateRestoreStatus(initialStatus, null);
@@ -291,8 +291,8 @@ class S3NodeIdRepositoryIT {
   @Test
   void shouldGetAndUpdateMultipleRestoreId() {
     // given
-    final long restoreId1 = 123L;
-    final long restoreId2 = 456L;
+    final String restoreId1 = "test-id-1";
+    final String restoreId2 = "test-id-2";
     repository = fixed(Clock.systemUTC().millis());
     final var status1 = new RestoreStatus(restoreId1, Set.of(1));
     final var status2 = new RestoreStatus(restoreId2, Set.of(2));

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.restore;
 
+import static io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -68,8 +68,7 @@ public class RestoreValidator {
 
   private static boolean checkPartitionDirectoryIsNotEmpty(
       final PartitionMetadata partitionMetadata, final String rootDataDirectory) {
-    final var partitionDirectory =
-        RaftPartitionFactory.getPartitionDirectory(partitionMetadata.id(), rootDataDirectory);
+    final var partitionDirectory = getPartitionDirectory(partitionMetadata.id(), rootDataDirectory);
     final var directory = partitionDirectory.toFile();
     final var files = directory.listFiles();
     return directory.exists() && directory.isDirectory() && files != null && files.length > 0;

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
+import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * Provides a simple validator that verifies that data for partitions to be restored are not empty
+ * and topology file is restored.
+ */
+public class RestoreValidator {
+
+  private static final Logger LOGGER = getLogger(RestoreValidator.class);
+
+  /**
+   * Validates that the restore was successful by checking that partition directories are not empty
+   * and topology file is restored. This is not a comprehensive validation of the restore, for
+   * example it cannot detect partial restores or whether the restored data is correct, but it can
+   * be used as a basic sanity check after the restore process completes.
+   */
+  public static boolean validate(final BrokerCfg configuration) {
+    final var localBrokerId = configuration.getCluster().getNodeId();
+    final var localMember = MemberId.from(String.valueOf(localBrokerId));
+    final var clusterTopology =
+        new PartitionDistribution(
+            StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
+                .generatePartitionDistribution());
+
+    final var partitionsToRestore =
+        clusterTopology.partitions().stream()
+            .filter(partitionMetadata -> partitionMetadata.members().contains(localMember))
+            .collect(Collectors.toSet());
+    for (final var partitionMetadata : partitionsToRestore) {
+      if (!checkPartitionDirectoryIsNotEmpty(
+          partitionMetadata, configuration.getData().getDirectory())) {
+        LOGGER.error(
+            "Expected to find restored partition {} on broker {}, but the partition directory is empty or does not exist.",
+            partitionMetadata.id(),
+            localBrokerId);
+        return false;
+      }
+    }
+
+    if (!checkTopologyFileIsRestored(configuration)) {
+      LOGGER.error(
+          "Expected to find restored topology file on broker {}, but it is missing in the data directory.",
+          localBrokerId);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean checkPartitionDirectoryIsNotEmpty(
+      final PartitionMetadata partitionMetadata, final String rootDataDirectory) {
+    final var partitionDirectory =
+        RaftPartitionFactory.getPartitionDirectory(partitionMetadata.id(), rootDataDirectory);
+    final var directory = partitionDirectory.toFile();
+    final var files = directory.listFiles();
+    return directory.exists() && directory.isDirectory() && files != null && files.length > 0;
+  }
+
+  private static boolean checkTopologyFileIsRestored(final BrokerCfg configuration) {
+    if (configuration.getCluster().getNodeId() == 0) {
+      final var topologyFile =
+          Path.of(configuration.getData().getDirectory())
+              .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+      return topologyFile.toFile().exists() && topologyFile.toFile().isFile();
+    }
+    return true;
+  }
+}

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreValidatorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RestoreValidatorTest {
+
+  @TempDir Path dataDirectory;
+
+  private BrokerCfg brokerCfg;
+
+  @BeforeEach
+  void setUp() {
+    brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setDirectory(dataDirectory.toString());
+    brokerCfg.getCluster().setNodeId(0);
+    brokerCfg.getCluster().setClusterSize(1);
+    brokerCfg.getCluster().setPartitionsCount(1);
+    brokerCfg.getCluster().setReplicationFactor(1);
+  }
+
+  @Test
+  void shouldReturnFalseWhenPartitionDirectoryDoesNotExist() {
+    // given - no partition directory created
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldReturnFalseWhenPartitionDirectoryIsEmpty() throws IOException {
+    // given
+    final Path partitionDir = getPartitionDir();
+    Files.createDirectories(partitionDir);
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldReturnFalseWhenTopologyFileIsMissing() throws IOException {
+    // given
+    final Path partitionDir = getPartitionDir();
+    Files.createDirectories(partitionDir);
+    Files.writeString(partitionDir.resolve("segment-1.log"), "data");
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueWhenPartitionDirectoryAndTopologyFileExist() throws IOException {
+    // given
+    final Path partitionDir = getPartitionDir();
+    Files.createDirectories(partitionDir);
+    Files.writeString(partitionDir.resolve("segment-1.log"), "data");
+
+    final Path topologyFile =
+        dataDirectory.resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+    Files.writeString(topologyFile, "topology");
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenTopologyFileIsDirectory() throws IOException {
+    // given
+    final Path partitionDir = getPartitionDir();
+    Files.createDirectories(partitionDir);
+    Files.writeString(partitionDir.resolve("segment-1.log"), "data");
+
+    final Path topologyDir =
+        dataDirectory.resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+    Files.createDirectories(topologyDir);
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueWithMultiplePartitions() throws IOException {
+    // given
+    brokerCfg.getCluster().setPartitionsCount(3);
+
+    for (int i = 1; i <= 3; i++) {
+      final Path partitionDir = getPartitionDir(i);
+      Files.createDirectories(partitionDir);
+      Files.writeString(partitionDir.resolve("segment-1.log"), "data");
+    }
+
+    final Path topologyFile =
+        dataDirectory.resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+    Files.writeString(topologyFile, "topology");
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenOneOfMultiplePartitionsIsEmpty() throws IOException {
+    // given
+    brokerCfg.getCluster().setPartitionsCount(3);
+
+    for (int i = 1; i <= 3; i++) {
+      final Path partitionDir = getPartitionDir(i);
+      Files.createDirectories(partitionDir);
+      if (i < 3) {
+        Files.writeString(partitionDir.resolve("segment-1.log"), "data");
+      }
+    }
+
+    final Path topologyFile =
+        dataDirectory.resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
+    Files.writeString(topologyFile, "topology");
+
+    // when
+    final boolean result = RestoreValidator.validate(brokerCfg);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  private Path getPartitionDir() {
+    return getPartitionDir(1);
+  }
+
+  private Path getPartitionDir(final int partitionId) {
+    return RaftPartitionFactory.getPartitionDirectory(
+        PartitionId.from(RaftPartitionFactory.GROUP_NAME, partitionId), dataDirectory.toString());
+  }
+}


### PR DESCRIPTION
## Description

RestoreApp is expected to be running on an init container. It can happen that the task restarts and the init container runs again. In this case we want to skip the restore as it was successfully restored before. To enable this, in this PR

* Check the restore status in pre-restore action
* Skip restore if the node is marked as restored
* Added a basic validation to ensure restored data exists to prevent cases where we skip restore but the disk is actually empty. This can happen if the restore is retries after deleting the disk but not deleting s3 objects.
* A restore Id is added to the restore status stored in the s3. 

## Related issues

closes #44873 
