### PR TITLE
Add feature flag to disable fetching userinfo during the authorization code flow

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -12,6 +12,8 @@ import static io.camunda.security.configuration.OidcAuthenticationConfiguration.
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration.Builder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
@@ -19,6 +21,7 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
 public final class ClientRegistrationFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientRegistrationFactory.class);
 
   private ClientRegistrationFactory() {}
 
@@ -73,6 +76,12 @@ public final class ClientRegistrationFactory {
       builder.clientAuthenticationMethod(
           ClientAuthenticationMethod.valueOf(configuration.getClientAuthenticationMethod()));
     }
+
+    if (!configuration.isUserInfoEnabled()) {
+      LOGGER.debug("Fetching user info is disabled for client registration {}", registrationId);
+      builder.userInfoUri(null);
+    }
+
     return builder.build();
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcAuthenticationConfigurationTest.java
@@ -123,10 +123,6 @@ public class OidcAuthenticationConfigurationTest {
             OidcAuthenticationConfiguration.builder().build(),
             false),
         Arguments.of(
-            "idpLogoutEnabled is set",
-            OidcAuthenticationConfiguration.builder().idpLogoutEnabled(false).build(),
-            true),
-        Arguments.of(
             "issuerUri is set",
             OidcAuthenticationConfiguration.builder().issuerUri("issuer").build(),
             true),
@@ -263,10 +259,6 @@ public class OidcAuthenticationConfigurationTest {
         Arguments.of(
             "default scope is set",
             OidcAuthenticationConfiguration.builder().scope(List.of("openid", "profile")).build(),
-            false),
-        Arguments.of(
-            "default for idpLogoutEnabled is set",
-            OidcAuthenticationConfiguration.builder().idpLogoutEnabled(true).build(),
             false),
         Arguments.of(
             "default clientAuthenticationMethod is set",

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.config;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 class OidcClientRegistrationTest {
@@ -40,5 +41,61 @@ class OidcClientRegistrationTest {
             () -> ClientRegistrationFactory.createClientRegistration("foo", config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("unsupported client authentication method: does_not_exist");
+  }
+
+  @Test
+  void shouldEnableUserInfoEndpoint() {
+    // given
+    final var config = new OidcAuthenticationConfiguration();
+    final var builder =
+        ClientRegistration.withRegistrationId("foo").userInfoUri("http://localhost:8080");
+    config.setClientId("clientId");
+    config.setRedirectUri("redirectUri");
+    config.setAuthorizationUri("authorizationUri");
+    config.setTokenUri("tokenUri");
+    config.setClientAuthenticationMethod("client_secret_basic");
+    config.setUserInfoEnabled(true);
+
+    try (final var mockedRegistration = Mockito.mockStatic(ClientRegistration.class)) {
+      mockedRegistration
+          .when(() -> ClientRegistration.withRegistrationId(Mockito.anyString()))
+          .thenReturn(builder);
+
+      // when
+      final var clientRegistration =
+          ClientRegistrationFactory.createClientRegistration("foo", config);
+
+      // then
+      Assertions.assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+          .isEqualTo("http://localhost:8080");
+    }
+  }
+
+  @Test
+  void shouldDisableUserInfoEndpoint() {
+    // given
+    final var config = new OidcAuthenticationConfiguration();
+    final var builder =
+        ClientRegistration.withRegistrationId("foo").userInfoUri("http://localhost:8080");
+    config.setClientId("clientId");
+    config.setRedirectUri("redirectUri");
+    config.setAuthorizationUri("authorizationUri");
+    config.setTokenUri("tokenUri");
+    config.setClientAuthenticationMethod("client_secret_basic");
+    config.setUserInfoEnabled(false);
+
+    try (final var mockedRegistration = Mockito.mockStatic(ClientRegistration.class)) {
+      mockedRegistration
+          .when(() -> ClientRegistration.withRegistrationId(Mockito.anyString()))
+          .thenReturn(builder);
+
+      // when
+      final var clientRegistration =
+          ClientRegistrationFactory.createClientRegistration("foo", config);
+
+      // then
+      Assertions.assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+          .isNull();
+    }
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -55,6 +55,7 @@ public class OidcAuthenticationConfiguration {
   private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
   private Duration clockSkew = DEFAULT_CLOCK_SKEW;
   private boolean idpLogoutEnabled = true;
+  private boolean userInfoEnabled = true;
 
   @PostConstruct
   public void validate() {
@@ -259,6 +260,14 @@ public class OidcAuthenticationConfiguration {
     this.idpLogoutEnabled = idpLogoutEnabled;
   }
 
+  public boolean isUserInfoEnabled() {
+    return userInfoEnabled;
+  }
+
+  public void setUserInfoEnabled(final boolean userInfoEnabled) {
+    this.userInfoEnabled = userInfoEnabled;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -290,7 +299,8 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
         || assertionConfiguration.getKidCase() != null
         || !DEFAULT_CLOCK_SKEW.equals(clockSkew)
-        || !idpLogoutEnabled;
+        || !idpLogoutEnabled
+        || !userInfoEnabled;
   }
 
   public static Builder builder() {
@@ -322,6 +332,7 @@ public class OidcAuthenticationConfiguration {
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
     private boolean idpLogoutEnabled = true;
+    private boolean userInfoEnabled = true;
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -440,6 +451,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder userInfoEnabled(final boolean userInfoEnabled) {
+      this.userInfoEnabled = userInfoEnabled;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -465,6 +481,7 @@ public class OidcAuthenticationConfiguration {
       config.setAssertion(assertionConfiguration);
       config.setClockSkew(clockSkew);
       config.setIdpLogoutEnabled(idpLogoutEnabled);
+      config.setUserInfoEnabled(userInfoEnabled);
       return config;
     }
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -298,9 +298,7 @@ public class OidcAuthenticationConfiguration {
         || assertionConfiguration.getKidDigestAlgorithm() != KidDigestAlgorithm.SHA256
         || assertionConfiguration.getKidEncoding() != KidEncoding.BASE64URL
         || assertionConfiguration.getKidCase() != null
-        || !DEFAULT_CLOCK_SKEW.equals(clockSkew)
-        || !idpLogoutEnabled
-        || !userInfoEnabled;
+        || !DEFAULT_CLOCK_SKEW.equals(clockSkew);
   }
 
   public static Builder builder() {


### PR DESCRIPTION
## Description

This PR adds a feature flag to disable fetching `userinfo` during authorization code flow. 

While `OidcUserService` allows you to set a predicate to disable fetching the userinfo endpoint, keep in mind you have _one_ service for the app, not per registration/OIDC provider. If you want it to be registration aware, you need to somehow link the original configuration with the created `ClientRegistration`.

This PR thus piggybacks on the default behavior of not fetching `/userinfo` if there is no URI configured for it, by removing the URI during `ClientRegistration` creation.

Testing is unfortunately quite mocked, because we don't have any login flow tests yet :(

By default, we always fetch `/userinfo`.

Some drive-by refactoring: this PR also removes the `!idpLogoutEnabled` from the `OidcAuthenticationConfiguration#isSet` check. This means if you configure `basic` auth, and also _only this flag_, the app will start with basic auth. I think that's OK imo, and admittedly the `isSet` method doesn't work with boolean flags, unless we make them `Boolean`. I think it's acceptable anyway.

## Related issues

Bringing this back, because it's again causing some worries in SaaS, and increasing users/rate limits could increase the bill, so this is a cheap "fix".
