### PR TITLE
test: only create containers when we need to

### DIFF
--- a/search/search-test-utils/pom.xml
+++ b/search/search-test-utils/pom.xml
@@ -28,11 +28,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
     </dependency>
@@ -58,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -65,6 +65,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
     </dependency>
 
     <dependency>

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/ContainerizedSearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/ContainerizedSearchDBExtension.java
@@ -9,16 +9,22 @@ package io.camunda.search.test.utils;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.jackson.JacksonConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.testcontainers.OpenSearchContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 /**
@@ -30,74 +36,132 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
  * tests may be executed against both types of databases.
  */
 public class ContainerizedSearchDBExtension extends SearchDBExtension {
+  private final LazySearchContainer<ElasticsearchContainer, ElasticsearchClient> elasticsearch =
+      new LazySearchContainer<>(
+          TestSearchContainers::createDefeaultElasticsearchContainer,
+          ContainerizedSearchDBExtension::createElasticSearchClient,
+          ElasticsearchClient::close);
+  private final LazySearchContainer<OpenSearchContainer<?>, OpenSearchClient> opensearch =
+      new LazySearchContainer<>(
+          TestSearchContainers::createDefaultOpensearchContainer,
+          ContainerizedSearchDBExtension::createOpenSearchClient,
+          osClient -> osClient._transport().close());
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(ContainerizedSearchDBExtension.class);
-
-  private static ElasticsearchContainer elasticsearchContainer;
-  private static OpenSearchContainer opensearchContainer;
-
-  private static ElasticsearchClient elsClient;
-  private static OpenSearchClient osClient;
-  private ObjectMapper osObjectMapper;
-  private ObjectMapper esObjectMapper;
+  private final AtomicInteger refCount = new AtomicInteger();
+  private final ObjectMapper objectMapper =
+      new JacksonConfiguration(new ConnectConfiguration()).createObjectMapper();
 
   @Override
   public void beforeAll(final ExtensionContext context) throws Exception {
-    elasticsearchContainer = TestSearchContainers.createDefeaultElasticsearchContainer();
-    opensearchContainer = TestSearchContainers.createDefaultOpensearchContainer();
+    refCount.getAndIncrement();
+  }
 
-    elasticsearchContainer.start();
-    opensearchContainer.start();
-
+  private static ElasticsearchClient createElasticSearchClient(
+      final ElasticsearchContainer container) {
     final var config = new ConnectConfiguration();
-    config.setUrl(elasticsearchContainer.getHttpHostAddress());
+    config.setUrl(container.getHttpHostAddress());
     final var esConnector = new ElasticsearchConnector(config);
-    esObjectMapper = esConnector.objectMapper();
-    elsClient = esConnector.createClient();
+    return esConnector.createClient();
+  }
 
+  private static OpenSearchClient createOpenSearchClient(final OpenSearchContainer<?> container) {
     final var osConfig = new ConnectConfiguration();
     osConfig.setType(DatabaseConfig.OPENSEARCH);
-    osConfig.setUrl(opensearchContainer.getHttpHostAddress());
+    osConfig.setUrl(container.getHttpHostAddress());
     final var osConnector = new OpensearchConnector(osConfig);
-    osObjectMapper = osConnector.objectMapper();
-    osClient = osConnector.createClient();
+    return osConnector.createClient();
   }
 
   /** {@inheritDoc} */
   @Override
   public ObjectMapper objectMapper() {
-    // which one to return?
-    return osObjectMapper;
+    return objectMapper;
   }
 
   /** {@inheritDoc} */
   @Override
   public ElasticsearchClient esClient() {
-    return elsClient;
+    return elasticsearch.getClient();
   }
 
   /** {@inheritDoc} */
   @Override
   public OpenSearchClient osClient() {
-    return osClient;
+    return opensearch.getClient();
   }
 
   /** {@inheritDoc} */
   @Override
   public String esUrl() {
-    return elasticsearchContainer.getHttpHostAddress();
+    return elasticsearch.getContainer().getHttpHostAddress();
   }
 
   /** {@inheritDoc} */
   @Override
   public String osUrl() {
-    return opensearchContainer.getHttpHostAddress();
+    return opensearch.getContainer().getHttpHostAddress();
   }
 
   @Override
   public void afterAll(final ExtensionContext context) throws Exception {
-    elsClient.close();
-    osClient._transport().close();
+    // if we are using @Nested then beforeAll/afterAll will be called multiple times, so we need to
+    // make sure to only close the containers when the last afterAll is called
+    if (refCount.decrementAndGet() == 0) {
+      elasticsearch.close();
+      opensearch.close();
+    }
+  }
+
+  record ContainerAndClient<T extends GenericContainer<?>, C>(T container, C client) {}
+
+  static class LazySearchContainer<T extends GenericContainer<?>, C> implements AutoCloseable {
+    private final AtomicReference<ContainerAndClient<T, C>> containerAndClient =
+        new AtomicReference<>();
+    private final Supplier<ContainerAndClient<T, C>> containerAndClientCreator;
+    private final ClientCloser<C> clientCloser;
+
+    public LazySearchContainer(
+        final Supplier<T> containerSupplier,
+        final Function<T, C> clientCreator,
+        final ClientCloser<C> clientCloser) {
+      // using the memoize supplier to ensure we only create one container instance
+      containerAndClientCreator =
+          Suppliers.memoize(
+              () -> {
+                final var container = containerSupplier.get();
+                container.start();
+                final var client = clientCreator.apply(container);
+                return new ContainerAndClient<>(container, client);
+              });
+      this.clientCloser = clientCloser;
+    }
+
+    @Override
+    public void close() throws IOException {
+      final var containerAndClient = this.containerAndClient.get();
+      if (containerAndClient != null) {
+        try {
+          clientCloser.close(containerAndClient.client());
+        } finally {
+          containerAndClient.container().stop();
+        }
+      }
+    }
+
+    public T getContainer() {
+      return getContainerAndClient().container();
+    }
+
+    public C getClient() {
+      return getContainerAndClient().client();
+    }
+
+    private ContainerAndClient<T, C> getContainerAndClient() {
+      return containerAndClient.updateAndGet(previous -> containerAndClientCreator.get());
+    }
+  }
+
+  interface ClientCloser<C> {
+    void close(C client) throws IOException;
   }
 }


### PR DESCRIPTION
otherwise we end up creating way more containers than we actually end up using if we have a test that uses `@Nested` classes (as `beforeAll` is called for each one of those _and_ the parent class)
    
also some tests only want one of the opensearch or elasticsearch containers, so this avoids them making and starting both when they don't need to.


