### PR TITLE
Introduce optimize mode filter

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -45,5 +45,7 @@ public interface FilterConfiguration {
     List<String> getVariableValueTypeInclusion();
 
     List<String> getVariableValueTypeExclusion();
+
+    boolean isOptimizeModeEnabled();
   }
 }

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.EnumSet;
+
+/**
+ * Filter that selects only the records relevant for Optimize:
+ *
+ * <ul>
+ *   <li>PROCESS: only {@link ProcessIntent#CREATED}
+ *   <li>PROCESS_INSTANCE: only specific intents and BPMN element types
+ *   <li>INCIDENT: {@link IncidentIntent#CREATED}, {@link IncidentIntent#RESOLVED}
+ *   <li>USER_TASK: ASSIGNED, CANCELED, COMPLETED, CREATING
+ *   <li>VARIABLE: CREATED, UPDATED
+ * </ul>
+ *
+ * <p>The filter is applied only if the broker version is at least 8.9.0.
+ *
+ * <p>Note that this filter is applied after the metadata filter in the exporter pipeline, which is
+ * implemented by the {@link RecordFilter} interface via its acceptType, acceptValue, and
+ * acceptIntent methods.
+ */
+public final class OptimizeModeFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 9, 0, null, null);
+
+  private static final EnumSet<ProcessInstanceIntent> ALLOWED_PROCESS_INSTANCE_INTENTS =
+      EnumSet.of(
+          ProcessInstanceIntent.ELEMENT_COMPLETED,
+          ProcessInstanceIntent.ELEMENT_TERMINATED,
+          ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+  private static final EnumSet<BpmnElementType> EXCLUDED_PROCESS_INSTANCE_ELEMENT_TYPES =
+      EnumSet.of(BpmnElementType.UNSPECIFIED, BpmnElementType.SEQUENCE_FLOW);
+
+  private static final EnumSet<IncidentIntent> ALLOWED_INCIDENT_INTENTS =
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
+
+  private static final EnumSet<UserTaskIntent> ALLOWED_USER_TASK_INTENTS =
+      EnumSet.of(
+          UserTaskIntent.ASSIGNED,
+          UserTaskIntent.CANCELED,
+          UserTaskIntent.COMPLETED,
+          UserTaskIntent.CREATING);
+
+  private static final EnumSet<VariableIntent> ALLOWED_VARIABLE_INTENTS =
+      EnumSet.of(VariableIntent.CREATED, VariableIntent.UPDATED);
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    return switch (record.getValueType()) {
+      case PROCESS -> isAcceptedProcess(record);
+      case PROCESS_INSTANCE -> isAcceptedProcessInstance(record);
+      case INCIDENT -> isAcceptedIncident(record);
+      case USER_TASK -> isAcceptedUserTask(record);
+      case VARIABLE -> isAcceptedVariable(record);
+      default -> false;
+    };
+  }
+
+  private boolean isAcceptedProcess(final Record<?> record) {
+    return record.getIntent() == ProcessIntent.CREATED;
+  }
+
+  private boolean isAcceptedProcessInstance(final Record<?> record) {
+    final var intent = (ProcessInstanceIntent) record.getIntent();
+
+    // Only selected lifecycle events are relevant
+    if (!ALLOWED_PROCESS_INSTANCE_INTENTS.contains(intent)) {
+      return false;
+    }
+
+    // Exclude specific BPMN element types
+    final var value = (ProcessInstanceRecordValue) record.getValue();
+    final var elementType = value.getBpmnElementType();
+
+    return !EXCLUDED_PROCESS_INSTANCE_ELEMENT_TYPES.contains(elementType);
+  }
+
+  private boolean isAcceptedIncident(final Record<?> record) {
+    final var intent = (IncidentIntent) record.getIntent();
+    return ALLOWED_INCIDENT_INTENTS.contains(intent);
+  }
+
+  private boolean isAcceptedUserTask(final Record<?> record) {
+    final var intent = (UserTaskIntent) record.getIntent();
+    return ALLOWED_USER_TASK_INTENTS.contains(intent);
+  }
+
+  private boolean isAcceptedVariable(final Record<?> record) {
+    final var intent = (VariableIntent) record.getIntent();
+    return ALLOWED_VARIABLE_INTENTS.contains(intent);
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -298,6 +298,32 @@ final class DefaultRecordFilterTest {
   }
 
   @Test
+  void shouldApplyOptimizeModeFilterWhenOptimizeModeEnabled() {
+    // given
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            // We pick JOB because OptimizeModeFilter never accepts JOB records
+            .withIndexedValueType(ValueType.JOB);
+
+    // Enable Optimize mode on the index config so that createRecordFilters()
+    // adds an OptimizeModeFilter to the chain.
+    configuration.filterIndexConfig().withOptimizeModeEnabled(true);
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    @SuppressWarnings("unchecked")
+    final Record<?> jobRecord = (Record<?>) mock(Record.class);
+    when(jobRecord.getRecordType()).thenReturn(RecordType.EVENT);
+    when(jobRecord.getValueType()).thenReturn(ValueType.JOB);
+
+    // when / then
+    assertThat(filter.acceptRecord(jobRecord))
+        .as("With Optimize mode enabled, non-Optimize value types like JOB should be rejected")
+        .isFalse();
+  }
+
+  @Test
   void shouldNotApplyVariableValueTypeFilterWhenNoTypeRulesConfigured() {
     // given
     final var configuration =

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilterTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class OptimizeModeFilterTest {
+
+  private final OptimizeModeFilter filter = new OptimizeModeFilter();
+
+  // ---------------------------------------------------------------------------
+  // PROCESS
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptOnlyCreatedProcessRecords() {
+    final var created = record(ValueType.PROCESS, ProcessIntent.CREATED);
+    final var deleting = record(ValueType.PROCESS, ProcessIntent.DELETING);
+
+    assertThat(filter.accept(created)).as("PROCESS.CREATED should be accepted").isTrue();
+    assertThat(filter.accept(deleting)).as("PROCESS.DELETING should be rejected").isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // PROCESS_INSTANCE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptSelectedProcessInstanceIntentsForNonExcludedElementTypes() {
+    final var elementCompleted =
+        processInstanceRecord(
+            ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SERVICE_TASK);
+    final var elementTerminated =
+        processInstanceRecord(
+            ProcessInstanceIntent.ELEMENT_TERMINATED, BpmnElementType.START_EVENT);
+    final var elementActivating =
+        processInstanceRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, BpmnElementType.END_EVENT);
+
+    assertThat(filter.accept(elementCompleted))
+        .as("ELEMENT_COMPLETED for normal BPMN element should be accepted")
+        .isTrue();
+    assertThat(filter.accept(elementTerminated))
+        .as("ELEMENT_TERMINATED for normal BPMN element should be accepted")
+        .isTrue();
+    assertThat(filter.accept(elementActivating))
+        .as("ELEMENT_ACTIVATING for normal BPMN element should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldRejectProcessInstanceRecordsWithNonAllowedIntents() {
+    final var allowed =
+        processInstanceRecord(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING, BpmnElementType.SERVICE_TASK);
+    final var notAllowed =
+        processInstanceRecord(
+            ProcessInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.SERVICE_TASK);
+
+    assertThat(filter.accept(allowed))
+        .as("ELEMENT_ACTIVATING is allowed for normal elements")
+        .isTrue();
+    assertThat(filter.accept(notAllowed))
+        .as("ELEMENT_ACTIVATED is not in the allowed intent set and must be rejected")
+        .isFalse();
+  }
+
+  @Test
+  void shouldRejectProcessInstanceRecordsForExcludedElementTypes() {
+    final var unspecified =
+        processInstanceRecord(ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.UNSPECIFIED);
+    final var sequenceFlow =
+        processInstanceRecord(
+            ProcessInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.SEQUENCE_FLOW);
+
+    assertThat(filter.accept(unspecified))
+        .as("UNSPECIFIED element type should be excluded")
+        .isFalse();
+    assertThat(filter.accept(sequenceFlow))
+        .as("SEQUENCE_FLOW element type should be excluded")
+        .isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // INCIDENT
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptOnlyCreatedAndResolvedIncidents() {
+    final var created = record(ValueType.INCIDENT, IncidentIntent.CREATED);
+    final var resolved = record(ValueType.INCIDENT, IncidentIntent.RESOLVED);
+    final var resolveCommand = record(ValueType.INCIDENT, IncidentIntent.RESOLVE);
+
+    assertThat(filter.accept(created)).as("INCIDENT.CREATED should be accepted").isTrue();
+    assertThat(filter.accept(resolved)).as("INCIDENT.RESOLVED should be accepted").isTrue();
+    assertThat(filter.accept(resolveCommand)).as("INCIDENT.RESOLVE should be rejected").isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // USER_TASK
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptOnlySelectedUserTaskIntents() {
+    final var creating = record(ValueType.USER_TASK, UserTaskIntent.CREATING);
+    final var assigned = record(ValueType.USER_TASK, UserTaskIntent.ASSIGNED);
+    final var canceled = record(ValueType.USER_TASK, UserTaskIntent.CANCELED);
+    final var completed = record(ValueType.USER_TASK, UserTaskIntent.COMPLETED);
+    final var completeCommand = record(ValueType.USER_TASK, UserTaskIntent.COMPLETE);
+
+    assertThat(filter.accept(creating)).as("USER_TASK.CREATING should be accepted").isTrue();
+    assertThat(filter.accept(assigned)).as("USER_TASK.ASSIGNED should be accepted").isTrue();
+    assertThat(filter.accept(canceled)).as("USER_TASK.CANCELED should be accepted").isTrue();
+    assertThat(filter.accept(completed)).as("USER_TASK.COMPLETED should be accepted").isTrue();
+    assertThat(filter.accept(completeCommand))
+        .as("USER_TASK.COMPLETE is not in the allowed set and should be rejected")
+        .isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // VARIABLE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptOnlyCreatedAndUpdatedVariables() {
+    final var created = record(ValueType.VARIABLE, VariableIntent.CREATED);
+    final var updated = record(ValueType.VARIABLE, VariableIntent.UPDATED);
+    final var migrated = record(ValueType.VARIABLE, VariableIntent.MIGRATED);
+
+    assertThat(filter.accept(created)).as("VARIABLE.CREATED should be accepted").isTrue();
+    assertThat(filter.accept(updated)).as("VARIABLE.UPDATED should be accepted").isTrue();
+    assertThat(filter.accept(migrated)).as("VARIABLE.MIGRATED should be rejected").isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // DEFAULT CASE
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRejectUnsupportedValueTypes() {
+    final var jobRecord = record(ValueType.JOB, null);
+
+    assertThat(filter.accept(jobRecord))
+        .as("Unsupported value types should be rejected by default")
+        .isFalse();
+  }
+
+  @Test
+  void shouldExposeMinimumBrokerVersion() {
+    final var filter = new VariableTypeFilter(Set.of(), Set.of());
+
+    assertThat(filter.minRecordBrokerVersion()).isEqualTo(new SemanticVersion(8, 9, 0, null, null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static Record<ProcessInstanceRecordValue> processInstanceRecord(
+      final ProcessInstanceIntent intent, final BpmnElementType elementType) {
+
+    final Record<ProcessInstanceRecordValue> record =
+        (Record<ProcessInstanceRecordValue>) mock(Record.class);
+    final ProcessInstanceRecordValue value = mock(ProcessInstanceRecordValue.class);
+
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getIntent()).thenReturn(intent);
+    when(record.getValue()).thenReturn(value);
+    when(value.getBpmnElementType()).thenReturn(elementType);
+
+    return record;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<?> record(final ValueType valueType, final Intent intent) {
+    final Record<?> record = (Record<?>) mock(Record.class);
+    when(record.getValueType()).thenReturn(valueType);
+    if (intent != null) {
+      when(record.getIntent()).thenReturn(intent);
+    }
+    return record;
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
@@ -29,6 +29,8 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   private List<String> variableValueTypeInclusion = List.of();
   private List<String> variableValueTypeExclusion = List.of();
 
+  private boolean optimizeModeEnabled = false;
+
   // --- fluent setters -------------------------------------------------------
 
   public TestIndexConfig withVariableNameInclusionExact(final List<String> names) {
@@ -68,6 +70,11 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
 
   public TestIndexConfig withVariableValueTypeExclusion(final List<String> typeExclusion) {
     variableValueTypeExclusion = typeExclusion != null ? typeExclusion : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withOptimizeModeEnabled(final boolean optimizeModeEnabled) {
+    this.optimizeModeEnabled = optimizeModeEnabled;
     return this;
   }
 
@@ -111,5 +118,10 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   @Override
   public List<String> getVariableValueTypeExclusion() {
     return variableValueTypeExclusion;
+  }
+
+  @Override
+  public boolean isOptimizeModeEnabled() {
+    return optimizeModeEnabled;
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -268,6 +268,9 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeInclusion = new ArrayList<>();
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
+    // optimize mode
+    private boolean optimizeModeEnabled = false;
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -330,6 +333,15 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     @Override
     public List<String> getVariableValueTypeExclusion() {
       return List.copyOf(variableValueTypeExclusion);
+    }
+
+    @Override
+    public boolean isOptimizeModeEnabled() {
+      return optimizeModeEnabled;
+    }
+
+    public void setOptimizeModeEnabled(final boolean optimizeModeEnabled) {
+      this.optimizeModeEnabled = optimizeModeEnabled;
     }
 
     public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
@@ -477,6 +489,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeInclusion
           + ", variableValueTypeExclusion="
           + variableValueTypeExclusion
+          + ", optimizeModeEnabled="
+          + optimizeModeEnabled
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -259,6 +259,9 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeInclusion = new ArrayList<>();
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
+    // optimize mode
+    private boolean optimizeModeEnabled = false;
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -321,6 +324,15 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     @Override
     public List<String> getVariableValueTypeExclusion() {
       return List.copyOf(variableValueTypeExclusion);
+    }
+
+    @Override
+    public boolean isOptimizeModeEnabled() {
+      return optimizeModeEnabled;
+    }
+
+    public void setOptimizeModeEnabled(final boolean optimizeModeEnabled) {
+      this.optimizeModeEnabled = optimizeModeEnabled;
     }
 
     public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
@@ -466,6 +478,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeInclusion
           + ", variableValueTypeExclusion="
           + variableValueTypeExclusion
+          + ", optimizeModeEnabled="
+          + optimizeModeEnabled
           + '}';
     }
   }


### PR DESCRIPTION
## Description

This PR introduces an Optimize mode filter that restricts exported records to those relevant for Optimize. When isOptimizeModeEnabled() is true, DefaultRecordFilter prepends an OptimizeModeFilter that selectively accepts only specific intents for PROCESS, PROCESS_INSTANCE, INCIDENT, USER_TASK, and VARIABLE records, while excluding irrelevant BPMN element types (e.g., UNSPECIFIED, SEQUENCE_FLOW) and rejecting unsupported value types by default. Existing variable name and type filters remain available and are still applied as configured.

The configuration is extended via FilterConfiguration.isOptimizeModeEnabled(), and unit tests are added/updated to cover both the new filter behavior and its integration into DefaultRecordFilter. When Optimize mode is disabled, the exporter’s behavior remains unchanged from before this PR.

## Related issues

Closes: https://github.com/camunda/camunda/issues/44139
