### PR TITLE
fix: remove auto schedule

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.backup.schedule.Schedule.AutoSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.CronSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
@@ -150,25 +149,6 @@ public class PrimaryStorageBackupPropertiesTest {
     void shouldParseConfig() {
       assertThat(backupSchedulerCfg.getRetention().getCleanupSchedule())
           .isInstanceOf(NoneSchedule.class);
-    }
-  }
-
-  @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.primary-storage.backup.retention.clean-up-schedule=auto",
-      })
-  class AutoRetentionSchedulerConfiguration {
-    final BackupCfg backupSchedulerCfg;
-
-    AutoRetentionSchedulerConfiguration(@Autowired final BrokerBasedProperties brokerCfg) {
-      backupSchedulerCfg = brokerCfg.getData().getBackup();
-    }
-
-    @Test
-    void shouldParseConfig() {
-      assertThat(backupSchedulerCfg.getRetention().getCleanupSchedule())
-          .isInstanceOf(AutoSchedule.class);
     }
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 /** Represents a schedule which can be either a CRON expression or an ISO8601 duration interval. */
 public sealed interface Schedule {
 
-  String AUTO = "auto";
   String NONE = "none";
 
   /*
@@ -55,9 +54,6 @@ public sealed interface Schedule {
     }
     if (expression.equalsIgnoreCase(NONE)) {
       return none();
-    }
-    if (expression.equalsIgnoreCase(AUTO)) {
-      return new AutoSchedule();
     }
     try {
       final var cron =
@@ -117,25 +113,6 @@ public sealed interface Schedule {
     @Override
     public Optional<Instant> nextExecution(final Instant from) {
       return Optional.empty();
-    }
-
-    @Override
-    public Optional<Instant> previousExecution(final Instant from) {
-      return Optional.empty();
-    }
-  }
-
-  record AutoSchedule() implements Schedule {
-
-    @Override
-    public Optional<Instant> nextExecution(final Instant from) {
-      return Optional.empty();
-    }
-
-    @Override
-    public Optional<Instant> nextExecution(
-        final Instant from, final Supplier<Duration> intervalSupplier) {
-      return Optional.of(from.plus(intervalSupplier.get()));
     }
 
     @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
@@ -67,7 +67,7 @@ public sealed interface Schedule {
         return new IntervalSchedule(duration);
       } catch (final DateTimeParseException ex) {
         throw new IllegalArgumentException(
-            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE or AUTO. Given: "
+            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE. Given: "
                 + expression,
             ex);
       }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -819,7 +819,7 @@ final class SystemContextTest {
     assertThatThrownBy(() -> initSystemContext(brokerCfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE or AUTO. Given: invalid-schedule");
+            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE. Given: invalid-schedule");
   }
 
   @Test
@@ -836,7 +836,7 @@ final class SystemContextTest {
     assertThatThrownBy(() -> initSystemContext(brokerCfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE or AUTO. Given: invalid-schedule");
+            "Invalid expression for schedule: must be one of CRON, ISO8601, NONE. Given: invalid-schedule");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Currently there is no direct metric to associate with the automatic scheduling regarding taking backups. If we are to support this we'd need some more structured approach on what to tie the scheduler's time to perform auto-checkpoints. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
