### PR TITLE
deps: bump up ch.qos.logback to 1.5.25

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -61,7 +61,7 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.130.Final</netty.version>
     <lombok.version>1.18.34</lombok.version>
-    <logback.version>1.5.19</logback.version>
+    <logback.version>1.5.25</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
     <commons.lang3.version>3.18.0</commons.lang3.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,7 +101,7 @@
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
     <version.spring-boot>3.5.6</version.spring-boot>
-    <version.logback>1.5.19</version.logback>
+    <version.logback>1.5.25</version.logback>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>


### PR DESCRIPTION
## Description

CVE-2026-1225 for <=1.5.24

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45385
