### PR TITLE
feat: add missing audit logs transformation for root PI key

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogSearchClientIT.java
@@ -202,6 +202,7 @@ public class AuditLogSearchClientIT {
     // given
     final var userTask = utils.getUserTasks().getFirst();
     final long elementInstanceKey = userTask.getElementInstanceKey();
+    final long rootProcessInstanceKey = userTask.getRootProcessInstanceKey();
 
     // when
     final var auditLogItems =
@@ -215,6 +216,8 @@ public class AuditLogSearchClientIT {
             auditLogResult -> {
               assertThat(auditLogResult.getElementInstanceKey())
                   .isEqualTo(String.valueOf(elementInstanceKey));
+              assertThat(auditLogResult.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
               assertCommonAuditLogFields(
                   auditLogResult,
                   AuditLogEntityTypeEnum.USER_TASK,
@@ -229,6 +232,7 @@ public class AuditLogSearchClientIT {
     // given
     final var userTask = utils.getUserTasks().getFirst();
     final long userTaskKey = userTask.getUserTaskKey();
+    final long rootProcessInstanceKey = userTask.getRootProcessInstanceKey();
 
     // when
     final var auditLogItems =
@@ -241,6 +245,8 @@ public class AuditLogSearchClientIT {
         .allSatisfy(
             auditLogResult -> {
               assertThat(auditLogResult.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+              assertThat(auditLogResult.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
               assertCommonAuditLogFields(
                   auditLogResult,
                   AuditLogEntityTypeEnum.USER_TASK,
@@ -633,6 +639,7 @@ public class AuditLogSearchClientIT {
     // given
     final var userTask = utils.getUserTasks().getFirst();
     final long userTaskKey = userTask.getUserTaskKey();
+    final long rootProcessInstanceKey = userTask.getRootProcessInstanceKey();
 
     // when
     final var auditLogItems =
@@ -645,6 +652,8 @@ public class AuditLogSearchClientIT {
         .allSatisfy(
             auditLogResult -> {
               assertThat(auditLogResult.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+              assertThat(auditLogResult.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
               assertThat(auditLogResult.getActorId()).isEqualTo(DEFAULT_USERNAME);
               assertCommonAuditLogFields(
                   auditLogResult,
@@ -658,10 +667,11 @@ public class AuditLogSearchClientIT {
   void shouldSearchUserTaskAuditLogByKey(
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // given
-    final long userTask = utils.getUserTasks().getFirst().getUserTaskKey();
+    final long userTaskKey = utils.getUserTasks().getFirst().getUserTaskKey();
+    final long rootProcessInstanceKey = utils.getUserTasks().getFirst().getRootProcessInstanceKey();
 
     // when
-    final var response = client.newUserTaskAuditLogSearchRequest(userTask).send().join();
+    final var response = client.newUserTaskAuditLogSearchRequest(userTaskKey).send().join();
 
     // then
     final var auditLogItems = response.items();
@@ -669,7 +679,9 @@ public class AuditLogSearchClientIT {
     assertThat(auditLogItems)
         .allSatisfy(
             auditLog -> {
-              assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTask));
+              assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+              assertThat(auditLog.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
               assertCommonAuditLogFields(
                   auditLog,
                   AuditLogEntityTypeEnum.USER_TASK,
@@ -683,6 +695,7 @@ public class AuditLogSearchClientIT {
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // given
     final long userTask = utils.getUserTasks().getFirst().getUserTaskKey();
+    final long rootProcessInstanceKey = utils.getUserTasks().getFirst().getRootProcessInstanceKey();
 
     // when
     final var response =
@@ -699,6 +712,8 @@ public class AuditLogSearchClientIT {
         .allSatisfy(
             auditLog -> {
               assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTask));
+              assertThat(auditLog.getRootProcessInstanceKey())
+                  .isEqualTo(String.valueOf(rootProcessInstanceKey));
               assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
               assertCommonAuditLogFields(
                   auditLog,

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -40,13 +40,5 @@ public class DecisionEvaluationAuditLogTransformer
     if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
       log.setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
     }
-    final long processInstanceKey = value.getProcessInstanceKey();
-    if (processInstanceKey > 0) {
-      log.setProcessInstanceKey(processInstanceKey);
-    }
-    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
-    if (rootProcessInstanceKey > 0) {
-      log.setRootProcessInstanceKey(rootProcessInstanceKey);
-    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -40,5 +40,13 @@ public class DecisionEvaluationAuditLogTransformer
     if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
       log.setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
     }
+    final long processInstanceKey = value.getProcessInstanceKey();
+    if (processInstanceKey > 0) {
+      log.setProcessInstanceKey(processInstanceKey);
+    }
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
@@ -22,5 +22,9 @@ public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTask
   public void transform(final Record<UserTaskRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setUserTaskKey(value.getUserTaskKey()).setEntityKey(String.valueOf(value.getUserTaskKey()));
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 
 public class VariableAddUpdateAuditLogTransformer
@@ -15,5 +17,13 @@ public class VariableAddUpdateAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.VARIABLE_ADD_UPDATE_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
+    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -39,8 +39,6 @@ class DecisionEvaluationAuditLogTransformerTest {
             .withDecisionRequirementsId("drg-1")
             .withDecisionRequirementsKey(789L)
             .withTenantId("tenant-1")
-            .withProcessInstanceKey(37L)
-            .withRootProcessInstanceKey(73L)
             .build();
 
     final Record<DecisionEvaluationRecordValue> record =
@@ -58,8 +56,6 @@ class DecisionEvaluationAuditLogTransformerTest {
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("drg-1");
     assertThat(entity.getDecisionRequirementsKey()).isEqualTo(789L);
     assertThat(entity.getTenant().get().tenantId()).isEqualTo("tenant-1");
-    assertThat(entity.getProcessInstanceKey()).isEqualTo(37L);
-    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(73L);
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -39,6 +39,8 @@ class DecisionEvaluationAuditLogTransformerTest {
             .withDecisionRequirementsId("drg-1")
             .withDecisionRequirementsKey(789L)
             .withTenantId("tenant-1")
+            .withProcessInstanceKey(37L)
+            .withRootProcessInstanceKey(73L)
             .build();
 
     final Record<DecisionEvaluationRecordValue> record =
@@ -55,6 +57,9 @@ class DecisionEvaluationAuditLogTransformerTest {
     assertThat(entity.getDecisionDefinitionKey()).isEqualTo(456L);
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("drg-1");
     assertThat(entity.getDecisionRequirementsKey()).isEqualTo(789L);
+    assertThat(entity.getTenant().get().tenantId()).isEqualTo("tenant-1");
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(37L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(73L);
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
@@ -52,5 +52,9 @@ class UserTaskAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(789L);
     assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");
     assertThat(entity.getElementInstanceKey()).isEqualTo(111L);
+    assertThat(entity.getTenant().get().tenantId()).isEqualTo("tenant-1");
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
@@ -52,5 +52,9 @@ class VariableAddUpdateAuditLogTransformerTest {
     assertThat(entity.getProcessInstanceKey()).isEqualTo(123L);
     assertThat(entity.getElementInstanceKey()).isEqualTo(789L);
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getTenant().get().tenantId()).isEqualTo("tenant-1");
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding missing `rootProcessInstanceKey` setting audit log entities in their corresponding transformers. It also updates acceptance and unit tests to verify the presence and correctness of this field, and enables audit logs clean up checks in `ProcessInstanceHistoryCleanupIT`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
