### PR TITLE
feat: client sdk support for cluster variable update

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -62,6 +62,7 @@ import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
+import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PinClockCommandStep1;
@@ -75,6 +76,7 @@ import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableDeletionCommandStep1;
+import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignClientFromTenantCommandStep1;
@@ -1963,6 +1965,36 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for creating a tenant-scoped cluster variable
    */
   TenantScopedClusterVariableCreationCommandStep1 newTenantScopedClusterVariableCreateRequest(
+      String tenantId);
+
+  /**
+   * Creates a request to update a globally-scoped cluster variable.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newGloballyScopedClusterVariableUpdateRequest()
+   *       .update("myVariable", "newValue")
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for updating a globally-scoped cluster variable
+   */
+  GloballyScopedClusterVariableUpdateCommandStep1 newGloballyScopedClusterVariableUpdateRequest();
+
+  /**
+   * Creates a request to update a tenant-scoped cluster variable.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newTenantScopedClusterVariableUpdateRequest("my-tenant-id")
+   *       .update("myVariable", "newValue")
+   *       .send();
+   * </pre>
+   *
+   * @param tenantId the ID of the tenant for which the variable is scoped
+   * @return a builder for updating a tenant-scoped cluster variable
+   */
+  TenantScopedClusterVariableUpdateCommandStep1 newTenantScopedClusterVariableUpdateRequest(
       String tenantId);
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableUpdateCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableUpdateCommandStep1.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateClusterVariableResponse;
+
+/**
+ * Represents a request to update a globally-scoped cluster variable.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   UpdateClusterVariableResponse response = camundaClient
+ *       .newGloballyScopedClusterVariableUpdateRequest()
+ *       .update("myVariable", "newValue")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface GloballyScopedClusterVariableUpdateCommandStep1
+    extends FinalCommandStep<UpdateClusterVariableResponse> {
+
+  /**
+   * Sets the name and new value of the cluster variable to update.
+   *
+   * <p>The variable value will be serialized to JSON format.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newGloballyScopedClusterVariableUpdateRequest()
+   *       .update("myVariable", "newValue")  // for string values
+   *       .send();
+   * </pre>
+   *
+   * @param name the name of the variable. Must not be null or empty.
+   * @param value the new value of the variable. Must not be null. Will be serialized to JSON.
+   * @return this builder for method chaining
+   */
+  GloballyScopedClusterVariableUpdateCommandStep1 update(String name, Object value);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableUpdateCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableUpdateCommandStep1.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateClusterVariableResponse;
+
+/**
+ * Represents a request to update a tenant-scoped cluster variable.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   UpdateClusterVariableResponse response = camundaClient
+ *       .newTenantScopedClusterVariableUpdateRequest("my-tenant-id")
+ *       .update("myVariable", "newValue")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface TenantScopedClusterVariableUpdateCommandStep1
+    extends FinalCommandStep<UpdateClusterVariableResponse> {
+
+  /**
+   * Sets the name and new value of the cluster variable to update.
+   *
+   * <p>The variable value will be serialized to JSON format.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newTenantScopedClusterVariableUpdateRequest("my-tenant-id")
+   *       .update("myVariable", "newValue")  // for string values
+   *       .send();
+   * </pre>
+   *
+   * @param name the name of the variable. Must not be null or empty.
+   * @param value the new value of the variable. Must not be null. Will be serialized to JSON.
+   * @return this builder for method chaining
+   */
+  TenantScopedClusterVariableUpdateCommandStep1 update(String name, Object value);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateClusterVariableResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateClusterVariableResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+
+public interface UpdateClusterVariableResponse {
+
+  String getName();
+
+  Object getValue();
+
+  ClusterVariableScope getScope();
+
+  String getTenantId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -71,6 +71,7 @@ import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.GloballyScopedClusterVariableDeletionCommandStep1;
+import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PinClockCommandStep1;
@@ -85,6 +86,7 @@ import io.camunda.client.api.command.StreamJobsCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableDeletionCommandStep1;
+import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignClientFromGroupCommandStep1;
@@ -234,6 +236,7 @@ import io.camunda.client.impl.command.EvaluateDecisionCommandImpl;
 import io.camunda.client.impl.command.EvaluateExpressionCommandImpl;
 import io.camunda.client.impl.command.GloballyScopedCreateClusterVariableImpl;
 import io.camunda.client.impl.command.GloballyScopedDeleteClusterVariableImpl;
+import io.camunda.client.impl.command.GloballyScopedUpdateClusterVariableImpl;
 import io.camunda.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.camunda.client.impl.command.JobUpdateTimeoutCommandImpl;
 import io.camunda.client.impl.command.MigrateProcessInstanceCommandImpl;
@@ -250,6 +253,7 @@ import io.camunda.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
 import io.camunda.client.impl.command.TenantScopedCreateClusterVariableImpl;
 import io.camunda.client.impl.command.TenantScopedDeleteClusterVariableImpl;
+import io.camunda.client.impl.command.TenantScopedUpdateClusterVariableImpl;
 import io.camunda.client.impl.command.TopologyRequestImpl;
 import io.camunda.client.impl.command.UnassignClientFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignClientFromTenantCommandImpl;
@@ -1203,6 +1207,18 @@ public final class CamundaClientImpl implements CamundaClient {
   public TenantScopedClusterVariableCreationCommandStep1
       newTenantScopedClusterVariableCreateRequest(final String tenantId) {
     return new TenantScopedCreateClusterVariableImpl(httpClient, jsonMapper, tenantId);
+  }
+
+  @Override
+  public GloballyScopedClusterVariableUpdateCommandStep1
+      newGloballyScopedClusterVariableUpdateRequest() {
+    return new GloballyScopedUpdateClusterVariableImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public TenantScopedClusterVariableUpdateCommandStep1 newTenantScopedClusterVariableUpdateRequest(
+      final String tenantId) {
+    return new TenantScopedUpdateClusterVariableImpl(httpClient, jsonMapper, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedUpdateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedUpdateClusterVariableImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.response.UpdateClusterVariableResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateClusterVariableResponseImpl;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.UpdateClusterVariableRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GloballyScopedUpdateClusterVariableImpl
+    implements GloballyScopedClusterVariableUpdateCommandStep1 {
+
+  private final UpdateClusterVariableRequest updateVariableRequest;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private String name;
+
+  public GloballyScopedUpdateClusterVariableImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    updateVariableRequest = new UpdateClusterVariableRequest();
+  }
+
+  @Override
+  public GloballyScopedClusterVariableUpdateCommandStep1 update(
+      final String name, final Object value) {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
+    ArgumentUtil.ensureNotNull("value", value);
+    this.name = name;
+    updateVariableRequest.value(value);
+    return this;
+  }
+
+  @Override
+  public GloballyScopedClusterVariableUpdateCommandStep1 requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateClusterVariableResponse> send() {
+    final HttpCamundaFuture<UpdateClusterVariableResponse> result = new HttpCamundaFuture<>();
+    final UpdateClusterVariableResponseImpl response = new UpdateClusterVariableResponseImpl();
+    final String path = "/cluster-variables/global/" + name;
+    httpClient.put(
+        path,
+        jsonMapper.toJson(updateVariableRequest),
+        httpRequestConfig.build(),
+        ClusterVariableResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedUpdateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedUpdateClusterVariableImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.response.UpdateClusterVariableResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateClusterVariableResponseImpl;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.UpdateClusterVariableRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class TenantScopedUpdateClusterVariableImpl
+    implements TenantScopedClusterVariableUpdateCommandStep1 {
+
+  private final UpdateClusterVariableRequest updateVariableRequest;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String tenantId;
+  private String name;
+
+  public TenantScopedUpdateClusterVariableImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String tenantId) {
+    ArgumentUtil.ensureNotNullNorEmpty("tenantId", tenantId);
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    this.tenantId = tenantId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    updateVariableRequest = new UpdateClusterVariableRequest();
+  }
+
+  @Override
+  public TenantScopedClusterVariableUpdateCommandStep1 update(
+      final String name, final Object value) {
+    ArgumentUtil.ensureNotNullNorEmpty("name", name);
+    ArgumentUtil.ensureNotNull("value", value);
+    this.name = name;
+    updateVariableRequest.value(value);
+    return this;
+  }
+
+  @Override
+  public TenantScopedClusterVariableUpdateCommandStep1 requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateClusterVariableResponse> send() {
+    final HttpCamundaFuture<UpdateClusterVariableResponse> result = new HttpCamundaFuture<>();
+    final UpdateClusterVariableResponseImpl response = new UpdateClusterVariableResponseImpl();
+    final String path = "/cluster-variables/tenants/" + tenantId + "/" + name;
+    httpClient.put(
+        path,
+        jsonMapper.toJson(updateVariableRequest),
+        httpRequestConfig.build(),
+        ClusterVariableResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateClusterVariableResponseImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UpdateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+
+public class UpdateClusterVariableResponseImpl implements UpdateClusterVariableResponse {
+
+  private String name;
+  private String value;
+  private ClusterVariableScope scope;
+  private String tenantId;
+
+  public UpdateClusterVariableResponse setResponse(
+      final ClusterVariableResult clusterVariableResult) {
+    name = clusterVariableResult.getName();
+    value = clusterVariableResult.getValue();
+    tenantId = clusterVariableResult.getTenantId();
+    scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Object getValue() {
+    return value;
+  }
+
+  @Override
+  public ClusterVariableScope getScope() {
+    return scope;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/UpdateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/UpdateClusterVariableTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.clustervariable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ClusterVariableResult;
+import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+public class UpdateClusterVariableTest extends ClientRestTest {
+
+  private static final String VARIABLE_NAME = "myVariable";
+  private static final String VARIABLE_VALUE = "myValue";
+  private static final String TENANT_ID = "tenant_1";
+
+  @Test
+  void shouldUpdateGlobalScopedClusterVariable() {
+    // given
+    gatewayService.onUpdateGlobalClusterVariableRequest(
+        VARIABLE_NAME,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
+
+    // when
+    client
+        .newGloballyScopedClusterVariableUpdateRequest()
+        .update(VARIABLE_NAME, VARIABLE_VALUE)
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getClusterVariablesUpdateGlobalUrl(VARIABLE_NAME));
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+  }
+
+  @Test
+  void shouldUpdateTenantScopedClusterVariable() {
+    // given
+    gatewayService.onUpdateTenantClusterVariableRequest(
+        TENANT_ID,
+        VARIABLE_NAME,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
+
+    // when
+    client
+        .newTenantScopedClusterVariableUpdateRequest(TENANT_ID)
+        .update(VARIABLE_NAME, VARIABLE_VALUE)
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .isEqualTo(RestGatewayPaths.getClusterVariablesUpdateTenantUrl(TENANT_ID, VARIABLE_NAME));
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFound() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUpdateGlobalUrl(VARIABLE_NAME),
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGloballyScopedClusterVariableUpdateRequest()
+                    .update(VARIABLE_NAME, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getClusterVariablesUpdateGlobalUrl(VARIABLE_NAME),
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGloballyScopedClusterVariableUpdateRequest()
+                    .update(VARIABLE_NAME, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGloballyScopedClusterVariableUpdateRequest()
+                    .update(null, VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyVariableName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGloballyScopedClusterVariableUpdateRequest()
+                    .update("", VARIABLE_VALUE)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullVariableValue() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newGloballyScopedClusterVariableUpdateRequest()
+                    .update(VARIABLE_NAME, null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("value must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullTenantId() {
+    // when / then
+    assertThatThrownBy(() -> client.newTenantScopedClusterVariableUpdateRequest(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyTenantId() {
+    // when / then
+    assertThatThrownBy(() -> client.newTenantScopedClusterVariableUpdateRequest(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be empty");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -33,6 +33,10 @@ public class RestGatewayPaths {
       URL_CLUSTER_VARIABLES + "/global/%s";
   private static final String URL_CLUSTER_VARIABLES_GET_TENANT =
       URL_CLUSTER_VARIABLES + "/tenants/%s/%s";
+  private static final String URL_CLUSTER_VARIABLES_UPDATE_GLOBAL =
+      URL_CLUSTER_VARIABLES + "/global/%s";
+  private static final String URL_CLUSTER_VARIABLES_UPDATE_TENANT =
+      URL_CLUSTER_VARIABLES + "/tenants/%s/%s";
   private static final String URL_CLUSTER_VARIABLES_SEARCH = URL_CLUSTER_VARIABLES + "/search";
   private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
   private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
@@ -392,12 +396,12 @@ public class RestGatewayPaths {
   }
 
   public static String getClusterVariablesUpdateGlobalUrl(final String variableName) {
-    return String.format(URL_CLUSTER_VARIABLES_GET_GLOBAL, variableName);
+    return String.format(URL_CLUSTER_VARIABLES_UPDATE_GLOBAL, variableName);
   }
 
   public static String getClusterVariablesUpdateTenantUrl(
       final String tenantId, final String variableName) {
-    return String.format(URL_CLUSTER_VARIABLES_GET_TENANT, tenantId, variableName);
+    return String.format(URL_CLUSTER_VARIABLES_UPDATE_TENANT, tenantId, variableName);
   }
 
   public static String getAuditLogGetUrl(final String auditLogKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -391,6 +391,15 @@ public class RestGatewayPaths {
     return URL_CLUSTER_VARIABLES_SEARCH;
   }
 
+  public static String getClusterVariablesUpdateGlobalUrl(final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GET_GLOBAL, variableName);
+  }
+
+  public static String getClusterVariablesUpdateTenantUrl(
+      final String tenantId, final String variableName) {
+    return String.format(URL_CLUSTER_VARIABLES_GET_TENANT, tenantId, variableName);
+  }
+
   public static String getAuditLogGetUrl(final String auditLogKey) {
     return String.format(URL_AUDIT_LOG_GET, auditLogKey);
   }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -414,6 +414,17 @@ public class RestGatewayService {
     registerGet(RestGatewayPaths.getClusterVariablesGetTenantUrl(tenantId, variableName), response);
   }
 
+  public void onUpdateGlobalClusterVariableRequest(
+      final String variableName, final ClusterVariableResult response) {
+    registerPut(RestGatewayPaths.getClusterVariablesUpdateGlobalUrl(variableName), response);
+  }
+
+  public void onUpdateTenantClusterVariableRequest(
+      final String tenantId, final String variableName, final ClusterVariableResult response) {
+    registerPut(
+        RestGatewayPaths.getClusterVariablesUpdateTenantUrl(tenantId, variableName), response);
+  }
+
   public void onSearchClusterVariableRequest(final SearchQueryResponse response) {
     registerPost(RestGatewayPaths.getClusterVariablesSearchUrl(), response);
   }


### PR DESCRIPTION
## Description

This pull request adds support for updating cluster variables in the Java client, both globally and for specific tenants. It introduces new command interfaces and implementations for updating cluster variables, as well as the corresponding response types. The changes ensure that users can now update cluster variables through the client API in a consistent and type-safe way.

**New feature: Update cluster variables**

* Added `GloballyScopedClusterVariableUpdateCommandStep1` and `TenantScopedClusterVariableUpdateCommandStep1` interfaces to provide builder-style APIs for updating global and tenant-scoped cluster variables. [[1]](diffhunk://#diff-818fbcce70a3f88f1197642e17837e8c0eca716ab69cf9807d053218c6042a9eR1-R53) [[2]](diffhunk://#diff-58af289fae6be165922491484604af40a8557a0eb340bcff8dde98603082fe3eR1-R53)
* Introduced `UpdateClusterVariableResponse` interface and its implementation to represent the response from an update cluster variable operation. [[1]](diffhunk://#diff-ee2cf78dca34de8c10667cec547d6a6b2e27fbbe51617da6574a6e4ae71f3d84R1-R29) [[2]](diffhunk://#diff-622e8a4a97d1aa95d00dfc0ae20da97445cbdaa40f4f988a913e162391dfc8ebR1-R58)
* Implemented `GloballyScopedUpdateClusterVariableImpl` and `TenantScopedUpdateClusterVariableImpl` classes to handle HTTP requests for updating cluster variables globally and for a tenant, respectively. [[1]](diffhunk://#diff-1dd4ac5017d82aa2ed143822a2298d91057a34423f45a7461384a16646022a6cR1-R79) [[2]](diffhunk://#diff-4a775de3989e92634ebf461f38aa948ebcd24e5d94b09bcf9da0e43a48957134R1-R82)

**API surface and integration**

* Extended `CamundaClient` and `CamundaClientImpl` to include new methods for creating update requests for both globally-scoped and tenant-scoped cluster variables, and registered the new command implementations. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR65) [[2]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR79) [[3]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR1970-R1999) [[4]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R74) [[5]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R89) [[6]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R239) [[7]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R256) [[8]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R1212-R1223)

## Related issues

closes #44659