### PR TITLE
feat: raft multi engine forwards compatibility

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -142,8 +142,8 @@ public class Cluster implements Cloneable {
    */
   @NestedConfigurationProperty private Partitioning partitioning = new Partitioning();
 
-  private boolean legacySenderSubjectsDisabled;
-  private boolean legacyReceiverSubjectsDisabled;
+  private boolean sendOnLegacySubject = true;
+  private boolean receiveOnLegacySubject = true;
 
   public NodeIdProvider getNodeIdProvider() {
     return nodeIdProvider;
@@ -300,20 +300,20 @@ public class Cluster implements Cloneable {
     this.partitioning = partitioning;
   }
 
-  public boolean isLegacyReceiverSubjectsDisabled() {
-    return legacyReceiverSubjectsDisabled;
+  public boolean isReceiveOnLegacySubject() {
+    return receiveOnLegacySubject;
   }
 
-  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
-    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
+  public void setReceiveOnLegacySubject(final boolean receiveOnLegacySubject) {
+    this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
-  public boolean isLegacySenderSubjectsDisabled() {
-    return legacySenderSubjectsDisabled;
+  public boolean isSendOnLegacySubject() {
+    return sendOnLegacySubject;
   }
 
-  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
-    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
+  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
+    this.sendOnLegacySubject = sendOnLegacySubject;
   }
 
   @Override
@@ -355,6 +355,10 @@ public class Cluster implements Cloneable {
         + compressionAlgorithm
         + ", globalListeners="
         + globalListeners
+        + ", sendOnLegacySubject="
+        + sendOnLegacySubject
+        + ", receiveOnLegacySubject="
+        + receiveOnLegacySubject
         + '}';
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -142,6 +142,9 @@ public class Cluster implements Cloneable {
    */
   @NestedConfigurationProperty private Partitioning partitioning = new Partitioning();
 
+  private boolean legacySenderSubjectsDisabled;
+  private boolean legacyReceiverSubjectsDisabled;
+
   public NodeIdProvider getNodeIdProvider() {
     return nodeIdProvider;
   }
@@ -295,6 +298,22 @@ public class Cluster implements Cloneable {
 
   public void setPartitioning(final Partitioning partitioning) {
     this.partitioning = partitioning;
+  }
+
+  public boolean isLegacyReceiverSubjectsDisabled() {
+    return legacyReceiverSubjectsDisabled;
+  }
+
+  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
+    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
+  }
+
+  public boolean isLegacySenderSubjectsDisabled() {
+    return legacySenderSubjectsDisabled;
+  }
+
+  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
+    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -424,6 +424,13 @@ public class BrokerBasedPropertiesOverride {
     populateFromGlobalListeners(override);
 
     populateFromPartitioning(override);
+
+    override
+        .getExperimental()
+        .setLegacySenderSubjectsDisabled(cluster.isLegacySenderSubjectsDisabled());
+    override
+        .getExperimental()
+        .setLegacyReceiverSubjectsDisabled(cluster.isLegacyReceiverSubjectsDisabled());
   }
 
   private void populateFromPartitioning(final BrokerBasedProperties override) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -425,12 +425,8 @@ public class BrokerBasedPropertiesOverride {
 
     populateFromPartitioning(override);
 
-    override
-        .getExperimental()
-        .setLegacySenderSubjectsDisabled(cluster.isLegacySenderSubjectsDisabled());
-    override
-        .getExperimental()
-        .setLegacyReceiverSubjectsDisabled(cluster.isLegacyReceiverSubjectsDisabled());
+    override.getExperimental().setSendOnLegacySubject(cluster.isSendOnLegacySubject());
+    override.getExperimental().setReceiveOnLegacySubject(cluster.isReceiveOnLegacySubject());
   }
 
   private void populateFromPartitioning(final BrokerBasedProperties override) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 
 /** Abstract partition. */
 public final class RaftPartition implements Partition, HealthMonitorable {
+  public static final String PARTITION_NAME_FORMAT = "%s-partition-%d";
   private static final Logger LOG = LoggerFactory.getLogger(RaftPartition.class);
-  private static final String PARTITION_NAME_FORMAT = "%s-partition-%d";
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "RaftPartition-%d";
 
   private final PartitionId partitionId;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -30,6 +30,8 @@ public class RaftPartitionConfig {
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
+  private static final String DEFAULT_ENGINE_NAME = "default";
+  private static final boolean DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED = false;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -45,6 +47,8 @@ public class RaftPartitionConfig {
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout;
   private int snapshotChunkSize;
+  private String engineName = DEFAULT_ENGINE_NAME;
+  private boolean legacyRaftServerReceiverDisabled = DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED;
 
   /**
    * Returns the Raft leader election timeout.
@@ -209,6 +213,22 @@ public class RaftPartitionConfig {
     this.entryValidator = entryValidator;
   }
 
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(final String engineName) {
+    this.engineName = engineName;
+  }
+
+  public boolean isLegacyRaftServerReceiverDisabled() {
+    return legacyRaftServerReceiverDisabled;
+  }
+
+  public void setLegacyRaftServerReceiverDisabled(final boolean legacyRaftServerReceiverDisabled) {
+    this.legacyRaftServerReceiverDisabled = legacyRaftServerReceiverDisabled;
+  }
+
   @Override
   public String toString() {
     return "RaftPartitionConfig{"
@@ -236,6 +256,11 @@ public class RaftPartitionConfig {
         + maxQuorumResponseTimeout
         + ", preferSnapshotReplicationThreshold="
         + preferSnapshotReplicationThreshold
+        + minStepDownFailureCount
+        + ", engineName="
+        + engineName
+        + ", legacyRaftServerReceiverDisabled="
+        + legacyRaftServerReceiverDisabled
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -31,8 +31,8 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final String DEFAULT_ENGINE_NAME = "default";
-  private static final boolean DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED = false;
-  private static final boolean DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED = false;
+  private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
+  private static final boolean DEFAULT_SEND_ON_LEGACY_SUBJECT = true;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -49,8 +49,8 @@ public class RaftPartitionConfig {
   private Duration configurationChangeTimeout;
   private int snapshotChunkSize;
   private String engineName = DEFAULT_ENGINE_NAME;
-  private boolean legacyReceiverSubjectsDisabled = DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED;
-  private boolean legacySenderSubjectsDisabled = DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED;
+  private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
+  private boolean sendOnLegacySubject = DEFAULT_SEND_ON_LEGACY_SUBJECT;
 
   /**
    * Returns the Raft leader election timeout.
@@ -223,20 +223,20 @@ public class RaftPartitionConfig {
     this.engineName = engineName;
   }
 
-  public boolean isLegacyReceiverSubjectsDisabled() {
-    return legacyReceiverSubjectsDisabled;
+  public boolean isReceiveOnLegacySubject() {
+    return receiveOnLegacySubject;
   }
 
-  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
-    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
+  public void setReceiveOnLegacySubject(final boolean receiveOnLegacySubject) {
+    this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
-  public boolean isLegacySenderSubjectsDisabled() {
-    return legacySenderSubjectsDisabled;
+  public boolean isSendOnLegacySubject() {
+    return sendOnLegacySubject;
   }
 
-  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
-    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
+  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
+    this.sendOnLegacySubject = sendOnLegacySubject;
   }
 
   @Override
@@ -268,10 +268,10 @@ public class RaftPartitionConfig {
         + preferSnapshotReplicationThreshold
         + ", engineName="
         + engineName
-        + ", legacyReceiverSubjectsDisabled="
-        + legacyReceiverSubjectsDisabled
-        + ", legacySenderSubjectsDisabled="
-        + legacySenderSubjectsDisabled
+        + ", receiveOnLegacySubject="
+        + receiveOnLegacySubject
+        + ", sendOnLegacySubject="
+        + sendOnLegacySubject
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -32,6 +32,7 @@ public class RaftPartitionConfig {
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final String DEFAULT_ENGINE_NAME = "default";
   private static final boolean DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED = false;
+  private static final boolean DEFAULT_LEGACY_RAFT_SERVER_SENDER_DISABLED = false;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -49,6 +50,7 @@ public class RaftPartitionConfig {
   private int snapshotChunkSize;
   private String engineName = DEFAULT_ENGINE_NAME;
   private boolean legacyRaftServerReceiverDisabled = DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED;
+  private boolean legacyRaftServerSenderDisabled = DEFAULT_LEGACY_RAFT_SERVER_SENDER_DISABLED;
 
   /**
    * Returns the Raft leader election timeout.
@@ -229,6 +231,14 @@ public class RaftPartitionConfig {
     this.legacyRaftServerReceiverDisabled = legacyRaftServerReceiverDisabled;
   }
 
+  public boolean isLegacyRaftServerSenderDisabled() {
+    return legacyRaftServerSenderDisabled;
+  }
+
+  public void setLegacyRaftServerSenderDisabled(final boolean legacyRaftServerSenderDisabled) {
+    this.legacyRaftServerSenderDisabled = legacyRaftServerSenderDisabled;
+  }
+
   @Override
   public String toString() {
     return "RaftPartitionConfig{"
@@ -261,6 +271,8 @@ public class RaftPartitionConfig {
         + engineName
         + ", legacyRaftServerReceiverDisabled="
         + legacyRaftServerReceiverDisabled
+        + ", enableLegacyRaftServerSender="
+        + legacyRaftServerSenderDisabled
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -31,8 +31,8 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final String DEFAULT_ENGINE_NAME = "default";
-  private static final boolean DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED = false;
-  private static final boolean DEFAULT_LEGACY_RAFT_SERVER_SENDER_DISABLED = false;
+  private static final boolean DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED = false;
+  private static final boolean DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED = false;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -49,8 +49,8 @@ public class RaftPartitionConfig {
   private Duration configurationChangeTimeout;
   private int snapshotChunkSize;
   private String engineName = DEFAULT_ENGINE_NAME;
-  private boolean legacyRaftServerReceiverDisabled = DEFAULT_LEGACY_RAFT_SERVER_RECEIVER_DISABLED;
-  private boolean legacyRaftServerSenderDisabled = DEFAULT_LEGACY_RAFT_SERVER_SENDER_DISABLED;
+  private boolean legacyReceiverSubjectsDisabled = DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED;
+  private boolean legacySenderSubjectsDisabled = DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED;
 
   /**
    * Returns the Raft leader election timeout.
@@ -223,20 +223,20 @@ public class RaftPartitionConfig {
     this.engineName = engineName;
   }
 
-  public boolean isLegacyRaftServerReceiverDisabled() {
-    return legacyRaftServerReceiverDisabled;
+  public boolean isLegacyReceiverSubjectsDisabled() {
+    return legacyReceiverSubjectsDisabled;
   }
 
-  public void setLegacyRaftServerReceiverDisabled(final boolean legacyRaftServerReceiverDisabled) {
-    this.legacyRaftServerReceiverDisabled = legacyRaftServerReceiverDisabled;
+  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
+    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
   }
 
-  public boolean isLegacyRaftServerSenderDisabled() {
-    return legacyRaftServerSenderDisabled;
+  public boolean isLegacySenderSubjectsDisabled() {
+    return legacySenderSubjectsDisabled;
   }
 
-  public void setLegacyRaftServerSenderDisabled(final boolean legacyRaftServerSenderDisabled) {
-    this.legacyRaftServerSenderDisabled = legacyRaftServerSenderDisabled;
+  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
+    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
   }
 
   @Override
@@ -269,10 +269,10 @@ public class RaftPartitionConfig {
         + minStepDownFailureCount
         + ", engineName="
         + engineName
-        + ", legacyRaftServerReceiverDisabled="
-        + legacyRaftServerReceiverDisabled
-        + ", enableLegacyRaftServerSender="
-        + legacyRaftServerSenderDisabled
+        + ", legacyReceiverSubjectsDisabled="
+        + legacyReceiverSubjectsDisabled
+        + ", legacySenderSubjectsDisabled="
+        + legacySenderSubjectsDisabled
         + '}';
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -266,7 +266,6 @@ public class RaftPartitionConfig {
         + maxQuorumResponseTimeout
         + ", preferSnapshotReplicationThreshold="
         + preferSnapshotReplicationThreshold
-        + minStepDownFailureCount
         + ", engineName="
         + engineName
         + ", legacyReceiverSubjectsDisabled="

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -61,11 +61,11 @@ class RaftMessageContext {
     leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 
-  String getAppendV1subject() {
+  String getAppendV1Subject() {
     return appendV1subject;
   }
 
-  String getAppendV2subject() {
+  String getAppendV2Subject() {
     return appendV2subject;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -61,6 +61,50 @@ class RaftMessageContext {
     leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 
+  String getAppendV1subject() {
+    return appendV1subject;
+  }
+
+  String getAppendV2subject() {
+    return appendV2subject;
+  }
+
+  String getConfigureSubject() {
+    return configureSubject;
+  }
+
+  String getForceConfigureSubject() {
+    return forceConfigureSubject;
+  }
+
+  String getInstallSubject() {
+    return installSubject;
+  }
+
+  String getJoinSubject() {
+    return joinSubject;
+  }
+
+  String getLeaveSubject() {
+    return leaveSubject;
+  }
+
+  String getPollSubject() {
+    return pollSubject;
+  }
+
+  String getReconfigureSubject() {
+    return reconfigureSubject;
+  }
+
+  String getVoteSubject() {
+    return voteSubject;
+  }
+
+  String getTransferSubject() {
+    return transferSubject;
+  }
+
   private static String getSubject(final String prefix, final String type) {
     if (prefix == null) {
       return type;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -320,9 +320,15 @@ public class RaftPartitionServer implements HealthMonitorable {
   private RaftServerCommunicator createServerProtocol() {
     final var legacySubjects = createLegacySubjects();
     final var engineSubjects = createEngineSubjects();
+
+    final var receivingSubjects =
+        config.isLegacyRaftServerReceiverDisabled()
+            ? List.of(engineSubjects)
+            : List.of(legacySubjects, engineSubjects);
+
     return new RaftServerCommunicator(
         legacySubjects,
-        List.of(legacySubjects, engineSubjects),
+        receivingSubjects,
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
         requestTimeout,
@@ -336,7 +342,8 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftMessageContext createEngineSubjects() {
-    final var enginePrefix = PARTITION_NAME_FORMAT.formatted("default", partition.id().id());
+    final var engineName = config.getEngineName();
+    final var enginePrefix = PARTITION_NAME_FORMAT.formatted(engineName, partition.id().id());
     return new RaftMessageContext(enginePrefix);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -322,10 +322,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     final var engineSubjects = createEngineSubjects();
 
     final var sendingSubject =
-        config.isLegacyRaftServerSenderDisabled() ? engineSubjects : legacySubjects;
+        config.isLegacySenderSubjectsDisabled() ? engineSubjects : legacySubjects;
 
     final var receivingSubjects =
-        config.isLegacyRaftServerReceiverDisabled()
+        config.isLegacyReceiverSubjectsDisabled()
             ? List.of(engineSubjects)
             : List.of(legacySubjects, engineSubjects);
 
@@ -345,8 +345,7 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftMessageContext createEngineSubjects() {
-    final var engineName = config.getEngineName();
-    final var enginePrefix = PARTITION_NAME_FORMAT.formatted(engineName, partition.id().id());
+    final var enginePrefix = getPartitionNameWithEnginePrefix();
     return new RaftMessageContext(enginePrefix);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -321,13 +321,16 @@ public class RaftPartitionServer implements HealthMonitorable {
     final var legacySubjects = createLegacySubjects();
     final var engineSubjects = createEngineSubjects();
 
+    final var sendingSubject =
+        config.isLegacyRaftServerSenderDisabled() ? engineSubjects : legacySubjects;
+
     final var receivingSubjects =
         config.isLegacyRaftServerReceiverDisabled()
             ? List.of(engineSubjects)
             : List.of(legacySubjects, engineSubjects);
 
     return new RaftServerCommunicator(
-        legacySubjects,
+        sendingSubject,
         receivingSubjects,
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
@@ -361,5 +364,11 @@ public class RaftPartitionServer implements HealthMonitorable {
 
   public CompletableFuture<SegmentInfo> getTailSegments(final long index) {
     return server.getContext().getTailSegments(index);
+  }
+
+  private String getPartitionNameWithEnginePrefix() {
+    final var engineName = config.getEngineName();
+    final var partitionId = partition.id().id();
+    return PARTITION_NAME_FORMAT.formatted(engineName, partitionId);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -16,6 +16,8 @@
  */
 package io.atomix.raft.partition.impl;
 
+import static io.atomix.raft.partition.RaftPartition.PARTITION_NAME_FORMAT;
+
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
@@ -29,6 +31,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.SnapshotReplicationListener;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.metrics.RaftRequestMetrics;
 import io.atomix.raft.metrics.RaftStartupMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartition;
@@ -50,6 +53,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -314,14 +318,26 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftServerCommunicator createServerProtocol() {
+    final var legacySubjects = createLegacySubjects();
+    final var engineSubjects = createEngineSubjects();
     return new RaftServerCommunicator(
-        partition.name(),
+        legacySubjects,
+        List.of(legacySubjects, engineSubjects),
         Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
         clusterCommunicator,
         requestTimeout,
         snapshotRequestTimeout,
         configurationChangeTimeout,
-        meterRegistry);
+        new RaftRequestMetrics(partition.name(), meterRegistry));
+  }
+
+  private RaftMessageContext createLegacySubjects() {
+    return new RaftMessageContext(partition.name());
+  }
+
+  private RaftMessageContext createEngineSubjects() {
+    final var enginePrefix = PARTITION_NAME_FORMAT.formatted("default", partition.id().id());
+    return new RaftMessageContext(enginePrefix);
   }
 
   public CompletableFuture<Void> stepDown() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -322,13 +322,12 @@ public class RaftPartitionServer implements HealthMonitorable {
     final var legacySubjects = createLegacySubjects();
     final var engineSubjects = createEngineSubjects();
 
-    final var sendingSubject =
-        config.isLegacySenderSubjectsDisabled() ? engineSubjects : legacySubjects;
+    final var sendingSubject = config.isSendOnLegacySubject() ? legacySubjects : engineSubjects;
 
     final var receivingSubjects =
-        config.isLegacyReceiverSubjectsDisabled()
-            ? List.of(engineSubjects)
-            : List.of(legacySubjects, engineSubjects);
+        config.isReceiveOnLegacySubject()
+            ? List.of(legacySubjects, engineSubjects)
+            : List.of(engineSubjects);
 
     return new RaftServerCommunicator(
         sendingSubject,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -369,5 +370,10 @@ public class RaftPartitionServer implements HealthMonitorable {
     final var engineName = config.getEngineName();
     final var partitionId = partition.id().id();
     return PARTITION_NAME_FORMAT.formatted(engineName, partitionId);
+  }
+
+  @VisibleForTesting
+  public RaftServer getServer() {
+    return server;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -251,19 +251,19 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void registerAppendV1Handler(
       final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
-    registerHandler(RaftMessageContext::getAppendV1subject, handler);
+    registerHandler(RaftMessageContext::getAppendV1Subject, handler);
   }
 
   @Override
   public void registerAppendV2Handler(
       final Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> handler) {
-    registerHandler(RaftMessageContext::getAppendV2subject, handler);
+    registerHandler(RaftMessageContext::getAppendV2Subject, handler);
   }
 
   @Override
   public void unregisterAppendHandler() {
-    unregisterHandler(RaftMessageContext::getAppendV1subject);
-    unregisterHandler(RaftMessageContext::getAppendV2subject);
+    unregisterHandler(RaftMessageContext::getAppendV1Subject);
+    unregisterHandler(RaftMessageContext::getAppendV2Subject);
   }
 
   private <M extends RaftRequest, R extends RaftResponse> void registerHandler(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -86,67 +86,69 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public CompletableFuture<ConfigureResponse> configure(
       final MemberId memberId, final ConfigureRequest request) {
-    return sendAndReceive(sendingSubject.configureSubject, request, memberId);
+    return sendAndReceive(sendingSubject.getConfigureSubject(), request, memberId);
   }
 
   @Override
   public CompletableFuture<ReconfigureResponse> reconfigure(
       final MemberId memberId, final ReconfigureRequest request) {
     return sendAndReceive(
-        sendingSubject.reconfigureSubject, request, memberId, configurationChangeTimeout);
+        sendingSubject.getReconfigureSubject(), request, memberId, configurationChangeTimeout);
   }
 
   @Override
   public CompletableFuture<ForceConfigureResponse> forceConfigure(
       final MemberId memberId, final ForceConfigureRequest request) {
-    return sendAndReceive(sendingSubject.forceConfigureSubject, request, memberId, requestTimeout);
+    return sendAndReceive(
+        sendingSubject.getForceConfigureSubject(), request, memberId, requestTimeout);
   }
 
   @Override
   public CompletableFuture<JoinResponse> join(final MemberId memberId, final JoinRequest request) {
     return sendAndReceive(
-        sendingSubject.joinSubject, request, memberId, configurationChangeTimeout);
+        sendingSubject.getJoinSubject(), request, memberId, configurationChangeTimeout);
   }
 
   @Override
   public CompletableFuture<LeaveResponse> leave(
       final MemberId memberId, final LeaveRequest request) {
     return sendAndReceive(
-        sendingSubject.leaveSubject, request, memberId, configurationChangeTimeout);
+        sendingSubject.getLeaveSubject(), request, memberId, configurationChangeTimeout);
   }
 
   @Override
   public CompletableFuture<InstallResponse> install(
       final MemberId memberId, final InstallRequest request) {
-    return sendAndReceive(sendingSubject.installSubject, request, memberId, snapshotRequestTimeout);
+    return sendAndReceive(
+        sendingSubject.getInstallSubject(), request, memberId, snapshotRequestTimeout);
   }
 
   @Override
   public CompletableFuture<TransferResponse> transfer(
       final MemberId memberId, final TransferRequest request) {
-    return sendAndReceive(sendingSubject.transferSubject, request, memberId);
+    return sendAndReceive(sendingSubject.getTransferSubject(), request, memberId);
   }
 
   @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
-    return sendAndReceive(sendingSubject.pollSubject, request, memberId);
+    return sendAndReceive(sendingSubject.getPollSubject(), request, memberId);
   }
 
   @Override
   public CompletableFuture<VoteResponse> vote(final MemberId memberId, final VoteRequest request) {
-    return sendAndReceive(sendingSubject.voteSubject, request, memberId);
+    return sendAndReceive(sendingSubject.getVoteSubject(), request, memberId);
   }
 
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final AppendRequest request) {
-    return sendAndReceive(sendingSubject.appendV1subject, request, memberId);
+    return sendAndReceive(sendingSubject.getAppendV1Subject(), request, memberId);
   }
 
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final VersionedAppendRequest request) {
-    return sendAndReceive(sendingSubject.appendV2subject, request, memberId);
+    return sendAndReceive(sendingSubject.getAppendV2Subject(), request, memberId);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.partition;
+
+import static io.atomix.raft.partition.RaftPartition.PARTITION_NAME_FORMAT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RaftServerReceiverSubjectsTest {
+
+  private static final String PARTITION_GROUP = "group";
+  private static final MemberId MEMBER_ID = new MemberId("0");
+  private static final PartitionId PARTITION_ID = new PartitionId(PARTITION_GROUP, 1);
+  private static final PartitionMetadata METADATA =
+      new PartitionMetadata(PARTITION_ID, Set.of(), Map.of(), 1, MEMBER_ID);
+
+  @Mock private ClusterMembershipService clusterMembershipService;
+  @AutoClose private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  @Mock private ClusterCommunicationService clusterCommunicationService;
+  @Mock private ReceivableSnapshotStore receivableSnapshotStore;
+
+  private RaftPartitionServer createRaftPartitionServer(
+      final RaftPartitionConfig raftPartitionConfig, final Path tempDir) {
+    final var raftPartition =
+        new RaftPartition(METADATA, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    return new RaftPartitionServer(
+        raftPartition,
+        raftPartitionConfig,
+        MEMBER_ID,
+        clusterMembershipService,
+        clusterCommunicationService,
+        receivableSnapshotStore,
+        METADATA,
+        meterRegistry);
+  }
+
+  private RaftPartitionConfig createRaftPartitionConfig(final boolean disableLegacyReceiver) {
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    final var raftStorageConfig = new RaftStorageConfig();
+
+    raftPartitionConfig.setLegacyReceiverSubjectsDisabled(disableLegacyReceiver);
+    raftPartitionConfig.setStorageConfig(raftStorageConfig);
+
+    return raftPartitionConfig;
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldRegisterSubjects(final boolean disableLegacyReceiver, @TempDir final Path tempDir) {
+    // given
+    final var config = createRaftPartitionConfig(disableLegacyReceiver);
+
+    // when
+    createRaftPartitionServer(config, tempDir);
+
+    // then
+    assertLegacySubjectsRegistered(disableLegacyReceiver);
+    assertEngineAwareSubjectsRegistered(config.getEngineName());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void shouldUnregisterSubjects(final boolean disableLegacyReceiver, @TempDir final Path tempDir) {
+    // given
+    final var config = createRaftPartitionConfig(disableLegacyReceiver);
+    final var server = createRaftPartitionServer(config, tempDir);
+
+    // when
+    server.stop().join();
+
+    // then
+    assertLegacySubjectsUnregistered(disableLegacyReceiver);
+    assertEngineAwareSubjectsUnregistered(config.getEngineName());
+  }
+
+  void assertLegacySubjectsRegistered(final boolean isLegacyReceiverDisabled) {
+    assertSubjectsRegistered(PARTITION_GROUP, isLegacyReceiverDisabled ? 0 : 1);
+  }
+
+  void assertEngineAwareSubjectsRegistered(final String engineName) {
+    assertSubjectsRegistered(engineName, 1);
+  }
+
+  void assertSubjectsRegistered(final String prefix, final int expected) {
+    final var subjectPrefix = PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.id()) + "-%s";
+    final var expectedNumberOfInvocations = expected > 0 ? times(expected) : never();
+
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("append")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("append-versioned")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("configure")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("force-configure")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("install")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("join")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("leave")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("poll")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("reconfigure")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("vote")), any(), any(), any());
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .replyTo(eq(subjectPrefix.formatted("transfer")), any(), any(), any());
+  }
+
+  void assertLegacySubjectsUnregistered(final boolean isLegacyReceiverDisabled) {
+    assertSubjectsUnregistered(PARTITION_GROUP, isLegacyReceiverDisabled ? 0 : 1);
+  }
+
+  void assertEngineAwareSubjectsUnregistered(final String engineName) {
+    assertSubjectsUnregistered(engineName, 1);
+  }
+
+  void assertSubjectsUnregistered(final String prefix, final int expected) {
+    final var partitionName = PARTITION_NAME_FORMAT.formatted(prefix, PARTITION_ID.id()) + "-%s";
+    final var expectedNumberOfInvocations = expected > 0 ? times(expected) : never();
+
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("append")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("append-versioned")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("configure")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("force-configure")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("install")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("join")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("leave")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("poll")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("reconfigure")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("vote")));
+    verify(clusterCommunicationService, expectedNumberOfInvocations)
+        .unsubscribe(eq(partitionName.formatted("transfer")));
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
@@ -69,7 +69,7 @@ public class RaftServerReceiverSubjectsTest {
   @MethodSource("provideConfigurations")
   void shouldRegisterSubjects(final RaftPartitionConfig config, @TempDir final Path tempDir) {
     // given
-    final var legacyReceiverSubjectsDisabled = config.isLegacyReceiverSubjectsDisabled();
+    final var legacyReceiverSubjectsDisabled = config.isReceiveOnLegacySubject();
     final var engineName = config.getEngineName();
 
     // when
@@ -85,19 +85,19 @@ public class RaftServerReceiverSubjectsTest {
   void shouldUnregisterSubjects(final RaftPartitionConfig config, @TempDir final Path tempDir) {
     // given
     final var server = createRaftPartitionServer(config, tempDir);
-    final var legacyReceiverSubjectsDisabled = config.isLegacyReceiverSubjectsDisabled();
+    final var receiveOnLegacySubject = config.isReceiveOnLegacySubject();
     final var engineName = config.getEngineName();
 
     // when
     server.stop().join();
 
     // then
-    assertLegacySubjectsUnregistered(legacyReceiverSubjectsDisabled);
+    assertLegacySubjectsUnregistered(receiveOnLegacySubject);
     assertEngineAwareSubjectsUnregistered(engineName);
   }
 
-  void assertLegacySubjectsRegistered(final boolean isLegacyReceiverDisabled) {
-    assertSubjectsRegistered(PARTITION_GROUP, isLegacyReceiverDisabled ? 0 : 1);
+  void assertLegacySubjectsRegistered(final boolean receiveOnLegacySubject) {
+    assertSubjectsRegistered(PARTITION_GROUP, receiveOnLegacySubject ? 1 : 0);
   }
 
   void assertEngineAwareSubjectsRegistered(final String engineName) {
@@ -132,8 +132,8 @@ public class RaftServerReceiverSubjectsTest {
         .replyTo(eq(subjectPrefix.formatted("transfer")), any(), any(), any());
   }
 
-  void assertLegacySubjectsUnregistered(final boolean isLegacyReceiverDisabled) {
-    assertSubjectsUnregistered(PARTITION_GROUP, isLegacyReceiverDisabled ? 0 : 1);
+  void assertLegacySubjectsUnregistered(final boolean receiveOnLegacySubject) {
+    assertSubjectsUnregistered(PARTITION_GROUP, receiveOnLegacySubject ? 1 : 0);
   }
 
   void assertEngineAwareSubjectsUnregistered(final String engineName) {
@@ -171,9 +171,9 @@ public class RaftServerReceiverSubjectsTest {
   static Stream<Arguments> provideConfigurations() {
     return Stream.of(
         Arguments.of(createDefaultConfig()),
-        Arguments.of(createRaftWithDisabledLegacyReceiverSubjects()),
+        Arguments.of(createConfigAndDisableReceiveOnLegacySubject()),
         Arguments.of(createConfigWithEngineName()),
-        Arguments.of(createConfigWithEngineNameAndDisabledLegacyReceiverSubjects()));
+        Arguments.of(createConfigWithEngineNameAndDisableReceiveOnLegacySubject()));
   }
 
   static RaftPartitionConfig createDefaultConfig() {
@@ -183,10 +183,10 @@ public class RaftServerReceiverSubjectsTest {
     return raftPartitionConfig;
   }
 
-  static RaftPartitionConfig createRaftWithDisabledLegacyReceiverSubjects() {
+  static RaftPartitionConfig createConfigAndDisableReceiveOnLegacySubject() {
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var raftStorageConfig = new RaftStorageConfig();
-    raftPartitionConfig.setLegacyReceiverSubjectsDisabled(true);
+    raftPartitionConfig.setReceiveOnLegacySubject(false);
     raftPartitionConfig.setStorageConfig(raftStorageConfig);
     return raftPartitionConfig;
   }
@@ -199,11 +199,11 @@ public class RaftServerReceiverSubjectsTest {
     return raftPartitionConfig;
   }
 
-  static RaftPartitionConfig createConfigWithEngineNameAndDisabledLegacyReceiverSubjects() {
+  static RaftPartitionConfig createConfigWithEngineNameAndDisableReceiveOnLegacySubject() {
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var raftStorageConfig = new RaftStorageConfig();
     raftPartitionConfig.setEngineName("foo");
-    raftPartitionConfig.setLegacyReceiverSubjectsDisabled(true);
+    raftPartitionConfig.setReceiveOnLegacySubject(false);
     raftPartitionConfig.setStorageConfig(raftStorageConfig);
     return raftPartitionConfig;
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
@@ -92,8 +92,8 @@ public class RaftServerSenderSubjectsTest {
   }
 
   @ParameterizedTest
-  @MethodSource("provideTestClusters")
-  void shouldRegisterSubjects(
+  @MethodSource("provideScenarios")
+  void shouldCallWithCorrectSubject(
       final boolean disableLegacySender,
       final String subjectSuffix,
       final Consumer<RaftServerProtocol> applier,
@@ -116,8 +116,7 @@ public class RaftServerSenderSubjectsTest {
         .send(eq(subject), any(), any(), any(), any(), any());
   }
 
-  static Stream<Arguments> provideTestClusters() {
-
+  static Stream<Arguments> provideScenarios() {
     return Stream.of(
         Arguments.of(false, "append", applyAppendRequestV1()),
         Arguments.of(false, "append-versioned", applyAppendRequestV2()),

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.partition;
+
+import static io.atomix.raft.partition.RaftPartition.PARTITION_NAME_FORMAT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.atomix.raft.primitive.TestMember;
+import io.atomix.raft.protocol.AppendRequest;
+import io.atomix.raft.protocol.ConfigureRequest;
+import io.atomix.raft.protocol.ForceConfigureRequest;
+import io.atomix.raft.protocol.InstallRequest;
+import io.atomix.raft.protocol.JoinRequest;
+import io.atomix.raft.protocol.LeaveRequest;
+import io.atomix.raft.protocol.PollRequest;
+import io.atomix.raft.protocol.RaftServerProtocol;
+import io.atomix.raft.protocol.ReconfigureRequest;
+import io.atomix.raft.protocol.TransferRequest;
+import io.atomix.raft.protocol.VersionedAppendRequest;
+import io.atomix.raft.protocol.VoteRequest;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RaftServerSenderSubjectsTest {
+
+  private static final String PARTITION_GROUP = "group";
+  private static final MemberId MEMBER_ID = new MemberId("0");
+  private static final PartitionId PARTITION_ID = new PartitionId(PARTITION_GROUP, 1);
+  private static final PartitionMetadata METADATA =
+      new PartitionMetadata(PARTITION_ID, Set.of(), Map.of(), 1, MEMBER_ID);
+
+  @Mock private ClusterMembershipService clusterMembershipService;
+  @AutoClose private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  @Mock private ClusterCommunicationService clusterCommunicationService;
+  @Mock private ReceivableSnapshotStore receivableSnapshotStore;
+
+  private RaftPartitionServer createRaftPartitionServer(
+      final RaftPartitionConfig raftPartitionConfig, final Path tempDir) {
+    final var raftPartition =
+        new RaftPartition(METADATA, raftPartitionConfig, tempDir.toFile(), meterRegistry);
+    return new RaftPartitionServer(
+        raftPartition,
+        raftPartitionConfig,
+        MEMBER_ID,
+        clusterMembershipService,
+        clusterCommunicationService,
+        receivableSnapshotStore,
+        METADATA,
+        meterRegistry);
+  }
+
+  private RaftPartitionConfig createRaftPartitionConfig(final boolean disableLegacySender) {
+    final var raftPartitionConfig = new RaftPartitionConfig();
+    final var raftStorageConfig = new RaftStorageConfig();
+
+    raftPartitionConfig.setLegacySenderSubjectsDisabled(disableLegacySender);
+    raftPartitionConfig.setStorageConfig(raftStorageConfig);
+
+    return raftPartitionConfig;
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestClusters")
+  void shouldRegisterSubjects(
+      final boolean disableLegacySender,
+      final String subjectSuffix,
+      final Consumer<RaftServerProtocol> applier,
+      @TempDir final Path tempDir) {
+    // given
+    final var config = createRaftPartitionConfig(disableLegacySender);
+    final var server = createRaftPartitionServer(config, tempDir);
+    final var protocol = server.getServer().getContext().getProtocol();
+
+    final var prefixSubject =
+        PARTITION_NAME_FORMAT.formatted(
+            !disableLegacySender ? PARTITION_GROUP : config.getEngineName(), 1);
+    final var subject = "%s-%s".formatted(prefixSubject, subjectSuffix);
+
+    // when
+    applier.accept(protocol);
+
+    // then
+    verify(clusterCommunicationService, times(1))
+        .send(eq(subject), any(), any(), any(), any(), any());
+  }
+
+  static Stream<Arguments> provideTestClusters() {
+
+    return Stream.of(
+        Arguments.of(false, "append", applyAppendRequestV1()),
+        Arguments.of(false, "append-versioned", applyAppendRequestV2()),
+        Arguments.of(false, "configure", configureRequest()),
+        Arguments.of(false, "force-configure", forceConfigureRequest()),
+        Arguments.of(false, "install", installRequest()),
+        Arguments.of(false, "join", joinRequest()),
+        Arguments.of(false, "leave", leaveRequest()),
+        Arguments.of(false, "poll", pollRequest()),
+        Arguments.of(false, "reconfigure", reconfigureRequest()),
+        Arguments.of(false, "vote", voteRequest()),
+        Arguments.of(false, "transfer", transferRequest()),
+        Arguments.of(true, "append", applyAppendRequestV1()),
+        Arguments.of(true, "append-versioned", applyAppendRequestV2()),
+        Arguments.of(true, "configure", configureRequest()),
+        Arguments.of(true, "force-configure", forceConfigureRequest()),
+        Arguments.of(true, "install", installRequest()),
+        Arguments.of(true, "join", joinRequest()),
+        Arguments.of(true, "leave", leaveRequest()),
+        Arguments.of(true, "poll", pollRequest()),
+        Arguments.of(true, "reconfigure", reconfigureRequest()),
+        Arguments.of(true, "vote", voteRequest()),
+        Arguments.of(true, "transfer", transferRequest()));
+  }
+
+  static Consumer<RaftServerProtocol> applyAppendRequestV1() {
+    return p -> p.append(MEMBER_ID, new AppendRequest(2, "a", 0, 0, List.of(), 1));
+  }
+
+  static Consumer<RaftServerProtocol> applyAppendRequestV2() {
+    return p -> p.append(MEMBER_ID, new VersionedAppendRequest(2, 1, "a", 0, 0, List.of(), 1));
+  }
+
+  static Consumer<RaftServerProtocol> configureRequest() {
+    return p ->
+        p.configure(
+            MEMBER_ID,
+            new ConfigureRequest(1, "b", 0, 0, Collections.emptyList(), Collections.emptyList()));
+  }
+
+  static Consumer<RaftServerProtocol> forceConfigureRequest() {
+    return p ->
+        p.forceConfigure(
+            MEMBER_ID, new ForceConfigureRequest(1, 0, 0, Collections.emptySet(), "a"));
+  }
+
+  static Consumer<RaftServerProtocol> installRequest() {
+    return p ->
+        p.install(
+            MEMBER_ID, new InstallRequest(1, MEMBER_ID, 0, 0, 0, null, null, null, true, false));
+  }
+
+  static Consumer<RaftServerProtocol> joinRequest() {
+    return p ->
+        p.join(
+            MEMBER_ID,
+            JoinRequest.builder()
+                .withJoiningMember(new TestMember(MEMBER_ID, Type.ACTIVE))
+                .build());
+  }
+
+  static Consumer<RaftServerProtocol> leaveRequest() {
+    return p ->
+        p.leave(
+            MEMBER_ID,
+            LeaveRequest.builder()
+                .withLeavingMember(new TestMember(MEMBER_ID, Type.ACTIVE))
+                .build());
+  }
+
+  static Consumer<RaftServerProtocol> pollRequest() {
+    return p -> p.poll(MEMBER_ID, new PollRequest(0, "a", 0, 0));
+  }
+
+  static Consumer<RaftServerProtocol> reconfigureRequest() {
+    return p ->
+        p.reconfigure(MEMBER_ID, new ReconfigureRequest(Collections.emptyList(), 0, 0, "b"));
+  }
+
+  static Consumer<RaftServerProtocol> voteRequest() {
+    return p -> p.vote(MEMBER_ID, new VoteRequest(0, "b", 0, 0));
+  }
+
+  static Consumer<RaftServerProtocol> transferRequest() {
+    return p -> p.transfer(MEMBER_ID, TransferRequest.builder().withMember(MEMBER_ID).build());
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -114,6 +114,12 @@ public final class RaftPartitionFactory {
     partitionConfig.setPreferSnapshotReplicationThreshold(
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
 
+    partitionConfig.setEngineName(brokerCfg.getExperimental().getDefaultEngineName());
+    partitionConfig.setLegacySenderSubjectsDisabled(
+        brokerCfg.getExperimental().isLegacySenderSubjectsDisabled());
+    partitionConfig.setLegacyReceiverSubjectsDisabled(
+        brokerCfg.getExperimental().isLegacyReceiverSubjectsDisabled());
+
     return new RaftPartition(
         partitionMetadata, partitionConfig, partitionDirectory.toFile(), partitionMeterRegistry);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -115,10 +115,9 @@ public final class RaftPartitionFactory {
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
 
     partitionConfig.setEngineName(brokerCfg.getExperimental().getDefaultEngineName());
-    partitionConfig.setLegacySenderSubjectsDisabled(
-        brokerCfg.getExperimental().isLegacySenderSubjectsDisabled());
-    partitionConfig.setLegacyReceiverSubjectsDisabled(
-        brokerCfg.getExperimental().isLegacyReceiverSubjectsDisabled());
+    partitionConfig.setSendOnLegacySubject(brokerCfg.getExperimental().isSendOnLegacySubject());
+    partitionConfig.setReceiveOnLegacySubject(
+        brokerCfg.getExperimental().isReceiveOnLegacySubject());
 
     return new RaftPartition(
         partitionMetadata, partitionConfig, partitionDirectory.toFile(), partitionMeterRegistry);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -25,7 +25,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
   private static final boolean DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED = false;
   private static final boolean DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED = false;
-  private static final String DEFAULT_DEFAULT_ENGINE_NAME = "default";
+  private static final String DEFAULT_ENGINE_NAME = "default";
 
   private boolean continuousBackups = false;
 
@@ -40,7 +40,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
   private boolean legacySenderSubjectsDisabled = DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED;
   private boolean legacyReceiverSubjectsDisabled = DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED;
-  private String defaultEngineName = DEFAULT_DEFAULT_ENGINE_NAME;
+  private String defaultEngineName = DEFAULT_ENGINE_NAME;
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private ExperimentalRaftCfg raft = new ExperimentalRaftCfg();
   private PartitioningCfg partitioning = new PartitioningCfg();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -23,6 +23,9 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
   public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
+  private static final boolean DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED = false;
+  private static final boolean DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED = false;
+  private static final String DEFAULT_DEFAULT_ENGINE_NAME = "default";
 
   private boolean continuousBackups = false;
 
@@ -35,6 +38,9 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
+  private boolean legacySenderSubjectsDisabled = DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED;
+  private boolean legacyReceiverSubjectsDisabled = DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED;
+  private String defaultEngineName = DEFAULT_DEFAULT_ENGINE_NAME;
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private ExperimentalRaftCfg raft = new ExperimentalRaftCfg();
   private PartitioningCfg partitioning = new PartitioningCfg();
@@ -161,6 +167,30 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.features = features;
   }
 
+  public boolean isLegacySenderSubjectsDisabled() {
+    return legacySenderSubjectsDisabled;
+  }
+
+  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
+    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
+  }
+
+  public boolean isLegacyReceiverSubjectsDisabled() {
+    return legacyReceiverSubjectsDisabled;
+  }
+
+  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
+    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
+  }
+
+  public String getDefaultEngineName() {
+    return defaultEngineName;
+  }
+
+  public void setDefaultEngineName(final String defaultEngineName) {
+    this.defaultEngineName = defaultEngineName;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -182,6 +212,12 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + engine
         + ", features="
         + features
+        + ", legacySenderSubjectsDisabled="
+        + legacySenderSubjectsDisabled
+        + ", legacyReceiverSubjectsDisabled="
+        + legacyReceiverSubjectsDisabled
+        + ", defaultEngineName="
+        + defaultEngineName
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -23,8 +23,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
   public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
-  private static final boolean DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED = false;
-  private static final boolean DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED = false;
+  private static final boolean DEFAULT_SEND_ON_LEGACY_SUBJECT = true;
+  private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
   private static final String DEFAULT_ENGINE_NAME = "default";
 
   private boolean continuousBackups = false;
@@ -38,8 +38,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
-  private boolean legacySenderSubjectsDisabled = DEFAULT_LEGACY_SENDER_SUBJECTS_DISABLED;
-  private boolean legacyReceiverSubjectsDisabled = DEFAULT_LEGACY_RECEIVER_SUBJECTS_DISABLED;
+  private boolean sendOnLegacySubject = DEFAULT_SEND_ON_LEGACY_SUBJECT;
+  private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
   private String defaultEngineName = DEFAULT_ENGINE_NAME;
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private ExperimentalRaftCfg raft = new ExperimentalRaftCfg();
@@ -167,20 +167,20 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.features = features;
   }
 
-  public boolean isLegacySenderSubjectsDisabled() {
-    return legacySenderSubjectsDisabled;
+  public boolean isSendOnLegacySubject() {
+    return sendOnLegacySubject;
   }
 
-  public void setLegacySenderSubjectsDisabled(final boolean legacySenderSubjectsDisabled) {
-    this.legacySenderSubjectsDisabled = legacySenderSubjectsDisabled;
+  public void setSendOnLegacySubject(final boolean sendOnLegacySubject) {
+    this.sendOnLegacySubject = sendOnLegacySubject;
   }
 
-  public boolean isLegacyReceiverSubjectsDisabled() {
-    return legacyReceiverSubjectsDisabled;
+  public boolean isReceiveOnLegacySubject() {
+    return receiveOnLegacySubject;
   }
 
-  public void setLegacyReceiverSubjectsDisabled(final boolean legacyReceiverSubjectsDisabled) {
-    this.legacyReceiverSubjectsDisabled = legacyReceiverSubjectsDisabled;
+  public void setReceiveOnLegacySubject(final boolean receiveOnLegacySubject) {
+    this.receiveOnLegacySubject = receiveOnLegacySubject;
   }
 
   public String getDefaultEngineName() {
@@ -212,10 +212,10 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + engine
         + ", features="
         + features
-        + ", legacySenderSubjectsDisabled="
-        + legacySenderSubjectsDisabled
-        + ", legacyReceiverSubjectsDisabled="
-        + legacyReceiverSubjectsDisabled
+        + ", sendOnLegacySubject="
+        + sendOnLegacySubject
+        + ", receiveOnLegacySubject="
+        + receiveOnLegacySubject
         + ", defaultEngineName="
         + defaultEngineName
         + '}';

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Timeout(2 * 60)
 public class RaftServerForwardCompatibilityIT {
 
-  private static final int DEFAULT_COUNT = 3;
+  private static final int PARTITION_COUNT = 3;
+  private static final int REPLICATION_FACTOR = 2;
   private static final String MEMBER_NODE_ID_0 = "0";
 
   @ParameterizedTest(name = "{0}")
@@ -37,7 +38,7 @@ public class RaftServerForwardCompatibilityIT {
 
     // then
     try (final var camundaClient = cluster.availableGateway().newClientBuilder().build()) {
-      createInstanceWithAJobOnAllPartitions(camundaClient, "foo", DEFAULT_COUNT);
+      createInstanceWithAJobOnAllPartitions(camundaClient, "foo", PARTITION_COUNT);
     }
   }
 
@@ -69,9 +70,9 @@ public class RaftServerForwardCompatibilityIT {
   static TestCluster createTestClusterWithBrokerConfiguration(
       final BiConsumer<MemberId, TestStandaloneBroker> brokerConfigurationApplier) {
     return TestCluster.builder()
-        .withBrokersCount(DEFAULT_COUNT)
-        .withPartitionsCount(DEFAULT_COUNT)
-        .withReplicationFactor(DEFAULT_COUNT)
+        .withBrokersCount(PARTITION_COUNT)
+        .withPartitionsCount(PARTITION_COUNT)
+        .withReplicationFactor(REPLICATION_FACTOR)
         .withBrokerConfig(brokerConfigurationApplier)
         .build();
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ZeebeIntegration
+@Timeout(2 * 60)
+public class RaftServerForwardCompatibilityIT {
+
+  private static final int DEFAULT_COUNT = 3;
+  private static final String MEMBER_NODE_ID_0 = "0";
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideTestClusters")
+  public void shouldCreateProcessInstances(final String description, final TestCluster cluster) {
+    // given test cluster
+
+    // when
+    cluster.start().awaitCompleteTopology();
+
+    // then
+    try (final var camundaClient = cluster.availableGateway().newClientBuilder().build()) {
+      createInstanceWithAJobOnAllPartitions(camundaClient, "foo", DEFAULT_COUNT);
+    }
+  }
+
+  static Stream<Arguments> provideTestClusters() {
+
+    return Stream.of(
+        Arguments.of(
+            "8.9 Mode",
+            createTestClusterWithBrokerConfiguration(
+                RaftServerForwardCompatibilityIT::configure89Mode)),
+        Arguments.of(
+            "8.9 to 8.10 Upgrade",
+            createTestClusterWithBrokerConfiguration(
+                RaftServerForwardCompatibilityIT::configure89To810Mode)),
+        Arguments.of(
+            "8.10 Mode",
+            createTestClusterWithBrokerConfiguration(
+                RaftServerForwardCompatibilityIT::configure810Mode)),
+        Arguments.of(
+            "8.10 to 8.11 Upgrade",
+            createTestClusterWithBrokerConfiguration(
+                RaftServerForwardCompatibilityIT::configure810To811Mode)),
+        Arguments.of(
+            "8.11 Mode",
+            createTestClusterWithBrokerConfiguration(
+                RaftServerForwardCompatibilityIT::configure811Mode)));
+  }
+
+  static TestCluster createTestClusterWithBrokerConfiguration(
+      final BiConsumer<MemberId, TestStandaloneBroker> brokerConfigurationApplier) {
+    return TestCluster.builder()
+        .withBrokersCount(DEFAULT_COUNT)
+        .withPartitionsCount(DEFAULT_COUNT)
+        .withReplicationFactor(DEFAULT_COUNT)
+        .withBrokerConfig(brokerConfigurationApplier)
+        .build();
+  }
+
+  /**
+   * 8.9.x cluster with the following configuration:
+   *
+   * <ul>
+   *   <li>Sending: All nodes send with subject: "raft-partition-partition-*"
+   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
+   *       "raft-partition-partition-*"
+   * </ul>
+   */
+  static void configure89Mode(final MemberId memberId, final TestStandaloneBroker broker) {
+    // noop (default configuration)
+  }
+
+  /**
+   * Simulating upgrade path from 8.9 to 8.10 cluster with the following configuration:
+   *
+   * <ul>
+   *   <li>Sending (Node "0"): Node sends with subject: "default-partition-*"
+   *   <li>Sending (Node "1" and "2"): Nodes send with subject: "raft-partition-partition-*"
+   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
+   *       "raft-partition-partition-*"
+   * </ul>
+   */
+  static void configure89To810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
+    if (memberId.id().equals(MEMBER_NODE_ID_0)) {
+      broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+    }
+  }
+
+  /**
+   * Simulating future 8.10 cluster with the following configuration:
+   *
+   * <ul>
+   *   <li>Sending: All nodes send with subject: "default-partition-*"
+   *   <li>Receiving: All nodes listen to subjects: "default-partition-*" and
+   *       "raft-partition-partition-*"
+   * </ul>
+   */
+  static void configure810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
+    broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+  }
+
+  /**
+   * Simulating future upgrade path from 8.10 to 8.11 with the following configuration:
+   *
+   * <ul>
+   *   <li>Sending: All nodes send with subject: "default-partition-*"
+   *   <li>Receiving (Node "0" / 8.11): Node listens to subject: "default-partition-*"
+   *   <li>Receiving (Node "1" and "2" / 8.10): Nodes listen to subject: "default -partition-*" and
+   *       * "raft-partition-partition-*"
+   * </ul>
+   */
+  static void configure810To811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
+    broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+    if (memberId.id().equals(MEMBER_NODE_ID_0)) {
+      broker.withClusterConfig(
+          c -> {
+            c.setLegacyReceiverSubjectsDisabled(true);
+          });
+    }
+  }
+
+  /**
+   * Simulating future 8.11 cluster with the following configuration:
+   *
+   * <ul>
+   *   <li>Sending: All nodes send with subject: "default-partition-*"
+   *   <li>Receiving: All nodes listen to subject: "default -partition-*"
+   * </ul>
+   */
+  static void configure811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
+    broker.withClusterConfig(
+        c -> {
+          c.setLegacySenderSubjectsDisabled(true);
+          c.setLegacyReceiverSubjectsDisabled(true);
+        });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -125,7 +125,7 @@ public class RaftServerForwardCompatibilityIT {
    *   <li>Sending: All nodes send with subject: "default-partition-*"
    *   <li>Receiving (Node "0" / 8.11): Node listens to subject: "default-partition-*"
    *   <li>Receiving (Node "1" and "2" / 8.10): Nodes listen to subject: "default -partition-*" and
-   *       * "raft-partition-partition-*"
+   *       "raft-partition-partition-*"
    * </ul>
    */
   static void configure810To811Mode(final MemberId memberId, final TestStandaloneBroker broker) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -102,7 +102,7 @@ public class RaftServerForwardCompatibilityIT {
    */
   static void configure89To810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
     if (memberId.id().equals(MEMBER_NODE_ID_0)) {
-      broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+      broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
     }
   }
 
@@ -116,7 +116,7 @@ public class RaftServerForwardCompatibilityIT {
    * </ul>
    */
   static void configure810Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+    broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
   }
 
   /**
@@ -130,11 +130,11 @@ public class RaftServerForwardCompatibilityIT {
    * </ul>
    */
   static void configure810To811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
-    broker.withClusterConfig(c -> c.setLegacySenderSubjectsDisabled(true));
+    broker.withClusterConfig(c -> c.setSendOnLegacySubject(false));
     if (memberId.id().equals(MEMBER_NODE_ID_0)) {
       broker.withClusterConfig(
           c -> {
-            c.setLegacyReceiverSubjectsDisabled(true);
+            c.setReceiveOnLegacySubject(false);
           });
     }
   }
@@ -150,8 +150,8 @@ public class RaftServerForwardCompatibilityIT {
   static void configure811Mode(final MemberId memberId, final TestStandaloneBroker broker) {
     broker.withClusterConfig(
         c -> {
-          c.setLegacySenderSubjectsDisabled(true);
-          c.setLegacyReceiverSubjectsDisabled(true);
+          c.setSendOnLegacySubject(false);
+          c.setReceiveOnLegacySubject(false);
         });
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/Utils.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/Utils.java
@@ -33,7 +33,7 @@ import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 
-final class Utils {
+public final class Utils {
 
   public static final String DEFAULT_PROCESS_ID = "processId";
 
@@ -135,7 +135,7 @@ final class Utils {
     return deployProcessModel(camundaClient, process, waitDeployment);
   }
 
-  static List<Long> createInstanceWithAJobOnAllPartitions(
+  public static List<Long> createInstanceWithAJobOnAllPartitions(
       final CamundaClient camundaClient, final String jobType, final int partitionsCount) {
     return createInstanceWithAJobOnAllPartitions(
         camundaClient, jobType, partitionsCount, true, DEFAULT_PROCESS_ID);


### PR DESCRIPTION
## Description

Adds Raft multi-engine forward compatibility by introducing engine-aware messaging subjects and supporting legacy subjects. That way, the (default) Raft Server listens to subjects with those prefixes `default-partition-` and `raft-partition-partition-`.

* Add configuration options for legacy sender/receiver subjects and a default engine name
* Update Raft partition server/communicator to send via one subject prefix while receiving on one or two prefixes (legacy + engine-aware)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45259
