### PR TITLE
feat: backup state endpoint shows more information

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -212,10 +212,21 @@ public final class BackupEndpoint {
   private PartitionBackupRange toRange(final BackupRangesResponse.PartitionBackupRange range) {
     final var response = new PartitionBackupRange();
     response.setPartitionId(range.partitionId());
-    response.setStart(range.first() == null ? null : range.first().checkpointId());
-    response.setEnd(range.last() == null ? null : range.last().checkpointId());
+    response.setStart(range.first() == null ? null : toBackupState(range.first()));
+    response.setEnd(range.last() == null ? null : toBackupState(range.last()));
     response.setMissingCheckpoints(range.missingCheckpoints().stream().toList());
     return response;
+  }
+
+  private PartitionBackupState toBackupState(final BackupRangesResponse.CheckpointInfo info) {
+    final var state = new PartitionBackupState();
+    state.setCheckpointId(info.checkpointId());
+    state.setCheckpointPosition(info.checkpointPosition());
+    state.setFirstLogPosition(info.firstLogPosition());
+    state.setCheckpointType(toBackupType(info.checkpointType()));
+    state.setCheckpointTimestamp(
+        OffsetDateTime.ofInstant(info.checkpointTimestamp(), ZoneId.of("UTC")));
+    return state;
   }
 
   private CheckpointType toCheckpointType(

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -202,6 +202,7 @@ public final class BackupEndpoint {
     response.setPartitionId(state.partitionId());
     response.setCheckpointId(state.checkpointId());
     response.setCheckpointPosition(state.checkpointPosition());
+    response.setFirstLogPosition(state.firstLogPosition());
     response.setCheckpointTimestamp(
         OffsetDateTime.ofInstant(
             Instant.ofEpochMilli(state.checkpointTimestamp()), ZoneId.of("UTC")));

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -644,6 +644,11 @@ components:
           type: integer
           format: int64
           example: 1500
+        firstLogPosition:
+          description: The first log position included in this backup.
+          type: integer
+          format: int64
+          example: 5
         checkpointTimestamp:
           type: string
           format: date-time
@@ -659,10 +664,10 @@ components:
             - $ref: '#/components/schemas/PartitionId'
         start:
           allOf:
-            - $ref: '#/components/schemas/CheckpointId'
+            - $ref: '#/components/schemas/PartitionBackupState'
         end:
           allOf:
-            - $ref: '#/components/schemas/CheckpointId'
+            - $ref: '#/components/schemas/PartitionBackupState'
         missingCheckpoints:
           type: array
           description: List of missing checkpoint IDs within the backup range

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -771,7 +771,7 @@ final class BackupEndpointTest {
       stateResponse.setBackupStates(
           Set.of(
               new CheckpointStateResponse.PartitionCheckpointState(
-                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L, 5L)));
       when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
       when(api.getBackupRanges())
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
@@ -790,6 +790,7 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
+                              .firstLogPosition(5L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
@@ -807,7 +808,7 @@ final class BackupEndpointTest {
       stateResponse.setBackupStates(
           Set.of(
               new CheckpointStateResponse.PartitionCheckpointState(
-                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L)));
+                  1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L, 5L)));
       stateResponse.setCheckpointStates(
           Set.of(
               new CheckpointStateResponse.PartitionCheckpointState(
@@ -830,6 +831,7 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
+                              .firstLogPosition(5L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
@@ -890,13 +892,13 @@ final class BackupEndpointTest {
 
       final CheckpointStateResponse.PartitionCheckpointState p1BackupState =
           new CheckpointStateResponse.PartitionCheckpointState(
-              1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L);
+              1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L, 5L);
       final CheckpointStateResponse.PartitionCheckpointState p2BackupState =
           new CheckpointStateResponse.PartitionCheckpointState(
-              2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L);
+              2, 1L, CheckpointType.MANUAL_BACKUP, 20L, 20L, 15L);
       final CheckpointStateResponse.PartitionCheckpointState p3BackupState =
           new CheckpointStateResponse.PartitionCheckpointState(
-              3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L);
+              3, 1L, CheckpointType.MANUAL_BACKUP, 30L, 40L, 25L);
 
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
       stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
@@ -945,6 +947,7 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
+                              .firstLogPosition(5L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
@@ -953,6 +956,7 @@ final class BackupEndpointTest {
                               .partitionId(2)
                               .checkpointId(1L)
                               .checkpointPosition(20L)
+                              .firstLogPosition(15L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(20L), ZoneId.of("UTC")))
@@ -961,6 +965,7 @@ final class BackupEndpointTest {
                               .partitionId(3)
                               .checkpointId(1L)
                               .checkpointPosition(40L)
+                              .firstLogPosition(25L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(30L), ZoneId.of("UTC")))
@@ -1008,6 +1013,7 @@ final class BackupEndpointTest {
                               .partitionId(1)
                               .checkpointId(1L)
                               .checkpointPosition(10L)
+                              .firstLogPosition(-1L)
                               .checkpointTimestamp(
                                   OffsetDateTime.ofInstant(
                                       Instant.ofEpochMilli(20L), ZoneId.of("UTC")))

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -22,6 +22,7 @@ public class CheckpointBackupConfirmedApplier {
         checkpointRecord.getCheckpointId(),
         checkpointRecord.getCheckpointPosition(),
         checkpointTimestamp,
-        checkpointRecord.getCheckpointType());
+        checkpointRecord.getCheckpointType(),
+        checkpointRecord.getFirstLogPosition());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -20,13 +20,15 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
   private final LongProperty timestamp = new LongProperty("timestamp");
   private final EnumProperty<CheckpointType> typeProperty =
       new EnumProperty<>("type", CheckpointType.class, CheckpointType.MANUAL_BACKUP);
+  private final LongProperty firstLogPositionProperty = new LongProperty("firstLogPosition", -1L);
 
   public CheckpointInfo() {
-    super(4);
+    super(5);
     declareProperty(idProperty)
         .declareProperty(positionProperty)
         .declareProperty(timestamp)
-        .declareProperty(typeProperty);
+        .declareProperty(typeProperty)
+        .declareProperty(firstLogPositionProperty);
   }
 
   public long getId() {
@@ -62,6 +64,15 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
 
   public CheckpointInfo setType(final CheckpointType type) {
     typeProperty.setValue(type);
+    return this;
+  }
+
+  public long getFirstLogPosition() {
+    return firstLogPositionProperty.getValue();
+  }
+
+  public CheckpointInfo setFirstLogPosition(final long firstLogPosition) {
+    firstLogPositionProperty.setValue(firstLogPosition);
     return this;
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -59,7 +59,8 @@ public interface CheckpointState {
       final long checkpointId,
       final long checkpointPosition,
       final long timestamp,
-      final CheckpointType type);
+      final CheckpointType type,
+      final long firstLogPosition);
 
   /** Returns the id of the last checkpoint with a successful backup. */
   long getLatestBackupId();
@@ -72,4 +73,7 @@ public interface CheckpointState {
 
   /** Returns the type of the last created backup. */
   CheckpointType getLatestBackupType();
+
+  /** Returns the first log position of the last checkpoint with a successful backup. */
+  long getLatestBackupFirstLogPosition();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -71,13 +71,15 @@ public final class DbCheckpointState implements CheckpointState {
       final long checkpointId,
       final long checkpointPosition,
       final long timestamp,
-      final CheckpointType type) {
+      final CheckpointType type,
+      final long firstLogPosition) {
     checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
     checkpointInfo
         .setId(checkpointId)
         .setPosition(checkpointPosition)
         .setTimestamp(timestamp)
-        .setType(type);
+        .setType(type)
+        .setFirstLogPosition(firstLogPosition);
     checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
   }
 
@@ -99,6 +101,11 @@ public final class DbCheckpointState implements CheckpointState {
   @Override
   public CheckpointType getLatestBackupType() {
     return getCheckpointType(LATEST_BACKUP_KEY);
+  }
+
+  @Override
+  public long getLatestBackupFirstLogPosition() {
+    return getFirstLogPosition(LATEST_BACKUP_KEY);
   }
 
   private long getCheckpointId(final String key) {
@@ -123,5 +130,11 @@ public final class DbCheckpointState implements CheckpointState {
     checkpointInfoKey.wrapString(key);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
     return info != null ? info.getType() : null;
+  }
+
+  private long getFirstLogPosition(final String key) {
+    checkpointInfoKey.wrapString(key);
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getFirstLogPosition() : -1L;
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -404,7 +404,7 @@ final class CheckpointRecordsProcessorTest {
     final var currentBackupPosition = 50;
     final var timestamp = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(
-        currentBackupId, currentBackupPosition, timestamp, CheckpointType.MANUAL_BACKUP);
+        currentBackupId, currentBackupPosition, timestamp, CheckpointType.MANUAL_BACKUP, -1L);
 
     final var newCheckpointId = 10;
     final var newCheckpointPosition = 100;
@@ -445,7 +445,8 @@ final class CheckpointRecordsProcessorTest {
         currentBackupId,
         currentBackupPosition,
         Instant.now().toEpochMilli(),
-        CheckpointType.MARKER);
+        CheckpointType.MARKER,
+        -1L);
 
     final var oldCheckpointId = 5;
     final var oldCheckpointPosition = 50;
@@ -474,7 +475,8 @@ final class CheckpointRecordsProcessorTest {
         currentBackupId,
         currentBackupPosition,
         Instant.now().toEpochMilli(),
-        CheckpointType.MANUAL_BACKUP);
+        CheckpointType.MANUAL_BACKUP,
+        -1L);
 
     final var sameCheckpointId = 10;
     final var sameCheckpointPosition = 100;
@@ -544,7 +546,7 @@ final class CheckpointRecordsProcessorTest {
     final var currentBackupPosition = 50;
     final var timestamp = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(
-        currentBackupId, currentBackupPosition, timestamp, CheckpointType.MANUAL_BACKUP);
+        currentBackupId, currentBackupPosition, timestamp, CheckpointType.MANUAL_BACKUP, -1L);
 
     final var newCheckpointId = 10;
     final var newCheckpointPosition = 100;

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -104,23 +104,24 @@ final class DbCheckpointStateTest {
   void shouldSetAndGetLatestBackupIdAndPosition() {
     // when
     final var timestamp = Instant.now().toEpochMilli();
-    state.setLatestBackupInfo(7L, 14L, timestamp, CheckpointType.MARKER);
+    state.setLatestBackupInfo(7L, 14L, timestamp, CheckpointType.MARKER, 3L);
 
     // then
     assertThat(state.getLatestBackupId()).isEqualTo(7L);
     assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
     assertThat(state.getLatestBackupTimestamp()).isEqualTo(timestamp);
+    assertThat(state.getLatestBackupFirstLogPosition()).isEqualTo(3L);
   }
 
   @Test
   void shouldOverwriteBackupInfo() {
     // given
     final var tsBefore = Instant.now().toEpochMilli();
-    state.setLatestBackupInfo(7L, 14L, tsBefore, CheckpointType.MARKER);
+    state.setLatestBackupInfo(7L, 14L, tsBefore, CheckpointType.MARKER, 3L);
 
     // when
     final var tsAfter = Instant.now().toEpochMilli();
-    state.setLatestBackupInfo(21L, 28L, tsAfter, CheckpointType.SCHEDULED_BACKUP);
+    state.setLatestBackupInfo(21L, 28L, tsAfter, CheckpointType.SCHEDULED_BACKUP, 10L);
 
     // then
     assertThat(state.getLatestBackupId()).isEqualTo(21L);
@@ -134,7 +135,7 @@ final class DbCheckpointStateTest {
     final var tsCheckpoint = Instant.now().toEpochMilli();
     final var tsBackup = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(5L, 10L, tsCheckpoint, CheckpointType.MARKER);
-    state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP);
+    state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP, 3L);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(5L);
@@ -146,6 +147,7 @@ final class DbCheckpointStateTest {
     assertThat(state.getLatestBackupPosition()).isEqualTo(14L);
     assertThat(state.getLatestBackupTimestamp()).isEqualTo(tsBackup);
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(state.getLatestBackupFirstLogPosition()).isEqualTo(3L);
   }
 
   @Test
@@ -154,7 +156,7 @@ final class DbCheckpointStateTest {
     final var tsCheckpoint = Instant.now().toEpochMilli();
     final var tsBackup = Instant.now().toEpochMilli();
     state.setLatestCheckpointInfo(5L, 10L, tsCheckpoint, CheckpointType.MARKER);
-    state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP);
+    state.setLatestBackupInfo(7L, 14L, tsBackup, CheckpointType.MANUAL_BACKUP, 3L);
 
     // when
     final var tsCheckpointUpdated = Instant.now().toEpochMilli();
@@ -176,11 +178,12 @@ final class DbCheckpointStateTest {
   void shouldUpdateBackupInfoWithoutAffectingCheckpointInfo() {
     // given
     state.setLatestCheckpointInfo(5L, 10L, Instant.now().toEpochMilli(), CheckpointType.MARKER);
-    state.setLatestBackupInfo(7L, 14L, Instant.now().toEpochMilli(), CheckpointType.MANUAL_BACKUP);
+    state.setLatestBackupInfo(
+        7L, 14L, Instant.now().toEpochMilli(), CheckpointType.MANUAL_BACKUP, 3L);
 
     // when
     state.setLatestBackupInfo(
-        21L, 28L, Instant.now().toEpochMilli(), CheckpointType.SCHEDULED_BACKUP);
+        21L, 28L, Instant.now().toEpochMilli(), CheckpointType.SCHEDULED_BACKUP, 10L);
 
     // then
     assertThat(state.getLatestCheckpointId()).isEqualTo(5L);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -230,7 +230,8 @@ public final class BackupApiRequestHandler
               checkpointState.getLatestBackupId(),
               checkpointState.getLatestBackupType(),
               checkpointState.getLatestBackupTimestamp(),
-              checkpointState.getLatestBackupPosition());
+              checkpointState.getLatestBackupPosition(),
+              checkpointState.getLatestBackupFirstLogPosition());
       response.getBackupStates().add(backupState);
     }
     if (checkpointState.getLatestCheckpointId() != CheckpointState.NO_CHECKPOINT) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -458,6 +458,7 @@ final class BackupApiRequestHandlerTest {
     when(checkpointState.getLatestBackupType()).thenReturn(CheckpointType.SCHEDULED_BACKUP);
     when(checkpointState.getLatestBackupTimestamp()).thenReturn(100L);
     when(checkpointState.getLatestBackupPosition()).thenReturn(20L);
+    when(checkpointState.getLatestBackupFirstLogPosition()).thenReturn(5L);
     when(checkpointState.getLatestCheckpointId()).thenReturn(NO_CHECKPOINT);
 
     final var request =
@@ -475,7 +476,8 @@ final class BackupApiRequestHandlerTest {
         .returns(1, PartitionCheckpointState::partitionId)
         .returns(CheckpointType.SCHEDULED_BACKUP, PartitionCheckpointState::checkpointType)
         .returns(100L, PartitionCheckpointState::checkpointTimestamp)
-        .returns(20L, PartitionCheckpointState::checkpointPosition);
+        .returns(20L, PartitionCheckpointState::checkpointPosition)
+        .returns(5L, PartitionCheckpointState::firstLogPosition);
     assertThat(stateResponse.getCheckpointStates()).isEmpty();
   }
 
@@ -485,6 +487,7 @@ final class BackupApiRequestHandlerTest {
     when(checkpointState.getLatestBackupType()).thenReturn(CheckpointType.SCHEDULED_BACKUP);
     when(checkpointState.getLatestBackupTimestamp()).thenReturn(100L);
     when(checkpointState.getLatestBackupPosition()).thenReturn(20L);
+    when(checkpointState.getLatestBackupFirstLogPosition()).thenReturn(5L);
     when(checkpointState.getLatestCheckpointId()).thenReturn(15L);
     when(checkpointState.getLatestCheckpointType()).thenReturn(CheckpointType.MANUAL_BACKUP);
     when(checkpointState.getLatestCheckpointTimestamp()).thenReturn(150L);
@@ -505,7 +508,8 @@ final class BackupApiRequestHandlerTest {
         .returns(1, PartitionCheckpointState::partitionId)
         .returns(CheckpointType.SCHEDULED_BACKUP, PartitionCheckpointState::checkpointType)
         .returns(100L, PartitionCheckpointState::checkpointTimestamp)
-        .returns(20L, PartitionCheckpointState::checkpointPosition);
+        .returns(20L, PartitionCheckpointState::checkpointPosition)
+        .returns(5L, PartitionCheckpointState::firstLogPosition);
     assertThat(stateResponse.getCheckpointStates())
         .hasSize(1)
         .singleElement()

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -119,6 +119,7 @@
       <field name="checkpointType" id="3"  type="uint8"/>
       <field name="checkpointPosition" id="4"  type="uint64"/>
       <field name="checkpointTimestamp" id="5"  type="uint64"/>
+      <field name="firstLogPosition" id="6"  type="int64"/>
     </group>
   </sbe:message>
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupAcceptance.java
@@ -170,8 +170,8 @@ public interface BackupAcceptance {
                   .describedAs("All backup ranges should start and end with the same backup")
                   .allSatisfy(
                       range -> {
-                        assertThat(range.getStart()).isEqualTo(backupId);
-                        assertThat(range.getEnd()).isEqualTo(backupId);
+                        assertThat(range.getStart().getCheckpointId()).isEqualTo(backupId);
+                        assertThat(range.getEnd().getCheckpointId()).isEqualTo(backupId);
                         assertThat(range.getMissingCheckpoints()).isEmpty();
                       });
             });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -110,7 +110,7 @@ final class BackupRangeTrackingIT {
                                   assertThat(state.getPartitionId())
                                       .isEqualTo(range.getPartitionId());
                                   assertThat(state.getCheckpointId())
-                                      .isGreaterThanOrEqualTo(range.getStart());
+                                      .isGreaterThanOrEqualTo(range.getStart().getCheckpointId());
                                 });
                         assertThat(range.getEnd()).isNotEqualTo(range.getStart());
                       });
@@ -171,7 +171,7 @@ final class BackupRangeTrackingIT {
                       .filter(range -> range.getPartitionId() == 1)
                       .findFirst()
                       .orElseThrow();
-              assertThat(latestRange.getEnd())
+              assertThat(latestRange.getEnd().getCheckpointId())
                   .describedAs("Range should end with the latest checkpoint")
                   .isEqualTo(lastBackupAfterLeaderChange.getCheckpointId());
             });


### PR DESCRIPTION
- Reuses `PartitionBackupState` to include more information about the first and last backup in each range.
- Adds `firstLogPosition` to `PartitionBackupState`, both for range status and for last backup status.