### PR TITLE
fix: statistics endpoint returns incorrect counts without sort param

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -746,8 +746,11 @@ public final class SearchQueryRequestMapper {
           ProblemDetail, io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery>
       toProcessDefinitionInstanceStatisticsQuery(
           final ProcessDefinitionInstanceStatisticsQuery request) {
+    final var filter =
+        FilterBuilders.processInstance().states(ProcessInstanceState.ACTIVE.name()).build();
     if (request == null) {
-      return Either.right(SearchQueryBuilders.processDefinitionInstanceStatisticsQuery().build());
+      return Either.right(
+          SearchQueryBuilders.processDefinitionInstanceStatisticsQuery().filter(filter).build());
     }
 
     final var page = toOffsetPagination(request.getPage());
@@ -757,8 +760,6 @@ public final class SearchQueryRequestMapper {
                 request.getSort()),
             SortOptionBuilders::processDefinitionInstanceStatistics,
             SearchQuerySortRequestMapper::applyProcessDefinitionInstanceStatisticsSortField);
-    final var filter =
-        FilterBuilders.processInstance().states(ProcessInstanceState.ACTIVE.name()).build();
     return buildSearchQuery(
         filter, sort, page, SearchQueryBuilders::processDefinitionInstanceStatisticsQuery);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The process definitions "get process instance statistics" endpoint was returning incorrect data when no `sort` parameter was provided. Without the sort parameter, the `activeInstancesWithoutIncidentCount` incorrectly included completed and canceled process instances, leading to inflated counts.

This PR ensures that the statistics endpoint returns consistent and correct data regardless of whether a sort parameter is present.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44368
