### PR TITLE
refactor: `/backupRuntime/state` endpoint returns proper timestamps

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -189,7 +189,9 @@ public final class BackupEndpoint {
     response.setPartitionId(state.partitionId());
     response.setCheckpointId(state.checkpointId());
     response.setCheckpointPosition(state.checkpointPosition());
-    response.setCheckpointTimestamp(state.checkpointTimestamp());
+    response.setCheckpointTimestamp(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(state.checkpointTimestamp()), ZoneId.of("UTC")));
     response.setCheckpointType(toCheckpointType(state.checkpointType()));
     return response;
   }
@@ -200,7 +202,9 @@ public final class BackupEndpoint {
     response.setPartitionId(state.partitionId());
     response.setCheckpointId(state.checkpointId());
     response.setCheckpointPosition(state.checkpointPosition());
-    response.setCheckpointTimestamp(state.checkpointTimestamp());
+    response.setCheckpointTimestamp(
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(state.checkpointTimestamp()), ZoneId.of("UTC")));
     response.setCheckpointType(toBackupType(state.checkpointType()));
     return response;
   }

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -621,9 +621,9 @@ components:
           format: int64
           example: 1500
         checkpointTimestamp:
-          type: integer
-          format: int64
-          example: 1765208671134
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00Z"
 
     PartitionBackupState:
       title: Partition Checkpoint State
@@ -645,9 +645,9 @@ components:
           format: int64
           example: 1500
         checkpointTimestamp:
-          type: integer
-          format: int64
-          example: 1765208671134
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00Z"
 
     PartitionBackupRange:
       title: Partition Backup Range

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -51,6 +51,8 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.netty.channel.ConnectTimeoutException;
 import java.net.ConnectException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -700,8 +702,8 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setCheckpointStates(
           Set.of(
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L)));
+              new CheckpointStateResponse.PartitionCheckpointState(
+                  1, 1L, CheckpointType.MARKER, 20L, 10L)));
       final var rangesResponse = new BackupRangesResponse();
       rangesResponse.setRanges(
           List.of(
@@ -734,7 +736,9 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(io.camunda.management.backups.CheckpointType.MARKER)))
                   .ranges(
                       List.of(
@@ -755,8 +759,8 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
           Set.of(
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+              new CheckpointStateResponse.PartitionCheckpointState(
+                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
       when(api.getBackupRanges())
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
@@ -775,7 +779,9 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(BackupType.MANUAL_BACKUP))));
     }
 
@@ -789,12 +795,12 @@ final class BackupEndpointTest {
       final var stateResponse = new CheckpointStateResponse();
       stateResponse.setBackupStates(
           Set.of(
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+              new CheckpointStateResponse.PartitionCheckpointState(
+                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
       stateResponse.setCheckpointStates(
           Set.of(
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 2L, CheckpointType.MARKER, 30L, 50L)));
+              new CheckpointStateResponse.PartitionCheckpointState(
+                  1, 2L, CheckpointType.MARKER, 30L, 50L)));
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
       when(api.getBackupRanges())
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
@@ -813,7 +819,9 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(BackupType.MANUAL_BACKUP)))
                   .checkpointStates(
                       List.of(
@@ -821,7 +829,9 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(2L)
                               .checkpointPosition(50L)
-                              .checkpointTimestamp(30L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(30L), ZoneId.of("UTC")))
                               .checkpointType(
                                   io.camunda.management.backups.CheckpointType.MARKER))));
     }
@@ -857,31 +867,25 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
 
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p1State =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 1L, CheckpointType.MARKER, 20L, 10L);
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p2State =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(2, 1L, CheckpointType.MARKER, 20L, 20L);
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p3State =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(3, 1L, CheckpointType.MARKER, 30L, 40L);
+      final CheckpointStateResponse.PartitionCheckpointState p1State =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              1, 1L, CheckpointType.MARKER, 20L, 10L);
+      final CheckpointStateResponse.PartitionCheckpointState p2State =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              2, 1L, CheckpointType.MARKER, 20L, 20L);
+      final CheckpointStateResponse.PartitionCheckpointState p3State =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              3, 1L, CheckpointType.MARKER, 30L, 40L);
 
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p1BackupState =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p2BackupState =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
-      final io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState
-          p3BackupState =
-              new io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse
-                  .PartitionCheckpointState(3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
+      final CheckpointStateResponse.PartitionCheckpointState p1BackupState =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
+      final CheckpointStateResponse.PartitionCheckpointState p2BackupState =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
+      final CheckpointStateResponse.PartitionCheckpointState p3BackupState =
+          new CheckpointStateResponse.PartitionCheckpointState(
+              3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
 
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
       stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
@@ -904,19 +908,25 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(io.camunda.management.backups.CheckpointType.MARKER),
                           new PartitionCheckpointState()
                               .partitionId(2)
                               .checkpointId(1L)
                               .checkpointPosition(20L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(io.camunda.management.backups.CheckpointType.MARKER),
                           new PartitionCheckpointState()
                               .partitionId(3)
                               .checkpointId(1L)
                               .checkpointPosition(40L)
-                              .checkpointTimestamp(30L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(30L), ZoneId.of("UTC")))
                               .checkpointType(io.camunda.management.backups.CheckpointType.MARKER)))
                   .backupStates(
                       List.of(
@@ -924,19 +934,25 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(BackupType.MANUAL_BACKUP),
                           new PartitionBackupState()
                               .partitionId(2)
                               .checkpointId(1L)
                               .checkpointPosition(20L)
-                              .checkpointTimestamp(20L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
                               .checkpointType(BackupType.MANUAL_BACKUP),
                           new PartitionBackupState()
                               .partitionId(3)
                               .checkpointId(1L)
                               .checkpointPosition(40L)
-                              .checkpointTimestamp(30L)
+                              .checkpointTimestamp(
+                                  OffsetDateTime.ofInstant(
+                                      Instant.ofEpochMilli(30L), ZoneId.of("UTC")))
                               .checkpointType(BackupType.MANUAL_BACKUP))));
     }
   }


### PR DESCRIPTION
Plain epoch millis are difficult to read, this replaces them with nicely formatted datetime strings like we already do for backup `createdAt` and `modifiedAt` timestamps.
