### PR TITLE
ci: increase Renovate PR priority of security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -119,6 +119,20 @@
       ]
     },
     {
+      "description": "Docker base image updates are usually security-relevant, get those first (prio 10)",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchFileNames": [
+        "Dockerfile",
+        "camunda.Dockerfile",
+        "operate.Dockerfile",
+        "optimize.Dockerfile",
+        "tasklist.Dockerfile"
+      ],
+      "prPriority": 10
+    },
+    {
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
## Description

TIL https://docs.renovatebot.com/configuration-options/#prpriority exists and can help us (see [Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1770627190130879)).

This PR proposes to introduce the mechanism to help prioritizing our backlog as long as it exists, for https://github.com/camunda/product-hub/issues/3101

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed, no effect.

## Related issues

Related to https://github.com/camunda/product-hub/issues/3101
