### PR TITLE
feat: broker api listens to default- prefix

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayBasedPropertiesOverride.java
@@ -205,6 +205,7 @@ public class GatewayBasedPropertiesOverride {
 
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
     override.getCluster().setClusterName(cluster.getName());
+    override.getCluster().setSendOnLegacySubject(cluster.isSendOnLegacySubject());
 
     override
         .getCluster()

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -9,7 +9,7 @@ package io.camunda.application.commons.configuration;
 
 import io.atomix.cluster.ClusterConfig;
 import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
-import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientCfg;
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
@@ -64,9 +64,11 @@ public class BrokerBasedConfiguration {
   }
 
   @Bean
-  public BrokerClientTimeoutConfiguration brokerClientConfig() {
-    return new BrokerClientTimeoutConfiguration(
-        properties.getGateway().getCluster().getRequestTimeout());
+  public BrokerClientCfg brokerClientConfig() {
+    return new BrokerClientCfg(
+        properties.getGateway().getCluster().getRequestTimeout(),
+        properties.getExperimental().isSendOnLegacySubject(),
+        properties.getExperimental().getDefaultEngineName());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -14,7 +14,7 @@ import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
 import io.atomix.utils.net.Address;
 import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
-import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientCfg;
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.configuration.beans.GatewayBasedProperties;
@@ -77,8 +77,9 @@ public final class GatewayBasedConfiguration {
   }
 
   @Bean
-  public BrokerClientTimeoutConfiguration brokerClientConfig() {
-    return new BrokerClientTimeoutConfiguration(properties.getCluster().getRequestTimeout());
+  public BrokerClientCfg brokerClientConfig() {
+    // In 8.9, there is no need to expose those properties via Gateway Configuration.
+    return new BrokerClientCfg(properties.getCluster().getRequestTimeout(), true, "default");
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -78,8 +78,10 @@ public final class GatewayBasedConfiguration {
 
   @Bean
   public BrokerClientCfg brokerClientConfig() {
-    // In 8.9, there is no need to expose those properties via Gateway Configuration.
-    return new BrokerClientCfg(properties.getCluster().getRequestTimeout(), true, "default");
+    return new BrokerClientCfg(
+        properties.getCluster().getRequestTimeout(),
+        properties.getCluster().isSendOnLegacySubject(),
+        properties.getCluster().getDefaultEngineName());
   }
 
   @Bean

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -45,12 +46,14 @@ public final class BrokerClientImpl implements BrokerClient {
       final ClusterEventService eventService,
       final ActorSchedulingService schedulingService,
       final BrokerTopologyManager topologyManager,
-      final BrokerClientRequestMetrics metrics) {
+      final BrokerClientRequestMetrics metrics,
+      final TopicSupplier sendingTopicSupplier) {
     this.eventService = eventService;
     this.schedulingService = schedulingService;
 
     this.topologyManager = topologyManager;
-    atomixTransportAdapter = new AtomixClientTransportAdapter(messagingService);
+    atomixTransportAdapter =
+        new AtomixClientTransportAdapter(messagingService, sendingTopicSupplier);
     requestManager =
         new BrokerRequestManager(
             atomixTransportAdapter,

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.ExecuteCommandRequest;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.StubBroker;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -122,7 +123,8 @@ public final class BrokerClientTest {
             atomixCluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry));
+            new BrokerClientRequestMetrics(meterRegistry),
+            TopicSupplier.withLegacyTopicName());
     client.start().forEach(ActorFuture::join);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class TestBrokerClientFactory {
@@ -37,7 +38,8 @@ public final class TestBrokerClientFactory {
             atomixCluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry));
+            new BrokerClientRequestMetrics(meterRegistry),
+            TopicSupplier.withLegacyTopicName());
     client.start().forEach(ActorFuture::join);
     return client;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -109,11 +110,16 @@ public class SnapshotApiRequestHandlerTest {
             clusterService,
             scheduler.getActorScheduler(),
             brokerTopology,
-            metrics);
+            metrics,
+            TopicSupplier.withLegacyTopicName());
     brokerClient.start();
 
     serverTransport =
-        submitActor(new AtomixServerTransport(messagingService, new SnowflakeIdGenerator(1L)));
+        submitActor(
+            new AtomixServerTransport(
+                messagingService,
+                new SnowflakeIdGenerator(1L),
+                List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix("default"))));
 
     scaleUpProgressInvocationCount = new AtomicInteger();
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.asserts.grpc.ClientStatusExceptionAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -91,7 +92,8 @@ class UnavailableBrokersTest {
             cluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(REGISTRY));
+            new BrokerClientRequestMetrics(REGISTRY),
+            TopicSupplier.withLegacyTopicName());
     jobStreamClient =
         new JobStreamClientImpl(actorScheduler, cluster.getCommunicationService(), REGISTRY);
     jobStreamClient.start().join();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.gateway.interceptors.util.TestInterceptor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -92,7 +93,8 @@ final class InterceptorIT {
             cluster.getEventService(),
             scheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry));
+            new BrokerClientRequestMetrics(meterRegistry),
+            TopicSupplier.withLegacyTopicName());
 
     jobStreamClient =
         new JobStreamClientImpl(scheduler, cluster.getCommunicationService(), meterRegistry);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -184,7 +185,8 @@ final class SecurityTest {
             atomix.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry));
+            new BrokerClientRequestMetrics(meterRegistry),
+            TopicSupplier.withLegacyTopicName());
     jobStreamClient =
         new JobStreamClientImpl(actorScheduler, atomix.getCommunicationService(), meterRegistry);
     jobStreamClient.start().join();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -45,6 +45,8 @@ public final class ClusterCfg {
   private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
   private DataSize socketSendBuffer = null;
   private DataSize socketReceiveBuffer = null;
+  private boolean sendOnLegacySubject = true;
+  private String defaultEngineName = "default";
 
   public String getMemberId() {
     return memberId;
@@ -178,6 +180,24 @@ public final class ClusterCfg {
     return this;
   }
 
+  public boolean isSendOnLegacySubject() {
+    return sendOnLegacySubject;
+  }
+
+  public ClusterCfg setSendOnLegacySubject(final boolean sendOnLegacySubject) {
+    this.sendOnLegacySubject = sendOnLegacySubject;
+    return this;
+  }
+
+  public String getDefaultEngineName() {
+    return defaultEngineName;
+  }
+
+  public ClusterCfg setDefaultEngineName(final String defaultEngineName) {
+    this.defaultEngineName = defaultEngineName;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -192,7 +212,9 @@ public final class ClusterCfg {
         messageCompression,
         configManager,
         socketSendBuffer,
-        socketReceiveBuffer);
+        socketReceiveBuffer,
+        defaultEngineName,
+        sendOnLegacySubject);
   }
 
   @Override
@@ -215,7 +237,9 @@ public final class ClusterCfg {
         && Objects.equals(messageCompression, that.messageCompression)
         && Objects.equals(configManager, that.configManager)
         && Objects.equals(socketSendBuffer, that.socketSendBuffer)
-        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer);
+        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer)
+        && Objects.equals(defaultEngineName, that.defaultEngineName)
+        && Objects.equals(sendOnLegacySubject, that.sendOnLegacySubject);
   }
 
   @Override
@@ -248,6 +272,10 @@ public final class ClusterCfg {
         + socketSendBuffer
         + ", socketReceiveBuffer="
         + socketReceiveBuffer
+        + ", sendOnLegacySubject="
+        + sendOnLegacySubject
+        + ", engineName="
+        + defaultEngineName
         + '}';
   }
 }

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,7 +97,10 @@ public final class StubBroker implements AutoCloseable {
     final var transportFactory = new TransportFactory(scheduler);
     final var requestIdGenerator = new SnowflakeIdGenerator(nodeId);
     serverTransport =
-        transportFactory.createServerTransport(cluster.getMessagingService(), requestIdGenerator);
+        transportFactory.createServerTransport(
+            cluster.getMessagingService(),
+            requestIdGenerator,
+            List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix("default")));
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(partitionId, RequestType.COMMAND, channelHandler);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RaftServerForwardCompatibilityIT.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ZeebeIntegration
-@Timeout(2 * 60)
+@Timeout(3 * 60)
 public class RaftServerForwardCompatibilityIT {
 
   private static final int PARTITION_COUNT = 3;
@@ -46,25 +46,49 @@ public class RaftServerForwardCompatibilityIT {
 
     return Stream.of(
         Arguments.of(
-            "8.9 Mode",
+            "8.9 Mode with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure89Mode)),
         Arguments.of(
-            "8.9 to 8.10 Upgrade",
+            "8.9 to 8.10 Upgrade with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure89To810Mode)),
         Arguments.of(
-            "8.10 Mode",
+            "8.10 Mode with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure810Mode)),
         Arguments.of(
-            "8.10 to 8.11 Upgrade",
+            "8.10 to 8.11 Upgrade with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
                 RaftServerForwardCompatibilityIT::configure810To811Mode)),
         Arguments.of(
-            "8.11 Mode",
+            "8.11 Mode with Embedded Gateway",
             createTestClusterWithBrokerConfiguration(
-                RaftServerForwardCompatibilityIT::configure811Mode)));
+                RaftServerForwardCompatibilityIT::configure811Mode)),
+        Arguments.of(
+            "8.9 Mode with Standalone Gateway",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure89Mode, true)),
+        Arguments.of(
+            "8.9 to 8.10 Upgrade with Standalone Gateway (sendOnLegacySubject = true)",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure89To810Mode, true)),
+        Arguments.of(
+            "8.9 to 8.10 Upgrade with Standalone Gateway (sendOnLegacySubject = false)",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure89To810Mode, false)),
+        Arguments.of(
+            "8.10 Mode with Standalone Gateway",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure810Mode, false)),
+        Arguments.of(
+            "8.10 to 8.11 Upgrade with Standalone Gateway",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure810To811Mode, false)),
+        Arguments.of(
+            "8.11 Mode with Standalone Gateway",
+            createTestClusterWithStandaloneGateway(
+                RaftServerForwardCompatibilityIT::configure811Mode, false)));
   }
 
   static TestCluster createTestClusterWithBrokerConfiguration(
@@ -74,6 +98,21 @@ public class RaftServerForwardCompatibilityIT {
         .withPartitionsCount(PARTITION_COUNT)
         .withReplicationFactor(REPLICATION_FACTOR)
         .withBrokerConfig(brokerConfigurationApplier)
+        .build();
+  }
+
+  static TestCluster createTestClusterWithStandaloneGateway(
+      final BiConsumer<MemberId, TestStandaloneBroker> brokerConfigurationApplier,
+      final boolean gatewaySendOnLegacySubject) {
+    return TestCluster.builder()
+        .withBrokersCount(PARTITION_COUNT)
+        .withPartitionsCount(PARTITION_COUNT)
+        .withReplicationFactor(REPLICATION_FACTOR)
+        .withBrokerConfig(brokerConfigurationApplier)
+        .withEmbeddedGateway(false)
+        .withGatewaysCount(1)
+        .withGatewayConfig(
+            m -> m.withClusterConfig(c -> c.setSendOnLegacySubject(gatewaySendOnLegacySubject)))
         .build();
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -92,7 +92,8 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     LOG.trace("Subscribe for topic {}", topic);
     messagingService.registerHandler(
         topic,
-        (sender, request) -> handleAtomixRequest(request, partitionId, requestType, handler));
+        (sender, request) ->
+            handleAtomixRequest(request, topic, partitionId, requestType, handler));
   }
 
   private void removePartition(final int partitionId) {
@@ -119,6 +120,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   private CompletableFuture<byte[]> handleAtomixRequest(
       final byte[] requestBytes,
+      final String topicName,
       final int partitionId,
       final RequestType requestType,
       final RequestHandler requestHandler) {
@@ -143,10 +145,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
                 0,
                 requestBytes.length);
             if (LOG.isTraceEnabled()) {
-              LOG.trace(
-                  "Handled request {} for topic {}",
-                  requestId,
-                  legacyTopicName(partitionId, requestType));
+              LOG.trace("Handled request {} for topic {}", requestId, topicName);
             }
             // we only add the request to the map after successful handling
             requestMap.put(requestId, completableFuture);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerResponse;
 import io.camunda.zeebe.transport.ServerTransport;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
@@ -25,8 +27,9 @@ import org.slf4j.Logger;
 public class AtomixServerTransport extends Actor implements ServerTransport {
 
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
-  private static final String API_TOPIC_FORMAT = "%s-api-%d";
-  private static final String ERROR_MSG_MISSING_PARTITON_MAP =
+  private static final String LEGACY_API_TOPIC_FORMAT = "%s-api-%d";
+  private static final String API_TOPIC_FORMAT = "%s-%s-api-%d";
+  private static final String ERROR_MSG_MISSING_PARTITION_MAP =
       "Node already unsubscribed from partition %d, this can only happen when atomix does not cleanly remove its handlers.";
 
   private final Int2ObjectHashMap<Long2ObjectHashMap<CompletableFuture<byte[]>>>
@@ -34,12 +37,16 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   private final MessagingService messagingService;
 
   private final IdGenerator requestIdGenerator;
+  private final List<TopicSupplier> topicSuppliers;
 
   public AtomixServerTransport(
-      final MessagingService messagingService, final IdGenerator requestIdGenerator) {
+      final MessagingService messagingService,
+      final IdGenerator requestIdGenerator,
+      final List<TopicSupplier> topicSuppliers) {
     this.messagingService = messagingService;
     this.requestIdGenerator = requestIdGenerator;
     partitionsRequestMap = new Int2ObjectHashMap<>();
+    this.topicSuppliers = topicSuppliers;
   }
 
   @Override
@@ -65,19 +72,27 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
       final int partitionId, final RequestType requestType, final RequestHandler requestHandler) {
     return actor.call(
         () -> {
-          final var topicName = topicName(partitionId, requestType);
-          LOG.trace("Subscribe for topic {}", topicName);
           partitionsRequestMap.computeIfAbsent(partitionId, id -> new Long2ObjectHashMap<>());
-          messagingService.registerHandler(
-              topicName,
-              (sender, request) ->
-                  handleAtomixRequest(request, partitionId, requestType, requestHandler));
+          topicSuppliers.stream()
+              .map(s -> s.apply(partitionId, requestType))
+              .forEach(t -> registerHandler(t, partitionId, requestType, requestHandler));
         });
   }
 
   @Override
   public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
     return actor.call(() -> removeRequestHandlers(partitionId, requestType));
+  }
+
+  private void registerHandler(
+      final String topic,
+      final int partitionId,
+      final RequestType requestType,
+      final RequestHandler handler) {
+    LOG.trace("Subscribe for topic {}", topic);
+    messagingService.registerHandler(
+        topic,
+        (sender, request) -> handleAtomixRequest(request, partitionId, requestType, handler));
   }
 
   private void removePartition(final int partitionId) {
@@ -92,9 +107,14 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   private void removeRequestHandlers(final int partitionId, final RequestType requestType) {
-    final var topicName = topicName(partitionId, requestType);
-    LOG.trace("Unsubscribe from topic {}", topicName);
-    messagingService.unregisterHandler(topicName);
+    topicSuppliers.stream()
+        .map(s -> s.apply(partitionId, requestType))
+        .forEach(this::unregisterHandler);
+  }
+
+  private void unregisterHandler(final String topic) {
+    LOG.trace("Unsubscribe from topic {}", topic);
+    messagingService.unregisterHandler(topic);
   }
 
   private CompletableFuture<byte[]> handleAtomixRequest(
@@ -108,7 +128,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
           final long requestId = requestIdGenerator.nextId();
           final var requestMap = partitionsRequestMap.get(partitionId);
           if (requestMap == null) {
-            final var errorMsg = String.format(ERROR_MSG_MISSING_PARTITON_MAP, partitionId);
+            final var errorMsg = String.format(ERROR_MSG_MISSING_PARTITION_MAP, partitionId);
             LOG.trace(errorMsg);
             completableFuture.completeExceptionally(new IllegalStateException(errorMsg));
             return;
@@ -126,7 +146,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
               LOG.trace(
                   "Handled request {} for topic {}",
                   requestId,
-                  topicName(partitionId, requestType));
+                  legacyTopicName(partitionId, requestType));
             }
             // we only add the request to the map after successful handling
             requestMap.put(requestId, completableFuture);
@@ -177,7 +197,25 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
         });
   }
 
-  static String topicName(final int partitionId, final RequestType requestType) {
-    return String.format(API_TOPIC_FORMAT, requestType.getId(), partitionId);
+  static String topicName(
+      final String prefix, final int partitionId, final RequestType requestType) {
+    return String.format(API_TOPIC_FORMAT, prefix, requestType.getId(), partitionId);
+  }
+
+  static String legacyTopicName(final int partitionId, final RequestType requestType) {
+    return String.format(LEGACY_API_TOPIC_FORMAT, requestType.getId(), partitionId);
+  }
+
+  public interface TopicSupplier extends BiFunction<Integer, RequestType, String> {
+    @Override
+    String apply(Integer partitionId, RequestType requestType);
+
+    static TopicSupplier withLegacyTopicName() {
+      return AtomixServerTransport::legacyTopicName;
+    }
+
+    static TopicSupplier withPrefix(final String prefix) {
+      return (p, r) -> topicName(prefix, p, r);
+    }
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/RequestContext.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/RequestContext.java
@@ -7,13 +7,10 @@
  */
 package io.camunda.zeebe.transport.impl;
 
-import static io.camunda.zeebe.transport.impl.AtomixServerTransport.topicName;
-
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.transport.RequestType;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -24,8 +21,7 @@ final class RequestContext {
 
   private final CompletableActorFuture<DirectBuffer> currentFuture;
   private final Supplier<String> nodeAddressSupplier;
-  private final int partitionId;
-  private final RequestType requestType;
+  private final String topicName;
   private final byte[] requestBytes;
   private final boolean shouldRetry;
   private final long startTime;
@@ -37,16 +33,14 @@ final class RequestContext {
   RequestContext(
       final CompletableActorFuture<DirectBuffer> currentFuture,
       final Supplier<String> nodeAddressSupplier,
-      final int partitionId,
-      final RequestType requestType,
+      final String topicName,
       final byte[] requestBytes,
       final Predicate<DirectBuffer> responseValidator,
       final boolean shouldRetry,
       final Duration timeout) {
     this.currentFuture = currentFuture;
     this.nodeAddressSupplier = nodeAddressSupplier;
-    this.partitionId = partitionId;
-    this.requestType = requestType;
+    this.topicName = topicName;
     this.requestBytes = requestBytes;
     this.shouldRetry = shouldRetry;
     startTime = ActorClock.currentTimeMillis();
@@ -64,7 +58,7 @@ final class RequestContext {
   }
 
   String getTopicName() {
-    return topicName(partitionId, requestType);
+    return topicName;
   }
 
   byte[] getRequestBytes() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -25,12 +25,14 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -63,6 +65,9 @@ public class AtomixTransportTest {
 
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
   private static final Duration REQUEST_TIMEOUT_NO_SUCCESS = Duration.ofMillis(200);
+  private static final String TOPIC_PREFIX = "default";
+  private static final List<TopicSupplier> TOPIC_SUPPLIERS =
+      List.of(TopicSupplier.withLegacyTopicName(), TopicSupplier.withPrefix(TOPIC_PREFIX));
 
   private static Supplier<String> nodeAddressSupplier;
   private static AtomixCluster cluster;
@@ -99,7 +104,22 @@ public class AtomixTransportTest {
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
                   return transportFactory.createServerTransport(
-                      messagingService, requestIdGenerator);
+                      messagingService, requestIdGenerator, TOPIC_SUPPLIERS);
+                }
+          },
+          {
+            "use default-{topic}-prefixed topics in client requests",
+            (Function<AtomixCluster, ClientTransport>)
+                (cluster) -> {
+                  final var messagingService = cluster.getMessagingService();
+                  return transportFactory.createClientTransport(
+                      messagingService, TopicSupplier.withPrefix(TOPIC_PREFIX));
+                },
+            (Function<AtomixCluster, ServerTransport>)
+                (cluster) -> {
+                  final var messagingService = cluster.getMessagingService();
+                  return transportFactory.createServerTransport(
+                      messagingService, requestIdGenerator, TOPIC_SUPPLIERS);
                 }
           },
           {
@@ -111,25 +131,40 @@ public class AtomixTransportTest {
                 },
             (Function<AtomixCluster, ServerTransport>)
                 (cluster) -> {
-                  if (nettyMessagingService == null) {
-                    // do only once
-                    final var socketAddress = SocketUtil.getNextAddress();
-                    serverAddress = socketAddress.getHostName() + ":" + socketAddress.getPort();
-                    nodeAddressSupplier = () -> serverAddress;
-                    nettyMessagingService =
-                        new NettyMessagingService(
-                            "cluster",
-                            Address.from(serverAddress),
-                            new MessagingConfig(),
-                            meterRegistry);
-                    nettyMessagingService.start().join();
-                  }
-
+                  createNettyMessagingServiceIfNull();
                   return transportFactory.createServerTransport(
-                      nettyMessagingService, requestIdGenerator);
+                      nettyMessagingService, requestIdGenerator, TOPIC_SUPPLIERS);
+                }
+          },
+          {
+            "use different messaging service and prefixed client requests",
+            (Function<AtomixCluster, ClientTransport>)
+                (cluster) -> {
+                  final var messagingService = cluster.getMessagingService();
+                  return transportFactory.createClientTransport(
+                      messagingService, TopicSupplier.withPrefix(TOPIC_PREFIX));
+                },
+            (Function<AtomixCluster, ServerTransport>)
+                (cluster) -> {
+                  createNettyMessagingServiceIfNull();
+                  return transportFactory.createServerTransport(
+                      nettyMessagingService, requestIdGenerator, TOPIC_SUPPLIERS);
                 }
           }
         });
+  }
+
+  static void createNettyMessagingServiceIfNull() {
+    if (nettyMessagingService == null) {
+      // do only once
+      final var socketAddress = SocketUtil.getNextAddress();
+      serverAddress = socketAddress.getHostName() + ":" + socketAddress.getPort();
+      nodeAddressSupplier = () -> serverAddress;
+      nettyMessagingService =
+          new NettyMessagingService(
+              "cluster", Address.from(serverAddress), new MessagingConfig(), meterRegistry);
+      nettyMessagingService.start().join();
+    }
   }
 
   @BeforeClass


### PR DESCRIPTION
## Description

This PR prepares Zeebe’s broker API transport layer for multi Raft partition groups by allowing the broker-side server transport to listen on both legacy (prefix-less) subjects and default- prefixed subjects, while enabling clients to optionally send requests to prefixed subjects.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45262
