### PR TITLE
ci: adjust Renovate settings for Spring framework

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -204,6 +204,29 @@
       "enabled": false
     },
     {
+      "description": "Exclude major updates to Spring, we will do those manually",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.springframework**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Spring updates are often security-relevant, get those first (prio 10)",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.springframework**"
+      ],
+      "prPriority": 10
+    },
+    {
       "description": "Digest + patch updates cover all use cases since they are used as base, so we disable other types.",
       "matchManagers": [
         "dockerfile"


### PR DESCRIPTION
## Description

- disable automated major updates as we do them manually
- increase PR priority since those updates often fix CVEs

Discussed in [Slack](https://camunda.slack.com/archives/C08F5RD5X8B/p1770640919382699?thread_ts=1770636519.477809&cid=C08F5RD5X8B)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - no, effective from main already

## Related issues

None
