### PR TITLE
refactor: remove services dependency from authentication module

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -81,10 +81,6 @@
       <artifactId>parsson</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
@@ -99,10 +95,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-gateway-model</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-service</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -157,10 +149,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-protocol</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -227,11 +215,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-broker-client</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -17,18 +17,16 @@ import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
 import io.camunda.authentication.converter.OidcUserAuthenticationConverter;
 import io.camunda.authentication.converter.TokenClaimsConverter;
-import io.camunda.authentication.converter.UsernamePasswordAuthenticationTokenConverter;
 import io.camunda.authentication.csrf.CsrfProtectionRequestMatcher;
 import io.camunda.authentication.exception.BasicAuthenticationNotSupportedException;
-import io.camunda.authentication.filters.AdminUserCheckFilter;
+import io.camunda.authentication.filters.AbstractAdminUserCheckFilter;
+import io.camunda.authentication.filters.AbstractWebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.filters.OAuth2RefreshTokenFilter;
-import io.camunda.authentication.filters.WebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.handler.LoggingAuthenticationFailureHandler;
 import io.camunda.authentication.handler.OAuth2AuthenticationExceptionHandler;
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
-import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
@@ -37,10 +35,6 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import io.camunda.security.configuration.headers.values.FrameOptionMode;
 import io.camunda.security.entity.AuthenticationMethod;
-import io.camunda.security.reader.ResourceAccessProvider;
-import io.camunda.service.GroupServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
@@ -61,7 +55,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -438,6 +434,25 @@ public class WebSecurityConfig {
     }
   }
 
+  @Bean
+  @ConditionalOnBean(AbstractAdminUserCheckFilter.class)
+  public FilterRegistrationBean<AbstractAdminUserCheckFilter> disableAdminFilterAutoRegistration(
+      final AbstractAdminUserCheckFilter filter) {
+    final var reg = new FilterRegistrationBean<>(filter);
+    reg.setEnabled(false);
+    return reg;
+  }
+
+  @Bean
+  @ConditionalOnBean(AbstractWebComponentAuthorizationCheckFilter.class)
+  public FilterRegistrationBean<AbstractWebComponentAuthorizationCheckFilter>
+      disableWebComponentFilterAutoRegistration(
+          AbstractWebComponentAuthorizationCheckFilter filter) {
+    final var reg = new FilterRegistrationBean<>(filter);
+    reg.setEnabled(false);
+    return reg;
+  }
+
   @Configuration
   @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
   @ConditionalOnSecondaryStorageEnabled
@@ -470,15 +485,6 @@ public class WebSecurityConfig {
           .map(Map::values)
           .map(values -> values.stream().anyMatch(OidcAuthenticationConfiguration::isSet))
           .orElse(false);
-    }
-
-    @Bean
-    public CamundaAuthenticationConverter<Authentication> usernamePasswordAuthenticationConverter(
-        final RoleServices roleServices,
-        final GroupServices groupServices,
-        final TenantServices tenantServices) {
-      return new UsernamePasswordAuthenticationTokenConverter(
-          roleServices, groupServices, tenantServices);
     }
 
     @Bean
@@ -536,10 +542,9 @@ public class WebSecurityConfig {
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
         final SecurityConfiguration securityConfiguration,
-        final CamundaAuthenticationProvider authenticationProvider,
-        final ResourceAccessProvider resourceAccessProvider,
-        final RoleServices roleServices,
-        final CookieCsrfTokenRepository csrfTokenRepository)
+        final CookieCsrfTokenRepository csrfTokenRepository,
+        final AbstractWebComponentAuthorizationCheckFilter webComponentAuthFilter,
+        final AbstractAdminUserCheckFilter adminUserCheckFilter)
         throws Exception {
       LOG.info("Web Applications Login/Logout is setup.");
       final var filterChainBuilder =
@@ -580,13 +585,8 @@ public class WebSecurityConfig {
                       exceptionHandling
                           .authenticationEntryPoint(authFailureHandler)
                           .accessDeniedHandler(authFailureHandler))
-              .addFilterAfter(
-                  new WebComponentAuthorizationCheckFilter(
-                      securityConfiguration, authenticationProvider, resourceAccessProvider),
-                  AuthorizationFilter.class)
-              .addFilterBefore(
-                  new AdminUserCheckFilter(securityConfiguration, roleServices),
-                  AuthorizationFilter.class);
+              .addFilterAfter(webComponentAuthFilter, AuthorizationFilter.class)
+              .addFilterBefore(adminUserCheckFilter, AuthorizationFilter.class);
 
       applyCsrfConfiguration(httpSecurity, securityConfiguration, csrfTokenRepository);
 
@@ -945,14 +945,13 @@ public class WebSecurityConfig {
         final OidcAuthenticationConfigurationRepository oidcProviderRepository,
         final JwtDecoder jwtDecoder,
         final SecurityConfiguration securityConfiguration,
-        final CamundaAuthenticationProvider authenticationProvider,
-        final ResourceAccessProvider resourceAccessProvider,
         final CookieCsrfTokenRepository csrfTokenRepository,
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final OAuth2AuthorizedClientManager authorizedClientManager,
         final OidcTokenEndpointCustomizer tokenEndpointCustomizer,
         final LogoutSuccessHandler logoutSuccessHandler,
-        final OidcUserService oidcUserService)
+        final OidcUserService oidcUserService,
+        final AbstractWebComponentAuthorizationCheckFilter webComponentAuthFilter)
         throws Exception {
       final var filterChainBuilder =
           httpSecurity
@@ -1011,10 +1010,7 @@ public class WebSecurityConfig {
                           .deleteCookies(SESSION_COOKIE, X_CSRF_TOKEN)
                           .invalidateHttpSession(true)
                           .logoutSuccessHandler(logoutSuccessHandler))
-              .addFilterAfter(
-                  new WebComponentAuthorizationCheckFilter(
-                      securityConfiguration, authenticationProvider, resourceAccessProvider),
-                  AuthorizationFilter.class);
+              .addFilterAfter(webComponentAuthFilter, AuthorizationFilter.class);
 
       applyOauth2RefreshTokenFilter(
           httpSecurity, authorizedClientRepository, authorizedClientManager);

--- a/authentication/src/main/java/io/camunda/authentication/filters/AbstractAdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AbstractAdminUserCheckFilter.java
@@ -5,12 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.authentication.filters;
 
-import io.camunda.authentication.entity.CamundaUserDTO;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-public interface CamundaUserService {
-  CamundaUserDTO getCurrentUser();
-
-  String getUserToken();
-}
+public abstract class AbstractAdminUserCheckFilter extends OncePerRequestFilter {}

--- a/authentication/src/main/java/io/camunda/authentication/filters/AbstractWebComponentAuthorizationCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AbstractWebComponentAuthorizationCheckFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Implements a check whether the user has access to the requested web component.
+ *
+ * <p>Allowed access lets the request through without side-effects.
+ *
+ * <p>Denied access should be logged and the user redirected to the appropriate page.
+ */
+public abstract class AbstractWebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
+
+  @Override
+  protected abstract void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException;
+}

--- a/authentication/src/main/java/io/camunda/authentication/filters/NoOpAdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/NoOpAdminUserCheckFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class NoOpAdminUserCheckFilter extends AbstractAdminUserCheckFilter {
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+    filterChain.doFilter(request, response);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/filters/NoOpWebComponentAuthorizationCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/NoOpWebComponentAuthorizationCheckFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class NoOpWebComponentAuthorizationCheckFilter
+    extends AbstractWebComponentAuthorizationCheckFilter {
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+    filterChain.doFilter(request, response);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/NoDBMembershipService.java
@@ -10,16 +10,12 @@ package io.camunda.authentication.service;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.stereotype.Service;
 
-@Service
-@ConditionalOnSecondaryStorageDisabled
 public class NoDBMembershipService implements MembershipService {
 
   private final OidcGroupsLoader oidcGroupsLoader;

--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -10,8 +10,6 @@ package io.camunda.authentication;
 import static io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder.LAST_REFRESH_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.authentication.config.controllers.TestApiController;
@@ -20,7 +18,6 @@ import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.RoleServices;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -47,17 +44,13 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 public class SessionAuthenticationRefreshTest {
 
-  abstract class BaseTest {
+  abstract static class BaseTest {
     @Autowired MockMvcTester mockMvcTester;
     Duration refreshInterval;
-    @MockitoBean RoleServices roleServices;
     @Autowired private SecurityConfiguration securityConfiguration;
 
     @BeforeEach
     public void setup() {
-      when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(roleServices);
-      when(roleServices.hasMembersOfType(any(), any())).thenReturn(true);
       refreshInterval =
           Duration.parse(
               securityConfiguration.getAuthentication().getAuthenticationRefreshInterval());
@@ -93,8 +86,8 @@ public class SessionAuthenticationRefreshTest {
 
       assertThat(testResult).hasStatusOk();
       final Instant lastRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
-      assertThat(lastRefreshTime).isNotNull();
       assertThat(lastRefreshTime)
+          .isNotNull()
           .isCloseTo(Instant.now(), within(refreshInterval.toMillis(), ChronoUnit.MILLIS));
       // verify(httpSessionBasedAuthenticationHolder, never()).set(any());
     }
@@ -142,13 +135,14 @@ public class SessionAuthenticationRefreshTest {
     void shouldOnlyRefreshOnceWhenMultipleConcurrentRequests() throws Exception {
       final MockHttpSession session = new MockHttpSession();
       setSessionRefreshAttribute(session, refreshInterval.multipliedBy(2));
+      final Instant oldRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
 
       final var result = getSendMultipleRequest(session, mockMvcTester);
 
       assertThat(result.successfulRequests().get()).isEqualTo(result.threads().length);
       // verify(httpSessionBasedAuthenticationHolder, times(1)).set(any());
       final Instant newRefreshTime = (Instant) session.getAttribute(LAST_REFRESH_ATTR);
-      assertThat(newRefreshTime).isAfter(Instant.now().minusMillis(refreshInterval.toMillis()));
+      assertThat(newRefreshTime).isAfter(oldRefreshTime);
     }
 
     private void setupAuthentication(final MockHttpSession session) {
@@ -156,6 +150,7 @@ public class SessionAuthenticationRefreshTest {
       final var testAuthentication = new TestingAuthenticationToken(mockAuthentication, null);
       testAuthentication.setAuthenticated(true);
       final var securityContext = SecurityContextHolder.createEmptyContext();
+      SecurityContextHolder.setContext(securityContext);
       securityContext.setAuthentication(testAuthentication);
       session.setAttribute(
           HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
@@ -184,10 +179,10 @@ public class SessionAuthenticationRefreshTest {
         final MockHttpSession session, final MockMvcTester mockMvcTester)
         throws InterruptedException {
       final AtomicInteger successfulRequests = new AtomicInteger(0);
-      setupAuthentication(session);
       final Runnable requestTask =
           () -> {
             try {
+              setupAuthentication(session);
               final MvcTestResult testResult =
                   mockMvcTester
                       .get()

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
@@ -9,12 +9,9 @@ package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.service.ApiServicesExecutorProvider;
-import io.camunda.service.UserServices;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -25,10 +22,7 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+import org.springframework.context.annotation.Import;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class BasicAuthWebSecurityConfigParameterizedTest {
@@ -102,33 +96,6 @@ public class BasicAuthWebSecurityConfigParameterizedTest {
 
   @AutoConfigureMockMvc
   @AutoConfigureWebMvc
-  @ComponentScan(
-      basePackages = {"io.camunda.authentication"},
-      excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*Controller"),
-        @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*OidcFlowTestContext")
-      })
-  public static class TestApplication {
-    @Bean
-    public ObjectMapper objectMapper() {
-      return new ObjectMapper();
-    }
-
-    @Bean
-    public UserServices userServices() {
-      return new UserServices(
-          null,
-          null,
-          null,
-          null,
-          null,
-          new ApiServicesExecutorProvider(ForkJoinPool.commonPool()),
-          null);
-    }
-
-    @Bean
-    public HandlerMappingIntrospector mvcHandlerMappingIntrospector() {
-      return new HandlerMappingIntrospector();
-    }
-  }
+  @Import({WebSecurityConfig.class, WebSecurityConfigTestContext.class})
+  public static class TestApplication {}
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/WebSecurityFilterAutoRegistrationRegressionTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebSecurityFilterAutoRegistrationRegressionTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_UNPROTECTED_ENDPOINT;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_V2_API_ENDPOINT;
+import static io.camunda.authentication.config.controllers.TestApiController.DUMMY_WEBAPP_ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.controllers.OidcFlowTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.filters.AbstractAdminUserCheckFilter;
+import io.camunda.authentication.filters.AbstractWebComponentAuthorizationCheckFilter;
+import io.camunda.security.auth.CamundaAuthentication;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Regression tests for filter auto-registration in servlet container.
+ *
+ * <p>Both filters must only run when explicitly added to the WEBAPP security chain and must not be
+ * globally applied to API or unprotected paths.
+ */
+class WebSecurityFilterAutoRegistrationRegressionTest {
+
+  @Nested
+  @SuppressWarnings({"SpringBootApplicationProperties", "WrongPropertyKeyValueDelimiter"})
+  @AutoConfigureMockMvc
+  @AutoConfigureWebMvc
+  @SpringBootTest(
+      classes = {
+        BasicFilterInvocationTestConfig.class,
+        WebSecurityConfig.class,
+      },
+      properties = {
+        "camunda.security.authentication.method=basic",
+        "camunda.security.authentication.unprotected-api=false",
+      })
+  @ActiveProfiles("consolidated-auth")
+  class BasicAuthMode {
+
+    @Autowired MockMvcTester mockMvcTester;
+    @Autowired AbstractAdminUserCheckFilter adminUserCheckFilter;
+    @Autowired AbstractWebComponentAuthorizationCheckFilter webComponentAuthorizationCheckFilter;
+
+    @Test
+    void shouldNotApplyWebappFiltersToApiPaths() throws ServletException, IOException {
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .exchange();
+      assertThat(apiResult).hasStatus(HttpStatus.UNAUTHORIZED);
+
+      verify(adminUserCheckFilter, never()).doFilter(any(), any(), any());
+      verify(webComponentAuthorizationCheckFilter, never()).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void shouldNotApplyWebappFiltersToUnprotectedPaths() throws ServletException, IOException {
+      final MvcTestResult unprotectedResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_UNPROTECTED_ENDPOINT)
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+      assertThat(unprotectedResult).hasStatus(HttpStatus.OK);
+
+      verify(adminUserCheckFilter, never()).doFilter(any(), any(), any());
+      verify(webComponentAuthorizationCheckFilter, never()).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void shouldApplyWebappFiltersOnlyToWebappChain() throws ServletException, IOException {
+      final CamundaAuthentication auth =
+          new CamundaAuthentication(
+              "test-user", null, false, List.of(), List.of(), List.of(), List.of(), Map.of());
+      SecurityContextHolder.getContext()
+          .setAuthentication(new TestingAuthenticationToken(auth, null));
+
+      final MvcTestResult webappResult =
+          mockMvcTester.get().uri(DUMMY_WEBAPP_ENDPOINT).accept(MediaType.TEXT_HTML).exchange();
+      assertThat(webappResult).hasStatus(HttpStatus.OK);
+
+      verify(adminUserCheckFilter).doFilter(any(), any(), any());
+      verify(webComponentAuthorizationCheckFilter).doFilter(any(), any(), any());
+
+      clearInvocations(adminUserCheckFilter, webComponentAuthorizationCheckFilter);
+      SecurityContextHolder.clearContext();
+    }
+  }
+
+  @Nested
+  @AutoConfigureMockMvc
+  @AutoConfigureWebMvc
+  @SpringBootTest(
+      classes = {
+        OidcFilterInvocationTestConfig.class,
+        WebSecurityConfig.class,
+      },
+      properties = {
+        "camunda.security.authentication.unprotected-api=false",
+        "camunda.security.authentication.method=oidc",
+        "camunda.security.authentication.oidc.client-id=dummy-client",
+        "camunda.security.authentication.oidc.client-secret=dummy-secret",
+        "camunda.security.authentication.oidc.redirect-uri=http://localhost/sso-callback",
+      })
+  @ActiveProfiles("consolidated-auth")
+  class OidcAuthMode {
+
+    static final String REALM = "dummy";
+    static final String ENDPOINT_WELL_KNOWN_OIDC =
+        "/realms/" + REALM + "/.well-known/openid-configuration";
+    static final String ENDPOINT_WELL_KNOWN_JWKS = "/realms/" + REALM + "/.well-known/jwks.json";
+
+    @RegisterExtension
+    static WireMockExtension wireMock =
+        WireMockExtension.newInstance()
+            .configureStaticDsl(true)
+            .options(wireMockConfig().notifier(new Slf4jNotifier(false)).dynamicPort())
+            .failOnUnmatchedRequests(true)
+            .build();
+
+    @Autowired MockMvcTester mockMvcTester;
+    @Autowired AbstractWebComponentAuthorizationCheckFilter webComponentAuthorizationCheckFilter;
+
+    @DynamicPropertySource
+    static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+      registry.add(
+          "camunda.security.authentication.oidc.issuer-uri",
+          () -> "http://localhost:" + wireMock.getPort() + "/realms/" + REALM);
+    }
+
+    @BeforeAll
+    static void stubOidcDiscoveryEndpoint() {
+      stubFor(
+          get(urlEqualTo(ENDPOINT_WELL_KNOWN_OIDC))
+              .willReturn(
+                  aResponse()
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(wellKnownResponse())));
+
+      stubFor(
+          get(urlEqualTo(ENDPOINT_WELL_KNOWN_JWKS))
+              .willReturn(
+                  aResponse()
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(
+                          """
+                          {"keys":[{"kty":"RSA","kid":"test-key","n":"AQAB","e":"AQAB"}]}
+                          """)));
+    }
+
+    private static String wellKnownResponse() {
+      return """
+          {
+            "issuer": "http://localhost:000000/realms/dummy",
+            "authorization_endpoint": "http://localhost:000000/realms/dummy/protocol/openid-connect/auth",
+            "token_endpoint": "http://localhost:000000/realms/dummy/protocol/openid-connect/token",
+            "userinfo_endpoint": "http://localhost:000000/realms/dummy/protocol/openid-connect/userinfo",
+            "jwks_uri": "http://localhost:000000/realms/dummy/.well-known/jwks.json",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "scopes_supported": ["openid","profile"]
+          }
+          """
+          .replace("000000", String.valueOf(wireMock.getPort()));
+    }
+
+    @Test
+    void shouldNotApplyWebappFiltersToApiPaths() throws ServletException, IOException {
+      final MvcTestResult apiResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_V2_API_ENDPOINT)
+              .accept(MediaType.APPLICATION_JSON)
+              .exchange();
+      assertThat(apiResult).hasStatus(HttpStatus.UNAUTHORIZED);
+
+      verify(webComponentAuthorizationCheckFilter, never()).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void shouldNotApplyWebappFiltersToUnprotectedPaths() throws ServletException, IOException {
+      final MvcTestResult unprotectedResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_UNPROTECTED_ENDPOINT)
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+      assertThat(unprotectedResult).hasStatus(HttpStatus.OK);
+
+      verify(webComponentAuthorizationCheckFilter, never()).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void shouldApplyWebappFilterOnlyToWebappChain() throws ServletException, IOException {
+      final CamundaAuthentication auth =
+          new CamundaAuthentication(
+              "test-user", null, false, List.of(), List.of(), List.of(), List.of(), Map.of());
+      final var principalAuth = new TestingAuthenticationToken(auth, null);
+      principalAuth.setAuthenticated(true);
+
+      final MvcTestResult webappResult =
+          mockMvcTester
+              .get()
+              .uri(DUMMY_WEBAPP_ENDPOINT)
+              .with(authentication(principalAuth))
+              .accept(MediaType.TEXT_HTML)
+              .exchange();
+
+      assertThat(webappResult).hasStatus(HttpStatus.OK);
+      verify(webComponentAuthorizationCheckFilter).doFilter(any(), any(), any());
+      clearInvocations(webComponentAuthorizationCheckFilter);
+    }
+  }
+
+  @TestConfiguration
+  @Import(WebSecurityConfigTestContext.class)
+  static class BasicFilterInvocationTestConfig {
+
+    @Bean
+    @Primary
+    AbstractAdminUserCheckFilter adminUserCheckFilter() {
+      return Mockito.spy(new DelegatingAdminUserCheckFilter());
+    }
+
+    @Bean
+    @Primary
+    AbstractWebComponentAuthorizationCheckFilter webComponentAuthorizationCheckFilter() {
+      return Mockito.spy(new DelegatingWebComponentAuthorizationCheckFilter());
+    }
+  }
+
+  @TestConfiguration
+  @Import(OidcFlowTestContext.class)
+  static class OidcFilterInvocationTestConfig {
+
+    @Bean
+    @Primary
+    AbstractWebComponentAuthorizationCheckFilter webComponentAuthorizationCheckFilter() {
+      return Mockito.spy(new DelegatingWebComponentAuthorizationCheckFilter());
+    }
+  }
+
+  static final class DelegatingAdminUserCheckFilter extends AbstractAdminUserCheckFilter {
+    @Override
+    protected void doFilterInternal(
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final FilterChain filterChain)
+        throws ServletException, IOException {
+      filterChain.doFilter(request, response);
+    }
+  }
+
+  static final class DelegatingWebComponentAuthorizationCheckFilter
+      extends AbstractWebComponentAuthorizationCheckFilter {
+    @Override
+    protected void doFilterInternal(
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final FilterChain filterChain)
+        throws ServletException, IOException {
+      filterChain.doFilter(request, response);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -8,6 +8,8 @@
 package io.camunda.authentication.config.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.filters.AbstractWebComponentAuthorizationCheckFilter;
+import io.camunda.authentication.filters.NoOpWebComponentAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.service.MembershipService;
 import io.camunda.authentication.service.NoDBMembershipService;
@@ -72,5 +74,10 @@ public class OidcFlowTestContext {
   public MembershipService createMembershipService(
       final SecurityConfiguration securityConfiguration) {
     return new NoDBMembershipService(securityConfiguration);
+  }
+
+  @Bean
+  public AbstractWebComponentAuthorizationCheckFilter createWebComponentAuthorizationCheckFilter() {
+    return new NoOpWebComponentAuthorizationCheckFilter();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -10,6 +10,9 @@ package io.camunda.authentication.config.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
 import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConverter;
+import io.camunda.authentication.filters.AbstractAdminUserCheckFilter;
+import io.camunda.authentication.filters.AbstractWebComponentAuthorizationCheckFilter;
+import io.camunda.authentication.filters.NoOpAdminUserCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
 import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
@@ -20,13 +23,12 @@ import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.reader.ResourceAccessProvider;
-import io.camunda.service.ApiServicesExecutorProvider;
-import io.camunda.service.GroupServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ForkJoinPool;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +36,7 @@ import org.springframework.security.access.expression.method.DefaultMethodSecuri
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -66,26 +69,6 @@ public class WebSecurityConfigTestContext {
   @Bean
   public UserDetailsService createUserDetailsService() {
     return new TestUserDetailsService();
-  }
-
-  @Bean
-  public ApiServicesExecutorProvider apiServicesExecutorProvider() {
-    return new ApiServicesExecutorProvider(ForkJoinPool.commonPool());
-  }
-
-  @Bean
-  public RoleServices createRoleServices(final ApiServicesExecutorProvider executorProvider) {
-    return new RoleServices(null, null, null, null, executorProvider, null);
-  }
-
-  @Bean
-  public GroupServices createGroupServices(final ApiServicesExecutorProvider executorProvider) {
-    return new GroupServices(null, null, null, null, executorProvider, null);
-  }
-
-  @Bean
-  public TenantServices createTenantServices(final ApiServicesExecutorProvider executorProvider) {
-    return new TenantServices(null, null, null, null, executorProvider, null);
   }
 
   @Bean
@@ -149,5 +132,33 @@ public class WebSecurityConfigTestContext {
   @ConfigurationProperties("camunda.security")
   public SecurityConfiguration createSecurityConfiguration() {
     return new SecurityConfiguration();
+  }
+
+  @Bean
+  public AbstractWebComponentAuthorizationCheckFilter createWebComponentAuthorizationCheckFilter(
+      CamundaAuthenticationProvider camundaAuthenticationProvider) {
+    return new AbstractWebComponentAuthorizationCheckFilter() {
+      @Override
+      protected void doFilterInternal(
+          final HttpServletRequest request,
+          final HttpServletResponse response,
+          final FilterChain filterChain)
+          throws ServletException, IOException {
+        // SessionAuthenticationRefreshTest FAILS without fetching authentication because that is
+        // the mechanism used to set the authentication in the session.
+        // It worked previously because the WebComponentAuthorizationCheckFilter, as the name
+        // implies, fetched (and refreshed) the session implicitly.
+        // To be resolved with https://github.com/camunda/camunda/issues/47027
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+          camundaAuthenticationProvider.getCamundaAuthentication();
+        }
+        filterChain.doFilter(request, response);
+      }
+    };
+  }
+
+  @Bean
+  public AbstractAdminUserCheckFilter createAdminUserCheckFilter() {
+    return new NoOpAdminUserCheckFilter();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -7,13 +7,9 @@
  */
 package io.camunda.authentication.config.controllers;
 
-import io.camunda.authentication.service.DefaultMembershipService;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.ApiServicesExecutorProvider;
-import io.camunda.service.GroupServices;
-import io.camunda.service.MappingRuleServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,19 +18,8 @@ import org.springframework.context.annotation.Configuration;
 public class WebSecurityOidcTestContext {
 
   @Bean
-  public MappingRuleServices createMappingRuleServices(
-      final ApiServicesExecutorProvider executorProvider) {
-    return new MappingRuleServices(null, null, null, null, executorProvider, null);
-  }
-
-  @Bean
-  public DefaultMembershipService createMembershipService(
-      final MappingRuleServices mappingRuleServices,
-      final TenantServices tenantServices,
-      final RoleServices roleServices,
-      final GroupServices groupServices,
+  public MembershipService createMembershipService(
       final SecurityConfiguration securityConfiguration) {
-    return new DefaultMembershipService(
-        mappingRuleServices, tenantServices, roleServices, groupServices, securityConfiguration);
+    return new NoDBMembershipService(securityConfiguration);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterTest.java
@@ -7,32 +7,18 @@
  */
 package io.camunda.authentication.converter;
 
-import static io.camunda.security.auth.OidcGroupsLoader.DERIVED_GROUPS_ARE_NOT_STRING_ARRAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import io.camunda.authentication.service.DefaultMembershipService;
 import io.camunda.authentication.service.MembershipService;
-import io.camunda.search.entities.GroupEntity;
-import io.camunda.search.entities.MappingRuleEntity;
-import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.entities.TenantEntity;
-import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.GroupServices;
-import io.camunda.service.MappingRuleServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,8 +31,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 @TestInstance(Lifecycle.PER_CLASS)
 public class TokenClaimsConverterTest {
 
-  public static final String GROUP1_NAME = "idp-g1";
-  public static final String GROUP2_NAME = "idp-g2";
   private static final String USERNAME_CLAIM = "email";
   private static final String APPLICATION_ID_CLAIM = "client-id";
   private TokenClaimsConverter converter;
@@ -55,10 +39,6 @@ public class TokenClaimsConverterTest {
   @Nested
   class ClientIdClaimConfiguration {
 
-    @Mock private MappingRuleServices mappingRuleServices;
-    @Mock private TenantServices tenantServices;
-    @Mock private RoleServices roleServices;
-    @Mock private GroupServices groupServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -72,22 +52,7 @@ public class TokenClaimsConverterTest {
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
       when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
 
-      when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(mappingRuleServices);
-      when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(tenantServices);
-      when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(roleServices);
-      when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(groupServices);
-
-      membershipService =
-          new DefaultMembershipService(
-              mappingRuleServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              securityConfiguration);
+      membershipService = new NoDBMembershipService(securityConfiguration);
 
       converter = new TokenClaimsConverter(securityConfiguration, membershipService);
     }
@@ -171,10 +136,6 @@ public class TokenClaimsConverterTest {
   @Nested
   class UsernameClaimConfiguration {
 
-    @Mock private MappingRuleServices mappingRuleServices;
-    @Mock private TenantServices tenantServices;
-    @Mock private RoleServices roleServices;
-    @Mock private GroupServices groupServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -187,22 +148,8 @@ public class TokenClaimsConverterTest {
       when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
       when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
-      when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(mappingRuleServices);
-      when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(tenantServices);
-      when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(roleServices);
-      when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(groupServices);
 
-      membershipService =
-          new DefaultMembershipService(
-              mappingRuleServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              securityConfiguration);
+      membershipService = new NoDBMembershipService(securityConfiguration);
 
       converter = new TokenClaimsConverter(securityConfiguration, membershipService);
     }
@@ -240,131 +187,6 @@ public class TokenClaimsConverterTest {
     }
 
     @Test
-    public void loadUser() {
-      // given
-      final Map<String, Object> claims =
-          Map.of(
-              "sub", "test|foo@camunda.test",
-              "email", "foo@camunda.test",
-              "role", "R1",
-              "group", "G1");
-      when(mappingRuleServices.getMatchingMappingRules(claims))
-          .thenReturn(
-              Stream.of(
-                  new MappingRuleEntity("test-id", 5L, "role", "R1", "role-r1"),
-                  new MappingRuleEntity("test-id-2", 7L, "group", "G1", "group-g1")));
-
-      final var groupRole = new RoleEntity(3L, "roleGroup", "Role Group", "description");
-      when(groupServices.getGroupsByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("test-id", "test-id-2"),
-                  EntityType.USER,
-                  Set.of("foo@camunda.test"))))
-          .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
-
-      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
-      when(roleServices.getRolesByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("test-id", "test-id-2"),
-                  EntityType.USER,
-                  Set.of("foo@camunda.test"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"))))
-          .thenReturn(List.of(roleR1, groupRole));
-
-      final var tenantT1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
-      final var groupTenant = new TenantEntity(200L, "tenant1", "Tenant One", "First Tenant");
-      when(tenantServices.getTenantsByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("test-id", "test-id-2"),
-                  EntityType.USER,
-                  Set.of("foo@camunda.test"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"),
-                  EntityType.ROLE,
-                  Set.of("roleR1", "roleGroup"))))
-          .thenReturn(List.of(tenantT1, groupTenant));
-
-      // when
-      final var authentication = converter.convert(claims);
-
-      // then
-      assertThat(authentication).isNotNull();
-      assertThat(authentication.authenticatedUsername()).isEqualTo("foo@camunda.test");
-      assertThat(authentication.claims()).isEqualTo(claims);
-      assertThat(authentication.authenticatedMappingRuleIds())
-          .containsExactlyInAnyOrder("test-id", "test-id-2");
-      assertThat(authentication.authenticatedRoleIds())
-          .containsExactlyInAnyOrder(roleR1.roleId(), groupRole.roleId());
-      assertThat(authentication.authenticatedGroupIds()).containsExactly("group-g1");
-      assertThat(authentication.authenticatedTenantIds())
-          .containsExactlyInAnyOrder(tenantT1.tenantId(), groupTenant.tenantId());
-    }
-
-    @Test
-    public void shouldLoadTenantsFromMappingRules() {
-      // given
-      final Map<String, Object> claims =
-          Map.of("sub", "user@example.com", USERNAME_CLAIM, "scooby-doo");
-
-      final var mappingRule1 = new MappingRuleEntity("map-1", 1L, "role", "R1", "role-r1");
-      final var mappingRule2 = new MappingRuleEntity("map-2", 2L, "group", "G1", "group-g1");
-
-      when(mappingRuleServices.getMatchingMappingRules(claims))
-          .thenReturn(Stream.of(mappingRule1, mappingRule2));
-
-      when(groupServices.getGroupsByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("map-1", "map-2"),
-                  EntityType.USER,
-                  Set.of("scooby-doo"))))
-          .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
-
-      final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
-      when(roleServices.getRolesByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("map-1", "map-2"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"),
-                  EntityType.USER,
-                  Set.of("scooby-doo"))))
-          .thenReturn(List.of(roleR1));
-
-      final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
-      final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
-
-      when(tenantServices.getTenantsByMemberTypeAndMemberIds(
-              Map.of(
-                  EntityType.MAPPING_RULE,
-                  Set.of("map-1", "map-2"),
-                  EntityType.USER,
-                  Set.of("scooby-doo"),
-                  EntityType.GROUP,
-                  Set.of("group-g1"),
-                  EntityType.ROLE,
-                  Set.of("roleR1"))))
-          .thenReturn(List.of(tenantEntity1, tenantEntity2));
-
-      // when
-      final var authentication = converter.convert(claims);
-
-      // then
-      assertThat(authentication).isNotNull();
-      assertThat(authentication.authenticatedMappingRuleIds())
-          .containsExactlyInAnyOrder("map-1", "map-2");
-      assertThat(authentication.authenticatedUsername()).isEqualTo("scooby-doo");
-      assertThat(authentication.authenticatedRoleIds()).containsExactly(roleR1.roleId());
-      assertThat(authentication.authenticatedGroupIds()).containsExactly("group-g1");
-      assertThat(authentication.authenticatedTenantIds())
-          .containsExactlyInAnyOrder(tenantEntity1.tenantId(), tenantEntity2.tenantId());
-    }
-
-    @Test
     public void shouldExtractUsernameWhenPreferUsernameClaimIsTrueAndClientIdIsPresent() {
       when(oidcAuthenticationConfiguration.isPreferUsernameClaim()).thenReturn(true);
       final var tokenConverter = new TokenClaimsConverter(securityConfiguration, membershipService);
@@ -399,10 +221,6 @@ public class TokenClaimsConverterTest {
 
     private static final String GROUPS_CLAIM = "$.groups[*].['name']";
 
-    @Mock private MappingRuleServices mappingRuleServices;
-    @Mock private TenantServices tenantServices;
-    @Mock private RoleServices roleServices;
-    @Mock private GroupServices groupServices;
     @Mock private SecurityConfiguration securityConfiguration;
     @Mock private AuthenticationConfiguration authenticationConfiguration;
     @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -417,90 +235,10 @@ public class TokenClaimsConverterTest {
       when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn("not-tested");
       when(oidcAuthenticationConfiguration.isGroupsClaimConfigured()).thenReturn(true);
       when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn(GROUPS_CLAIM);
-      when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(mappingRuleServices);
-      when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(tenantServices);
-      when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(roleServices);
-      when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
-          .thenReturn(groupServices);
 
-      membershipService =
-          new DefaultMembershipService(
-              mappingRuleServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              securityConfiguration);
+      membershipService = new NoDBMembershipService(securityConfiguration);
 
       converter = new TokenClaimsConverter(securityConfiguration, membershipService);
-    }
-
-    @Test
-    public void shouldFetchClaimGroupWhenGroupClaimIsPresent() {
-      // given
-      final Map<String, Object> claims =
-          Map.of(
-              "groups",
-              List.of(
-                  Map.of("name", GROUP1_NAME, "id", "idp-g1-id"),
-                  Map.of("name", GROUP2_NAME, "id", "idp-g2-id")),
-              "sub",
-              "user1");
-
-      // when
-      final var authentication = converter.convert(claims);
-
-      // then
-      assertThat(authentication.authenticatedGroupIds())
-          .containsExactlyInAnyOrder(GROUP1_NAME, GROUP2_NAME);
-      assertThat(authentication.claims()).isEqualTo(claims);
-    }
-
-    @Test
-    public void shouldLoadGroupWhenGroupsClaimIsAString() {
-      // given
-      when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn("$.groups['name']");
-
-      membershipService =
-          new DefaultMembershipService(
-              mappingRuleServices,
-              tenantServices,
-              roleServices,
-              groupServices,
-              securityConfiguration);
-      converter = new TokenClaimsConverter(securityConfiguration, membershipService);
-      final Map<String, Object> claims =
-          Map.of("groups", Map.of("name", GROUP1_NAME, "id", "idp-g1-id"), "sub", "user1");
-
-      // when
-      final var authentication = converter.convert(claims);
-
-      // then
-      assertThat(authentication.authenticatedGroupIds()).containsExactly(GROUP1_NAME);
-      assertThat(authentication.claims()).isEqualTo(claims);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenGroupsClaimIsNotStringArray() {
-      // given
-      final Map<String, Object> claims =
-          Map.of(
-              "groups",
-              List.of(
-                  Map.of("name", List.of(GROUP1_NAME), "id", "idp-g1-id"),
-                  Map.of("name", GROUP2_NAME, "id", "idp-g2-id")),
-              "sub",
-              "user1");
-      // when
-      final var exception =
-          assertThatExceptionOfType(IllegalArgumentException.class)
-              .isThrownBy(() -> converter.convert(claims))
-              .actual();
-
-      assertThat(exception.getMessage())
-          .isEqualTo(DERIVED_GROUPS_ARE_NOT_STRING_ARRAY.formatted(GROUPS_CLAIM));
     }
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -502,6 +502,21 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-resource-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.session</groupId>
       <artifactId>spring-session-core</artifactId>
     </dependency>
@@ -617,6 +632,11 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
     </dependency>
 
     <dependency>

--- a/dist/src/main/java/io/camunda/application/commons/authentication/AdminUserCheckFilter.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/AdminUserCheckFilter.java
@@ -5,8 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.filters;
+package io.camunda.application.commons.authentication;
 
+import io.camunda.authentication.filters.AbstractAdminUserCheckFilter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
@@ -21,9 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.filter.OncePerRequestFilter;
 
-public class AdminUserCheckFilter extends OncePerRequestFilter {
+public class AdminUserCheckFilter extends AbstractAdminUserCheckFilter {
 
   public static final String ADMIN_ROLE_ID = DefaultRole.ADMIN.getId();
   public static final String USER_MEMBERS = "users";

--- a/dist/src/main/java/io/camunda/application/commons/authentication/BasicCamundaUserService.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/BasicCamundaUserService.java
@@ -5,32 +5,24 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 
-import io.camunda.authentication.ConditionalOnAuthenticationMethod;
-import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.security.reader.ResourceAccessProvider;
+import io.camunda.service.CamundaUserDTO;
 import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
-import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.zeebe.gateway.rest.controller.authentication.CamundaUserService;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
 
-@Service
-@ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
-@ConditionalOnSecondaryStorageEnabled
-@Profile("consolidated-auth")
 public class BasicCamundaUserService implements CamundaUserService {
 
   private final CamundaAuthenticationProvider authenticationProvider;

--- a/dist/src/main/java/io/camunda/application/commons/authentication/CamundaAuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/CamundaAuthenticationConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.authentication;
 
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
+import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.authentication.DefaultCamundaAuthenticationProvider;
 import io.camunda.authentication.converter.CamundaAuthenticationDelegatingConverter;
@@ -15,19 +16,32 @@ import io.camunda.authentication.converter.UnprotectedCamundaAuthenticationConve
 import io.camunda.authentication.holder.CamundaAuthenticationDelegatingHolder;
 import io.camunda.authentication.holder.HttpSessionBasedAuthenticationHolder;
 import io.camunda.authentication.holder.RequestContextBasedAuthenticationHolder;
+import io.camunda.authentication.service.MembershipService;
+import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.reader.ResourceAccessProvider;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingRuleServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import io.camunda.service.UserServices;
+import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
+import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.zeebe.gateway.rest.controller.authentication.CamundaUserService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 
 @Configuration(proxyBeanMethods = false)
-@ComponentScan(basePackages = {"io.camunda.service.validation"})
 @ConditionalOnAnyHttpGatewayEnabled
 public class CamundaAuthenticationConfiguration {
 
@@ -57,5 +71,84 @@ public class CamundaAuthenticationConfiguration {
     return new DefaultCamundaAuthenticationProvider(
         new CamundaAuthenticationDelegatingHolder(holders),
         new CamundaAuthenticationDelegatingConverter(converters));
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageEnabled
+  public WebComponentAuthorizationCheckFilter webComponentAuthorizationCheckFilter(
+      final SecurityConfiguration securityConfig,
+      final CamundaAuthenticationProvider authenticationProvider,
+      final ResourceAccessProvider resourceAccessProvider) {
+    return new WebComponentAuthorizationCheckFilter(
+        securityConfig, authenticationProvider, resourceAccessProvider);
+  }
+
+  @Bean
+  @Primary
+  @ConditionalOnSecondaryStorageEnabled
+  public MembershipService membershipService(
+      final MappingRuleServices mappingRuleServices,
+      final TenantServices tenantServices,
+      final RoleServices roleServices,
+      final GroupServices groupServices,
+      final SecurityConfiguration securityConfiguration) {
+    return new DefaultMembershipService(
+        mappingRuleServices, tenantServices, roleServices, groupServices, securityConfiguration);
+  }
+
+  @Bean
+  @ConditionalOnSecondaryStorageDisabled
+  public MembershipService noDBMembershipService(SecurityConfiguration securityConfiguration) {
+    return new NoDBMembershipService(securityConfiguration);
+  }
+
+  @Bean
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+  @ConditionalOnSecondaryStorageEnabled
+  @Profile("consolidated-auth")
+  public CamundaUserService oidcCamundaUserService(
+      final CamundaAuthenticationProvider authenticationProvider,
+      final ResourceAccessProvider resourceAccessProvider,
+      final TenantServices tenantServices,
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final HttpServletRequest request) {
+    return new OidcCamundaUserService(
+        authenticationProvider,
+        resourceAccessProvider,
+        tenantServices,
+        authorizedClientRepository,
+        request);
+  }
+
+  @Bean
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
+  @ConditionalOnSecondaryStorageEnabled
+  @Profile("consolidated-auth")
+  public CamundaUserService basicCamundaUserService(
+      final CamundaAuthenticationProvider authenticationProvider,
+      final ResourceAccessProvider resourceAccessProvider,
+      final UserServices userServices,
+      final TenantServices tenantServices) {
+    return new BasicCamundaUserService(
+        authenticationProvider, resourceAccessProvider, userServices, tenantServices);
+  }
+
+  @Bean
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
+  @ConditionalOnSecondaryStorageEnabled
+  public CamundaAuthenticationConverter<Authentication> usernamePasswordAuthenticationConverter(
+      final RoleServices roleServices,
+      final GroupServices groupServices,
+      final TenantServices tenantServices) {
+    return new UsernamePasswordAuthenticationTokenConverter(
+        roleServices, groupServices, tenantServices);
+  }
+
+  @Bean
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
+  @ConditionalOnSecondaryStorageEnabled
+  public AdminUserCheckFilter adminUserCheckFilter(
+      final SecurityConfiguration securityConfig, final RoleServices roleServices) {
+    return new AdminUserCheckFilter(securityConfig, roleServices);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/authentication/DefaultMembershipService.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/DefaultMembershipService.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING_RULE;
 
+import io.camunda.authentication.service.MembershipService;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
@@ -21,7 +22,6 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,13 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.stereotype.Service;
 
-@Service
-@Primary
-@ConditionalOnSecondaryStorageEnabled
 public class DefaultMembershipService implements MembershipService {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultMembershipService.class);
 

--- a/dist/src/main/java/io/camunda/application/commons/authentication/OidcCamundaUserService.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/OidcCamundaUserService.java
@@ -5,28 +5,25 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 
-import io.camunda.authentication.ConditionalOnAuthenticationMethod;
-import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
-import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.security.entity.ClusterMetadata.AppName;
 import io.camunda.security.reader.ResourceAccessProvider;
+import io.camunda.service.CamundaUserDTO;
 import io.camunda.service.TenantServices;
-import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.zeebe.gateway.rest.controller.authentication.CamundaUserService;
 import jakarta.json.Json;
 import jakarta.json.JsonString;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -37,12 +34,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.StandardClaimAccessor;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
-import org.springframework.stereotype.Service;
 
-@Service
-@ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
-@ConditionalOnSecondaryStorageEnabled
-@Profile("consolidated-auth")
 public class OidcCamundaUserService implements CamundaUserService {
   private static final String SALES_PLAN_TYPE = "";
 

--- a/dist/src/main/java/io/camunda/application/commons/authentication/UsernamePasswordAuthenticationTokenConverter.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/UsernamePasswordAuthenticationTokenConverter.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.converter;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.EntityType.ROLE;

--- a/dist/src/main/java/io/camunda/application/commons/authentication/WebComponentAuthorizationCheckFilter.java
+++ b/dist/src/main/java/io/camunda/application/commons/authentication/WebComponentAuthorizationCheckFilter.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.filters;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 
+import io.camunda.authentication.filters.AbstractWebComponentAuthorizationCheckFilter;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.reader.ResourceAccessProvider;
@@ -21,10 +22,10 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.UrlPathHelper;
 
-public class WebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
+public class WebComponentAuthorizationCheckFilter
+    extends AbstractWebComponentAuthorizationCheckFilter {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(WebComponentAuthorizationCheckFilter.class);

--- a/dist/src/test/java/io/camunda/application/commons/DefaultConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/DefaultConfigurationTest.java
@@ -15,7 +15,6 @@ import io.camunda.security.entity.AuthenticationMethod;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @SpringBootTest(
@@ -39,7 +38,6 @@ class DefaultConfigurationTest {
     assertThat(multiTenancyConfig.isApiEnabled()).isTrue();
   }
 
-  @Configuration
   @Import({CamundaSecurityConfiguration.class})
   static class TestConfig {}
 }

--- a/dist/src/test/java/io/camunda/application/commons/authentication/AdminUserCheckFilterTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/AdminUserCheckFilterTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.filters;
+package io.camunda.application.commons.authentication;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/dist/src/test/java/io/camunda/application/commons/authentication/BasicCamundaUserServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/BasicCamundaUserServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;

--- a/dist/src/test/java/io/camunda/application/commons/authentication/DefaultMembershipServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/DefaultMembershipServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.authentication;
+
+import static io.camunda.security.auth.OidcGroupsLoader.DERIVED_GROUPS_ARE_NOT_STRING_ARRAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.service.MembershipService.PrincipalType;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.MappingRuleEntity;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingRuleServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DefaultMembershipServiceTest {
+
+  public static final String GROUP1_NAME = "idp-g1";
+  public static final String GROUP2_NAME = "idp-g2";
+  private static final String USERNAME_CLAIM = "email";
+  private static final String APPLICATION_ID_CLAIM = "client-id";
+  private DefaultMembershipService membershipService;
+
+  @Nested
+  class ClientIdClaimConfiguration {
+
+    @Mock private MappingRuleServices mappingRuleServices;
+    @Mock private TenantServices tenantServices;
+    @Mock private RoleServices roleServices;
+    @Mock private GroupServices groupServices;
+    @Mock private SecurityConfiguration securityConfiguration;
+    @Mock private AuthenticationConfiguration authenticationConfiguration;
+    @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
+
+      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+      when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
+      when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
+
+      when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(mappingRuleServices);
+      when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(tenantServices);
+      when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(roleServices);
+      when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+          .thenReturn(groupServices);
+
+      membershipService =
+          new DefaultMembershipService(
+              mappingRuleServices,
+              tenantServices,
+              roleServices,
+              groupServices,
+              securityConfiguration);
+    }
+
+    @Nested
+    class UsernameClaimConfiguration {
+
+      @Mock private MappingRuleServices mappingRuleServices;
+      @Mock private TenantServices tenantServices;
+      @Mock private RoleServices roleServices;
+      @Mock private GroupServices groupServices;
+      @Mock private SecurityConfiguration securityConfiguration;
+      @Mock private AuthenticationConfiguration authenticationConfiguration;
+      @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+
+      @BeforeEach
+      public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this).close();
+
+        when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+        when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+        when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
+        when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
+        when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(mappingRuleServices);
+        when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(tenantServices);
+        when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(roleServices);
+        when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(groupServices);
+
+        membershipService =
+            new DefaultMembershipService(
+                mappingRuleServices,
+                tenantServices,
+                roleServices,
+                groupServices,
+                securityConfiguration);
+      }
+
+      @Test
+      public void loadUser() {
+        // given
+        final Map<String, Object> claims =
+            Map.of(
+                "sub", "test|foo@camunda.test",
+                "email", "foo@camunda.test",
+                "role", "R1",
+                "group", "G1");
+        when(mappingRuleServices.getMatchingMappingRules(claims))
+            .thenReturn(
+                Stream.of(
+                    new MappingRuleEntity("test-id", 5L, "role", "R1", "role-r1"),
+                    new MappingRuleEntity("test-id-2", 7L, "group", "G1", "group-g1")));
+
+        final var groupRole = new RoleEntity(3L, "roleGroup", "Role Group", "description");
+        when(groupServices.getGroupsByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("test-id", "test-id-2"),
+                    EntityType.USER,
+                    Set.of("foo@camunda.test"))))
+            .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
+
+        final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
+        when(roleServices.getRolesByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("test-id", "test-id-2"),
+                    EntityType.USER,
+                    Set.of("foo@camunda.test"),
+                    EntityType.GROUP,
+                    Set.of("group-g1"))))
+            .thenReturn(List.of(roleR1, groupRole));
+
+        final var tenantT1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
+        final var groupTenant = new TenantEntity(200L, "tenant1", "Tenant One", "First Tenant");
+        when(tenantServices.getTenantsByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("test-id", "test-id-2"),
+                    EntityType.USER,
+                    Set.of("foo@camunda.test"),
+                    EntityType.GROUP,
+                    Set.of("group-g1"),
+                    EntityType.ROLE,
+                    Set.of("roleR1", "roleGroup"))))
+            .thenReturn(List.of(tenantT1, groupTenant));
+
+        // when
+        final var authentication =
+            membershipService.resolveMemberships(claims, "foo@camunda.test", PrincipalType.USER);
+
+        // then
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.authenticatedUsername()).isEqualTo("foo@camunda.test");
+        assertThat(authentication.claims()).isEqualTo(claims);
+        assertThat(authentication.authenticatedMappingRuleIds())
+            .containsExactlyInAnyOrder("test-id", "test-id-2");
+        assertThat(authentication.authenticatedRoleIds())
+            .containsExactlyInAnyOrder(roleR1.roleId(), groupRole.roleId());
+        assertThat(authentication.authenticatedGroupIds()).containsExactly("group-g1");
+        assertThat(authentication.authenticatedTenantIds())
+            .containsExactlyInAnyOrder(tenantT1.tenantId(), groupTenant.tenantId());
+      }
+
+      @Test
+      public void shouldLoadTenantsFromMappingRules() {
+        // given
+        final Map<String, Object> claims =
+            Map.of("sub", "user@example.com", USERNAME_CLAIM, "scooby-doo");
+
+        final var mappingRule1 = new MappingRuleEntity("map-1", 1L, "role", "R1", "role-r1");
+        final var mappingRule2 = new MappingRuleEntity("map-2", 2L, "group", "G1", "group-g1");
+
+        when(mappingRuleServices.getMatchingMappingRules(claims))
+            .thenReturn(Stream.of(mappingRule1, mappingRule2));
+
+        when(groupServices.getGroupsByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("map-1", "map-2"),
+                    EntityType.USER,
+                    Set.of("scooby-doo"))))
+            .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
+
+        final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
+        when(roleServices.getRolesByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("map-1", "map-2"),
+                    EntityType.GROUP,
+                    Set.of("group-g1"),
+                    EntityType.USER,
+                    Set.of("scooby-doo"))))
+            .thenReturn(List.of(roleR1));
+
+        final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
+        final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
+
+        when(tenantServices.getTenantsByMemberTypeAndMemberIds(
+                Map.of(
+                    EntityType.MAPPING_RULE,
+                    Set.of("map-1", "map-2"),
+                    EntityType.USER,
+                    Set.of("scooby-doo"),
+                    EntityType.GROUP,
+                    Set.of("group-g1"),
+                    EntityType.ROLE,
+                    Set.of("roleR1"))))
+            .thenReturn(List.of(tenantEntity1, tenantEntity2));
+
+        // when
+        final var authentication =
+            membershipService.resolveMemberships(claims, "scooby-doo", PrincipalType.USER);
+
+        // then
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.authenticatedMappingRuleIds())
+            .containsExactlyInAnyOrder("map-1", "map-2");
+        assertThat(authentication.authenticatedUsername()).isEqualTo("scooby-doo");
+        assertThat(authentication.authenticatedRoleIds()).containsExactly(roleR1.roleId());
+        assertThat(authentication.authenticatedGroupIds()).containsExactly("group-g1");
+        assertThat(authentication.authenticatedTenantIds())
+            .containsExactlyInAnyOrder(tenantEntity1.tenantId(), tenantEntity2.tenantId());
+      }
+    }
+
+    @Nested
+    class GroupsClaimConfiguration {
+
+      private static final String GROUPS_CLAIM = "$.groups[*].['name']";
+
+      @Mock private MappingRuleServices mappingRuleServices;
+      @Mock private TenantServices tenantServices;
+      @Mock private RoleServices roleServices;
+      @Mock private GroupServices groupServices;
+      @Mock private SecurityConfiguration securityConfiguration;
+      @Mock private AuthenticationConfiguration authenticationConfiguration;
+      @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+
+      @BeforeEach
+      public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this).close();
+
+        when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+        when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+        when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
+        when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn("not-tested");
+        when(oidcAuthenticationConfiguration.isGroupsClaimConfigured()).thenReturn(true);
+        when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn(GROUPS_CLAIM);
+        when(mappingRuleServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(mappingRuleServices);
+        when(tenantServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(tenantServices);
+        when(roleServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(roleServices);
+        when(groupServices.withAuthentication(any(CamundaAuthentication.class)))
+            .thenReturn(groupServices);
+
+        membershipService =
+            new DefaultMembershipService(
+                mappingRuleServices,
+                tenantServices,
+                roleServices,
+                groupServices,
+                securityConfiguration);
+      }
+
+      @Test
+      public void shouldFetchClaimGroupWhenGroupClaimIsPresent() {
+        // given
+        final Map<String, Object> claims =
+            Map.of(
+                "groups",
+                List.of(
+                    Map.of("name", GROUP1_NAME, "id", "idp-g1-id"),
+                    Map.of("name", GROUP2_NAME, "id", "idp-g2-id")),
+                "sub",
+                "user1");
+
+        // when
+        final var authentication =
+            membershipService.resolveMemberships(claims, "user1", PrincipalType.USER);
+
+        // then
+        assertThat(authentication.authenticatedGroupIds())
+            .containsExactlyInAnyOrder(GROUP1_NAME, GROUP2_NAME);
+        assertThat(authentication.claims()).isEqualTo(claims);
+      }
+
+      @Test
+      public void shouldLoadGroupWhenGroupsClaimIsAString() {
+        // given
+        when(oidcAuthenticationConfiguration.getGroupsClaim()).thenReturn("$.groups['name']");
+
+        membershipService =
+            new DefaultMembershipService(
+                mappingRuleServices,
+                tenantServices,
+                roleServices,
+                groupServices,
+                securityConfiguration);
+        final Map<String, Object> claims =
+            Map.of("groups", Map.of("name", GROUP1_NAME, "id", "idp-g1-id"), "sub", "user1");
+
+        // when
+        final var authentication =
+            membershipService.resolveMemberships(claims, "scooby-doo", PrincipalType.USER);
+
+        // then
+        assertThat(authentication.authenticatedGroupIds()).containsExactly(GROUP1_NAME);
+        assertThat(authentication.claims()).isEqualTo(claims);
+      }
+
+      @Test
+      public void shouldThrowExceptionWhenGroupsClaimIsNotStringArray() {
+        // given
+        final Map<String, Object> claims =
+            Map.of(
+                "groups",
+                List.of(
+                    Map.of("name", List.of(GROUP1_NAME), "id", "idp-g1-id"),
+                    Map.of("name", GROUP2_NAME, "id", "idp-g2-id")),
+                "sub",
+                "user1");
+        // when
+        final var exception =
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                    () -> membershipService.resolveMemberships(claims, "user1", PrincipalType.USER))
+                .actual();
+
+        assertThat(exception.getMessage())
+            .isEqualTo(DERIVED_GROUPS_ARE_NOT_STRING_ARRAY.formatted(GROUPS_CLAIM));
+      }
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/authentication/OidcCamundaUserServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/OidcCamundaUserServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.service;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;

--- a/dist/src/test/java/io/camunda/application/commons/authentication/UsernamePasswordAuthenticationTokenConverterTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/UsernamePasswordAuthenticationTokenConverterTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.converter;
+package io.camunda.application.commons.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/dist/src/test/java/io/camunda/application/commons/authentication/WebComponentAuthorizationCheckFilterTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/authentication/WebComponentAuthorizationCheckFilterTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.filters;
+package io.camunda.application.commons.authentication;
 
 import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
 import static org.mockito.ArgumentMatchers.eq;

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.security;
 
+import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.application.commons.CommonsModuleConfiguration;
@@ -14,29 +16,19 @@ import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.GatewayBasedPropertiesOverride;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.SpringApplication;
 
 public class CamundaSecurityConfigurationTest {
 
-  @BeforeEach
-  void setUp() {
-    // Reset system properties before each test to avoid side effects
-    final var mtProperty = "camunda.security.multiTenancy.checksEnabled";
-    final var apiProperty = "camunda.security.authentication.unprotected-api";
-    System.setProperty(mtProperty, "false");
-    System.setProperty(apiProperty, "true");
-  }
+  final String mtProperty = "camunda.security.multiTenancy.checksEnabled";
+  final String apiProperty = "camunda.security.authentication.unprotected-api";
+  final String idPatternProperty = "camunda.security.id-validation-pattern";
 
   @Test
   public void whenMultiTenancyEnabledAndApiUnprotectedThenFailsToStart() {
-    final var mtProperty = "camunda.security.multiTenancy.checksEnabled";
-    final var apiProperty = "camunda.security.authentication.unprotected-api";
-    System.setProperty(mtProperty, "true");
-    System.setProperty(apiProperty, "true");
-
     assertThatThrownBy(
             () -> {
               final SpringApplication app =
@@ -46,6 +38,11 @@ public class CamundaSecurityConfigurationTest {
                       UnifiedConfigurationHelper.class,
                       GatewayBasedPropertiesOverride.class,
                       SearchEngineConnectProperties.class);
+              app.setDefaultProperties(
+                  Map.of(
+                      UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE,
+                      mtProperty, "true",
+                      apiProperty, "true"));
               app.run();
             })
         .isInstanceOf(BeanCreationException.class)
@@ -58,9 +55,7 @@ public class CamundaSecurityConfigurationTest {
 
   @Test
   public void shouldFailToStartWhenIdPatternIsInvalid() {
-    final var idPatternProperty = "camunda.security.id-validation-pattern";
     final var idPatternValue = "[|";
-    System.setProperty(idPatternProperty, idPatternValue);
 
     assertThatThrownBy(
             () -> {
@@ -71,6 +66,16 @@ public class CamundaSecurityConfigurationTest {
                       UnifiedConfiguration.class,
                       GatewayBasedPropertiesOverride.class,
                       SearchEngineConnectProperties.class);
+              app.setDefaultProperties(
+                  Map.of(
+                      UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE,
+                      CAMUNDA_DATABASE_TYPE_NONE,
+                      mtProperty,
+                      "false",
+                      apiProperty,
+                      "true",
+                      idPatternProperty,
+                      idPatternValue));
               app.run();
             })
         .isInstanceOf(BeanCreationException.class)
@@ -83,9 +88,7 @@ public class CamundaSecurityConfigurationTest {
 
   @Test
   public void shouldFailToStartWhenIdPatternAllowsWildcardCharacter() {
-    final var idPatternProperty = "camunda.security.id-validation-pattern";
     final var idPatternValue = "^[a-zA-Z0-9_@.+*-]+$";
-    System.setProperty(idPatternProperty, idPatternValue);
 
     assertThatThrownBy(
             () -> {
@@ -96,6 +99,16 @@ public class CamundaSecurityConfigurationTest {
                       UnifiedConfiguration.class,
                       GatewayBasedPropertiesOverride.class,
                       SearchEngineConnectProperties.class);
+              app.setDefaultProperties(
+                  Map.of(
+                      UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE,
+                      CAMUNDA_DATABASE_TYPE_NONE,
+                      mtProperty,
+                      "false",
+                      apiProperty,
+                      "true",
+                      idPatternProperty,
+                      idPatternValue));
               app.run();
             })
         .isInstanceOf(BeanCreationException.class)

--- a/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @SpringBootTest(
@@ -131,7 +130,6 @@ class ConfiguredAuthorizationPropertiesTest {
     assertThat(auth.hasResourcePropertyName()).isFalse();
   }
 
-  @Configuration
   @Import({CamundaSecurityConfiguration.class})
   static class TestConfig {}
 }

--- a/dist/src/test/java/io/camunda/application/commons/security/NoSecondaryStorageAuthenticationIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/NoSecondaryStorageAuthenticationIT.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.security;
 
 import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
 import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -27,7 +28,6 @@ import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Integration test for authentication behavior in no-database mode. This test validates that the
@@ -43,7 +43,7 @@ public class NoSecondaryStorageAuthenticationIT {
     context
         .getEnvironment()
         .getSystemProperties()
-        .put(PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE);
+        .put(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE);
     context
         .getEnvironment()
         .getSystemProperties()
@@ -93,7 +93,6 @@ public class NoSecondaryStorageAuthenticationIT {
     context.close();
   }
 
-  @Configuration
   static class TestOidcAuthConfiguration {
     @Bean
     public SecurityConfiguration securityConfiguration() {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -12,7 +12,6 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
-import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.protocol.model.AuditLogActorTypeEnum;
 import io.camunda.gateway.protocol.model.AuditLogCategoryEnum;
@@ -186,6 +185,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.entity.ClusterMetadata.AppName;
+import io.camunda.service.CamundaUserDTO;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collections;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -68,6 +68,7 @@ final class SecuredClusteredMessagingIT {
   private final ZeebeContainer zeebe =
       new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
           .withNetwork(NETWORK)
+          .withEnv("SPRING_PROFILES_ACTIVE", "consolidated-auth")
           .withNetworkAliases("zeebe")
           .withEnv("CAMUNDA_SECURITY_TRANSPORTLAYERSECURITY_CLUSTER_ENABLED", "true")
           .withEnv(

--- a/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * ArchUnit rules for records in {@code io.camunda.search.entities} and {@code
- * io.camunda.authentication.entity}.
+ * io.camunda.service.CamundaUserDTO}.
  *
  * <p>These rules enforce:
  *
@@ -38,13 +38,13 @@ import java.util.Set;
  *       that defaults those fields to empty <b>mutable</b> instances (e.g. {@code new
  *       ArrayList<>()}). This is required because MyBatis hydrates collection-mapped fields by
  *       calling mutating methods on the existing instance.
- *   <li>Every record in {@code io.camunda.authentication.entity} with collection-type fields must
- *       declare a compact constructor that defaults those fields to empty instances (immutable
- *       defaults like {@code List.of()} are acceptable here).
+ *   <li>Record {@code io.camunda.service.CamundaUserDTO} with collection-type fields must declare a
+ *       compact constructor that defaults those fields to empty instances (immutable defaults like
+ *       {@code List.of()} are acceptable here).
  * </ol>
  */
 @AnalyzeClasses(
-    packages = {"io.camunda.search.entities", "io.camunda.authentication.entity"},
+    packages = {"io.camunda.search.entities", "io.camunda.service"},
     importOptions = ImportOption.DoNotIncludeTests.class)
 public final class SearchEntityArchTest {
 
@@ -167,16 +167,15 @@ public final class SearchEntityArchTest {
                   + "List.of() would cause UnsupportedOperationException at runtime");
 
   /**
-   * Every record in {@code io.camunda.authentication.entity} that declares collection-type fields
-   * must have a compact constructor that defaults them to non-null empty instances when {@code
-   * null} is passed. Unlike search entities, immutable defaults (e.g. {@code List.of()}) are
-   * acceptable.
+   * The record {@code io.camunda.service.CamundaUserDTO} that declares collection-type fields must
+   * have a compact constructor that defaults them to non-null empty instances when {@code null} is
+   * passed. Unlike search entities, immutable defaults (e.g. {@code List.of()}) are acceptable.
    */
   @ArchTest
   static final ArchRule AUTH_ENTITY_COLLECTION_FIELDS_MUST_HAVE_DEFAULTS =
       ArchRuleDefinition.classes()
           .that()
-          .resideInAPackage("io.camunda.authentication.entity..")
+          .haveFullyQualifiedName("io.camunda.service.CamundaUserDTO")
           .and()
           .areRecords()
           .should(

--- a/service/src/main/java/io/camunda/service/CamundaUserDTO.java
+++ b/service/src/main/java/io/camunda/service/CamundaUserDTO.java
@@ -5,10 +5,10 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.authentication.entity;
+package io.camunda.service;
 
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.security.entity.ClusterMetadata;
+import io.camunda.security.entity.ClusterMetadata.AppName;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +21,7 @@ public record CamundaUserDTO(
     List<String> groups,
     List<String> roles,
     String salesPlanType,
-    Map<ClusterMetadata.AppName, String> c8Links,
+    Map<AppName, String> c8Links,
     boolean canLogout) {
 
   public CamundaUserDTO {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationController.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest.controller.authentication;
 
 import static io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper.toCamundaUser;
 
-import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.gateway.protocol.model.CamundaUserResult;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/CamundaUserService.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/CamundaUserService.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.authentication;
+
+import io.camunda.service.CamundaUserDTO;
+
+public interface CamundaUserService {
+  CamundaUserDTO getCurrentUser();
+
+  String getUserToken();
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaaSTokenController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaaSTokenController.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.authentication;
 
-import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.security.ConditionalOnSaaSConfigured;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/AuthenticationControllerTest.java
@@ -11,9 +11,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.authentication.entity.CamundaUserDTO;
-import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.service.CamundaUserDTO;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Map;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/authentication/SaasTokenControllerTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest.controller.authentication;
 
 import static org.mockito.Mockito.when;
 
-import io.camunda.authentication.service.CamundaUserService;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.StandaloneCamunda;
 import io.camunda.application.commons.CommonsModuleConfiguration;
+import io.camunda.application.commons.authentication.CamundaAuthenticationConfiguration;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.Camunda;
@@ -71,6 +72,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     super(
         BrokerModuleConfiguration.class,
         CommonsModuleConfiguration.class,
+        CamundaAuthenticationConfiguration.class,
         UnifiedConfigurationHelper.class,
         UnifiedConfiguration.class,
         PrimaryStorageBackupPropertiesOverride.class,


### PR DESCRIPTION
## Description

The purpose of this PR is to remove the dependency on `camunda-service` from `camunda-authentication`.
In order to do this, we needed to move implementations out of the authentication module, and keep the interfaces inside. We needed to add a few new interfaces as well.

The intent is to keep current functionality intact, while preparing the minimum, least opinionated core of authentication for extraction.
This will give us the most flexibility and ease of integration with Hub.
As the contracts are neither live nor public, we are still able to change and add content to authentication in the future as we discover commonalities between Orchestration and Hub.

### List of changes

* **AdminUserCheckFilter**
  * new abstract class `AbstractAdminUserCheckFilter` injected into the filter chain creation method
  * replaces in-place filter creation
  * implementation class `AdminUserCheckFilter` moved to `camunda-zeebe` 
  * new no-op implementation `NoOpAdminUserCheckFilter`, used for tests, can be used to satisfy dependency when no functionality needed
* **WebComponentAuthorizationCheckFilter**
  * new abstract class `AbstractWebComponentAuthorizationCheckFilter` injected into the filter chain creation method 
  * replaces in-place filter creation
  * implementation class `WebComponentAuthorizationCheckFilter` moved to `camunda-zeebe` 
  * new no-op implementation `NoOpWebComponentAuthorizationCheckFilter`, used for tests, can be used to satisfy dependency when no functionality needed
* **CamundaUserDTO**
  * moved to `camunda-service` due to dependency compatibility - no `pom.xml` changes needed
  * aimed to be moved to gateway, as the place where it is used, in a separate PR
* **CamundaUserService**
  * interface `CamundaUserService` moved to `zeebe-gateway-rest` because it's only used in the `AuthenticationController`
  * implementation classes `BasicCamundaUserService` and `OidcCamundaUserService` moved to `camunda-zeebe`
    * bean creation in `CamundaAuthenticationConfiguration`
* **MembershipService**
  * implementation class `DefaultMembershipService` moved to `camunda-zeebe`
    * bean creation in `CamundaAuthenticationConfiguration`
  * `NoDBMembershipService` to be moved out of authentication in a separate PR
    * bean creation in `CamundaAuthenticationConfiguration`
* **CamundaAuthenticationConverter**
  * implementation class `UsernamePasswordAuthenticationTokenConverter` moved to `camunda-zeebe`
    * bean creation in `CamundaAuthenticationConfiguration`

In addition to the above, tests have been changed by either moving with their related classes or referencing new packages.

## Related issues

closes #43961 
