### PR TITLE
fix: allow checkpoint type to be visible again in checkpoint states response

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -220,25 +220,21 @@ public final class BackupEndpoint {
 
   private CheckpointType toCheckpointType(
       final io.camunda.zeebe.protocol.record.value.management.CheckpointType checkpointType) {
-    if (checkpointType == null) {
-      return null;
-    }
     return switch (checkpointType) {
       case SCHEDULED_BACKUP -> CheckpointType.SCHEDULED_BACKUP;
       case MANUAL_BACKUP -> CheckpointType.MANUAL_BACKUP;
       case MARKER -> CheckpointType.MARKER;
+      case null -> null;
     };
   }
 
   private BackupType toBackupType(
       final io.camunda.zeebe.protocol.record.value.management.CheckpointType checkpointType) {
-    if (checkpointType == null) {
-      return null;
-    }
     return switch (checkpointType) {
       case MANUAL_BACKUP -> BackupType.MANUAL_BACKUP;
       case SCHEDULED_BACKUP -> BackupType.SCHEDULED_BACKUP;
       case MARKER -> null;
+      case null -> null;
     };
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -220,14 +220,21 @@ public final class BackupEndpoint {
 
   private CheckpointType toCheckpointType(
       final io.camunda.zeebe.protocol.record.value.management.CheckpointType checkpointType) {
-    if (checkpointType == io.camunda.zeebe.protocol.record.value.management.CheckpointType.MARKER) {
-      return CheckpointType.MARKER;
+    if (checkpointType == null) {
+      return null;
     }
-    return null;
+    return switch (checkpointType) {
+      case SCHEDULED_BACKUP -> CheckpointType.SCHEDULED_BACKUP;
+      case MANUAL_BACKUP -> CheckpointType.MANUAL_BACKUP;
+      case MARKER -> CheckpointType.MARKER;
+    };
   }
 
   private BackupType toBackupType(
       final io.camunda.zeebe.protocol.record.value.management.CheckpointType checkpointType) {
+    if (checkpointType == null) {
+      return null;
+    }
     return switch (checkpointType) {
       case MANUAL_BACKUP -> BackupType.MANUAL_BACKUP;
       case SCHEDULED_BACKUP -> BackupType.SCHEDULED_BACKUP;

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -684,6 +684,8 @@ components:
       type: string
       enum:
         - MARKER
+        - SCHEDULED_BACKUP
+        - MANUAL_BACKUP
       example: MARKER
     CheckpointId:
       title: Checkpoint ID


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Have CheckpointType be visible in Backup `state` response. It makes identifying the latest operation easier as you won't have to cross-check the checkpoint IDs with the backup state to determine what was performed last by the scheduler.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
