### PR TITLE
fix: handle `null` resourcePropertyName for backward compatibility with pre-8.9 authorizations

### DIFF
--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationScope.java
@@ -22,9 +22,7 @@ public class AuthorizationScope {
   public AuthorizationScope() {}
 
   public AuthorizationScope(final AuthorizationResourceMatcher matcher, final String resourceId) {
-    this.matcher = matcher;
-    this.resourceId = resourceId;
-    this.resourcePropertyName = "";
+    this(matcher, resourceId, "");
   }
 
   public AuthorizationScope(
@@ -33,7 +31,10 @@ public class AuthorizationScope {
       final String resourcePropertyName) {
     this.matcher = matcher;
     this.resourceId = resourceId;
-    this.resourcePropertyName = resourcePropertyName;
+
+    // Since this class is used for comparisons, normalize null to empty string for this field
+    // (introduced in 8.9.0) to handle cases where null is provided while empty string is expected.
+    this.resourcePropertyName = resourcePropertyName != null ? resourcePropertyName : "";
   }
 
   public AuthorizationResourceMatcher getMatcher() {
@@ -77,6 +78,20 @@ public class AuthorizationScope {
           && Objects.equals(resourcePropertyName, other.resourcePropertyName);
     }
     return false;
+  }
+
+  @Override
+  public String toString() {
+    return "AuthorizationScope{"
+        + "matcher="
+        + matcher
+        + ", resourceId='"
+        + resourceId
+        + '\''
+        + ", resourcePropertyName='"
+        + resourcePropertyName
+        + '\''
+        + '}';
   }
 
   public static AuthorizationScope id(final String resourceId) throws IllegalArgumentException {

--- a/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
+++ b/security/security-services/src/test/java/io/camunda/security/impl/AuthorizationCheckerTest.java
@@ -1091,6 +1091,22 @@ public class AuthorizationCheckerTest {
               .accessesResource(AuthorizationResourceType.AUTHORIZATION, PermissionType.READ)
               .thenResultContains("client-res", "role-res", "mr-res")
               .build(),
+          RetrieveScopesScenario.displayName(
+                  "user alice legacy authz (resourcePropertyName = null) wildcard -> ['*']")
+              .given(
+                  authEntity(
+                      AuthorizationOwnerType.USER,
+                      "alice",
+                      AuthorizationResourceType.AUTHORIZATION,
+                      AuthorizationResourceMatcher.ANY,
+                      WILDCARD_RESOURCE_ID,
+                      // Simulate "8.8 persisted" entity, the field didn't exist, returned as `null`
+                      null,
+                      Set.of(PermissionType.READ)))
+              .whenUser("alice")
+              .accessesResource(AuthorizationResourceType.AUTHORIZATION, PermissionType.READ)
+              .thenResultContains(WILDCARD_RESOURCE_ID)
+              .build(),
           RetrieveScopesScenario.displayName("resource type mismatch -> empty")
               .given(
                   authEntity(
@@ -1139,6 +1155,18 @@ public class AuthorizationCheckerTest {
         final AuthorizationResourceMatcher matcher,
         final String resourceId,
         final Set<PermissionType> permissionTypes) {
+      return authEntity(
+          ownerType, ownerId, resourceType, matcher, resourceId, EMPTY_STRING, permissionTypes);
+    }
+
+    private AuthorizationEntity authEntity(
+        final AuthorizationOwnerType ownerType,
+        final String ownerId,
+        final AuthorizationResourceType resourceType,
+        final AuthorizationResourceMatcher matcher,
+        final String resourceId,
+        final String resourcePropertyName,
+        final Set<PermissionType> permissionTypes) {
       return new AuthorizationEntity(
           keyCounter.incrementAndGet(),
           ownerId,
@@ -1146,7 +1174,7 @@ public class AuthorizationCheckerTest {
           resourceType.name(),
           matcher.value(),
           resourceId,
-          EMPTY_STRING,
+          resourcePropertyName,
           permissionTypes);
     }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -24,8 +24,12 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
   @BeforeVersion880 private String resourceId;
   @BeforeVersion880 private Set<PermissionType> permissionTypes;
 
-  @SinceVersion(value = "8.9.0", requireDefault = false)
-  private String resourcePropertyName;
+  // Default to empty string for backward compatibility. All new resourceId-based authorizations
+  // (starting 8.9) will have an empty string value for resourcePropertyName. For authorizations
+  // created before 8.9, this field will be null in the database, so we set this default value
+  // to provide the same output as new resourceId-based authorizations.
+  @SinceVersion(value = "8.9.0")
+  private String resourcePropertyName = "";
 
   public AuthorizationEntity() {}
 


### PR DESCRIPTION
## Description


During the 8.8 -> 8.9 upgrade path, users who had authorizations created in 8.8 were unable to log in or access OC apps (Operate, Identity, Tasklist) after migration.

### Root cause

The `resourcePropertyName` field was introduced in 8.9-SNAPSHOT. Authorizations persisted before 8.9 therefore have no value for this field in the database, causing it to deserialize as `null`. However, newly created 8.9 authorizations use an empty string (`""`).

The authorization checker [compares scopes](https://github.com/camunda/camunda/blob/e074ad63c9b078e11da0dfec5dd46201aa9a00a9/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DefaultResourceAccessProvider.java#L60), where the static `WILDCARD` scope is constructed with `resourcePropertyName = ""`. When a legacy authorization came back from Elasticsearch with `resourcePropertyName = null`, the `null != ""` comparison caused the scope match to fail — effectively denying access to all users whose authorizations were created before 8.9.

Two places lacked proper null handling:

1. **`AuthorizationEntity`** was annotated with `@SinceVersion(value = "8.9.0", requireDefault = false)` and had no Java-level field default, so deserialized legacy records carried `null`.
2. **`AuthorizationScope`** 3-arg constructor assigned `resourcePropertyName` directly without null normalization, propagating the `null` into equality checks.

### Changes

**Backward compatibility and default handling:**
- `AuthorizationEntity`: Changed the field initializer to default `resourcePropertyName` to `""` and updated the `@SinceVersion` annotation to require default value (by removing `requireDefault = false`) so that pre 8.9 records without this field are treated identically to new resourceId-based authorizations.
- `AuthorizationScope`: In addition to the `AuthorizationEntity` default, defensive null-to-empty-string normalization was added to the 3-arg constructor, since `AuthorizationScope` is instantiated from several places across the codebase and relies on field-level `equals()` for authorization scopes matching. This ensures that even if `null` is passed from any call site, the comparison behavior remains correct. The 2-arg constructor was refactored to use constructor chaining for consistency.

#### Testing
- Added a new test scenario simulating a legacy (pre-8.9) authorization entity where `resourcePropertyName = null`, verifying that scope retrieval correctly matches and returns expected results.

#### Developer experience
- Added `toString()` to `AuthorizationScope` for improved debugging and logging output.

## Related issues

closes #45302 
