### PR TITLE
fix: remove erroneous `required: false` at body level

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -369,7 +369,6 @@ components:
             will be deleted. In those cases, the `batchOperation` field in the response
             will not be populated.
           type: boolean
-          required: false
           default: false
 
     DeleteResourceResponse:


### PR DESCRIPTION
## Description

Fixes #45369. 

Removes `required: false` at body field level. 

Field is optional by default, and `required` is used at the level of the request body as a list of fields that must be present, not as a boolean on individual fields. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
