### PR TITLE
fix: add version to the process instance creation by key DTO

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -794,7 +794,8 @@ components:
             deploy resources endpoint.
         processDefinitionVersion:
           description: |
-            The version of the process. By default, the latest version of the process is used.
+            As the version is already identified by the `processDefinitionKey`, the value of this field is ignored.
+            It's here for backwards-compatibility only as previous releases accepted it in request bodies.
           type: integer
           format: int32
           default: -1

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -792,6 +792,12 @@ components:
           description: |
             The unique key identifying the process definition, for example, returned for a process in the
             deploy resources endpoint.
+        processDefinitionVersion:
+          description: |
+            The version of the process. By default, the latest version of the process is used.
+          type: integer
+          format: int32
+          default: -1
         variables:
           description: |
             JSON object that will instantiate the variables for the root variable scope


### PR DESCRIPTION
## Description

This change is needed to ensure forward compatibility of the client. 8.8 java client send the create instance command with the version property, the server needs to be tolerant. The version will be not used in the service layer.

More context [here](https://camunda.slack.com/archives/C0A2AGG2Q2E/p1770709851417649)
