### PR TITLE
[Backport stable/optimize-8.6] deps: bump up ch.qos.logback to 1.5.25

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -61,7 +61,7 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.130.Final</netty.version>
     <lombok.version>1.18.34</lombok.version>
-    <logback.version>1.5.19</logback.version>
+    <logback.version>1.5.25</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
     <commons.lang3.version>3.18.0</commons.lang3.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,7 +101,7 @@
     <version.spring>6.2.10</version.spring>
     <version.spring-security>6.4.7</version.spring-security>
     <version.spring-boot>3.5.6</version.spring-boot>
-    <version.logback>1.5.19</version.logback>
+    <version.logback>1.5.25</version.logback>
     <version.tomcat>10.1.44</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>


### PR DESCRIPTION
# Description
Backport of #45386 to `stable/optimize-8.6`.

relates to #45385
original author: @konstantinos-mylosis