### PR TITLE
ci: stop tracking metrics of control flow job fe-merge

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -166,6 +166,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "observe-aborted-jobs"
         job_id != "setup-tests"
         job_id != "utils-flaky-tests-summary"
+        job_id != "fe-unit-tests-merge"
 
         # not enforced on jobs that invoke other reusable workflows (instead enforced there)
         not job.uses

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -183,15 +183,6 @@ jobs:
           merge-multiple: true
       - name: Merge reports
         run: npx vitest --merge-reports
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   # Typescript Checker
   operate-fe-type-check:


### PR DESCRIPTION
## Description

The Operate FE merge job will always fail if any of the previous unit tests jobs failed. We do not gain any additional insights from it, but it dilutes our data and alerting because we'll always have at least 2 jobs (actual failure + merge job) popping up:

<img width="849" height="161" alt="image" src="https://github.com/user-attachments/assets/3cb799d2-576a-48ae-8fb4-57f5dac7bac7" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not on older branches

## Related issues

None