### PR TITLE
MCP Gateway: Define a custom JSON schema generator + tool callback

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
@@ -9,6 +9,8 @@ package io.camunda.application.commons.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.CamundaMcpServerToolSpecificationsAutoConfiguration;
+import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +27,18 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
+/**
+ * Configuration for the MCP gateway implemented in the {@code gateway-mcp} module.
+ *
+ * <p>MCP specific beans overriding the default Spring AI behavior are created as part of the module
+ * autoconfigurations in the {@link io.camunda.gateway.mcp.config} package to resemble the
+ * overridden autoconfiguration logic as much as possible. See:
+ *
+ * <ul>
+ *   <li>{@link CamundaMcpToolScannerAutoConfiguration}
+ *   <li>{@link CamundaMcpServerToolSpecificationsAutoConfiguration}
+ * </ul>
+ */
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.gateway.mcp"})
 @ConditionalOnMcpGatewayEnabled

--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpGatewayConfiguration.java
@@ -9,8 +9,8 @@ package io.camunda.application.commons.mcp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
-import io.camunda.gateway.mcp.config.CamundaMcpServerToolSpecificationsAutoConfiguration;
 import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration;
+import io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,7 +36,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
  *
  * <ul>
  *   <li>{@link CamundaMcpToolScannerAutoConfiguration}
- *   <li>{@link CamundaMcpServerToolSpecificationsAutoConfiguration}
+ *   <li>{@link CamundaMcpToolSpecificationsAutoConfiguration}
  * </ul>
  */
 @Configuration(proxyBeanMethods = false)

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -151,6 +151,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -29,22 +29,18 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-gateway-mapping-http</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-service</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-impl</artifactId>
@@ -54,39 +50,7 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
-    <!-- MCP dependencies -->
-    <dependency>
-      <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springaicommunity</groupId>
-      <artifactId>mcp-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.modelcontextprotocol.sdk</groupId>
-      <artifactId>mcp-core</artifactId>
-    </dependency>
-
-    <!-- required for custom models -->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations-jakarta</artifactId>
-    </dependency>
-
-    <!-- utilities -->
+    <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
@@ -96,6 +60,10 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
@@ -108,10 +76,65 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
+
+    <!-- MCP dependencies -->
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-mcp-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springaicommunity</groupId>
+      <artifactId>mcp-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp-core</artifactId>
+    </dependency>
+
+    <!-- Various dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-generator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-module-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-module-swagger-2</artifactId>
     </dependency>
 
     <!-- test dependencies -->
@@ -120,7 +143,6 @@
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
@@ -139,27 +161,23 @@
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServerToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServerToolSpecificationsAutoConfiguration.java
@@ -35,10 +35,10 @@ public class CamundaMcpServerToolSpecificationsAutoConfiguration {
 
   @Bean
   public List<SyncToolSpecification> mcpGatewayToolSpecifications(
-      final CamundaMcpToolAnnotatedBeans annotatedBeans) {
+      final CamundaMcpToolAnnotatedBeans annotatedBeans,
+      final CamundaJsonSchemaGenerator jsonSchemaGenerator) {
     return new CamundaSyncStatelessMcpToolProvider(
-            annotatedBeans.getBeansByAnnotation(CamundaMcpTool.class),
-            mcpGatewayJsonSchemaGenerator())
+            annotatedBeans.getBeansByAnnotation(CamundaMcpTool.class), jsonSchemaGenerator)
         .getToolSpecifications();
   }
 }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServerToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServerToolSpecificationsAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config;
+
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration.CamundaMcpToolAnnotatedBeans;
+import io.camunda.gateway.mcp.config.schema.CamundaJsonSchemaGenerator;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.gateway.mcp.config.tool.CamundaSyncStatelessMcpToolProvider;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import java.util.List;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Autoconfiguration for creating MCP tool specifications from {@link CamundaMcpTool}-annotated
+ * methods.
+ *
+ * <p>This configuration runs after {@link CamundaMcpToolScannerAutoConfiguration} which populates
+ * the {@link CamundaMcpToolAnnotatedBeans} registry with discovered tool beans.
+ */
+@AutoConfiguration(after = CamundaMcpToolScannerAutoConfiguration.class)
+@ConditionalOnMcpGatewayEnabled
+public class CamundaMcpServerToolSpecificationsAutoConfiguration {
+
+  @Bean
+  public CamundaJsonSchemaGenerator mcpGatewayJsonSchemaGenerator() {
+    return new CamundaJsonSchemaGenerator();
+  }
+
+  @Bean
+  public List<SyncToolSpecification> mcpGatewayToolSpecifications(
+      final CamundaMcpToolAnnotatedBeans annotatedBeans) {
+    return new CamundaSyncStatelessMcpToolProvider(
+            annotatedBeans.getBeansByAnnotation(CamundaMcpTool.class),
+            mcpGatewayJsonSchemaGenerator())
+        .getToolSpecifications();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolScannerAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolScannerAutoConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config;
+
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Autoconfiguration for scanning beans annotated with {@link CamundaMcpTool}.
+ *
+ * <p>This configuration registers:
+ *
+ * <ul>
+ *   <li>{@link CamundaMcpToolAnnotatedBeans} - Registry for discovered tool beans
+ *   <li>{@link CamundaMcpToolBeanPostProcessor} - Post-processor that discovers and registers tool
+ *       beans during initialization
+ * </ul>
+ *
+ * <p>This follows the same pattern as Spring AI's annotation scanner, ensuring proper integration
+ * with Spring's bean lifecycle.
+ */
+@AutoConfiguration
+@ConditionalOnMcpGatewayEnabled
+public class CamundaMcpToolScannerAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CamundaMcpToolAnnotatedBeans camundaMcpToolAnnotatedBeans() {
+    return new CamundaMcpToolAnnotatedBeans();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public static CamundaMcpToolBeanPostProcessor camundaMcpToolBeanPostProcessor(
+      final CamundaMcpToolAnnotatedBeans registry) {
+    return new CamundaMcpToolBeanPostProcessor(registry, Set.of(CamundaMcpTool.class));
+  }
+
+  public static class CamundaMcpToolAnnotatedBeans extends AbstractMcpAnnotatedBeans {}
+
+  public static class CamundaMcpToolBeanPostProcessor
+      extends AbstractAnnotatedMethodBeanPostProcessor {
+
+    public CamundaMcpToolBeanPostProcessor(
+        final CamundaMcpToolAnnotatedBeans registry,
+        final Set<Class<? extends Annotation>> targetAnnotations) {
+      super(registry, targetAnnotations);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.gateway.mcp.config.tool.CamundaSyncStatelessMcpToolProvider;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import java.util.List;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -26,9 +27,10 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration(after = CamundaMcpToolScannerAutoConfiguration.class)
 @ConditionalOnMcpGatewayEnabled
-public class CamundaMcpServerToolSpecificationsAutoConfiguration {
+public class CamundaMcpToolSpecificationsAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean
   public CamundaJsonSchemaGenerator mcpGatewayJsonSchemaGenerator() {
     return new CamundaJsonSchemaGenerator();
   }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -101,7 +101,10 @@ public class CamundaJsonSchemaGenerator {
   }
 
   private static SchemaGeneratorConfigBuilder createSchemaGeneratorConfig() {
-    final Module jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+    final Module jacksonModule =
+        new JacksonModule(
+            JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+            JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
     final Module openApiModule = new Swagger2Module();
     final Module springAiSchemaModule =
         CamundaJsonSchemaGenerator.PROPERTY_REQUIRED_BY_DEFAULT

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.gateway.mcp.config.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.context.McpAsyncRequestContext;
+import org.springaicommunity.mcp.context.McpSyncRequestContext;
+import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
+import org.springaicommunity.mcp.method.tool.utils.ConcurrentReferenceHashMap;
+import org.springaicommunity.mcp.method.tool.utils.JsonParser;
+import org.springaicommunity.mcp.method.tool.utils.JsonSchemaGenerator;
+import org.springaicommunity.mcp.method.tool.utils.SpringAiSchemaModule;
+import org.springframework.lang.Nullable;
+
+/**
+ * This is an adapted variant of {@link JsonSchemaGenerator}, configured to inline defs and made
+ * non-static.
+ */
+public class CamundaJsonSchemaGenerator {
+
+  private static final boolean PROPERTY_REQUIRED_BY_DEFAULT = true;
+
+  private final Map<Method, String> methodSchemaCache = new ConcurrentReferenceHashMap<>(256);
+  private final Map<Type, String> typeSchemaCache = new ConcurrentReferenceHashMap<>(256);
+
+  private final ObjectMapper objectMapper;
+  private final SchemaGenerator typeSchemaGenerator;
+  private final SchemaGenerator subtypeSchemaGenerator;
+
+  public CamundaJsonSchemaGenerator() {
+    this(JsonParser.getObjectMapper());
+  }
+
+  public CamundaJsonSchemaGenerator(final ObjectMapper objectMapper) {
+    this(objectMapper, Function.identity(), Function.identity());
+  }
+
+  public CamundaJsonSchemaGenerator(
+      final ObjectMapper objectMapper,
+      final Function<SchemaGeneratorConfigBuilder, SchemaGeneratorConfigBuilder>
+          typeSchemaCustomizer,
+      final Function<SchemaGeneratorConfigBuilder, SchemaGeneratorConfigBuilder>
+          subtypeSchemaCustomizer) {
+    this.objectMapper = objectMapper;
+
+    final SchemaGeneratorConfigBuilder schemaGeneratorConfigBuilder =
+        typeSchemaCustomizer.apply(createSchemaGeneratorConfig());
+
+    typeSchemaGenerator = new SchemaGenerator(schemaGeneratorConfigBuilder.build());
+
+    final SchemaGeneratorConfig subtypeSchemaGeneratorConfig =
+        subtypeSchemaCustomizer
+            .apply(schemaGeneratorConfigBuilder.without(Option.SCHEMA_VERSION_INDICATOR))
+            .build();
+    subtypeSchemaGenerator = new SchemaGenerator(subtypeSchemaGeneratorConfig);
+  }
+
+  private static SchemaGeneratorConfigBuilder createSchemaGeneratorConfig() {
+    final Module jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+    final Module openApiModule = new Swagger2Module();
+    final Module springAiSchemaModule =
+        CamundaJsonSchemaGenerator.PROPERTY_REQUIRED_BY_DEFAULT
+            ? new SpringAiSchemaModule()
+            : new SpringAiSchemaModule(
+                SpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);
+
+    return new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+        .with(jacksonModule)
+        .with(openApiModule)
+        .with(springAiSchemaModule)
+        .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
+        .with(Option.STANDARD_FORMATS)
+        .with(Option.INLINE_ALL_SCHEMAS);
+  }
+
+  public String generateForMethodInput(final Method method) {
+    Assert.notNull(method, "method cannot be null");
+    return methodSchemaCache.computeIfAbsent(method, this::internalGenerateFromMethodArguments);
+  }
+
+  private String internalGenerateFromMethodArguments(final Method method) {
+    // Check if method has CallToolRequest parameter
+    final boolean hasCallToolRequestParam =
+        Arrays.stream(method.getParameterTypes()).anyMatch(CallToolRequest.class::isAssignableFrom);
+
+    // If method has CallToolRequest, return minimal schema
+    if (hasCallToolRequestParam) {
+      // Check if there are other parameters besides CallToolRequest, exchange
+      // types,
+      // @McpProgressToken annotated parameters, and McpMeta parameters
+      final boolean hasOtherParams =
+          Arrays.stream(method.getParameters())
+              .anyMatch(
+                  param -> {
+                    final Class<?> type = param.getType();
+                    return !McpSyncRequestContext.class.isAssignableFrom(type)
+                        && !McpAsyncRequestContext.class.isAssignableFrom(type)
+                        && !CallToolRequest.class.isAssignableFrom(type)
+                        && !McpSyncServerExchange.class.isAssignableFrom(type)
+                        && !McpAsyncServerExchange.class.isAssignableFrom(type)
+                        && !param.isAnnotationPresent(McpProgressToken.class)
+                        && !McpMeta.class.isAssignableFrom(type);
+                  });
+
+      // If only CallToolRequest (and possibly exchange), return empty schema
+      if (!hasOtherParams) {
+        final ObjectNode schema = objectMapper.createObjectNode();
+        schema.put("type", "object");
+        schema.putObject("properties");
+        schema.putArray("required");
+        return schema.toPrettyString();
+      }
+    }
+
+    final ObjectNode schema = objectMapper.createObjectNode();
+    schema.put("$schema", SchemaVersion.DRAFT_2020_12.getIdentifier());
+    schema.put("type", "object");
+
+    final ObjectNode properties = schema.putObject("properties");
+    final List<String> required = new ArrayList<>();
+
+    for (int i = 0; i < method.getParameterCount(); i++) {
+      final Parameter parameter = method.getParameters()[i];
+      final String parameterName = parameter.getName();
+      final Type parameterType = method.getGenericParameterTypes()[i];
+
+      // Skip parameters annotated with @McpProgressToken
+      if (parameter.isAnnotationPresent(McpProgressToken.class)) {
+        continue;
+      }
+
+      // Skip McpMeta parameters
+      if (parameterType instanceof final Class<?> parameterClass
+          && McpMeta.class.isAssignableFrom(parameterClass)) {
+        continue;
+      }
+
+      // Skip special parameter types
+      if (parameterType instanceof final Class<?> parameterClass
+          && (ClassUtils.isAssignable(McpSyncRequestContext.class, parameterClass)
+              || ClassUtils.isAssignable(McpAsyncRequestContext.class, parameterClass)
+              || ClassUtils.isAssignable(McpSyncServerExchange.class, parameterClass)
+              || ClassUtils.isAssignable(McpAsyncServerExchange.class, parameterClass)
+              || ClassUtils.isAssignable(CallToolRequest.class, parameterClass))) {
+        continue;
+      }
+
+      if (isMethodParameterRequired(method, i)) {
+        required.add(parameterName);
+      }
+
+      final ObjectNode parameterNode = subtypeSchemaGenerator.generateSchema(parameterType);
+      final String parameterDescription = getMethodParameterDescription(method, i);
+
+      if (Utils.hasText(parameterDescription)) {
+        parameterNode.put("description", parameterDescription);
+      }
+
+      properties.set(parameterName, parameterNode);
+    }
+
+    final var requiredArray = schema.putArray("required");
+    required.forEach(requiredArray::add);
+
+    return schema.toPrettyString();
+  }
+
+  public String generateFromType(final Type type) {
+    Assert.notNull(type, "type cannot be null");
+    return typeSchemaCache.computeIfAbsent(type, this::internalGenerateFromType);
+  }
+
+  private String internalGenerateFromType(final Type type) {
+    return typeSchemaGenerator.generateSchema(type).toPrettyString();
+  }
+
+  private boolean isMethodParameterRequired(final Method method, final int index) {
+    final Parameter parameter = method.getParameters()[index];
+
+    final var toolParamAnnotation = parameter.getAnnotation(McpToolParam.class);
+    if (toolParamAnnotation != null) {
+      return toolParamAnnotation.required();
+    }
+
+    final var propertyAnnotation = parameter.getAnnotation(JsonProperty.class);
+    if (propertyAnnotation != null) {
+      return propertyAnnotation.required();
+    }
+
+    final var schemaAnnotation = parameter.getAnnotation(Schema.class);
+    if (schemaAnnotation != null) {
+      return schemaAnnotation.requiredMode() == RequiredMode.REQUIRED
+          || schemaAnnotation.requiredMode() == RequiredMode.AUTO
+          || schemaAnnotation.required();
+    }
+
+    final var nullableAnnotation = parameter.getAnnotation(Nullable.class);
+    if (nullableAnnotation != null) {
+      return false;
+    }
+
+    return PROPERTY_REQUIRED_BY_DEFAULT;
+  }
+
+  private String getMethodParameterDescription(final Method method, final int index) {
+    final Parameter parameter = method.getParameters()[index];
+
+    final var toolParamAnnotation = parameter.getAnnotation(McpToolParam.class);
+    if (toolParamAnnotation != null && Utils.hasText(toolParamAnnotation.description())) {
+      return toolParamAnnotation.description();
+    }
+
+    final var jacksonAnnotation = parameter.getAnnotation(JsonPropertyDescription.class);
+    if (jacksonAnnotation != null && Utils.hasText(jacksonAnnotation.value())) {
+      return jacksonAnnotation.value();
+    }
+
+    final var schemaAnnotation = parameter.getAnnotation(Schema.class);
+    if (schemaAnnotation != null && Utils.hasText(schemaAnnotation.description())) {
+      return schemaAnnotation.description();
+    }
+
+    return null;
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaMcpTool.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaMcpTool.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config.tool;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
+
+/**
+ * Marks a method as an MCP tool.
+ *
+ * <p>This is our custom tool annotation that is functionally equivalent to Spring AI's {@link
+ * McpTool} but allows to control schema generation and output handling individually.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CamundaMcpTool {
+
+  /**
+   * Optional tool name. If not specified, the method name will be used.
+   *
+   * @return the tool name
+   */
+  String name() default "";
+
+  /**
+   * Description of what the tool does. This is shown to AI models to help them understand when to
+   * use the tool.
+   *
+   * @return the tool description
+   */
+  String description() default "";
+
+  /**
+   * Optional tool title for display purposes.
+   *
+   * @return the tool title
+   */
+  String title() default "";
+
+  /**
+   * MCP protocol annotations providing hints about the tool's behavior.
+   *
+   * @return the tool annotations
+   */
+  McpAnnotations annotations() default @McpAnnotations;
+
+  /**
+   * Whether to generate output schema for the tool's return type.
+   *
+   * @return true if output schema should be generated
+   */
+  boolean generateOutputSchema() default false;
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolMethodCallback.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolMethodCallback.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config.tool;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import java.lang.reflect.Method;
+import java.util.function.BiFunction;
+import org.springaicommunity.mcp.context.McpSyncRequestContext;
+import org.springaicommunity.mcp.method.tool.AbstractSyncMcpToolMethodCallback;
+import org.springaicommunity.mcp.method.tool.ReturnMode;
+import org.springaicommunity.mcp.method.tool.SyncStatelessMcpToolMethodCallback;
+
+/**
+ * Camunda-specific callback for synchronous stateless MCP tool methods.
+ *
+ * <p>Original Spring AI implementation: {@link SyncStatelessMcpToolMethodCallback}
+ */
+public class CamundaSyncStatelessMcpToolMethodCallback
+    extends AbstractSyncMcpToolMethodCallback<McpTransportContext, McpSyncRequestContext>
+    implements BiFunction<McpTransportContext, CallToolRequest, CallToolResult> {
+
+  public CamundaSyncStatelessMcpToolMethodCallback(
+      final ReturnMode returnMode,
+      final Method toolMethod,
+      final Object toolObject,
+      final Class<? extends Throwable> toolCallExceptionClass) {
+    super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
+  }
+
+  @Override
+  protected boolean isExchangeOrContextType(final Class<?> paramType) {
+    return McpTransportContext.class.isAssignableFrom(paramType)
+        || McpSyncRequestContext.class.isAssignableFrom(paramType);
+  }
+
+  @Override
+  public CallToolResult apply(
+      final McpTransportContext mcpTransportContext, final CallToolRequest callToolRequest) {
+    validateSyncRequest(callToolRequest);
+
+    try {
+      // Build arguments for the method call
+      final Object[] args =
+          buildMethodArguments(mcpTransportContext, callToolRequest.arguments(), callToolRequest);
+
+      // Invoke the method
+      final Object result = callMethod(args);
+
+      return processResult(result);
+    } catch (final Exception e) {
+      if (toolCallExceptionClass.isInstance(e)) {
+        return createSyncErrorResult(e);
+      }
+
+      throw e;
+    }
+  }
+
+  @Override
+  protected McpSyncRequestContext createRequestContext(
+      final McpTransportContext exchange, final CallToolRequest request) {
+    throw new UnsupportedOperationException(
+        "Stateless tool methods do not support McpSyncRequestContext parameter.");
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config.tool;
+
+import io.camunda.gateway.mcp.config.schema.CamundaJsonSchemaGenerator;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
+import io.modelcontextprotocol.util.Utils;
+import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.McpPredicates;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.method.tool.ReturnMode;
+import org.springaicommunity.mcp.method.tool.utils.ClassUtils;
+import org.springaicommunity.mcp.provider.tool.AbstractMcpToolProvider;
+import org.springaicommunity.mcp.provider.tool.SyncMcpToolProvider;
+import org.springframework.aop.support.AopUtils;
+
+/**
+ * Camunda-specific provider for synchronous stateless MCP tool methods.
+ *
+ * <p>This provider scans for {@link CamundaMcpTool} annotations (not Spring AI's {@link McpTool})
+ * and uses {@link CamundaJsonSchemaGenerator} for generating JSON schemas. This allows us to
+ * control tool registration independently without relying on Spring AI's autoconfig exclusions.
+ *
+ * <p>Original Spring AI implementation: {@link SyncMcpToolProvider}
+ */
+public class CamundaSyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CamundaSyncStatelessMcpToolProvider.class);
+
+  private final CamundaJsonSchemaGenerator jsonSchemaGenerator;
+
+  /**
+   * Create a new CamundaSyncStatelessMcpToolProvider.
+   *
+   * @param toolObjects the objects containing methods annotated with {@link CamundaMcpTool}
+   */
+  public CamundaSyncStatelessMcpToolProvider(
+      final List<Object> toolObjects, final CamundaJsonSchemaGenerator jsonSchemaGenerator) {
+    super(toolObjects);
+    this.jsonSchemaGenerator = jsonSchemaGenerator;
+  }
+
+  /**
+   * Get the stateless tool specifications using our custom schema generator.
+   *
+   * @return the list of stateless tool specifications
+   */
+  public List<SyncToolSpecification> getToolSpecifications() {
+    final List<SyncToolSpecification> toolSpecs =
+        toolObjects.stream()
+            .map(
+                toolObject ->
+                    Stream.of(doGetClassMethods(toolObject))
+                        .filter(method -> method.isAnnotationPresent(CamundaMcpTool.class))
+                        .filter(McpPredicates.filterReactiveReturnTypeMethod())
+                        .filter(McpPredicates.filterMethodWithBidirectionalParameters())
+                        .sorted(Comparator.comparing(Method::getName))
+                        .map(
+                            mcpToolMethod -> createSyncToolSpecification(toolObject, mcpToolMethod))
+                        .toList())
+            .flatMap(List::stream)
+            .toList();
+
+    if (toolSpecs.isEmpty()) {
+      LOGGER.warn("No tool methods found in the provided tool objects: {}", toolObjects);
+    }
+
+    return toolSpecs;
+  }
+
+  @Override
+  protected Method[] doGetClassMethods(final Object bean) {
+    // Unwrap CGLIB/JDK proxies to get the actual target class for annotation
+    // detection
+    final Class<?> targetClass =
+        AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass();
+
+    return targetClass.getDeclaredMethods();
+  }
+
+  private SyncToolSpecification createSyncToolSpecification(
+      final Object toolObject, final Method mcpToolMethod) {
+    final var toolAnnotation = mcpToolMethod.getAnnotation(CamundaMcpTool.class);
+
+    final String toolName =
+        Utils.hasText(toolAnnotation.name()) ? toolAnnotation.name() : mcpToolMethod.getName();
+    final String toolDescription = toolAnnotation.description();
+    String toolTitle = toolAnnotation.title();
+
+    final String inputSchema = jsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
+
+    final var toolBuilder =
+        McpSchema.Tool.builder()
+            .name(toolName)
+            .description(toolDescription)
+            .inputSchema(getJsonMapper(), inputSchema);
+
+    if (toolAnnotation.annotations() != null) {
+      final var toolAnnotations = toolAnnotation.annotations();
+      toolBuilder.annotations(
+          new ToolAnnotations(
+              toolAnnotations.title(),
+              toolAnnotations.readOnlyHint(),
+              toolAnnotations.destructiveHint(),
+              toolAnnotations.idempotentHint(),
+              toolAnnotations.openWorldHint(),
+              null));
+
+      if (!Utils.hasText(toolTitle)) {
+        toolTitle = toolAnnotations.title();
+      }
+    }
+
+    if (!Utils.hasText(toolTitle)) {
+      toolTitle = toolName;
+    }
+
+    toolBuilder.title(toolTitle);
+
+    // Generate Output Schema from the method return type.
+    final Class<?> methodReturnType = mcpToolMethod.getReturnType();
+    if (toolAnnotation.generateOutputSchema()
+        && methodReturnType != CallToolResult.class
+        && methodReturnType != Void.class
+        && methodReturnType != void.class
+        && !ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+        && !ClassUtils.isSimpleValueType(methodReturnType)) {
+
+      toolBuilder.outputSchema(
+          getJsonMapper(),
+          jsonSchemaGenerator.generateFromType(mcpToolMethod.getGenericReturnType()));
+    }
+
+    final var tool = toolBuilder.build();
+
+    final boolean useStructuredOutput = tool.outputSchema() != null;
+    final ReturnMode returnMode =
+        useStructuredOutput
+            ? ReturnMode.STRUCTURED
+            : methodReturnType == Void.TYPE ? ReturnMode.VOID : ReturnMode.TEXT;
+
+    final BiFunction<McpTransportContext, CallToolRequest, CallToolResult> methodCallback =
+        new CamundaSyncStatelessMcpToolMethodCallback(
+            returnMode, mcpToolMethod, toolObject, doGetToolCallException());
+
+    return SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/cluster/ClusterTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/cluster/ClusterTools.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mcp.tool.cluster;
 
 import io.camunda.gateway.mapping.http.ResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.TopologyServices;
@@ -28,7 +29,7 @@ public class ClusterTools {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.",
       annotations = @McpTool.McpAnnotations(readOnlyHint = true))
@@ -40,7 +41,7 @@ public class ClusterTools {
         Enum::name);
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Obtains the current topology of the cluster the gateway is part of.",
       annotations = @McpTool.McpAnnotations(readOnlyHint = true))
   public CallToolResult getTopology() {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/cluster/ClusterTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/cluster/ClusterTools.java
@@ -15,8 +15,10 @@ import io.camunda.service.TopologyServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import org.springaicommunity.mcp.annotation.McpTool;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 @Component
+@Validated
 public class ClusterTools {
 
   private final TopologyServices topologyServices;

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -17,6 +17,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.model.McpIncidentFilter;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
@@ -35,7 +36,6 @@ import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Component;
@@ -58,7 +58,7 @@ public class IncidentTools {
     this.jobServices = jobServices;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Search for incidents. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchIncidents(
@@ -85,7 +85,7 @@ public class IncidentTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Get incident by key. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getIncident(
@@ -105,7 +105,7 @@ public class IncidentTools {
     }
   }
 
-  @McpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
+  @CamundaMcpTool(description = "Resolve incident by key. " + EVENTUAL_CONSISTENCY_NOTE)
   public CallToolResult resolveIncident(
       @McpToolParam(description = "Key of the incident to resolve.")
           @Positive(message = INCIDENT_KEY_POSITIVE_MESSAGE)

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
@@ -16,6 +16,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.SORT_DESCRIPTION;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.model.McpProcessDefinitionFilter;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
@@ -27,7 +28,6 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Component;
@@ -47,7 +47,7 @@ public class ProcessDefinitionTools {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Search for process definitions. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchProcessDefinitions(
@@ -73,7 +73,7 @@ public class ProcessDefinitionTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Get process definition by key. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getProcessDefinition(
@@ -91,7 +91,7 @@ public class ProcessDefinitionTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Get the BPMN XML of a process definition by key. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getProcessDefinitionXml(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -18,6 +18,7 @@ import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.SimpleRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.model.McpProcessInstanceFilter;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
@@ -35,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Component;
@@ -58,7 +58,7 @@ public class ProcessInstanceTools {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Search for process instances. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult searchProcessInstances(
@@ -84,7 +84,7 @@ public class ProcessInstanceTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Get process instance by key. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getProcessInstance(
@@ -104,7 +104,7 @@ public class ProcessInstanceTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           """
           Create a new process instance of the given process definition. Either a processDefinitionKey or

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
@@ -20,6 +20,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_VALUE_RETURN
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
 import io.camunda.gateway.mcp.model.McpUserTaskAssignmentRequest;
@@ -33,7 +34,6 @@ import io.camunda.service.UserTaskServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Component;
@@ -53,7 +53,7 @@ public class UserTaskTools {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Search for user tasks. " + VARIABLE_FILTER_FORMAT_NOTE + " " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
@@ -81,7 +81,7 @@ public class UserTaskTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description = "Get user task by key. " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
   public CallToolResult getUserTask(
@@ -99,7 +99,7 @@ public class UserTaskTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Assign or unassign a user task. Provide an assignee to assign the task, or omit/provide null to unassign it.")
   public CallToolResult assignUserTask(
@@ -134,7 +134,7 @@ public class UserTaskTools {
   }
 
   private CallToolResult performAssignment(
-      final Long userTaskKey, UserTaskAssignmentRequest request) {
+      final Long userTaskKey, final UserTaskAssignmentRequest request) {
     final var mappedRequest = RequestMapper.toUserTaskAssignmentRequest(request, userTaskKey);
     if (mappedRequest.isLeft()) {
       return CallToolResultMapper.mapProblemToResult(mappedRequest.getLeft());
@@ -164,7 +164,7 @@ public class UserTaskTools {
         r -> "User task with key %s unassigned.".formatted(unassignRequest.userTaskKey()));
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Search user task variables based on given criteria. "
               + VARIABLE_VALUE_RETURN_FORMAT

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
@@ -17,6 +17,7 @@ import static io.camunda.gateway.mcp.tool.ToolDescriptions.VARIABLE_VALUE_RETURN
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.gateway.mcp.model.McpSearchQueryPageRequest;
 import io.camunda.gateway.mcp.model.McpVariableFilter;
@@ -26,7 +27,6 @@ import io.camunda.service.VariableServices;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
-import org.springaicommunity.mcp.annotation.McpTool;
 import org.springaicommunity.mcp.annotation.McpTool.McpAnnotations;
 import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.stereotype.Component;
@@ -46,7 +46,7 @@ public class VariableTools {
     this.authenticationProvider = authenticationProvider;
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Search for variables. " + VARIABLE_VALUE_RETURN_FORMAT + " " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))
@@ -77,7 +77,7 @@ public class VariableTools {
     }
   }
 
-  @McpTool(
+  @CamundaMcpTool(
       description =
           "Get variable by key. " + VARIABLE_VALUE_RETURN_FORMAT + " " + EVENTUAL_CONSISTENCY_NOTE,
       annotations = @McpAnnotations(readOnlyHint = true))

--- a/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,2 @@
 io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration
-io.camunda.gateway.mcp.config.CamundaMcpServerToolSpecificationsAutoConfiguration
+io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration

--- a/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration
+io.camunda.gateway.mcp.config.CamundaMcpServerToolSpecificationsAutoConfiguration

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
+import io.camunda.gateway.mcp.tool.incident.IncidentTools;
+import io.camunda.gateway.mcp.tool.process.definition.ProcessDefinitionTools;
+import io.camunda.gateway.mcp.tool.process.instance.ProcessInstanceTools;
+import io.camunda.gateway.mcp.tool.usertask.UserTaskTools;
+import io.camunda.gateway.mcp.tool.variable.VariableTools;
+import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
+import io.camunda.service.JobServices;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.TopologyServices;
+import io.camunda.service.UserTaskServices;
+import io.camunda.service.VariableServices;
+import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Regression test to ensure tool schemas remain stable across refactoring.
+ *
+ * <p>This test compares the current tool schema output against a stored snapshot to catch any
+ * unintended schema changes during migration (e.g., from @McpTool to @CamundaMcpTool).
+ *
+ * <p>To update the snapshot after intentional changes, manually update the file at:
+ * src/test/resources/schema/tools-schema-snapshot.json
+ */
+@ContextConfiguration(
+    classes = {
+      ClusterTools.class,
+      IncidentTools.class,
+      ProcessDefinitionTools.class,
+      ProcessInstanceTools.class,
+      UserTaskTools.class,
+      VariableTools.class
+    })
+class ToolsSchemaRegressionTest extends ToolsTest {
+
+  private static final String SNAPSHOT_PATH = "schema/tools-schema-snapshot.json";
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+  // Mock all services that tools depend on
+  @MockitoBean private TopologyServices topologyServices;
+  @MockitoBean private IncidentServices incidentServices;
+  @MockitoBean private JobServices<JobActivationResult> jobServices;
+  @MockitoBean private ProcessDefinitionServices processDefinitionServices;
+  @MockitoBean private ProcessInstanceServices processInstanceServices;
+  @MockitoBean private UserTaskServices userTaskServices;
+  @MockitoBean private VariableServices variableServices;
+  @MockitoBean private MultiTenancyConfiguration multiTenancyConfiguration;
+
+  @Test
+  void toolSchemasShouldMatchSnapshot() throws Exception {
+    // Get current tool schemas
+    final ListToolsResult toolsResult = mcpClient.listTools();
+
+    // Sort tools alphabetically for consistent comparison
+    final ObjectNode currentSchemas = OBJECT_MAPPER.createObjectNode();
+    final ArrayNode toolsArray = OBJECT_MAPPER.createArrayNode();
+
+    StreamSupport.stream(OBJECT_MAPPER.valueToTree(toolsResult).get("tools").spliterator(), false)
+        .map(ObjectNode.class::cast)
+        .sorted(Comparator.comparing(n -> n.get("name").asText()))
+        .forEach(toolsArray::add);
+
+    currentSchemas.set("tools", toolsArray);
+    final String currentJson = OBJECT_MAPPER.writeValueAsString(currentSchemas);
+
+    // Load expected snapshot
+    final String expectedJson = loadSnapshot();
+
+    // Compare with stored snapshot
+    JSONAssert.assertEquals(
+        "MCP tool schemas should match snapshot. "
+            + "If this is an intentional change, update the snapshot file at: "
+            + "src/test/resources/"
+            + SNAPSHOT_PATH,
+        expectedJson,
+        currentJson,
+        JSONCompareMode.STRICT);
+  }
+
+  private String loadSnapshot() throws IOException {
+    try (final InputStream is = getClass().getClassLoader().getResourceAsStream(SNAPSHOT_PATH)) {
+      if (is == null) {
+        throw new IllegalStateException(
+            "Snapshot file not found: "
+                + SNAPSHOT_PATH
+                + ". Create the snapshot file at src/test/resources/"
+                + SNAPSHOT_PATH);
+      }
+      // Sort the snapshot as well for consistent comparison
+      final ObjectNode snapshotNode = (ObjectNode) OBJECT_MAPPER.readTree(is);
+      final ObjectNode sortedSnapshot = OBJECT_MAPPER.createObjectNode();
+      final ArrayNode sortedTools = OBJECT_MAPPER.createArrayNode();
+
+      StreamSupport.stream(snapshotNode.get("tools").spliterator(), false)
+          .map(node -> (ObjectNode) node)
+          .sorted(Comparator.comparing(n -> n.get("name").asText()))
+          .forEach(sortedTools::add);
+
+      sortedSnapshot.set("tools", sortedTools);
+      return OBJECT_MAPPER.writeValueAsString(sortedSnapshot);
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/resources/application.yaml
+++ b/gateways/gateway-mcp/src/test/resources/application.yaml
@@ -16,3 +16,7 @@ spring:
           prompt: false
           resource: false
           tool: true
+
+camunda:
+  mcp:
+    enabled: true

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -10,11 +10,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -27,11 +23,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -52,11 +44,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -76,13 +64,7 @@
           "incidentKey"
         ]
       },
-      "annotations": {
-        "title": "",
-        "readOnlyHint": false,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
-      }
+      "annotations": {}
     },
     {
       "name": "searchIncidents",
@@ -224,11 +206,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -249,11 +227,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -274,11 +248,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -387,11 +357,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -439,13 +405,7 @@
         },
         "required": []
       },
-      "annotations": {
-        "title": "",
-        "readOnlyHint": false,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
-      }
+      "annotations": {}
     },
     {
       "name": "getProcessInstance",
@@ -465,11 +425,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -641,11 +597,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -683,13 +635,7 @@
           "userTaskKey"
         ]
       },
-      "annotations": {
-        "title": "",
-        "readOnlyHint": false,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
-      }
+      "annotations": {}
     },
     {
       "name": "getUserTask",
@@ -709,11 +655,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -803,11 +745,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -1037,11 +975,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -1061,11 +995,7 @@
         ]
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     },
     {
@@ -1168,11 +1098,7 @@
         "required": []
       },
       "annotations": {
-        "title": "",
-        "readOnlyHint": true,
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": true
+        "readOnlyHint": true
       }
     }
   ]

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -480,8 +480,9 @@
         "type": "object",
         "properties": {
           "filter": {
-            "$defs": {
-              "SimpleDateTimeFilterProperty": {
+            "type": "object",
+            "properties": {
+              "endDate": {
                 "type": "object",
                 "properties": {
                   "from": {
@@ -492,13 +493,7 @@
                     "type": "string",
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
-                }
-              }
-            },
-            "type": "object",
-            "properties": {
-              "endDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                },
                 "description": "The end date."
               },
               "hasIncident": {
@@ -527,7 +522,17 @@
                 "description": "The key of this process instance."
               },
               "startDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
                 "description": "The start date."
               },
               "state": {
@@ -813,8 +818,13 @@
         "type": "object",
         "properties": {
           "filter": {
-            "$defs": {
-              "SimpleDateTimeFilterProperty": {
+            "type": "object",
+            "properties": {
+              "assignee": {
+                "type": "string",
+                "description": "The assignee of the user task."
+              },
+              "completionDate": {
                 "type": "object",
                 "properties": {
                   "from": {
@@ -825,42 +835,35 @@
                     "type": "string",
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
-                }
-              },
-              "VariableValueFilterProperty": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Name of the variable."
-                  },
-                  "value": {
-                    "type": "string",
-                    "description": "The value of the variable."
-                  }
                 },
-                "required": [
-                  "name",
-                  "value"
-                ]
-              }
-            },
-            "type": "object",
-            "properties": {
-              "assignee": {
-                "type": "string",
-                "description": "The assignee of the user task."
-              },
-              "completionDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
                 "description": "The user task completion date."
               },
               "creationDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
                 "description": "The user task creation date."
               },
               "dueDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
                 "description": "The user task due date."
               },
               "elementId": {
@@ -872,13 +875,37 @@
                 "description": "The key of the element instance."
               },
               "followUpDate": {
-                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
                 "description": "The user task follow-up date."
               },
               "localVariables": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/$defs/VariableValueFilterProperty"
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the variable."
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The value of the variable."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ]
                 }
               },
               "name": {
@@ -905,7 +932,21 @@
               "processInstanceVariables": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/$defs/VariableValueFilterProperty"
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the variable."
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The value of the variable."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ]
                 }
               },
               "state": {

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -167,18 +167,18 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "INCIDENT_KEY",
-                    "PROCESS_DEFINITION_KEY",
-                    "PROCESS_DEFINITION_ID",
-                    "PROCESS_INSTANCE_KEY",
-                    "ERROR_TYPE",
-                    "ERROR_MESSAGE",
-                    "ELEMENT_ID",
-                    "ELEMENT_INSTANCE_KEY",
-                    "CREATION_TIME",
-                    "STATE",
-                    "JOB_KEY",
-                    "TENANT_ID"
+                    "incidentKey",
+                    "processDefinitionKey",
+                    "processDefinitionId",
+                    "processInstanceKey",
+                    "errorType",
+                    "errorMessage",
+                    "elementId",
+                    "elementInstanceKey",
+                    "creationTime",
+                    "state",
+                    "jobKey",
+                    "tenantId"
                   ],
                   "description": "The field to sort by."
                 },
@@ -335,13 +335,13 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "PROCESS_DEFINITION_KEY",
-                    "NAME",
-                    "RESOURCE_NAME",
-                    "VERSION",
-                    "VERSION_TAG",
-                    "PROCESS_DEFINITION_ID",
-                    "TENANT_ID"
+                    "processDefinitionKey",
+                    "name",
+                    "resourceName",
+                    "version",
+                    "versionTag",
+                    "processDefinitionId",
+                    "tenantId"
                   ],
                   "description": "The field to sort by."
                 },
@@ -583,19 +583,19 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "PROCESS_INSTANCE_KEY",
-                    "PROCESS_DEFINITION_ID",
-                    "PROCESS_DEFINITION_NAME",
-                    "PROCESS_DEFINITION_VERSION",
-                    "PROCESS_DEFINITION_VERSION_TAG",
-                    "PROCESS_DEFINITION_KEY",
-                    "PARENT_PROCESS_INSTANCE_KEY",
-                    "PARENT_ELEMENT_INSTANCE_KEY",
-                    "START_DATE",
-                    "END_DATE",
-                    "STATE",
-                    "HAS_INCIDENT",
-                    "TENANT_ID"
+                    "processInstanceKey",
+                    "processDefinitionId",
+                    "processDefinitionName",
+                    "processDefinitionVersion",
+                    "processDefinitionVersionTag",
+                    "processDefinitionKey",
+                    "parentProcessInstanceKey",
+                    "parentElementInstanceKey",
+                    "startDate",
+                    "endDate",
+                    "state",
+                    "hasIncident",
+                    "tenantId"
                   ],
                   "description": "The field to sort by."
                 },
@@ -746,12 +746,12 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "VALUE",
-                    "NAME",
-                    "TENANT_ID",
-                    "VARIABLE_KEY",
-                    "SCOPE_KEY",
-                    "PROCESS_INSTANCE_KEY"
+                    "value",
+                    "name",
+                    "tenantId",
+                    "variableKey",
+                    "scopeKey",
+                    "processInstanceKey"
                   ],
                   "description": "The field to sort by."
                 },
@@ -986,12 +986,12 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "CREATION_DATE",
-                    "COMPLETION_DATE",
-                    "FOLLOW_UP_DATE",
-                    "DUE_DATE",
-                    "PRIORITY",
-                    "NAME"
+                    "creationDate",
+                    "completionDate",
+                    "followUpDate",
+                    "dueDate",
+                    "priority",
+                    "name"
                   ],
                   "description": "The field to sort by."
                 },
@@ -1113,12 +1113,12 @@
                 "field": {
                   "type": "string",
                   "enum": [
-                    "VALUE",
-                    "NAME",
-                    "TENANT_ID",
-                    "VARIABLE_KEY",
-                    "SCOPE_KEY",
-                    "PROCESS_INSTANCE_KEY"
+                    "value",
+                    "name",
+                    "tenantId",
+                    "variableKey",
+                    "scopeKey",
+                    "processInstanceKey"
                   ],
                   "description": "The field to sort by."
                 },

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -1,0 +1,1138 @@
+{
+  "tools": [
+    {
+      "name": "getClusterStatus",
+      "title": "getClusterStatus",
+      "description": "Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getTopology",
+      "title": "getTopology",
+      "description": "Obtains the current topology of the cluster the gateway is part of.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getIncident",
+      "title": "getIncident",
+      "description": "Get incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "incidentKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The assigned key of the incident, which acts as a unique identifier for this incident."
+          }
+        },
+        "required": [
+          "incidentKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "resolveIncident",
+      "title": "resolveIncident",
+      "description": "Resolve incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "incidentKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Key of the incident to resolve."
+          }
+        },
+        "required": [
+          "incidentKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchIncidents",
+      "title": "searchIncidents",
+      "description": "Search for incidents. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "object",
+            "properties": {
+              "creationTime": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                },
+                "description": "Date of incident creation."
+              },
+              "elementId": {
+                "type": "string",
+                "description": "The element ID associated to this incident."
+              },
+              "errorType": {
+                "type": "string",
+                "enum": [
+                  "AD_HOC_SUB_PROCESS_NO_RETRIES",
+                  "CALLED_DECISION_ERROR",
+                  "CALLED_ELEMENT_ERROR",
+                  "CONDITION_ERROR",
+                  "DECISION_EVALUATION_ERROR",
+                  "EXECUTION_LISTENER_NO_RETRIES",
+                  "EXTRACT_VALUE_ERROR",
+                  "FORM_NOT_FOUND",
+                  "IO_MAPPING_ERROR",
+                  "JOB_NO_RETRIES",
+                  "MESSAGE_SIZE_EXCEEDED",
+                  "RESOURCE_NOT_FOUND",
+                  "TASK_LISTENER_NO_RETRIES",
+                  "UNHANDLED_ERROR_EVENT",
+                  "UNKNOWN",
+                  "UNSPECIFIED"
+                ],
+                "description": "Incident error type with a defined set of values."
+              },
+              "processDefinitionId": {
+                "type": "string",
+                "description": "The process definition ID associated to this incident."
+              },
+              "processDefinitionKey": {
+                "type": "string",
+                "description": "The process definition key associated to this incident."
+              },
+              "processInstanceKey": {
+                "type": "string",
+                "description": "The process instance key associated to this incident."
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "ACTIVE",
+                  "MIGRATED",
+                  "PENDING",
+                  "RESOLVED"
+                ],
+                "description": "State of this incident with a defined set of values."
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "INCIDENT_KEY",
+                    "PROCESS_DEFINITION_KEY",
+                    "PROCESS_DEFINITION_ID",
+                    "PROCESS_INSTANCE_KEY",
+                    "ERROR_TYPE",
+                    "ERROR_MESSAGE",
+                    "ELEMENT_ID",
+                    "ELEMENT_INSTANCE_KEY",
+                    "CREATION_TIME",
+                    "STATE",
+                    "JOB_KEY",
+                    "TENANT_ID"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getProcessDefinition",
+      "title": "getProcessDefinition",
+      "description": "Get process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "processDefinitionKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The assigned key of the process definition, which acts as a unique identifier for this process definition."
+          }
+        },
+        "required": [
+          "processDefinitionKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getProcessDefinitionXml",
+      "title": "getProcessDefinitionXml",
+      "description": "Get the BPMN XML of a process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "processDefinitionKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The assigned key of the process definition, which acts as a unique identifier for this process definition."
+          }
+        },
+        "required": [
+          "processDefinitionKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchProcessDefinitions",
+      "title": "searchProcessDefinitions",
+      "description": "Search for process definitions. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "object",
+            "properties": {
+              "hasStartForm": {
+                "type": "boolean",
+                "description": "Indicates whether the start event of the process has an associated Form Key."
+              },
+              "isLatestVersion": {
+                "type": "boolean",
+                "description": "Whether to only return the latest version of each process definition. When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`. The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`. "
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of this process definition."
+              },
+              "processDefinitionId": {
+                "type": "string",
+                "description": "Process definition ID of this process definition."
+              },
+              "processDefinitionKey": {
+                "type": "string",
+                "description": "The key for this process definition."
+              },
+              "resourceName": {
+                "type": "string",
+                "description": "Resource name of this process definition."
+              },
+              "version": {
+                "type": "integer",
+                "format": "int32",
+                "description": "Version of this process definition."
+              },
+              "versionTag": {
+                "type": "string",
+                "description": "Version tag of this process definition."
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "PROCESS_DEFINITION_KEY",
+                    "NAME",
+                    "RESOURCE_NAME",
+                    "VERSION",
+                    "VERSION_TAG",
+                    "PROCESS_DEFINITION_ID",
+                    "TENANT_ID"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "createProcessInstance",
+      "title": "createProcessInstance",
+      "description": "Create a new process instance of the given process definition. Either a processDefinitionKey or\na processDefinitionId (with an optional processDefinitionVersion) need to be passed.\n\nWhen using the awaitCompletion flag, the tool will wait for the process instance to complete\nand return its result variables. When using awaitCompletion, always include a unique tag\n`mcp-tool:<uniqueId>` which can be used to search for the started process instance in case\nof timeouts.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "processDefinitionKey": {
+            "type": "string",
+            "description": "The assigned key of the process definition, which acts as a unique identifier for this process definition."
+          },
+          "processDefinitionId": {
+            "type": "string",
+            "description": "The BPMN process id of the process definition to start an instance of."
+          },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The version of the process. By default, the latest version of the process is used. Can only be used in combination with processDefinitionId."
+          },
+          "variables": {
+            "type": "object",
+            "description": "Set of variables to instantiate in the root variable scope of the process instance. Can include nested/complex objects. Which variables to set depends on the process definition."
+          },
+          "awaitCompletion": {
+            "type": "boolean",
+            "description": "Wait for the process instance to complete. If the process instance does not complete within request timeout limits, the waiting will time out and the tool will return a 504 response status. Use the unique tag you added to query process instance status. Disabled by default."
+          },
+          "fetchVariables": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of variables by name to be included in the response when awaitCompletion is set to true. If empty, all visible variables in the root scope will be returned."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of tags to apply to the process instance. Tags must start with a letter, followed by letters, digits, or the special characters `_`, `-`, `:`, or `.`; length ≤ 100."
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getProcessInstance",
+      "title": "getProcessInstance",
+      "description": "Get process instance by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "processInstanceKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The assigned key of the process instance, which acts as a unique identifier for this process instance."
+          }
+        },
+        "required": [
+          "processInstanceKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchProcessInstances",
+      "title": "searchProcessInstances",
+      "description": "Search for process instances. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "$defs": {
+              "SimpleDateTimeFilterProperty": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                }
+              }
+            },
+            "type": "object",
+            "properties": {
+              "endDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The end date."
+              },
+              "hasIncident": {
+                "type": "boolean",
+                "description": "Whether this process instance has a related incident or not."
+              },
+              "processDefinitionId": {
+                "type": "string",
+                "description": "The process definition id."
+              },
+              "processDefinitionKey": {
+                "type": "string",
+                "description": "The process definition key."
+              },
+              "processDefinitionName": {
+                "type": "string",
+                "description": "The process definition name."
+              },
+              "processDefinitionVersion": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The process definition version."
+              },
+              "processInstanceKey": {
+                "type": "string",
+                "description": "The key of this process instance."
+              },
+              "startDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The start date."
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "ACTIVE",
+                  "COMPLETED",
+                  "TERMINATED"
+                ],
+                "description": "The process instance state."
+              },
+              "tags": {
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "variables": {
+                "description": "The process instance variables.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the variable."
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The value of the variable."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "value"
+                  ]
+                }
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "PROCESS_INSTANCE_KEY",
+                    "PROCESS_DEFINITION_ID",
+                    "PROCESS_DEFINITION_NAME",
+                    "PROCESS_DEFINITION_VERSION",
+                    "PROCESS_DEFINITION_VERSION_TAG",
+                    "PROCESS_DEFINITION_KEY",
+                    "PARENT_PROCESS_INSTANCE_KEY",
+                    "PARENT_ELEMENT_INSTANCE_KEY",
+                    "START_DATE",
+                    "END_DATE",
+                    "STATE",
+                    "HAS_INCIDENT",
+                    "TENANT_ID"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "assignUserTask",
+      "title": "assignUserTask",
+      "description": "Assign or unassign a user task. Provide an assignee to assign the task, or omit/provide null to unassign it.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userTaskKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The user task key."
+          },
+          "assignee": {
+            "type": "string",
+            "description": "The assignee for the user task. Provide a value to assign the task to that user, or omit/provide null to unassign the task."
+          },
+          "assignmentOptions": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to \"assign\". "
+              },
+              "allowOverride": {
+                "type": "boolean",
+                "description": "By default, the task is reassigned if it was already assigned. Set this to `false` to return an error in such cases. The task must then first be unassigned to be assigned again. Use this when you have users picking from group task queues to prevent race conditions. "
+              }
+            },
+            "description": "Assignment options."
+          }
+        },
+        "required": [
+          "userTaskKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getUserTask",
+      "title": "getUserTask",
+      "description": "Get user task by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userTaskKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The user task key."
+          }
+        },
+        "required": [
+          "userTaskKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchUserTaskVariables",
+      "title": "searchUserTaskVariables",
+      "description": "Search user task variables based on given criteria. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userTaskKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The user task key."
+          },
+          "filter": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the variable."
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "VALUE",
+                    "NAME",
+                    "TENANT_ID",
+                    "VARIABLE_KEY",
+                    "SCOPE_KEY",
+                    "PROCESS_INSTANCE_KEY"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          },
+          "truncateValues": {
+            "type": "boolean",
+            "description": "When true (default), long variable values in the response are truncated. When false, full variable values are returned."
+          }
+        },
+        "required": [
+          "userTaskKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchUserTasks",
+      "title": "searchUserTasks",
+      "description": "Search for user tasks. Variable values in filters need to be in serialized JSON format. Example string value: `\\\"myValue\\\"`. Example nested JSON value: `{\\\"myVar\\\":\\\"myValue\\\"}`. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "$defs": {
+              "SimpleDateTimeFilterProperty": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string",
+                    "description": "Filter from this time (inclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
+                  }
+                }
+              },
+              "VariableValueFilterProperty": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the variable."
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value of the variable."
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "type": "object",
+            "properties": {
+              "assignee": {
+                "type": "string",
+                "description": "The assignee of the user task."
+              },
+              "completionDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The user task completion date."
+              },
+              "creationDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The user task creation date."
+              },
+              "dueDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The user task due date."
+              },
+              "elementId": {
+                "type": "string",
+                "description": "The element ID of the user task."
+              },
+              "elementInstanceKey": {
+                "type": "string",
+                "description": "The key of the element instance."
+              },
+              "followUpDate": {
+                "$ref": "#/$defs/SimpleDateTimeFilterProperty",
+                "description": "The user task follow-up date."
+              },
+              "localVariables": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/VariableValueFilterProperty"
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "The task name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found. "
+              },
+              "priority": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The priority of the user task."
+              },
+              "processDefinitionId": {
+                "type": "string",
+                "description": "The ID of the process definition."
+              },
+              "processDefinitionKey": {
+                "type": "string",
+                "description": "The key of the process definition."
+              },
+              "processInstanceKey": {
+                "type": "string",
+                "description": "The key of the process instance."
+              },
+              "processInstanceVariables": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/VariableValueFilterProperty"
+                }
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "CREATING",
+                  "CREATED",
+                  "ASSIGNING",
+                  "UPDATING",
+                  "COMPLETING",
+                  "COMPLETED",
+                  "CANCELING",
+                  "CANCELED",
+                  "FAILED"
+                ],
+                "description": "The user task state."
+              },
+              "tags": {
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "userTaskKey": {
+                "type": "string",
+                "description": "The key for this user task."
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "CREATION_DATE",
+                    "COMPLETION_DATE",
+                    "FOLLOW_UP_DATE",
+                    "DUE_DATE",
+                    "PRIORITY",
+                    "NAME"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "getVariable",
+      "title": "getVariable",
+      "description": "Get variable by key. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "variableKey": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "variableKey"
+        ]
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "searchVariables",
+      "title": "searchVariables",
+      "description": "Search for variables. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "object",
+            "properties": {
+              "isTruncated": {
+                "type": "boolean",
+                "description": "Whether the value is truncated or not."
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the variable."
+              },
+              "processInstanceKey": {
+                "type": "string",
+                "description": "The key of the process instance of this variable."
+              },
+              "scopeKey": {
+                "type": "string",
+                "description": "The key of the scope of this variable."
+              },
+              "value": {
+                "type": "string",
+                "description": "Variable values in filters need to be in serialized JSON format. Example string value: `\\\"myValue\\\"`. Example nested JSON value: `{\\\"myVar\\\":\\\"myValue\\\"}`."
+              },
+              "variableKey": {
+                "type": "string",
+                "description": "The key for this variable."
+              }
+            },
+            "description": "Filter search by the given fields"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string",
+                  "enum": [
+                    "VALUE",
+                    "NAME",
+                    "TENANT_ID",
+                    "VARIABLE_KEY",
+                    "SCOPE_KEY",
+                    "PROCESS_INSTANCE_KEY"
+                  ],
+                  "description": "The field to sort by."
+                },
+                "order": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
+              },
+              "required": [
+                "field"
+              ]
+            },
+            "description": "Sort criteria"
+          },
+          "page": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string",
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
+              },
+              "before": {
+                "type": "string",
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
+              },
+              "from": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The index of items to start searching from."
+              },
+              "limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The maximum number of items to return in one request."
+              }
+            },
+            "description": "Pagination criteria"
+          },
+          "truncateValues": {
+            "type": "boolean",
+            "description": "When true (default), long variable values in the response are truncated. When false, full variable values are returned."
+          }
+        },
+        "required": []
+      },
+      "annotations": {
+        "title": "",
+        "readOnlyHint": true,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      }
+    }
+  ]
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,6 +111,7 @@
     <version.spring-ai>1.1.2</version.spring-ai>
     <version.spring-ai-community.mcp-annotations>0.8.0</version.spring-ai-community.mcp-annotations>
     <version.mcp-sdk>0.17.2</version.mcp-sdk>
+    <version.jsonschema-generator>4.38.0</version.jsonschema-generator>
     <version.tomcat>10.1.50</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
@@ -1076,6 +1077,22 @@
         <version>${version.mcp-sdk}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.victools</groupId>
+        <artifactId>jsonschema-generator</artifactId>
+        <version>${version.jsonschema-generator}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.victools</groupId>
+        <artifactId>jsonschema-module-jackson</artifactId>
+        <version>${version.jsonschema-generator}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.victools</groupId>
+        <artifactId>jsonschema-module-swagger-2</artifactId>
+        <version>${version.jsonschema-generator}</version>
       </dependency>
 
       <dependency>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -84,6 +84,7 @@
           </ignoredUnusedDeclaredDependencies>
           <ignoredUsedUndeclaredDependencies>
             <dep>io.camunda:zeebe-gateway-rest</dep>
+            <dep>io.camunda:camunda-gateway-mcp</dep>
             <dep>io.camunda:camunda-client-java</dep>
             <dep>io.camunda:camunda-service</dep>
             <dep>io.camunda:zeebe-protocol</dep>
@@ -96,6 +97,7 @@
             <dep>org.springframework:spring-web</dep>
             <dep>org.opensearch.client:opensearch-java</dep>
             <dep>com.fasterxml.jackson.core:jackson-databind</dep>
+            <dep>org.springaicommunity:mcp-annotations</dep>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/qa/archunit-tests/src/test/java/io/camunda/gateway/mcp/McpToolsAnnotationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/gateway/mcp/McpToolsAnnotationArchTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.gateway.mcp.tool.ToolDescriptions;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * ArchUnit tests to ensure consistent annotation patterns for MCP tool classes.
+ *
+ * <p>These rules verify that all *Tools classes in subpackages of io.camunda.gateway.mcp.tool:
+ *
+ * <ul>
+ *   <li>Are Spring beans (annotated with @Component)
+ *   <li>Enable parameter validation (annotated with @Validated)
+ *   <li>Use @CamundaMcpTool annotation on public methods, not @McpTool
+ * </ul>
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.gateway.mcp.tool",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class McpToolsAnnotationArchTest {
+
+  /**
+   * Tool classes must be Spring components to be auto-discovered and registered as MCP tools.
+   *
+   * <p>Excludes ToolDescriptions which is a utility class with constants only.
+   */
+  @ArchTest
+  public static final ArchRule RULE_TOOLS_SHOULD_BE_COMPONENTS =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAnyPackage("io.camunda.gateway.mcp.tool..")
+          .and()
+          .haveSimpleNameEndingWith("Tools")
+          .and()
+          .areNotAssignableFrom(ToolDescriptions.class)
+          .should()
+          .beAnnotatedWith(Component.class)
+          .because("MCP tool classes must be Spring components for auto-discovery");
+
+  /**
+   * Tool classes must be annotated with @Validated to enable bean validation on method parameters.
+   *
+   * <p>Excludes ToolDescriptions which is a utility class with constants only.
+   */
+  @ArchTest
+  public static final ArchRule RULE_TOOLS_SHOULD_BE_VALIDATED =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAnyPackage("io.camunda.gateway.mcp.tool..")
+          .and()
+          .haveSimpleNameEndingWith("Tools")
+          .and()
+          .areNotAssignableFrom(ToolDescriptions.class)
+          .should()
+          .beAnnotatedWith(Validated.class)
+          .because("MCP tool classes must enable parameter validation with @Validated");
+
+  /**
+   * Public methods in tool classes should use @CamundaMcpTool annotation instead of @McpTool.
+   *
+   * <p>We use @CamundaMcpTool for consistent schema generation and output handling control.
+   */
+  @ArchTest
+  public static final ArchRule RULE_METHODS_SHOULD_USE_CAMUNDA_MCP_TOOL =
+      ArchRuleDefinition.methods()
+          .that()
+          .areDeclaredInClassesThat()
+          .resideInAnyPackage("io.camunda.gateway.mcp.tool..")
+          .and()
+          .areDeclaredInClassesThat()
+          .haveSimpleNameEndingWith("Tools")
+          .and()
+          .arePublic()
+          .should()
+          .beAnnotatedWith(CamundaMcpTool.class)
+          .andShould()
+          .notBeAnnotatedWith(McpTool.class)
+          .because("MCP tools should use @CamundaMcpTool for consistent schema generation");
+}


### PR DESCRIPTION
## Description

Creates a dedicated tool discovery flow using a custom `@CamundaMcpTool` annotation. This allows us to control how JSON schemas for MCP tools are generated (e.g. no `$defs`). In addition, having a custom MCP tool method callbacks allows us to interfere with request parsing and error handling in a follow up (e.g. using a DTO to wrap params).

This is purely opt-in by using `@CamundaMcpTool` instead of `@McpTool` (where the default logic is still used). I chose this over overriding the core `@McpTool` detection as it would involve excluding certain autoconfigurations to be able to override those parts which led to a pretty brittle setup. An ArchUnit test ensures that our tools are annotated with the custom annotation.

Some changes like the custom tool callback not strictly needed for this change, but already prepared for the follow-up https://github.com/camunda/camunda/pull/45222

---

This pull request introduces a new mechanism for discovering, registering, and generating JSON schemas for MCP (Model Context Protocol) tools in the `gateway-mcp` module. It adds custom annotations and auto-configuration classes to enable flexible tool registration and schema generation, and updates project dependencies to support these new features.

The most important changes are:

**Spring MCP Tool Registration & Discovery:**
* Added the `CamundaMcpTool` annotation in `io.camunda.gateway.mcp.config.tool` to mark methods as MCP tools, providing customizability for schema generation and output handling.
* Introduced `CamundaMcpToolScannerAutoConfiguration` to scan and register beans annotated with `CamundaMcpTool`, including supporting registry and bean post-processor classes.
* Added `CamundaMcpServerToolSpecificationsAutoConfiguration` to generate MCP tool specifications from discovered beans, integrating with the Spring context.

**JSON Schema Generation:**
* Implemented `CamundaJsonSchemaGenerator`, a non-static, cache-enabled class for generating JSON schemas for tool method inputs and types, with support for inlining definitions and customizing required properties.

**Dependency and Build Configuration:**
* Updated `pom.xml` to add required Spring Boot, Spring AI, Jackson, Swagger, and JSON schema generator dependencies, and reorganized existing dependencies for clarity and correct grouping.
* Adjusted test dependencies in `pom.xml` to include `mockito-core` and `jsonassert`, and reordered `assertj-core` and `mockito-core` for consistency.

These changes lay the foundation for a robust, extensible MCP tool infrastructure in the gateway, enabling future expansion and integration with Spring and AI toolkits.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44926 
