### PR TITLE
feat: retention always maintains one backup

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -59,6 +59,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 public class RetentionTest {
@@ -441,6 +443,17 @@ public class RetentionTest {
         Optional.of(timestamp));
   }
 
+  private BackupStatus backupOnlyId(
+      final int partition, final int nodeId, final Instant timestamp) {
+    return new BackupStatusImpl(
+        new BackupIdentifierImpl(nodeId, partition, timestamp.toEpochMilli()),
+        Optional.empty(),
+        null,
+        null,
+        Optional.empty(),
+        Optional.empty());
+  }
+
   @Nested
   class ErrorHandling {
     @Test
@@ -522,6 +535,161 @@ public class RetentionTest {
       verify(backupStore, never()).deleteRangeMarker(eq(2), any());
 
       verifyRangeMarkerDeleted(1, backupsPerPartition.get(1).get(3));
+    }
+  }
+
+  @Nested
+  @MockitoSettings(strictness = Strictness.LENIENT)
+  class AtLeastOneAvailable {
+
+    @Test
+    void shouldAlwaysMaintainASingleBackup() {
+      // given
+      final var now = actorScheduler.getClock().instant();
+      final BackupStatus backup1 = backupNoDescriptor(1, 1, now.minusSeconds(300));
+      final BackupStatus backup2 = backupNoDescriptor(1, 1, now.minusSeconds(290));
+      final BackupStatus backup3 = backupNoDescriptor(1, 1, now.minusSeconds(280));
+
+      when(backupStore.list(any()))
+          .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
+
+      when(backupStore.rangeMarkers(1))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(
+                      new Start(now.minusSeconds(300).toEpochMilli()),
+                      new End(now.minusSeconds(280).toEpochMilli()))));
+
+      // when
+      runRetentionCycle();
+
+      // then
+      verify(backupStore).delete(backup1.id());
+      verify(backupStore).delete(backup2.id());
+      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
+
+      verifyRangeMarkerStored(1, backup3);
+      verifyRangeMarkerDeleted(1, backup1);
+    }
+
+    @Test
+    void shouldAlwaysMaintainASingleBackupWhenNoDescriptor() {
+      // given
+      final var now = actorScheduler.getClock().instant();
+      final BackupStatus backup1 = backupNoDescriptor(1, 1, now.minusSeconds(300));
+      final BackupStatus backup2 = backupNoDescriptor(1, 1, now.minusSeconds(290));
+      final BackupStatus backup3 = backupNoDescriptor(1, 1, now.minusSeconds(280));
+
+      when(backupStore.list(any()))
+          .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
+
+      when(backupStore.rangeMarkers(1))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(
+                      new Start(now.minusSeconds(300).toEpochMilli()),
+                      new End(now.minusSeconds(280).toEpochMilli()))));
+
+      // when
+      runRetentionCycle();
+
+      // then
+      verify(backupStore).delete(backup1.id());
+      verify(backupStore).delete(backup2.id());
+      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
+
+      verifyRangeMarkerStored(1, backup3);
+      verifyRangeMarkerDeleted(1, backup1);
+    }
+
+    @Test
+    void shouldNotDeleteBackupsIfOnlyOneExists() {
+      // given
+      final var now = actorScheduler.getClock().instant();
+      final BackupStatus backup1 = backup(now.minusSeconds(500));
+
+      when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(List.of(backup1)));
+
+      when(backupStore.rangeMarkers(1))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(new Start(now.minusSeconds(360).toEpochMilli()))));
+
+      // when multiple runs occur
+      actorScheduler.submitActor(backupRetention);
+      actorScheduler.workUntilDone();
+      actorScheduler.updateClock(Duration.ofSeconds(10));
+      actorScheduler.workUntilDone();
+      actorScheduler.updateClock(Duration.ofSeconds(10));
+      actorScheduler.workUntilDone();
+      actorScheduler.updateClock(Duration.ofSeconds(10));
+      actorScheduler.workUntilDone();
+
+      // then
+      verify(backupStore, never()).delete(any());
+    }
+
+    @Test
+    void shouldAlwaysMaintainASingleBackupOnCheckpointId() {
+      // given
+      final var now = actorScheduler.getClock().instant();
+      final BackupStatus backup1 = backup(1, 1, now.minusSeconds(300));
+      final BackupStatus backup2 = backup(1, 1, now.minusSeconds(290));
+      final BackupStatus backup3 = backupOnlyId(1, 1, now.minusSeconds(280));
+
+      when(backupStore.list(any()))
+          .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
+
+      when(backupStore.rangeMarkers(1))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(new Start(now.minusSeconds(360).toEpochMilli()))));
+
+      // when
+      runRetentionCycle();
+
+      // then
+      verify(backupStore).delete(backup1.id());
+      verify(backupStore).delete(backup2.id());
+      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
+    }
+
+    @Test
+    void shouldNotInterfereIfLatestNotWithinWindow() {
+      // given
+      final var now = actorScheduler.getClock().instant();
+      final BackupStatus backup1 = backup(1, 1, now.minusSeconds(360));
+      final BackupStatus backup2 = backup(1, 1, now.minusSeconds(120));
+      final BackupStatus backup3 = backup(1, 1, now.minusSeconds(110));
+      final BackupStatus backup4 = backup(1, 1, now.minusSeconds(100));
+
+      when(backupStore.list(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(List.of(backup1, backup2, backup3, backup4)));
+
+      final List<BackupRangeMarker> ranges =
+          List.of(
+              new Start(now.minusSeconds(360).toEpochMilli()),
+              new End(now.minusSeconds(120).toEpochMilli()),
+              new Start(now.minusSeconds(110).toEpochMilli()),
+              new End(now.minusSeconds(110).toEpochMilli()));
+
+      when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
+
+      // when
+      runRetentionCycle();
+
+      // then
+      verify(backupStore).delete(backup1.id());
+      verify(backupStore).delete(backup2.id());
+      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
+      verify(backupStore, never()).delete(argThat(id -> id.equals(backup4.id())));
+
+      verify(backupStore, never()).storeRangeMarker(eq(1), any());
+      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
+      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+      verify(backupStore, never()).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(2))));
+      verify(backupStore, never()).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(3))));
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Ensure that retention will always leave the latest backup intact even when this is outside the retention window. 
This is a safeguard to ensure no cluster is left without an active backup

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45208
