### PR TITLE
feat: GCS backup store transfers files in parallel

### DIFF
--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -147,6 +147,12 @@
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -143,14 +143,14 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>api-common</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -175,7 +175,18 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.api:*</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
+          <ignoredNonTestScopedDependencies>
+            <!--
+                Google libraries are used in whatever version was pulled through the main dependency
+                on google-cloud-core.
+                Explicitly defining dependencies on these libraries doesn't help and only increases
+                the risk that our definitions drift from what google-cloud-core wants to use whenever
+                dependabot updates one of these versions.
+              -->
+            <ignoredNonTestScopedDependency>com.google.api:api-common</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -88,6 +88,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -12,6 +12,8 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.transfermanager.TransferManager;
+import com.google.cloud.storage.transfermanager.TransferManagerConfig;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
@@ -51,6 +53,7 @@ public final class GcsBackupStore implements BackupStore {
   private final ExecutorService executor;
   private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
+  private final TransferManager transferManager;
   private final Storage client;
   private final BucketInfo bucketInfo;
   private final String basePath;
@@ -65,7 +68,13 @@ public final class GcsBackupStore implements BackupStore {
     this.client = client;
     executor = Executors.newWorkStealingPool(4);
     manifestManager = new ManifestManager(client, bucketInfo, basePath);
-    fileSetManager = new FileSetManager(client, bucketInfo, basePath);
+    transferManager =
+        TransferManagerConfig.newBuilder()
+            .setStorageOptions(client.getOptions())
+            .setAllowDivideAndConquerDownload(true)
+            .build()
+            .getService();
+    fileSetManager = new FileSetManager(client, transferManager, bucketInfo, basePath);
   }
 
   public static BackupStore of(final GcsBackupConfig config) {
@@ -212,6 +221,7 @@ public final class GcsBackupStore implements BackupStore {
               executor.shutdownNow();
             }
             client.close();
+            transferManager.close();
           } catch (final Exception e) {
             throw new RuntimeException(e);
           }


### PR DESCRIPTION
This replaces sequential up- and download of backup contents with a simple virtual thread per task approach.
Relies on the storage client behaving nicely with many concurrent connections.
