### PR TITLE
feat: port missing `BatchOperationCfg` properties to the unified config

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
@@ -7,13 +7,27 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import java.time.Duration;
 import java.util.Set;
 
 public class EngineBatchOperation {
 
   private static final String PREFIX = "camunda.processing.engine.batch-operations";
+  private static final Duration DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL = Duration.ofSeconds(1);
+  // reasonable size of a chunk record to avoid too many or too large records
+  private static final int DEFAULT_BATCH_OPERATION_CHUNK_SIZE = 100;
+  // key has 8 bytes, stay below 32KB block size
+  private static final int DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE = 3500;
+  // ES/OS have max 10000 entities per query
+  private static final int DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE = 10000;
+  // Oracle can only have 1000 elements in `IN` clause
+  private static final int DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE = 1000;
+  private static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX = 0;
+  private static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY =
+      Duration.ofSeconds(1);
+  private static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY =
+      Duration.ofSeconds(60);
+  private static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR = 2;
 
   private static final Set<String> LEGACY_SCHEDULER_INTERVAL_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.batchOperations.schedulerInterval");
@@ -44,61 +58,57 @@ public class EngineBatchOperation {
 
   /**
    * The interval at which the batch operation scheduler runs. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
+   * #DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
    */
-  private Duration schedulerInterval =
-      EngineConfiguration.DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
+  private Duration schedulerInterval = DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
 
   /**
    * Number of itemKeys in one BatchOperationChunkRecord. Must be below 4MB total record size.
-   * Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
+   * Defaults to {@link #DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
    */
-  private int chunkSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_CHUNK_SIZE;
+  private int chunkSize = DEFAULT_BATCH_OPERATION_CHUNK_SIZE;
 
   /**
    * Number of itemKeys in one PersistedBatchOperationChunk. Must be below 32KB total record size.
-   * Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
+   * Defaults to {@link #DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
    */
-  private int dbChunkSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE;
+  private int dbChunkSize = DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE;
 
   /**
    * The page size for batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
    */
-  private int queryPageSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
+  private int queryPageSize = DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
 
   /**
    * The size of the IN clause for batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
    */
-  private int queryInClauseSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
+  private int queryInClauseSize = DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
 
   /**
    * The maximum number of retries for batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
    */
-  private int queryRetryMax = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+  private int queryRetryMax = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
 
   /**
    * The initial delay for retrying batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
    */
-  private Duration queryRetryInitialDelay =
-      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+  private Duration queryRetryInitialDelay = DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
 
   /**
    * The maximum delay for retrying batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
    */
-  private Duration queryRetryMaxDelay =
-      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
+  private Duration queryRetryMaxDelay = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
 
   /**
    * The backoff factor for retrying batch operation queries. Defaults to {@link
-   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
+   * #DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
    */
-  private int queryRetryBackoffFactor =
-      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
+  private int queryRetryBackoffFactor = DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
 
   public Duration getSchedulerInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
@@ -18,12 +18,87 @@ public class EngineBatchOperation {
   private static final Set<String> LEGACY_SCHEDULER_INTERVAL_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.batchOperations.schedulerInterval");
 
+  private static final Set<String> LEGACY_CHUNK_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.chunkSize");
+
+  private static final Set<String> LEGACY_DB_CHUNK_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.dbChunkSize");
+
+  private static final Set<String> LEGACY_QUERY_PAGE_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryPageSize");
+
+  private static final Set<String> LEGACY_QUERY_IN_CLAUSE_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryInClauseSize");
+
+  private static final Set<String> LEGACY_QUERY_RETRY_MAX_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryRetryMax");
+
+  private static final Set<String> LEGACY_QUERY_RETRY_INITIAL_DELAY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryRetryInitialDelay");
+
+  private static final Set<String> LEGACY_QUERY_RETRY_MAX_DELAY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryRetryMaxDelay");
+
+  private static final Set<String> LEGACY_QUERY_RETRY_BACKOFF_FACTOR_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.batchOperations.queryRetryBackoffFactor");
+
   /**
    * The interval at which the batch operation scheduler runs. Defaults to {@link
    * EngineConfiguration#DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
    */
   private Duration schedulerInterval =
       EngineConfiguration.DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
+
+  /**
+   * Number of itemKeys in one BatchOperationChunkRecord. Must be below 4MB total record size.
+   * Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
+   */
+  private int chunkSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_CHUNK_SIZE;
+
+  /**
+   * Number of itemKeys in one PersistedBatchOperationChunk. Must be below 32KB total record size.
+   * Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
+   */
+  private int dbChunkSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE;
+
+  /**
+   * The page size for batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
+   */
+  private int queryPageSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE;
+
+  /**
+   * The size of the IN clause for batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
+   */
+  private int queryInClauseSize = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
+
+  /**
+   * The maximum number of retries for batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
+   */
+  private int queryRetryMax = EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX;
+
+  /**
+   * The initial delay for retrying batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
+   */
+  private Duration queryRetryInitialDelay =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY;
+
+  /**
+   * The maximum delay for retrying batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
+   */
+  private Duration queryRetryMaxDelay =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
+
+  /**
+   * The backoff factor for retrying batch operation queries. Defaults to {@link
+   * EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
+   */
+  private int queryRetryBackoffFactor =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
 
   public Duration getSchedulerInterval() {
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
@@ -36,5 +111,109 @@ public class EngineBatchOperation {
 
   public void setSchedulerInterval(final Duration schedulerInterval) {
     this.schedulerInterval = schedulerInterval;
+  }
+
+  public int getChunkSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".chunk-size",
+        chunkSize,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CHUNK_SIZE_PROPERTIES);
+  }
+
+  public void setChunkSize(final int chunkSize) {
+    this.chunkSize = chunkSize;
+  }
+
+  public int getDbChunkSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".db-chunk-size",
+        dbChunkSize,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_DB_CHUNK_SIZE_PROPERTIES);
+  }
+
+  public void setDbChunkSize(final int dbChunkSize) {
+    this.dbChunkSize = dbChunkSize;
+  }
+
+  public int getQueryPageSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-page-size",
+        queryPageSize,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_PAGE_SIZE_PROPERTIES);
+  }
+
+  public void setQueryPageSize(final int queryPageSize) {
+    this.queryPageSize = queryPageSize;
+  }
+
+  public int getQueryInClauseSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-in-clause-size",
+        queryInClauseSize,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_IN_CLAUSE_SIZE_PROPERTIES);
+  }
+
+  public void setQueryInClauseSize(final int queryInClauseSize) {
+    this.queryInClauseSize = queryInClauseSize;
+  }
+
+  public int getQueryRetryMax() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-retry-max",
+        queryRetryMax,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_RETRY_MAX_PROPERTIES);
+  }
+
+  public void setQueryRetryMax(final int queryRetryMax) {
+    this.queryRetryMax = queryRetryMax;
+  }
+
+  public Duration getQueryRetryInitialDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-retry-initial-delay",
+        queryRetryInitialDelay,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_RETRY_INITIAL_DELAY_PROPERTIES);
+  }
+
+  public void setQueryRetryInitialDelay(final Duration queryRetryInitialDelay) {
+    this.queryRetryInitialDelay = queryRetryInitialDelay;
+  }
+
+  public Duration getQueryRetryMaxDelay() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-retry-max-delay",
+        queryRetryMaxDelay,
+        Duration.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_RETRY_MAX_DELAY_PROPERTIES);
+  }
+
+  public void setQueryRetryMaxDelay(final Duration queryRetryMaxDelay) {
+    this.queryRetryMaxDelay = queryRetryMaxDelay;
+  }
+
+  public int getQueryRetryBackoffFactor() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".query-retry-backoff-factor",
+        queryRetryBackoffFactor,
+        Integer.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_QUERY_RETRY_BACKOFF_FACTOR_PROPERTIES);
+  }
+
+  public void setQueryRetryBackoffFactor(final int queryRetryBackoffFactor) {
+    this.queryRetryBackoffFactor = queryRetryBackoffFactor;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -231,11 +231,17 @@ public class BrokerBasedPropertiesOverride {
   private void populateFromBatchOperations(final BrokerBasedProperties override) {
     final var engineBatchOperation =
         unifiedConfiguration.getCamunda().getProcessing().getEngine().getBatchOperations();
-    override
-        .getExperimental()
-        .getEngine()
-        .getBatchOperations()
-        .setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
+    final var batchOperationsCfg = override.getExperimental().getEngine().getBatchOperations();
+    batchOperationsCfg.setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
+    batchOperationsCfg.setChunkSize(engineBatchOperation.getChunkSize());
+    batchOperationsCfg.setDbChunkSize(engineBatchOperation.getDbChunkSize());
+    batchOperationsCfg.setQueryPageSize(engineBatchOperation.getQueryPageSize());
+    batchOperationsCfg.setQueryInClauseSize(engineBatchOperation.getQueryInClauseSize());
+    batchOperationsCfg.setQueryRetryMax(engineBatchOperation.getQueryRetryMax());
+    batchOperationsCfg.setQueryRetryInitialDelay(engineBatchOperation.getQueryRetryInitialDelay());
+    batchOperationsCfg.setQueryRetryMaxDelay(engineBatchOperation.getQueryRetryMaxDelay());
+    batchOperationsCfg.setQueryRetryBackoffFactor(
+        engineBatchOperation.getQueryRetryBackoffFactor());
   }
 
   private void populateFromExpression(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/EngineBatchOperationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineBatchOperationTest.java
@@ -31,6 +31,14 @@ public class EngineBatchOperationTest {
   @TestPropertySource(
       properties = {
         "camunda.processing.engine.batch-operations.scheduler-interval=15s",
+        "camunda.processing.engine.batch-operations.chunk-size=500",
+        "camunda.processing.engine.batch-operations.db-chunk-size=100",
+        "camunda.processing.engine.batch-operations.query-page-size=200",
+        "camunda.processing.engine.batch-operations.query-in-clause-size=50",
+        "camunda.processing.engine.batch-operations.query-retry-max=5",
+        "camunda.processing.engine.batch-operations.query-retry-initial-delay=2s",
+        "camunda.processing.engine.batch-operations.query-retry-max-delay=30s",
+        "camunda.processing.engine.batch-operations.query-retry-backoff-factor=3",
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -42,7 +50,15 @@ public class EngineBatchOperationTest {
     @Test
     void shouldSetBatchOperation() {
       assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
-          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval)
+          .returns(500, BatchOperationCfg::getChunkSize)
+          .returns(100, BatchOperationCfg::getDbChunkSize)
+          .returns(200, BatchOperationCfg::getQueryPageSize)
+          .returns(50, BatchOperationCfg::getQueryInClauseSize)
+          .returns(5, BatchOperationCfg::getQueryRetryMax)
+          .returns(Duration.ofSeconds(2), BatchOperationCfg::getQueryRetryInitialDelay)
+          .returns(Duration.ofSeconds(30), BatchOperationCfg::getQueryRetryMaxDelay)
+          .returns(3, BatchOperationCfg::getQueryRetryBackoffFactor);
     }
   }
 
@@ -50,6 +66,14 @@ public class EngineBatchOperationTest {
   @TestPropertySource(
       properties = {
         "zeebe.broker.experimental.engine.batchOperations.schedulerInterval=15s",
+        "zeebe.broker.experimental.engine.batchOperations.chunkSize=500",
+        "zeebe.broker.experimental.engine.batchOperations.dbChunkSize=100",
+        "zeebe.broker.experimental.engine.batchOperations.queryPageSize=200",
+        "zeebe.broker.experimental.engine.batchOperations.queryInClauseSize=50",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryMax=5",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryInitialDelay=2s",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryMaxDelay=30s",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryBackoffFactor=3",
       })
   class WithOnlyLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -61,7 +85,15 @@ public class EngineBatchOperationTest {
     @Test
     void shouldSetBatchOperationFromLegacy() {
       assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
-          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval)
+          .returns(500, BatchOperationCfg::getChunkSize)
+          .returns(100, BatchOperationCfg::getDbChunkSize)
+          .returns(200, BatchOperationCfg::getQueryPageSize)
+          .returns(50, BatchOperationCfg::getQueryInClauseSize)
+          .returns(5, BatchOperationCfg::getQueryRetryMax)
+          .returns(Duration.ofSeconds(2), BatchOperationCfg::getQueryRetryInitialDelay)
+          .returns(Duration.ofSeconds(30), BatchOperationCfg::getQueryRetryMaxDelay)
+          .returns(3, BatchOperationCfg::getQueryRetryBackoffFactor);
     }
   }
 
@@ -70,8 +102,24 @@ public class EngineBatchOperationTest {
       properties = {
         // new
         "camunda.processing.engine.batch-operations.scheduler-interval=15s",
+        "camunda.processing.engine.batch-operations.chunk-size=500",
+        "camunda.processing.engine.batch-operations.db-chunk-size=100",
+        "camunda.processing.engine.batch-operations.query-page-size=200",
+        "camunda.processing.engine.batch-operations.query-in-clause-size=50",
+        "camunda.processing.engine.batch-operations.query-retry-max=5",
+        "camunda.processing.engine.batch-operations.query-retry-initial-delay=2s",
+        "camunda.processing.engine.batch-operations.query-retry-max-delay=30s",
+        "camunda.processing.engine.batch-operations.query-retry-backoff-factor=3",
         // legacy
         "zeebe.broker.experimental.engine.batchOperations.schedulerInterval=150s",
+        "zeebe.broker.experimental.engine.batchOperations.chunkSize=5000",
+        "zeebe.broker.experimental.engine.batchOperations.dbChunkSize=1000",
+        "zeebe.broker.experimental.engine.batchOperations.queryPageSize=2000",
+        "zeebe.broker.experimental.engine.batchOperations.queryInClauseSize=500",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryMax=50",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryInitialDelay=20s",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryMaxDelay=300s",
+        "zeebe.broker.experimental.engine.batchOperations.queryRetryBackoffFactor=30",
       })
   class WithNewAndLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -83,7 +131,15 @@ public class EngineBatchOperationTest {
     @Test
     void shouldSetBatchOperationFromNew() {
       assertThat(brokerCfg.getExperimental().getEngine().getBatchOperations())
-          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval);
+          .returns(Duration.ofSeconds(15), BatchOperationCfg::getSchedulerInterval)
+          .returns(500, BatchOperationCfg::getChunkSize)
+          .returns(100, BatchOperationCfg::getDbChunkSize)
+          .returns(200, BatchOperationCfg::getQueryPageSize)
+          .returns(50, BatchOperationCfg::getQueryInClauseSize)
+          .returns(5, BatchOperationCfg::getQueryRetryMax)
+          .returns(Duration.ofSeconds(2), BatchOperationCfg::getQueryRetryInitialDelay)
+          .returns(Duration.ofSeconds(30), BatchOperationCfg::getQueryRetryMaxDelay)
+          .returns(3, BatchOperationCfg::getQueryRetryBackoffFactor);
     }
   }
 }

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -606,6 +606,10 @@ camunda: # Type: io.camunda.configuration.Camunda
           cache-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROCESSCACHE_CACHENAME
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROCESSCACHE_DATABASENAME
         
+        # What default refresh interval we will use for all indices
+        refresh-interval: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_REFRESHINTERVAL
+        # Per-index refresh interval overrides.
+        refresh-interval-by-index-name: null # Type: Map<String,String>, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_REFRESHINTERVALBYINDEXNAME
         security: # Type: io.camunda.configuration.SecondaryStorageSecurity  
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_SECURITY_DATABASENAME
         
@@ -613,8 +617,12 @@ camunda: # Type: io.camunda.configuration.Camunda
         socket-timeout: null # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_SOCKETTIMEOUT
         # Template priority for index templates.
         template-priority: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_TEMPLATEPRIORITY
-        # Endpoint for the database configured as secondary storage.
+        # Endpoint for the database configured as secondary storage. Mutually exclusive with {@link #urls} -
+        # configure only one.
         url: "http://localhost:9200" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL
+        # List of endpoints for the database configured as secondary storage. Use for multi-node cluster
+        # connectivity. Mutually exclusive with {@link #url} - configure only one.
+        urls: null # Type: List<String>, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URLS
         # Username for the database configured as secondary storage.
         username: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_USERNAME
         # Variable size threshold for the database configured as secondary storage.
@@ -677,6 +685,10 @@ camunda: # Type: io.camunda.configuration.Camunda
           cache-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROCESSCACHE_CACHENAME
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROCESSCACHE_DATABASENAME
         
+        # What default refresh interval we will use for all indices
+        refresh-interval: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_REFRESHINTERVAL
+        # Per-index refresh interval overrides.
+        refresh-interval-by-index-name: null # Type: Map<String,String>, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_REFRESHINTERVALBYINDEXNAME
         security: # Type: io.camunda.configuration.SecondaryStorageSecurity  
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_SECURITY_DATABASENAME
         
@@ -684,14 +696,20 @@ camunda: # Type: io.camunda.configuration.Camunda
         socket-timeout: null # Type: Duration, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_SOCKETTIMEOUT
         # Template priority for index templates.
         template-priority: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_TEMPLATEPRIORITY
-        # Endpoint for the database configured as secondary storage.
+        # Endpoint for the database configured as secondary storage. Mutually exclusive with {@link #urls} -
+        # configure only one.
         url: "http://localhost:9200" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URL
+        # List of endpoints for the database configured as secondary storage. Use for multi-node cluster
+        # connectivity. Mutually exclusive with {@link #url} - configure only one.
+        urls: null # Type: List<String>, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_URLS
         # Username for the database configured as secondary storage.
         username: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_USERNAME
         # Variable size threshold for the database configured as secondary storage.
         variable-size-threshold: 8191 # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_VARIABLESIZETHRESHOLD
       
       rdbms: # Type: io.camunda.configuration.Rdbms  
+        # If true, the database schema is automatically created and updated on application startup.
+        auto-ddl: true # Type: Boolean, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_AUTODDL
         # Batch operation cache configuration. Defines the size of the batch operation cache.
         batch-operation-cache: null # Type: io.camunda.configuration.RdbmsCache, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_BATCHOPERATIONCACHE
         # The number of batch operation items to insert in a single batched SQL when creating the items for a
@@ -741,6 +759,8 @@ camunda: # Type: io.camunda.configuration.Camunda
         
         insert-batching: # Type: io.camunda.configuration.RdbmsInsertBatching  
           max-audit-log-insert-batch-size: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_INSERTBATCHING_MAXAUDITLOGINSERTBATCHSIZE
+          max-flow-node-insert-batch-size: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_INSERTBATCHING_MAXFLOWNODEINSERTBATCHSIZE
+          max-job-insert-batch-size: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_INSERTBATCHING_MAXJOBINSERTBATCHSIZE
           max-variable-insert-batch-size: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_INSERTBATCHING_MAXVARIABLEINSERTBATCHSIZE
         
         metrics: # Type: io.camunda.configuration.RdbmsMetrics  
@@ -759,8 +779,12 @@ camunda: # Type: io.camunda.configuration.Camunda
         queue-memory-limit: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_QUEUEMEMORYLIMIT
         # The maximum size of the exporters execution queue before it is flushed to the database.
         queue-size: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_QUEUESIZE
-        # Endpoint for the database configured as secondary storage.
+        # Endpoint for the database configured as secondary storage. Mutually exclusive with {@link #urls} -
+        # configure only one.
         url: "http://localhost:9200" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URL
+        # List of endpoints for the database configured as secondary storage. Use for multi-node cluster
+        # connectivity. Mutually exclusive with {@link #url} - configure only one.
+        urls: null # Type: List<String>, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URLS
         # Username for the database configured as secondary storage.
         username: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_USERNAME
       
@@ -781,6 +805,8 @@ camunda: # Type: io.camunda.configuration.Camunda
     index: # Type: io.camunda.configuration.beans.LegacySearchEngineIndexProperties  
       number-of-replicas: null # Type: Integer, Env: CAMUNDA_DATABASE_INDEX_NUMBEROFREPLICAS
       number-of-shards: null # Type: Integer, Env: CAMUNDA_DATABASE_INDEX_NUMBEROFSHARDS
+      refresh-interval: null # Type: String, Env: CAMUNDA_DATABASE_INDEX_REFRESHINTERVAL
+      refresh-interval-by-index-name: null # Type: Map<String,String>, Env: CAMUNDA_DATABASE_INDEX_REFRESHINTERVALBYINDEXNAME
       replicas-by-index-name: null # Type: Map<String,Integer>, Env: CAMUNDA_DATABASE_INDEX_REPLICASBYINDEXNAME
       shards-by-index-name: null # Type: Map<String,Integer>, Env: CAMUNDA_DATABASE_INDEX_SHARDSBYINDEXNAME
       template-priority: null # Type: Integer, Env: CAMUNDA_DATABASE_INDEX_TEMPLATEPRIORITY
@@ -800,6 +826,7 @@ camunda: # Type: io.camunda.configuration.Camunda
     security: null # Type: io.camunda.search.connect.configuration.SecurityConfiguration, Env: CAMUNDA_DATABASE_SECURITY
     socket-timeout: null # Type: Integer, Env: CAMUNDA_DATABASE_SOCKETTIMEOUT
     url: null # Type: String, Env: CAMUNDA_DATABASE_URL
+    urls: null # Type: List<String>, Env: CAMUNDA_DATABASE_URLS
     username: null # Type: String, Env: CAMUNDA_DATABASE_USERNAME
   
   expression: # Type: io.camunda.configuration.Expression  
@@ -853,6 +880,7 @@ camunda: # Type: io.camunda.configuration.Camunda
         verify-hostname: null # Type: Boolean, Env: CAMUNDA_OPERATE_ELASTICSEARCH_SSL_VERIFYHOSTNAME
       
       url: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_URL
+      urls: null # Type: List<String>, Env: CAMUNDA_OPERATE_ELASTICSEARCH_URLS
       username: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_USERNAME
     
     enterprise: null # Type: Boolean, Env: CAMUNDA_OPERATE_ENTERPRISE
@@ -890,16 +918,8 @@ camunda: # Type: io.camunda.configuration.Camunda
         verify-hostname: null # Type: Boolean, Env: CAMUNDA_OPERATE_OPENSEARCH_SSL_VERIFYHOSTNAME
       
       url: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_URL
+      urls: null # Type: List<String>, Env: CAMUNDA_OPERATE_OPENSEARCH_URLS
       username: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_USERNAME
-    
-    operation-executor: # Type: io.camunda.operate.property.OperationExecutorProperties  
-      batch-size: null # Type: Integer, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_BATCHSIZE
-      deletion-batch-size: null # Type: Integer, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_DELETIONBATCHSIZE
-      executor-enabled: null # Type: Boolean, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_EXECUTORENABLED
-      lock-timeout: null # Type: Long, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_LOCKTIMEOUT
-      queue-size: null # Type: Integer, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_QUEUESIZE
-      threads-count: null # Type: Integer, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_THREADSCOUNT
-      worker-id: null # Type: String, Env: CAMUNDA_OPERATE_OPERATIONEXECUTOR_WORKERID
     
     password: null # Type: String, Env: CAMUNDA_OPERATE_PASSWORD
     rfc3339-api-date-format: null # Type: Boolean, Env: CAMUNDA_OPERATE_RFC3339APIDATEFORMAT
@@ -953,17 +973,41 @@ camunda: # Type: io.camunda.configuration.Camunda
     # check preconditions, for example that a key does not already exist when inserting.
     enable-preconditions-check: false # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLEPRECONDITIONSCHECK
     enable-straightthrough-processing-loop-detector: true # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLESTRAIGHTTHROUGHPROCESSINGLOOPDETECTOR
-    # Changes the DueDateTimerCheckScheduler to give yield to other processing steps in situations where it has
-    # many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerCheckScheduler will
-    # activate all due timers. In the worst case, this can lead to the node being blocked for indefinite
-    # amount of time, being subsequently flagged as unhealthy. Currently, there is no known way to recover
-    # from this situation If set to true, the DueDateTimerCheckScheduler will give yield to other processing
-    # steps. This avoids the worst case described above. However, under consistent high load it may happen
-    # that the activated timers will fall behind real time, if more timers become due than can be
-    # activated during a certain time period.
+    # Changes the DueDateTimerCheckScheduler to give yield to other processing steps in situations where
+    # it has many (i.e. millions of) timers to process. If set to false (default) the
+    # DueDateTimerCheckScheduler will activate all due timers. In the worst case, this can lead to the
+    # node being blocked for indefinite amount of time, being subsequently flagged as unhealthy.
+    # Currently, there is no known way to recover from this situation If set to true, the
+    # DueDateTimerCheckScheduler will give yield to other processing steps. This avoids the worst case
+    # described above. However, under consistent high load it may happen that the activated timers will
+    # fall behind real time, if more timers become due than can be activated during a certain time period.
     enable-yielding-due-date-checker: true # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLEYIELDINGDUEDATECHECKER
     engine: # Type: io.camunda.configuration.Engine  
       batch-operations: # Type: io.camunda.configuration.EngineBatchOperation  
+        # Number of itemKeys in one BatchOperationChunkRecord. Must be below 4MB total record size. Defaults
+        # to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
+        chunk-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_CHUNKSIZE
+        # Number of itemKeys in one PersistedBatchOperationChunk. Must be below 32KB total record size.
+        # Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
+        db-chunk-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_DBCHUNKSIZE
+        # The size of the IN clause for batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
+        query-in-clause-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYINCLAUSESIZE
+        # The page size for batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
+        query-page-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYPAGESIZE
+        # The backoff factor for retrying batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
+        query-retry-backoff-factor: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYBACKOFFFACTOR
+        # The initial delay for retrying batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
+        query-retry-initial-delay: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYINITIALDELAY
+        # The maximum number of retries for batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
+        query-retry-max: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAX
+        # The maximum delay for retrying batch operation queries. Defaults to {@link
+        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
+        query-retry-max-delay: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAXDELAY
         # The interval at which the batch operation scheduler runs. Defaults to {@link
         # EngineConfiguration#DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
         scheduler-interval: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_SCHEDULERINTERVAL
@@ -1118,7 +1162,7 @@ camunda: # Type: io.camunda.configuration.Camunda
     # to disk. While writing, these threads are blocked which means that they yield the CPU.
     io-thread-count: 2 # Type: Integer, Env: CAMUNDA_SYSTEM_IOTHREADCOUNT
     restore: # Type: io.camunda.configuration.Restore  
-      ignore-files-in-target: "lost+found" # Type: List<String>, Env: CAMUNDA_SYSTEM_RESTORE_IGNOREFILESINTARGET
+      ignore-files-in-target: null # Type: List<String>, Env: CAMUNDA_SYSTEM_RESTORE_IGNOREFILESINTARGET
       validate-config: true # Type: Boolean, Env: CAMUNDA_SYSTEM_RESTORE_VALIDATECONFIG
     
     upgrade: # Type: io.camunda.configuration.Upgrade  
@@ -1174,6 +1218,7 @@ camunda: # Type: io.camunda.configuration.Camunda
         verify-hostname: null # Type: Boolean, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_SSL_VERIFYHOSTNAME
       
       url: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_URL
+      urls: null # Type: List<String>, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_URLS
       username: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_USERNAME
     
     enterprise: null # Type: Boolean, Env: CAMUNDA_TASKLIST_ENTERPRISE
@@ -1207,6 +1252,7 @@ camunda: # Type: io.camunda.configuration.Camunda
         verify-hostname: null # Type: Boolean, Env: CAMUNDA_TASKLIST_OPENSEARCH_SSL_VERIFYHOSTNAME
       
       url: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_URL
+      urls: null # Type: List<String>, Env: CAMUNDA_TASKLIST_OPENSEARCH_URLS
       username: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_USERNAME
     
     version: null # Type: String, Env: CAMUNDA_TASKLIST_VERSION

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -984,32 +984,75 @@ camunda: # Type: io.camunda.configuration.Camunda
     enable-yielding-due-date-checker: true # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLEYIELDINGDUEDATECHECKER
     engine: # Type: io.camunda.configuration.Engine  
       batch-operations: # Type: io.camunda.configuration.EngineBatchOperation  
-        # Number of itemKeys in one BatchOperationChunkRecord. Must be below 4MB total record size. Defaults
-        # to {@link #DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
+        # Number of itemKeys in one BatchOperationChunkRecord.
+        # To avoid too large records, the set of executed items ina batch operation is split into multiple
+        # chunks. Smaller values lead to more records needed to transport the items and the more metadata
+        # overhead is created. Larger values tend to overload the exporters as many rows need to be written
+        # per exported record.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
         chunk-size: 100 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_CHUNKSIZE
-        # Number of itemKeys in one PersistedBatchOperationChunk. Must be below 32KB total record size.
+        # Number of itemKeys in one PersistedBatchOperationChunk.
+        # The items of a batch operation are stored in a separate column family in the RocksDB database. To
+        # keep the single records/values of the RocksDb to a reasonable size, the items are split into
+        # multiple chunks. Setting this value to a higher value will result in larger chunks, which can lead
+        # to a more inefficient RocksDB cache. The default value 3500 means that each chunk record will be
+        # smaller than the default rocksdb block size of 32KB.
         # Defaults to {@link #DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
         db-chunk-size: 3500 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_DBCHUNKSIZE
-        # The size of the IN clause for batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
+        # The size of the IN clause for batch operation queries.
+        # Some batch operation types need to query the secondary storage in multiple steps. E.g.
+        # RESOLVE_INCIDENT first queries for processInstances and in a second step for all open incidents of
+        # these processInstances. This setting allows to configure the maximum number of itemKeys to be given
+        # in the second step query as processInstances "IN" clause. A higher value will result in fewer
+        # queries to the secondary storage, but may not be supported by all database systems. E.g. OracleDb
+        # only supports 1000 elements in an IN clause.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
         query-in-clause-size: 1000 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYINCLAUSESIZE
-        # The page size for batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
+        # The page size for batch operation queries.
+        # To initialize a batch operation, the engine will query the secondary storage for relevant items
+        # using the given filter object. Since the secondary storage uses paginated queries, this setting
+        # allows to configure the maximum number of items that can be returned in a single query. The higher
+        # the value, the more items can be returned in a single query, which can lead to better performance
+        # but also to memory issues when the pages are too large.
+        # When using Elasticsearch or OpenSearch as secondary storage, the default value of 10000 items is
+        # also the maximum pageSize of these databases and a higher value here will be ignored.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
         query-page-size: 10000 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYPAGESIZE
-        # The backoff factor for retrying batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
+        # The backoff factor by which the delay between retries is increased.
+        # This can be used to mitigate transient issues with the secondary database. A retry will be attempted
+        # after a delay, which can be configured with {@link #queryRetryInitialDelay} as initial delay and
+        # {@link #queryRetryMaxDelay} as maximum delay and will be increased exponentially with this backoff
+        # factor.
+        # A higher value will lead to a faster increase of the delay between retries, which can be useful to
+        # reduce the load on the secondary database in case of longer outages, but can also lead to longer
+        # delays between retries in case of a high number of retries or a high backoff factor.
+        # Setting the value to 1 will lead to a constant delay between retries.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
         query-retry-backoff-factor: 2 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYBACKOFFFACTOR
-        # The initial delay for retrying batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
+        # The initial delay for retrying batch operation queries in case a query to secondary storage fails.
+        # This can be used to mitigate transient issues with the secondary database. A retry will be attempted
+        # after a delay, which can be configured with this setting as initial delay and {@link
+        # #queryRetryMaxDelay} as maximum delay and will be increased exponentially with the given backoff
+        # factor {@link #queryRetryBackoffFactor}.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
         query-retry-initial-delay: "1s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYINITIALDELAY
-        # The maximum number of retries for batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
+        # The maximum number of retries for batch operation queries.
+        # Allows to configure the number of retries in case a query to the secondary database fails. This can
+        # be used to mitigate transient issues with the secondary database. A retry will be attempted after a
+        # delay, which can be configured with {@link #queryRetryInitialDelay} and {@link #queryRetryMaxDelay}
+        # and will be increased exponentially with the given backoff factor {@link #queryRetryBackoffFactor}.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
         query-retry-max: 0 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAX
-        # The maximum delay for retrying batch operation queries. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
+        # The maximum delay between retries if batch operation queries fail.
+        # This can be used to mitigate transient issues with the secondary database. A retry will be attempted
+        # after a delay, which can be configured with {@link #queryRetryInitialDelay} as initial delay and
+        # this setting as maximum delay and will be increased exponentially with the given backoff factor
+        # {@link #queryRetryBackoffFactor}. The maximum delay can be used to prevent too long delays between
+        # retries in case of a high backoff factor or many retries.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
         query-retry-max-delay: "60s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAXDELAY
-        # The interval at which the batch operation scheduler runs. Defaults to {@link
-        # #DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
+        # The interval at which the batch operation scheduler runs.
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
         scheduler-interval: "1s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_SCHEDULERINTERVAL
       
       distribution: # Type: io.camunda.configuration.Distribution  

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -985,32 +985,32 @@ camunda: # Type: io.camunda.configuration.Camunda
     engine: # Type: io.camunda.configuration.Engine  
       batch-operations: # Type: io.camunda.configuration.EngineBatchOperation  
         # Number of itemKeys in one BatchOperationChunkRecord. Must be below 4MB total record size. Defaults
-        # to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
-        chunk-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_CHUNKSIZE
+        # to {@link #DEFAULT_BATCH_OPERATION_CHUNK_SIZE}.
+        chunk-size: 100 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_CHUNKSIZE
         # Number of itemKeys in one PersistedBatchOperationChunk. Must be below 32KB total record size.
-        # Defaults to {@link EngineConfiguration#DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
-        db-chunk-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_DBCHUNKSIZE
+        # Defaults to {@link #DEFAULT_BATCH_OPERATION_DB_CHUNK_SIZE}.
+        db-chunk-size: 3500 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_DBCHUNKSIZE
         # The size of the IN clause for batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
-        query-in-clause-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYINCLAUSESIZE
+        # #DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE}.
+        query-in-clause-size: 1000 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYINCLAUSESIZE
         # The page size for batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
-        query-page-size: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYPAGESIZE
+        # #DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE}.
+        query-page-size: 10000 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYPAGESIZE
         # The backoff factor for retrying batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
-        query-retry-backoff-factor: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYBACKOFFFACTOR
+        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR}.
+        query-retry-backoff-factor: 2 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYBACKOFFFACTOR
         # The initial delay for retrying batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
-        query-retry-initial-delay: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYINITIALDELAY
+        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_INITIAL_DELAY}.
+        query-retry-initial-delay: "1s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYINITIALDELAY
         # The maximum number of retries for batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
-        query-retry-max: null # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAX
+        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX}.
+        query-retry-max: 0 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAX
         # The maximum delay for retrying batch operation queries. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
-        query-retry-max-delay: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAXDELAY
+        # #DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY}.
+        query-retry-max-delay: "60s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_QUERYRETRYMAXDELAY
         # The interval at which the batch operation scheduler runs. Defaults to {@link
-        # EngineConfiguration#DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
-        scheduler-interval: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_SCHEDULERINTERVAL
+        # #DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL}.
+        scheduler-interval: "1s" # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_BATCHOPERATIONS_SCHEDULERINTERVAL
       
       distribution: # Type: io.camunda.configuration.Distribution  
         # Allows configuring the maximum backoff duration for command redistribution retries. The retry


### PR DESCRIPTION
## Description
Ports the remaining engine batch operation configuration options from the legacy `BatchOperationCfg` into the unified configuration model (`EngineBatchOperation`), including backward-compatible legacy property fallbacks and wiring into the broker override.

**Changes:**
- Added missing batch operation tuning properties (chunk sizes, query paging, retry settings) to `EngineBatchOperation`, each with legacy property fallback via `UnifiedConfigurationHelper`.
- Updated `BrokerBasedPropertiesOverride` to populate the legacy `BatchOperationCfg` from the unified config for all batch operation fields.
- Expanded `EngineBatchOperationTest` coverage to assert unified-only, legacy-only, and “new wins over legacy” behavior for all fields.

## Related issues

closes #45292