### PR TITLE
45267 add root process instance key to batch operation items

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -799,6 +799,7 @@ public final class SearchQueryResponseMapper {
             warnIfNull(entity, BatchOperationItemEntity::processInstanceKey, "processInstanceKey")
                 .map(Object::toString)
                 .orElse(null))
+        .rootProcessInstanceKey(KeyUtil.keyToString(entity.rootProcessInstanceKey()))
         .processedDate(formatDate(entity.processedDate()))
         .errorMessage(entity.errorMessage())
         .state(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -74,6 +74,7 @@ class SearchQueryResponseMapperTest {
         .isEqualTo(BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE);
     assertThat(response.getItemKey()).isEqualTo("1234");
     assertThat(response.getProcessInstanceKey()).isEqualTo("4321");
+    assertThat(response.getRootProcessInstanceKey()).isEqualTo("4320");
     assertThat(response.getState()).isEqualTo(StateEnum.COMPLETED);
     assertThat(response.getProcessedDate()).isEqualTo("2025-01-15T11:53:00.000Z");
     assertThat(response.getErrorMessage()).isEqualTo("errorMessage");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchIT.java
@@ -495,8 +495,7 @@ public class BatchOperationSearchIT {
       assertThat(item.get().getProcessInstanceKey()).isEqualTo(key);
       assertThat(item.get().getOperationType()).isNotNull();
       assertThat(item.get().getStatus()).isEqualTo(BatchOperationItemState.COMPLETED);
-      // FIXME uncomment after the implementation of https://github.com/camunda/camunda/issues/45267
-      // assertThat(item.get().getRootProcessInstanceKey()).isEqualTo(key);
+      assertThat(item.get().getRootProcessInstanceKey()).isEqualTo(key);
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -110,6 +110,8 @@ public class BatchOperationIT {
     assertThat(updatedItems.items()).hasSize(3);
     assertThat(updatedItems.items().stream().map(BatchOperationItemEntity::state))
         .containsOnly(BatchOperationItemState.ACTIVE);
+    assertThat(updatedItems.items().getFirst().processInstanceKey()).isNotNull();
+    assertThat(updatedItems.items().getFirst().rootProcessInstanceKey()).isNotNull();
   }
 
   @TestTemplate
@@ -166,6 +168,9 @@ public class BatchOperationIT {
             .get();
     assertThat(firstItem.state()).isEqualTo(BatchOperationItemState.COMPLETED);
     assertThat(firstItem.operationType()).isEqualTo(batchOperation.operationType());
+    assertThat(firstItem.processInstanceKey()).isEqualTo(items.getFirst().processInstanceKey());
+    assertThat(firstItem.rootProcessInstanceKey())
+        .isEqualTo(items.getFirst().rootProcessInstanceKey());
     assertThat(firstItem.processedDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(firstItem.errorMessage()).isNull();
@@ -230,6 +235,8 @@ public class BatchOperationIT {
     final var updatedItem = updatedItems.getFirst();
 
     assertThat(updatedItem.state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(updatedItem.processInstanceKey()).isEqualTo(item.processInstanceKey());
+    assertThat(updatedItem.rootProcessInstanceKey()).isEqualTo(item.rootProcessInstanceKey());
     assertThat(updatedItem.processedDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(updatedItem.errorMessage()).isNotNull();
@@ -281,6 +288,9 @@ public class BatchOperationIT {
     assertThat(updatedItems).hasSize(1);
     final var firstItem = updatedItems.getFirst();
     assertThat(firstItem.state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(firstItem.processInstanceKey()).isEqualTo(items.getFirst().processInstanceKey());
+    assertThat(firstItem.rootProcessInstanceKey())
+        .isEqualTo(items.getFirst().rootProcessInstanceKey());
     assertThat(firstItem.processedDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(firstItem.errorMessage()).isNull();
@@ -339,6 +349,9 @@ public class BatchOperationIT {
             .findFirst()
             .orElseThrow();
     assertThat(firstItem.state()).isEqualTo(BatchOperationItemState.FAILED);
+    assertThat(firstItem.processInstanceKey()).isEqualTo(items.getFirst().processInstanceKey());
+    assertThat(firstItem.rootProcessInstanceKey())
+        .isEqualTo(items.getFirst().rootProcessInstanceKey());
     assertThat(firstItem.processedDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(firstItem.errorMessage()).isEqualTo("error");
@@ -405,6 +418,9 @@ public class BatchOperationIT {
             .findFirst()
             .orElseThrow();
     assertThat(firstItem.state()).isEqualTo(BatchOperationItemState.SKIPPED);
+    assertThat(firstItem.processInstanceKey()).isEqualTo(items.getFirst().processInstanceKey());
+    assertThat(firstItem.rootProcessInstanceKey())
+        .isEqualTo(items.getFirst().rootProcessInstanceKey());
     assertThat(firstItem.processedDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -96,8 +96,8 @@ public final class BatchOperationFixtures {
                     new BatchOperationItemDbModel(
                         batchOperationKey,
                         itemKey,
-                        itemKey,
-                        itemKey,
+                        itemKey + 10_000L, // process instance key
+                        itemKey + 20_000L, // root process instance key
                         BatchOperationItemState.ACTIVE,
                         NOW,
                         null))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -1170,6 +1170,7 @@ class RdbmsExporterIT {
 
     final var itemKey = 9043L;
     final var processInstanceKey = 9044L;
+    final var rootProcessInstanceKey = 9033L;
 
     final Record<BatchOperationChunkRecordValue> record =
         RecordFixtures.FACTORY.generateRecord(ValueType.BATCH_OPERATION_CHUNK);
@@ -1188,6 +1189,7 @@ class RdbmsExporterIT {
                             ImmutableBatchOperationItemValue.builder()
                                 .withItemKey(itemKey)
                                 .withProcessInstanceKey(processInstanceKey)
+                                .withRootProcessInstanceKey(rootProcessInstanceKey)
                                 .build()))
                     .build())
             .build();
@@ -1213,7 +1215,7 @@ class RdbmsExporterIT {
     final var item = items.getFirst();
     assertThat(item.itemKey()).isEqualTo(itemKey);
     assertThat(item.processInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(item.rootProcessInstanceKey()).isNull();
+    assertThat(item.rootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
     assertThat(item.operationType()).isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     assertThat(item.state()).isEqualTo(BatchOperationItemState.ACTIVE);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTransformer.java
@@ -20,8 +20,8 @@ public final class ProcessInstanceResultConfigTransformer
     if (value != null) {
       final var builder = new SearchSourceFilter.Builder();
 
-      if (value.onlyKey()) {
-        builder.includes(List.of("key"));
+      if (value.onlyKeys()) {
+        builder.includes(List.of("key", "rootProcessInstanceKey"));
       }
 
       return new SearchSourceConfig(builder.build());

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/SearchQueryBuilderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/SearchQueryBuilderTest.java
@@ -25,7 +25,7 @@ public class SearchQueryBuilderTest {
     final var searchQueryPage = new SearchQueryPage.Builder().size(50).build();
     final var searchQuerySort = ProcessInstanceSort.of(builder -> builder.startDate().asc());
     final var searchQueryResultConfig =
-        ProcessInstanceQueryResultConfig.of(builder -> builder.onlyKey(true));
+        ProcessInstanceQueryResultConfig.of(builder -> builder.onlyKeys(true));
     final var filter = new ProcessInstanceFilter.Builder().build(); // all
 
     // when

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTest.java
@@ -15,24 +15,24 @@ import org.junit.jupiter.api.Test;
 public class ProcessInstanceResultConfigTest extends AbstractResultConfigTest {
 
   @Test
-  public void shouldSourceConfigIncludeProcessKey() {
+  public void shouldSourceConfigIncludeProcessKeys() {
     // when
     final var source =
         transformRequest(
             SearchQueryBuilders.processInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.onlyKey(true))));
+                q -> q.resultConfig(r -> r.onlyKeys(true))));
 
     // then
-    assertThat(source.sourceFilter().includes()).containsExactly("key");
+    assertThat(source.sourceFilter().includes()).containsExactly("key", "rootProcessInstanceKey");
   }
 
   @Test
-  public void shouldSourceConfigExcludeProcessKey() {
+  public void shouldSourceConfigExcludeProcessKeys() {
     // when
     final var source =
         transformRequest(
             SearchQueryBuilders.processInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.onlyKey(false))));
+                q -> q.resultConfig(r -> r.onlyKeys(false))));
 
     // then
     assertThat(source.sourceFilter().includes()).isNull();

--- a/search/search-domain/src/main/java/io/camunda/search/result/ProcessInstanceQueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/ProcessInstanceQueryResultConfig.java
@@ -10,7 +10,7 @@ package io.camunda.search.result;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 
-public record ProcessInstanceQueryResultConfig(Boolean onlyKey) implements QueryResultConfig {
+public record ProcessInstanceQueryResultConfig(Boolean onlyKeys) implements QueryResultConfig {
 
   public static ProcessInstanceQueryResultConfig of(
       final Function<Builder, ObjectBuilder<ProcessInstanceQueryResultConfig>> fn) {
@@ -19,18 +19,18 @@ public record ProcessInstanceQueryResultConfig(Boolean onlyKey) implements Query
 
   public static final class Builder implements ObjectBuilder<ProcessInstanceQueryResultConfig> {
 
-    private static final Boolean DEFAULT_ONLY_KEY = false;
+    private static final Boolean DEFAULT_ONLY_KEYS = false;
 
-    private Boolean onlyKey = DEFAULT_ONLY_KEY;
+    private Boolean onlyKeys = DEFAULT_ONLY_KEYS;
 
-    public Builder onlyKey(final boolean onlyKey) {
-      this.onlyKey = onlyKey;
+    public Builder onlyKeys(final boolean onlyKey) {
+      onlyKeys = onlyKey;
       return this;
     }
 
     @Override
     public ProcessInstanceQueryResultConfig build() {
-      return new ProcessInstanceQueryResultConfig(onlyKey);
+      return new ProcessInstanceQueryResultConfig(onlyKeys);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/DecisionInstanceItemProvider.java
@@ -61,7 +61,12 @@ public class DecisionInstanceItemProvider implements ItemProvider {
 
     return new ItemPage(
         result.items().stream()
-            .map(di -> new Item(di.decisionInstanceKey(), di.processInstanceKey()))
+            .map(
+                di ->
+                    new Item(
+                        di.decisionInstanceKey(),
+                        di.processInstanceKey(),
+                        di.rootProcessInstanceKey()))
             .collect(Collectors.toList()),
         result.endCursor(),
         result.total(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProvider.java
@@ -130,7 +130,10 @@ public class IncidentItemProvider implements ItemProvider {
 
     return new ItemPage(
         result.items().stream()
-            .map(pi -> new Item(pi.incidentKey(), pi.processInstanceKey()))
+            .map(
+                pi ->
+                    new Item(
+                        pi.incidentKey(), pi.processInstanceKey(), pi.rootProcessInstanceKey()))
             .collect(Collectors.toList()),
         result.endCursor(),
         result.total(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProvider.java
@@ -28,8 +28,10 @@ public interface ItemProvider {
    *
    * @param itemKey the key of the item
    * @param processInstanceKey the key of the process instance this item belongs to
+   * @param rootProcessInstanceKey the key of the root process instance this item belongs to (or
+   *     null if not known)
    */
-  record Item(long itemKey, long processInstanceKey) {}
+  record Item(long itemKey, long processInstanceKey, Long rootProcessInstanceKey) {}
 
   /**
    * Internal abstraction to hold the result of a page of entity items.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProvider.java
@@ -65,7 +65,12 @@ public class ProcessInstanceItemProvider implements ItemProvider {
 
     return new ItemPage(
         result.items().stream()
-            .map(pi -> new Item(pi.processInstanceKey(), pi.processInstanceKey()))
+            .map(
+                pi ->
+                    new Item(
+                        pi.processInstanceKey(),
+                        pi.processInstanceKey(),
+                        pi.rootProcessInstanceKey()))
             .collect(Collectors.toList()),
         result.endCursor(),
         result.total(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ProcessInstanceItemProvider.java
@@ -47,7 +47,7 @@ public class ProcessInstanceItemProvider implements ItemProvider {
         SearchQueryBuilders.processInstanceSearchQuery()
             .filter(filter)
             .page(page)
-            .resultConfig(c -> c.onlyKey(true))
+            .resultConfig(c -> c.onlyKeys(true))
             .build();
 
     final SearchQueryResult<ProcessInstanceEntity> result;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -125,7 +126,8 @@ public class BatchOperationPageProcessor {
   private static BatchOperationItem mapItem(final Item item) {
     return new BatchOperationItem()
         .setItemKey(item.itemKey())
-        .setProcessInstanceKey(item.processInstanceKey());
+        .setProcessInstanceKey(item.processInstanceKey())
+        .setRootProcessInstanceKey(Optional.ofNullable(item.rootProcessInstanceKey()).orElse(-1L));
   }
 
   public record PageProcessingResult(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/IncidentItemProviderTest.java
@@ -69,11 +69,11 @@ class IncidentItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    createProcessInstanceEntity(1L),
-                    createProcessInstanceEntity(2L),
-                    createProcessInstanceEntity(3L),
-                    createProcessInstanceEntity(4L),
-                    createProcessInstanceEntity(5L)))
+                    createProcessInstanceEntity(1L, 1L),
+                    createProcessInstanceEntity(2L, 1L),
+                    createProcessInstanceEntity(3L, 3L),
+                    createProcessInstanceEntity(4L, null),
+                    createProcessInstanceEntity(5L, null)))
             .total(5)
             .build();
     when(searchClientsProxy.searchProcessInstances(piQueryCaptor.capture())).thenReturn(piResult);
@@ -82,22 +82,22 @@ class IncidentItemProviderTest {
         new SearchQueryResult.Builder<IncidentEntity>()
             .items(
                 List.of(
-                    mockIncidentEntity(11, 1),
-                    mockIncidentEntity(12, 1),
-                    mockIncidentEntity(21, 2),
-                    mockIncidentEntity(22, 2),
-                    mockIncidentEntity(31, 3)))
+                    mockIncidentEntity(11, 1, 1L),
+                    mockIncidentEntity(12, 1, 1L),
+                    mockIncidentEntity(21, 2, 1L),
+                    mockIncidentEntity(22, 2, 1L),
+                    mockIncidentEntity(31, 3, 3L)))
             .total(10)
             .build();
     final var incidentResult2 =
         new SearchQueryResult.Builder<IncidentEntity>()
             .items(
                 List.of(
-                    mockIncidentEntity(32, 3),
-                    mockIncidentEntity(41, 4),
-                    mockIncidentEntity(42, 4),
-                    mockIncidentEntity(51, 5),
-                    mockIncidentEntity(52, 5)))
+                    mockIncidentEntity(32, 3, 3L),
+                    mockIncidentEntity(41, 4, null),
+                    mockIncidentEntity(42, 4, null),
+                    mockIncidentEntity(51, 5, null),
+                    mockIncidentEntity(52, 5, null)))
             .total(10)
             .build();
     final var incidentResult3 =
@@ -114,16 +114,16 @@ class IncidentItemProviderTest {
     // then
     assertThat(resultPage.items())
         .containsExactly(
-            new Item(11, 1),
-            new Item(12, 1),
-            new Item(21, 2),
-            new Item(22, 2),
-            new Item(31, 3),
-            new Item(32, 3),
-            new Item(41, 4),
-            new Item(42, 4),
-            new Item(51, 5),
-            new Item(52, 5));
+            new Item(11, 1, 1L),
+            new Item(12, 1, 1L),
+            new Item(21, 2, 1L),
+            new Item(22, 2, 1L),
+            new Item(31, 3, 3L),
+            new Item(32, 3, 3L),
+            new Item(41, 4, null),
+            new Item(42, 4, null),
+            new Item(51, 5, null),
+            new Item(52, 5, null));
     assertThat(resultPage.isLastPage()).isFalse();
   }
 
@@ -137,11 +137,11 @@ class IncidentItemProviderTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    createProcessInstanceEntity(1L),
-                    createProcessInstanceEntity(2L),
-                    createProcessInstanceEntity(3L),
-                    createProcessInstanceEntity(4L),
-                    createProcessInstanceEntity(5L)))
+                    createProcessInstanceEntity(1L, 1L),
+                    createProcessInstanceEntity(2L, 2L),
+                    createProcessInstanceEntity(3L, 1L),
+                    createProcessInstanceEntity(4L, 2L),
+                    createProcessInstanceEntity(5L, null)))
             .total(5)
             .build();
     when(searchClientsProxy.searchProcessInstances(piQueryCaptor.capture())).thenReturn(piResult);
@@ -179,16 +179,20 @@ class IncidentItemProviderTest {
     assertThat(resultPage.isLastPage()).isTrue();
   }
 
-  private ProcessInstanceEntity createProcessInstanceEntity(final long processInstanceKey) {
+  private ProcessInstanceEntity createProcessInstanceEntity(
+      final long processInstanceKey, final Long rootProcessInstanceKey) {
     return Instancio.of(ProcessInstanceEntity.class)
         .set(field(ProcessInstanceEntity::processInstanceKey), processInstanceKey)
+        .set(field(ProcessInstanceEntity::rootProcessInstanceKey), rootProcessInstanceKey)
         .create();
   }
 
-  private IncidentEntity mockIncidentEntity(final long incidentKey, final long processInstanceKey) {
+  private IncidentEntity mockIncidentEntity(
+      final long incidentKey, final long processInstanceKey, final Long rootProcessInstanceKey) {
     final var entity = mock(IncidentEntity.class);
     when(entity.incidentKey()).thenReturn(incidentKey);
     when(entity.processInstanceKey()).thenReturn(processInstanceKey);
+    when(entity.rootProcessInstanceKey()).thenReturn(rootProcessInstanceKey);
     return entity;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelperTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationHelperTest.java
@@ -339,6 +339,6 @@ class BatchOperationInitializationHelperTest {
   }
 
   private Item createItem(final long key) {
-    return new Item(key, key + 1000);
+    return new Item(key, key + 1000, null);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
@@ -102,6 +102,11 @@ public class BatchOperationChunkCreatedItemHandler
         .setState(OperationState.SCHEDULED)
         .setProcessInstanceKey(item.getProcessInstanceKey())
         .setItemKey(item.getItemKey());
+
+    final var rootProcessInstanceKey = item.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      entity.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -151,6 +151,9 @@ class BatchOperationChunkCreatedHandlerTest {
                 .withValue(
                     new BatchOperationChunkRecord()
                         .setBatchOperationKey(123L)
-                        .setItems(List.of(new BatchOperationItem(itemKey, processInstanceKey)))));
+                        .setItems(
+                            List.of(
+                                new BatchOperationItem(
+                                    itemKey, processInstanceKey, processInstanceKey)))));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -127,6 +127,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
         .isEqualTo(String.valueOf(record.getValue().getBatchOperationKey()));
     assertThat(entity.getState()).isEqualTo(OperationState.SCHEDULED);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(item.getProcessInstanceKey());
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(item.getRootProcessInstanceKey());
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -54,7 +54,9 @@ public class BatchOperationChunkExportHandler
         Long.toString(batchOperationKey),
         value.getItemKey(),
         value.getProcessInstanceKey(),
-        null, // TODO root process instance key is not currently available in chunk record
+        // for RDBMS this should not be -1, but if it was we would want to make to NULL in the
+        // database
+        value.getRootProcessInstanceKey() > 0 ? value.getRootProcessInstanceKey() : null,
         BatchOperationItemState.ACTIVE,
         null,
         null);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -129,6 +129,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
                             "operationType":"CANCEL_PROCESS_INSTANCE",
                             "itemKey":"11",
                             "processInstanceKey":"12",
+                            "rootProcessInstanceKey":"13",
                             "state":"FAILED",
                             "processedDate":"2025-03-18T10:57:44.000+01:00",
                             "errorMessage": "error"

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
@@ -16,16 +16,22 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
   private final LongProperty itemKeyProperty = new LongProperty("itemKey", -1);
   private final LongProperty processInstanceKeyProperty =
       new LongProperty("processInstanceKey", -1);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty("rootProcessInstanceKey", -1);
 
   public BatchOperationItem() {
-    super(2);
-    declareProperty(itemKeyProperty).declareProperty(processInstanceKeyProperty);
+    super(3);
+    declareProperty(itemKeyProperty)
+        .declareProperty(processInstanceKeyProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
-  public BatchOperationItem(final long itemKey, final long processInstanceKey) {
+  public BatchOperationItem(
+      final long itemKey, final long processInstanceKey, final long rootProcessInstanceKey) {
     this();
     setItemKey(itemKey);
     setProcessInstanceKey(processInstanceKey);
+    setRootProcessInstanceKey(rootProcessInstanceKey);
   }
 
   @Override
@@ -48,9 +54,20 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
+    setRootProcessInstanceKey(value.getRootProcessInstanceKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3977,7 +3977,10 @@ final class JsonSerializableToJsonTest {
                     .setBatchOperationKey(12345L)
                     .setItems(
                         List.of(
-                            new BatchOperationItem().setItemKey(1L).setProcessInstanceKey(2L),
+                            new BatchOperationItem()
+                                .setItemKey(1L)
+                                .setProcessInstanceKey(2L)
+                                .setRootProcessInstanceKey(3L),
                             new BatchOperationItem().setItemKey(2L).setProcessInstanceKey(2L))),
         """
                 {
@@ -3985,14 +3988,16 @@ final class JsonSerializableToJsonTest {
                     {
                       "itemKey": 1,
                       "processInstanceKey": 2,
+                      "rootProcessInstanceKey": 3,
                       "empty": false,
-                      "encodedLength": 30
+                      "encodedLength": 54
                     },
                     {
                       "itemKey": 2,
                       "processInstanceKey": 2,
+                      "rootProcessInstanceKey": -1,
                       "empty": false,
-                      "encodedLength": 30
+                      "encodedLength": 54
                     }
                   ],
                   "batchOperationKey": 12345

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
@@ -16,16 +16,22 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
   private final LongProperty itemKeyProperty = new LongProperty("itemKey", -1);
   private final LongProperty processInstanceKeyProperty =
       new LongProperty("processInstanceKey", -1);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty("rootProcessInstanceKey", -1);
 
   public BatchOperationItem() {
-    super(2);
-    declareProperty(itemKeyProperty).declareProperty(processInstanceKeyProperty);
+    super(3);
+    declareProperty(itemKeyProperty)
+        .declareProperty(processInstanceKeyProperty)
+        .declareProperty(rootProcessInstanceKeyProperty);
   }
 
-  public BatchOperationItem(final long itemKey, final long processInstanceKey) {
+  public BatchOperationItem(
+      final long itemKey, final long processInstanceKey, final long rootProcessInstanceKey) {
     this();
     setItemKey(itemKey);
     setProcessInstanceKey(processInstanceKey);
+    setRootProcessInstanceKey(rootProcessInstanceKey);
   }
 
   @Override
@@ -48,9 +54,20 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
+    setRootProcessInstanceKey(value.getRootProcessInstanceKey());
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -42,5 +42,15 @@ public interface BatchOperationChunkRecordValue extends BatchOperationRelated, R
     long getItemKey();
 
     long getProcessInstanceKey();
+
+    /**
+     * Returns the key of the root process instance in the hierarchy. For items in top-level process
+     * instances, this is equal to {@link #getProcessInstanceKey()}. For items in child process
+     * instances (created via call activities), this is the key of the topmost parent process
+     * instance.
+     *
+     * @return the key of the root process instance, or {@code -1} if not set
+     */
+    long getRootProcessInstanceKey();
   }
 }


### PR DESCRIPTION
This just makes things consistent for batch operation items.  Previously the `BATCH_OPERATION_CHUNK` messages would only include the process instance key and not the root process instance key as well.  Later records would then include the root process instance key, but there was potential for an intermediate state where root process instance key was temporarily not set.

NB. I've also updated this for ES/OS as it was a really small change once the changes to Zeebe were done.

## Related issues

closes #45267
