### PR TITLE
fix: ensure restore app terminates when dynamic node id is configured

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
@@ -106,12 +106,13 @@ public class RestoreNodeIdProviderConfiguration {
         yield (context -> {
           final var restoreId = context.restoreId();
           final var nodeId = context.nodeId();
-          if (!context.skippedRestore()) {
-            restoreStatusManager.markNodeRestored(restoreId, nodeId);
-          }
           // Validate even if we skipped in case the restore was retried with empty disk, but the s3
           // object was not deleted.
           validateAfterRestore(brokerCfg, context);
+
+          if (!context.skippedRestore()) {
+            restoreStatusManager.markNodeRestored(restoreId, nodeId);
+          }
 
           restoreStatusManager.waitForAllNodesRestored(
               restoreId, cluster.getSize(), Duration.ofSeconds(10));

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -69,7 +69,13 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     this.onLeaseFailure = Objects.requireNonNull(onLeaseFailure, "onLeaseFailure cannot be null");
     backoff = new ExponentialBackoffRetryDelay(leaseAcquireMaxDelay, Duration.ofSeconds(1));
     renewalDelay = leaseDuration.dividedBy(3);
-    executor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "NodeIdProvider"));
+    executor =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              final var thread = new Thread(r, "NodeIdProvider");
+              thread.setDaemon(true);
+              return thread;
+            });
   }
 
   @Override

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
@@ -50,17 +50,19 @@ public class RestoreValidator {
       if (!checkPartitionDirectoryIsNotEmpty(
           partitionMetadata, configuration.getData().getDirectory())) {
         LOGGER.error(
-            "Expected to find restored partition {} on broker {}, but the partition directory is empty or does not exist.",
+            "Expected to find restored partition {} on broker {}, but the partition directory {} is empty or does not exist.",
             partitionMetadata.id(),
-            localBrokerId);
+            localBrokerId,
+            getPartitionDirectory(partitionMetadata.id(), configuration.getData().getDirectory()));
         return false;
       }
     }
 
     if (!checkTopologyFileIsRestored(configuration)) {
       LOGGER.error(
-          "Expected to find restored topology file on broker {}, but it is missing in the data directory.",
-          localBrokerId);
+          "Expected to find restored topology file on broker {}, but it is missing in the data directory {}.",
+          localBrokerId,
+          configuration.getData().getDirectory());
       return false;
     }
     return true;


### PR DESCRIPTION
## Description

Explicitly close node id provier restore is completed. Otherwise the application do not terminate because the node id provider is running in the background.

## Related issues

related to #44873 
