### PR TITLE
ci: increase timeout RDBMS IT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
     name: "General / Integration / RDBMS ITs"
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: gcp-perf-core-8-default
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}


### PR DESCRIPTION
## Description

The RDBMS IT job needs roughly 10 minutes to build and run tests in the merge queue.

It regularly times out while uploading test results, causing unnecessary evictions from the merge queue.

## Related issues

n/a
