### PR TITLE
AlwaysGreen - Make SaaS E2E dispatch correlation-based and harden downstream wait polling

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -79,6 +79,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
@@ -109,6 +110,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   build-tasklist-frontend:
     name: Build Tasklist Frontend
     needs: should-run
@@ -138,6 +140,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   build-identity-frontend:
     name: Build Identity Frontend
     needs: should-run
@@ -332,6 +335,7 @@ jobs:
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
@@ -341,6 +345,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
       - name: Generate GitHub App Token (for dispatch)
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
@@ -359,6 +364,7 @@ jobs:
       - name: Trigger repository_dispatch for SaaS Monorepo
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -367,6 +373,7 @@ jobs:
             -d '{
                   "event_type": "run-saas-generation-smoke-mono",
                   "client_payload": {
+                      "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
                       "c8Version": "8.9",
@@ -377,10 +384,6 @@ jobs:
                       "optimizeVersion": "8-SNAPSHOT"
                   }
                 }'
-
-      - name: Get trigger timestamp
-        id: trigger-time
-        run: echo "trigger_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
 
       - name: Observe build status
         if: always()
@@ -397,30 +400,64 @@ jobs:
         id: wait-downstream
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
-          TRIGGER_TIME: ${{ steps.trigger-time.outputs.trigger_time }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
         run: |
           set -euo pipefail
-          echo "Waiting for E2E workflow to complete in camunda/c8-cross-component-e2e-tests triggered after $TRIGGER_TIME"
+          echo "Waiting for downstream E2E workflow run in camunda/c8-cross-component-e2e-tests for correlation id: $CORRELATION_ID"
 
           TARGET_REPO="camunda/c8-cross-component-e2e-tests"
           WORKFLOW_FILE="playwright_saas_pr_trigger_monorepo.yml"
+
+          gh_api_with_retry() {
+            local endpoint="$1"
+            local max_attempts="${2:-6}"
+            local sleep_s="${3:-2}"
+            local attempt=1
+            local out
+
+            while true; do
+              if out="$(gh api "$endpoint" 2>&1)"; then
+                printf '%s' "$out"
+                return 0
+              fi
+
+              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF'; then
+                if (( attempt >= max_attempts )); then
+                  echo "gh api failed after ${attempt}/${max_attempts} attempts for $endpoint" >&2
+                  echo "$out" >&2
+                  return 1
+                fi
+                echo "Transient gh/api error (attempt ${attempt}/${max_attempts}) for $endpoint:" >&2
+                echo "$out" >&2
+                sleep "$sleep_s"
+                attempt=$((attempt + 1))
+                sleep_s=$((sleep_s * 2))
+                continue
+              fi
+
+              echo "Non-retryable gh/api error for $endpoint:" >&2
+              echo "$out" >&2
+              return 1
+            done
+          }
 
           RUN_ID=""
 
           for _ in {1..80}; do
             if [[ -z "$RUN_ID" ]]; then
-              # Find the first downstream run created after we triggered (do this ONCE, then lock onto it)
               RUN_ID=$(
-                gh api "/repos/$TARGET_REPO/actions/workflows/$WORKFLOW_FILE/runs?event=repository_dispatch&per_page=20" \
-                  --jq ".workflow_runs
-                        | map(select(.created_at > \"$TRIGGER_TIME\"))
-                        | sort_by(.created_at)
-                        | last
-                        | .id // empty"
+                gh_api_with_retry "/repos/$TARGET_REPO/actions/workflows/$WORKFLOW_FILE/runs?event=repository_dispatch&per_page=50" \
+                | jq -r --arg c "$CORRELATION_ID" '
+                    .workflow_runs
+                    | map(select(.display_title != null and (.display_title | contains($c))))
+                    | sort_by(.created_at)
+                    | last
+                    | .id // empty
+                  '
               )
 
               if [[ -z "$RUN_ID" ]]; then
-                echo "No downstream workflow run found yet. Sleeping..."
+                echo "No downstream run found yet for correlation id. Sleeping..."
                 sleep 30
                 continue
               fi
@@ -429,8 +466,9 @@ jobs:
               echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> "$GITHUB_OUTPUT"
             fi
 
-            STATUS=$(gh api "/repos/$TARGET_REPO/actions/runs/$RUN_ID" --jq .status)
-            CONCLUSION=$(gh api "/repos/$TARGET_REPO/actions/runs/$RUN_ID" --jq .conclusion)
+            RUN_JSON="$(gh_api_with_retry "/repos/$TARGET_REPO/actions/runs/$RUN_ID")"
+            STATUS="$(jq -r .status <<<"$RUN_JSON")"
+            CONCLUSION="$(jq -r .conclusion <<<"$RUN_JSON")"
             echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"
 
             if [[ "$STATUS" == "completed" ]]; then
@@ -456,9 +494,10 @@ jobs:
             {
               echo "### SaaS Downstream Workflow Run"
               echo ""
+              echo "**Correlation ID:** \`${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}\`"
+              echo ""
               echo "[Open the triggered SaaS E2E workflow run in camunda/c8-cross-component-e2e-tests](${{ steps.wait-downstream.outputs.downstream_run_url }})"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
           fi
-


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

**What / Why**

- The upstream workflow triggers SaaS E2E tests in camunda/c8-cross-component-e2e-tests via repository_dispatch and then waits for the downstream workflow run to finish.
- Previously, the wait logic relied on timestamps (created_at > trigger_time) and could select unrelated downstream runs when multiple dispatches occurred around the same time.
- The polling also occasionally failed due to transient GitHub API errors (e.g. gh: Server Error (HTTP 502)).

**Changes**

- Add a deterministic correlation_id to the repository_dispatch client_payload.
- Update the downstream waiting logic to locate the downstream run by matching the correlation id in the downstream run’s display_title (enabled by downstream workflow run-name).
- Add retry/backoff around gh api calls and reduce API calls per polling iteration by fetching run JSON once and parsing status/conclusion from it.
- Remove the timestamp-based trigger-time step (no longer needed).

**Result**

- The workflow reliably waits for the correct downstream SaaS E2E run, even under high activity.
- Transient GitHub API 5xx errors no longer cause the job to fail immediately; the step retries and continues polling.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
