### PR TITLE
Don't create batch operations for single instance deletions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteProcessInstanceResponse.java
@@ -15,16 +15,4 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.search.enums.BatchOperationType;
-
-public interface DeleteProcessInstanceResponse {
-  /**
-   * @return the unique key of the batch operation that was created.
-   */
-  String getBatchOperationKey();
-
-  /**
-   * @return the type of the batch operation that was created.
-   */
-  BatchOperationType getBatchOperationType();
-}
+public interface DeleteProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteProcessInstanceCommandImpl.java
@@ -24,7 +24,6 @@ import io.camunda.client.api.response.DeleteProcessInstanceResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DeleteProcessInstanceResponseImpl;
-import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.DeleteProcessInstanceRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +71,6 @@ public class DeleteProcessInstanceCommandImpl implements DeleteProcessInstanceCo
         "/process-instances/" + processInstanceKey + "/deletion",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        BatchOperationCreatedResult.class,
         DeleteProcessInstanceResponseImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteProcessInstanceResponseImpl.java
@@ -16,27 +16,8 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.DeleteProcessInstanceResponse;
-import io.camunda.client.api.search.enums.BatchOperationType;
-import io.camunda.client.impl.util.EnumUtil;
-import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 
 public class DeleteProcessInstanceResponseImpl implements DeleteProcessInstanceResponse {
-  private final String batchOperationKey;
-  private final BatchOperationType batchOperationType;
 
-  public DeleteProcessInstanceResponseImpl(final BatchOperationCreatedResult response) {
-    batchOperationKey = response.getBatchOperationKey();
-    batchOperationType =
-        EnumUtil.convert(response.getBatchOperationType(), BatchOperationType.class);
-  }
-
-  @Override
-  public String getBatchOperationKey() {
-    return batchOperationKey;
-  }
-
-  @Override
-  public BatchOperationType getBatchOperationType() {
-    return batchOperationType;
-  }
+  public DeleteProcessInstanceResponseImpl(final Void nothing) {}
 }

--- a/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/DeleteProcessInstanceRestTest.java
@@ -19,28 +19,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
-import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.client.protocol.rest.DeleteProcessInstanceRequest;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
-import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 public class DeleteProcessInstanceRestTest extends ClientRestTest {
 
-  private static final BatchOperationCreatedResult DUMMY_RESPONSE =
-      Instancio.create(BatchOperationCreatedResult.class)
-          .batchOperationKey("1")
-          .batchOperationType(BatchOperationTypeEnum.DELETE_PROCESS_INSTANCE);
   private static final long PROCESS_INSTANCE_KEY = 123L;
 
   @Test
   public void shouldSendDeleteCommand() {
-    // given
-    gatewayService.onDeleteProcessInstanceRequest(PROCESS_INSTANCE_KEY, DUMMY_RESPONSE);
-
     // when
     client.newDeleteInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
 
@@ -65,7 +55,6 @@ public class DeleteProcessInstanceRestTest extends ClientRestTest {
   @Test
   public void shouldSetOperationReference() {
     // given
-    gatewayService.onDeleteProcessInstanceRequest(PROCESS_INSTANCE_KEY, DUMMY_RESPONSE);
     final int operationReference = 456;
 
     // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
@@ -245,8 +245,8 @@ public class DeleteProcessInstanceHistoryIT {
         .satisfies(
             ex -> {
               final var details = ex.details();
-              assertThat(details.getTitle().equals("INVALID_STATE"));
-              assertThat(details.getStatus().equals(409));
+              assertThat(details.getTitle()).isEqualTo("INVALID_STATE");
+              assertThat(details.getStatus()).isEqualTo(409);
               assertThat(details.getDetail())
                   .contains(
                       "Expected to delete history for process instance with key '%d', but it is still active"

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessInstanceHistoryIT.java
@@ -193,11 +193,6 @@ public class DeleteProcessInstanceHistoryIT {
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-    waitForBatchOperationCompleted(camundaClient, result.getBatchOperationKey(), 1, 0);
-
-    // and - process instance should be deleted
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
   }
 
@@ -219,11 +214,6 @@ public class DeleteProcessInstanceHistoryIT {
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-    waitForBatchOperationCompleted(camundaClient, result.getBatchOperationKey(), 1, 0);
-
-    // and - first process instance should be deleted
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey1);
 
     // and - second process instance should still exist with all its data
@@ -246,31 +236,22 @@ public class DeleteProcessInstanceHistoryIT {
     final long piKey = startProcessInstance(camundaClient, processId).getProcessInstanceKey();
     waitForProcessInstances(camundaClient, f -> f.processInstanceKey(piKey), 1);
 
-    // when - try to delete active process instance
-    final DeleteProcessInstanceResponse result =
-        camundaClient.newDeleteInstanceCommand(piKey).send().join();
+    // when
+    final var resultFuture = camundaClient.newDeleteInstanceCommand(piKey).send();
 
-    // then - command should succeed but batch operation should fail
-    assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-
-    Awaitility.await("batch operation should complete with failure")
-        .atMost(DELETION_TIMEOUT)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var batch =
-                  camundaClient
-                      .newBatchOperationGetRequest(result.getBatchOperationKey())
-                      .send()
-                      .join();
-              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
-              assertThat(batch.getOperationsFailedCount()).isEqualTo(1);
-              assertThat(batch.getOperationsCompletedCount()).isEqualTo(0);
+    // then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(resultFuture::join)
+        .satisfies(
+            ex -> {
+              final var details = ex.details();
+              assertThat(details.getTitle().equals("INVALID_STATE"));
+              assertThat(details.getStatus().equals(409));
+              assertThat(details.getDetail())
+                  .contains(
+                      "Expected to delete history for process instance with key '%d', but it is still active"
+                          .formatted(piKey));
             });
-
-    // and - process instance should still exist
     waitForProcessInstances(camundaClient, f -> f.processInstanceKey(piKey), 1);
   }
 
@@ -294,11 +275,6 @@ public class DeleteProcessInstanceHistoryIT {
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-    waitForBatchOperationCompleted(camundaClient, result.getBatchOperationKey(), 1, 0);
-
-    // and - process instance should be deleted
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
   }
 
@@ -328,11 +304,6 @@ public class DeleteProcessInstanceHistoryIT {
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-    waitForBatchOperationCompleted(camundaClient, result.getBatchOperationKey(), 1, 0);
-
-    // and - process instance should be deleted
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
   }
 
@@ -357,11 +328,6 @@ public class DeleteProcessInstanceHistoryIT {
 
     // then - deletion should be successful
     assertThat(result).isNotNull();
-    assertThat(result.getBatchOperationKey()).isNotNull();
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, result.getBatchOperationKey(), 1);
-    waitForBatchOperationCompleted(camundaClient, result.getBatchOperationKey(), 1, 0);
-
-    // and - process instance should be deleted
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
   }
 

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -381,14 +381,19 @@ public final class ProcessInstanceServices
       final Long processInstanceKey, final Long operationReference) {
 
     // make sure process instance exists before deletion, otherwise return not found
-    getByKey(
-        processInstanceKey,
-        securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()));
+    final var processInstance =
+        getByKey(
+            processInstanceKey,
+            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()));
 
+    // We pass along the process id and tenant id as the process instance won't exist in primary
+    // storage anymore. We cannot rely on just the key.
     final var brokerRequest =
         new BrokerDeleteHistoryRequest()
             .setResourceKey(processInstanceKey)
-            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setProcessId(processInstance.processDefinitionId())
+            .setTenantId(processInstance.tenantId());
 
     if (operationReference != null) {
       brokerRequest.setOperationReference(operationReference);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -370,7 +370,7 @@ public final class EngineProcessors {
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);
 
     HistoryDeletionProcessors.addHistoryDeletionProcessors(
-        typedRecordProcessors, writers, processingState);
+        typedRecordProcessors, writers, processingState, authCheckBehavior);
     GlobalListenersProcessors.addGlobalListenersProcessors(
         keyGenerator,
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.historydeletion;
 
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -17,10 +18,11 @@ public class HistoryDeletionProcessors {
   public static void addHistoryDeletionProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final ProcessingState processingState) {
+      final ProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.HISTORY_DELETION,
         HistoryDeletionIntent.DELETE,
-        new HistoryDeletionDeleteProcessor(processingState, writers));
+        new HistoryDeletionDeleteProcessor(processingState, writers, authCheckBehavior));
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -92,12 +92,8 @@ paths:
             schema:
               $ref: '#/components/schemas/DeleteDecisionInstanceRequest'
       responses:
-        "200":
-          description: The operation to delete the decision instance was created.
-          content:
-            application/json:
-              schema:
-                $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
+        "204":
+          description: The decision instance is marked for deletion.
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -493,12 +493,8 @@ paths:
             schema:
               $ref: '#/components/schemas/DeleteProcessInstanceRequest'
       responses:
-        "200":
-          description: The operation to delete the process instance was created.
-          content:
-            application/json:
-              schema:
-                $ref: 'batch-operations.yaml#/components/schemas/BatchOperationCreatedResult'
+        "204":
+          description: The process instance is marked for deletion.
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -73,15 +73,13 @@ public class DecisionInstanceController {
   public CompletableFuture<ResponseEntity<Object>> deleteDecisionInstance(
       @PathVariable("decisionInstanceKey") final long decisionInstanceKey,
       @RequestBody(required = false) final DeleteDecisionInstanceRequest request) {
-    return RequestExecutor.executeServiceMethod(
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             decisionInstanceServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteDecisionInstance(
                     decisionInstanceKey,
-                    Objects.nonNull(request) ? request.getOperationReference() : null),
-        ResponseMapper::toBatchOperationCreatedWithResultResponse,
-        HttpStatus.OK);
+                    Objects.nonNull(request) ? request.getOperationReference() : null));
   }
 
   @RequiresSecondaryStorage

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -142,15 +142,13 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstance(
       @PathVariable("processInstanceKey") final Long processInstanceKey,
       @RequestBody(required = false) final DeleteProcessInstanceRequest request) {
-    return RequestExecutor.executeServiceMethod(
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices
                 .withAuthentication(authenticationProvider.getCamundaAuthentication())
                 .deleteProcessInstance(
                     processInstanceKey,
-                    Objects.nonNull(request) ? request.getOperationReference() : null),
-        ResponseMapper::toBatchOperationCreatedWithResultResponse,
-        HttpStatus.OK);
+                    Objects.nonNull(request) ? request.getOperationReference() : null));
   }
 
   @RequiresSecondaryStorage

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
@@ -17,7 +17,9 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,9 +48,9 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldDeleteDecisionInstance() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(123L);
-    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
     when(decisionInstanceServices.deleteDecisionInstance(1L, 123L))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -68,15 +70,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"123","batchOperationType":"DELETE_DECISION_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
 
     verify(decisionInstanceServices).deleteDecisionInstance(1L, 123L);
   }
@@ -84,9 +78,9 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldDeleteDecisionInstanceWithNoBody() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(456L);
-    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
     when(decisionInstanceServices.deleteDecisionInstance(2L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -98,15 +92,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"456","batchOperationType":"DELETE_DECISION_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
 
     verify(decisionInstanceServices).deleteDecisionInstance(2L, null);
   }
@@ -114,9 +100,9 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldDeleteDecisionInstanceWithEmptyBody() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(789L);
-    record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
     when(decisionInstanceServices.deleteDecisionInstance(3L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -134,15 +120,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"789","batchOperationType":"DELETE_DECISION_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
 
     verify(decisionInstanceServices).deleteDecisionInstance(3L, null);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -33,6 +33,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -2690,9 +2692,9 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldDeleteProcessInstance() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(123L);
-    record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
     when(processInstanceServices.deleteProcessInstance(1L, 123L))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -2712,23 +2714,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"123","batchOperationType":"DELETE_PROCESS_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
   }
 
   @Test
   void shouldDeleteProcessInstanceWithNoBody() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(123L);
-    record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
     when(processInstanceServices.deleteProcessInstance(1L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -2740,23 +2734,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"123","batchOperationType":"DELETE_PROCESS_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
   }
 
   @Test
   void shouldDeleteProcessInstanceWithEmptyBody() {
     // given
-    final var record = new BatchOperationCreationRecord();
-    record.setBatchOperationKey(123L);
-    record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    final var record = new HistoryDeletionRecord();
+    record.setResourceKey(123L);
+    record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
     when(processInstanceServices.deleteProcessInstance(1L, null))
         .thenReturn(CompletableFuture.completedFuture(record));
@@ -2774,15 +2760,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isOk()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_JSON)
-        .expectBody()
-        .json(
-            """
-          {"batchOperationKey":"123","batchOperationType":"DELETE_PROCESS_INSTANCE"}
-        """,
-            JsonCompareMode.STRICT);
+        .isNoContent();
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
@@ -43,6 +43,11 @@ public class BrokerDeleteHistoryRequest extends BrokerExecuteCommand<HistoryDele
     return this;
   }
 
+  public BrokerDeleteHistoryRequest setDecisionDefinitionId(final String decisionDefinitionId) {
+    requestDto.setDecisionDefinitionId(decisionDefinitionId);
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
@@ -17,7 +17,7 @@ import org.agrona.DirectBuffer;
 
 public class BrokerDeleteHistoryRequest extends BrokerExecuteCommand<HistoryDeletionRecord> {
 
-  HistoryDeletionRecord requestDto = new HistoryDeletionRecord();
+  private final HistoryDeletionRecord requestDto = new HistoryDeletionRecord();
 
   public BrokerDeleteHistoryRequest() {
     super(ValueType.HISTORY_DELETION, HistoryDeletionIntent.DELETE);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerDeleteHistoryRequest extends BrokerExecuteCommand<HistoryDeletionRecord> {
+
+  HistoryDeletionRecord requestDto = new HistoryDeletionRecord();
+
+  public BrokerDeleteHistoryRequest() {
+    super(ValueType.HISTORY_DELETION, HistoryDeletionIntent.DELETE);
+  }
+
+  public BrokerDeleteHistoryRequest setResourceKey(final long resourceKey) {
+    requestDto.setResourceKey(resourceKey);
+    return this;
+  }
+
+  public BrokerDeleteHistoryRequest setResourceType(final HistoryDeletionType resourceType) {
+    requestDto.setResourceType(resourceType);
+    return this;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected HistoryDeletionRecord toResponseDto(final DirectBuffer buffer) {
+    final HistoryDeletionRecord responseDto = new HistoryDeletionRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
@@ -33,6 +33,16 @@ public class BrokerDeleteHistoryRequest extends BrokerExecuteCommand<HistoryDele
     return this;
   }
 
+  public BrokerDeleteHistoryRequest setProcessId(final String processId) {
+    requestDto.setProcessId(processId);
+    return this;
+  }
+
+  public BrokerDeleteHistoryRequest setTenantId(final String tenantId) {
+    requestDto.setTenantId(tenantId);
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
@@ -24,6 +24,7 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
   private static final StringValue PROCESS_ID = new StringValue("processId");
   private static final StringValue TENANT_ID = new StringValue("tenantId");
+  private static final StringValue DECISION_DEFINITION_ID = new StringValue("decisionDefinitionId");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
   private final EnumProperty<HistoryDeletionType> resourceTypeProp =
@@ -31,13 +32,16 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
   private final StringProperty processIdProp = new StringProperty(PROCESS_ID, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty decisionDefinitionIdProp =
+      new StringProperty(DECISION_DEFINITION_ID, "");
 
   public HistoryDeletionRecord() {
-    super(4);
+    super(5);
     declareProperty(resourceKeyProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(processIdProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(decisionDefinitionIdProp);
   }
 
   @Override
@@ -67,6 +71,16 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   public HistoryDeletionRecord setProcessId(final String processId) {
     processIdProp.setValue(processId);
+    return this;
+  }
+
+  @Override
+  public String getDecisionDefinitionId() {
+    return BufferUtil.bufferAsString(decisionDefinitionIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setDecisionDefinitionId(final String decisionDefinitionId) {
+    decisionDefinitionIdProp.setValue(decisionDefinitionId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/history/HistoryDeletionRecord.java
@@ -9,24 +9,35 @@ package io.camunda.zeebe.protocol.impl.record.value.history;
 
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class HistoryDeletionRecord extends UnifiedRecordValue
     implements HistoryDeletionRecordValue {
 
   private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue PROCESS_ID = new StringValue("processId");
+  private static final StringValue TENANT_ID = new StringValue("tenantId");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
   private final EnumProperty<HistoryDeletionType> resourceTypeProp =
       new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
+  private final StringProperty processIdProp = new StringProperty(PROCESS_ID, "");
+  private final StringProperty tenantIdProp =
+      new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public HistoryDeletionRecord() {
-    super(2);
-    declareProperty(resourceKeyProp).declareProperty(resourceTypeProp);
+    super(4);
+    declareProperty(resourceKeyProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(processIdProp)
+        .declareProperty(tenantIdProp);
   }
 
   @Override
@@ -46,6 +57,26 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
     resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public String getProcessId() {
+    return BufferUtil.bufferAsString(processIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setProcessId(final String processId) {
+    processIdProp.setValue(processId);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3887,7 +3887,8 @@ final class JsonSerializableToJsonTest {
                         "resourceKey": 1,
                         "resourceType": "PROCESS_DEFINITION",
                         "processId": "",
-                        "tenantId": "<default>"
+                        "tenantId": "<default>",
+                        "decisionDefinitionId": ""
                       }
                     }
                  }
@@ -4151,13 +4152,15 @@ final class JsonSerializableToJsonTest {
                     .setResourceKey(1L)
                     .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
                     .setProcessId("processId")
-                    .setTenantId("tenantId"),
+                    .setTenantId("tenantId")
+                    .setDecisionDefinitionId("decisionDefinitionId"),
         """
       {
         "resourceKey": 1,
         "resourceType": "PROCESS_INSTANCE",
         "processId": "processId",
-        "tenantId": "tenantId"
+        "tenantId": "tenantId",
+        "decisionDefinitionId": "decisionDefinitionId"
       }
       """
       },
@@ -4176,7 +4179,8 @@ final class JsonSerializableToJsonTest {
         "resourceKey": 1,
         "resourceType": "PROCESS_INSTANCE",
         "processId": "",
-        "tenantId": "<default>"
+        "tenantId": "<default>",
+        "decisionDefinitionId": ""
       }
       """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3743,7 +3743,7 @@ final class JsonSerializableToJsonTest {
       // ///////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
-        "BatchOperationCreationRecord",
+        "Empty BatchOperationCreationRecord",
         (Supplier<BatchOperationCreationRecord>)
             () ->
                 new BatchOperationCreationRecord()
@@ -3885,7 +3885,9 @@ final class JsonSerializableToJsonTest {
                       "intent": "DELETE",
                       "recordValue": {
                         "resourceKey": 1,
-                        "resourceType": "PROCESS_DEFINITION"
+                        "resourceType": "PROCESS_DEFINITION",
+                        "processId": "",
+                        "tenantId": "<default>"
                       }
                     }
                  }
@@ -4147,11 +4149,34 @@ final class JsonSerializableToJsonTest {
             () ->
                 new HistoryDeletionRecord()
                     .setResourceKey(1L)
+                    .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+                    .setProcessId("processId")
+                    .setTenantId("tenantId"),
+        """
+      {
+        "resourceKey": 1,
+        "resourceType": "PROCESS_INSTANCE",
+        "processId": "processId",
+        "tenantId": "tenantId"
+      }
+      """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty HistoryDeletionRecord ///////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty HistoryDeletionRecord",
+        (Supplier<HistoryDeletionRecord>)
+            () ->
+                new HistoryDeletionRecord()
+                    .setResourceKey(1L)
                     .setResourceType(HistoryDeletionType.PROCESS_INSTANCE),
         """
       {
         "resourceKey": 1,
-        "resourceType": "PROCESS_INSTANCE"
+        "resourceType": "PROCESS_INSTANCE",
+        "processId": "",
+        "tenantId": "<default>"
       }
       """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/HistoryDeletionRecord.golden
@@ -9,24 +9,39 @@ package io.camunda.zeebe.protocol.impl.record.value.history;
 
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class HistoryDeletionRecord extends UnifiedRecordValue
     implements HistoryDeletionRecordValue {
 
   private static final StringValue RESOURCE_KEY = new StringValue("resourceKey");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue PROCESS_ID = new StringValue("processId");
+  private static final StringValue TENANT_ID = new StringValue("tenantId");
+  private static final StringValue DECISION_DEFINITION_ID = new StringValue("decisionDefinitionId");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY);
   private final EnumProperty<HistoryDeletionType> resourceTypeProp =
       new EnumProperty<>(RESOURCE_TYPE, HistoryDeletionType.class);
+  private final StringProperty processIdProp = new StringProperty(PROCESS_ID, "");
+  private final StringProperty tenantIdProp =
+      new StringProperty(TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty decisionDefinitionIdProp =
+      new StringProperty(DECISION_DEFINITION_ID, "");
 
   public HistoryDeletionRecord() {
-    super(2);
-    declareProperty(resourceKeyProp).declareProperty(resourceTypeProp);
+    super(5);
+    declareProperty(resourceKeyProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(processIdProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(decisionDefinitionIdProp);
   }
 
   @Override
@@ -46,6 +61,36 @@ public class HistoryDeletionRecord extends UnifiedRecordValue
 
   public HistoryDeletionRecord setResourceType(final HistoryDeletionType resourceType) {
     resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public String getProcessId() {
+    return BufferUtil.bufferAsString(processIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setProcessId(final String processId) {
+    processIdProp.setValue(processId);
+    return this;
+  }
+
+  @Override
+  public String getDecisionDefinitionId() {
+    return BufferUtil.bufferAsString(decisionDefinitionIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setDecisionDefinitionId(final String decisionDefinitionId) {
+    decisionDefinitionIdProp.setValue(decisionDefinitionId);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public HistoryDeletionRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -41,7 +41,21 @@ public interface HistoryDeletionRecordValue extends RecordValue, TenantOwned {
   /** Returns the type of resource to delete. */
   HistoryDeletionType getResourceType();
 
+  /**
+   * Returns the process id which belongs to the process instance to delete.
+   *
+   * <p>This is only set when performing a singular deletion (not a batch operation) and is used for
+   * performing the authorization checks. We cannot rely on the resource key for this as the
+   * resource will be deleted from primary storage.
+   */
   String getProcessId();
 
+  /**
+   * Returns the decision definition id which belongs to the decision instance to delete.
+   *
+   * <p>This is only set when performing a singular deletion (not a batch operation) and is used for
+   * performing the authorization checks. We cannot rely on the resource key for this as the
+   * resource will be deleted from primary storage.
+   */
   String getDecisionDefinitionId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -42,4 +42,6 @@ public interface HistoryDeletionRecordValue extends RecordValue, TenantOwned {
   HistoryDeletionType getResourceType();
 
   String getProcessId();
+
+  String getDecisionDefinitionId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/HistoryDeletionRecordValue.java
@@ -21,7 +21,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableHistoryDeletionRecordValue.Builder.class)
-public interface HistoryDeletionRecordValue extends RecordValue {
+public interface HistoryDeletionRecordValue extends RecordValue, TenantOwned {
 
   /**
    * The key of the resource to delete. Depending on the {@link HistoryDeletionType} this can be one
@@ -40,4 +40,6 @@ public interface HistoryDeletionRecordValue extends RecordValue {
 
   /** Returns the type of resource to delete. */
   HistoryDeletionType getResourceType();
+
+  String getProcessId();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Single delete operations would result in a batch operation. This does not align with our other commands (eg. cancellation).  By directly writing a `HistoryDeletion.DELETE` command we don't have to have a batch operation here. This is fixed for both process instances and decision instances.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44282 
