### PR TITLE
feat: exporter distribution service listens to default- prefix

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -33,6 +33,9 @@ public final class ExporterDirectorContext {
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
   private InstantSource clock;
+  private String engineName;
+  private boolean sendOnLegacySubject = true;
+  private boolean receiveOnLegacySubject = true;
 
   public int getId() {
     return id;
@@ -76,6 +79,18 @@ public final class ExporterDirectorContext {
 
   public InstantSource getClock() {
     return clock;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public boolean isSendOnLegacySubject() {
+    return sendOnLegacySubject;
+  }
+
+  public boolean isReceiveOnLegacySubject() {
+    return receiveOnLegacySubject;
   }
 
   public ExporterDirectorContext id(final int id) {
@@ -132,6 +147,22 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext clock(final InstantSource clock) {
     this.clock = clock;
+    return this;
+  }
+
+  public ExporterDirectorContext engineName(final String engineName) {
+    this.engineName = engineName;
+    return this;
+  }
+
+  public ExporterDirectorContext sendOnLegacySubject(final boolean legacySenderSubjectDisabled) {
+    sendOnLegacySubject = legacySenderSubjectDisabled;
+    return this;
+  }
+
+  public ExporterDirectorContext receiveOnLegacySubject(
+      final boolean legacyReceiverSubjectDisabled) {
+    receiveOnLegacySubject = legacyReceiverSubjectDisabled;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -155,14 +155,13 @@ public final class ExporterDirectorContext {
     return this;
   }
 
-  public ExporterDirectorContext sendOnLegacySubject(final boolean legacySenderSubjectDisabled) {
-    sendOnLegacySubject = legacySenderSubjectDisabled;
+  public ExporterDirectorContext sendOnLegacySubject(final boolean sendOnLegacySubject) {
+    this.sendOnLegacySubject = sendOnLegacySubject;
     return this;
   }
 
-  public ExporterDirectorContext receiveOnLegacySubject(
-      final boolean legacyReceiverSubjectDisabled) {
-    receiveOnLegacySubject = legacyReceiverSubjectDisabled;
+  public ExporterDirectorContext receiveOnLegacySubject(final boolean receiveOnLegacySubject) {
+    this.receiveOnLegacySubject = receiveOnLegacySubject;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -125,7 +125,10 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
-            .meterRegistry(context.getPartitionTransitionMeterRegistry());
+            .meterRegistry(context.getPartitionTransitionMeterRegistry())
+            .engineName(brokerCfg.getExperimental().getDefaultEngineName())
+            .sendOnLegacySubject(brokerCfg.getExperimental().isSendOnLegacySubject())
+            .receiveOnLegacySubject(brokerCfg.getExperimental().isReceiveOnLegacySubject());
 
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateDistributionTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
@@ -28,11 +29,11 @@ public class ExporterStateDistributionTest {
     partitionMessagingService = new SimplePartitionMessageService();
     exporterStateDistributionService =
         new ExporterStateDistributionService(
-            exporterState::put, partitionMessagingService, "topic");
+            exporterState::put, partitionMessagingService, "topic", List.of("topic", "foo"));
   }
 
   @Test
-  public void shouldSubscribeForGivenTopic() {
+  public void shouldSubscribeForGivenTopics() {
     // given
 
     // when
@@ -40,6 +41,7 @@ public class ExporterStateDistributionTest {
 
     // then
     assertThat(partitionMessagingService.consumers).containsKey("topic");
+    assertThat(partitionMessagingService.consumers).containsKey("foo");
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/SimplePartitionMessageService.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/SimplePartitionMessageService.java
@@ -38,4 +38,8 @@ final class SimplePartitionMessageService implements PartitionMessagingService {
   public void unsubscribe(final String subject) {
     consumers.remove(subject);
   }
+
+  public void clear() {
+    consumers.clear();
+  }
 }


### PR DESCRIPTION
## Description

This pull request implements support for the exporter distribution service to listen to multiple topic prefixes, enabling a phased migration from the legacy "exporterState-" prefix to the new "{engineName}-exporterState-" prefix (e.g., "default-exporterState-"). This prepares for supporting multiple Raft partition groups in Camunda 8.10.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45261 
