### PR TITLE
fix: Slower Zeebe Exporter CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,7 +685,7 @@ jobs:
             name: "Zeebe Exporter Modules"
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_IT_EXPORTER_MODULES }}
             maven-build-threads: 2
-            maven-test-fork-count: 3
+            maven-test-fork-count: 7
             runs-on: gcp-core-32-default
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -30,9 +30,9 @@ public final class TestSearchContainers {
           .withTag(
               Objects.requireNonNullElse(
                   org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
-                  "8.16.0"));
+                  "8.19.0"));
   private static final DockerImageName OPENSEARCH_IMAGE =
-      DockerImageName.parse("opensearchproject/opensearch").withTag("2.17.0");
+      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.0");
   private static final DockerImageName POSTGRES_IMAGE =
       DockerImageName.parse("postgres").withTag("15.3-alpine");
   private static final DockerImageName MARIADB_IMAGE =


### PR DESCRIPTION
## Description

- Restore fork count to 7 and branch to test fixes.
- Up the OpenSearch test container back to 2.19.0 and set ES test container at 8.19+ min.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
