### PR TITLE
Short circuit zeebe unit general misc tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/CommandDistributionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/CommandDistributionMetricsTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.collection.Tuple;
-import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -195,8 +194,7 @@ public class CommandDistributionMetricsTest {
   }
 
   private void waitUntilDistributionIsRetried(final long key) {
-    RecordingExporter.setMaximumWaitTime(100);
-    Awaitility.await()
+    RecordingExporter.await()
         .untilAsserted(
             () -> {
               // wait for retry mechanism to trigger second distribution
@@ -209,7 +207,6 @@ public class CommandDistributionMetricsTest {
               assertThat(RecordingExporter.records().withPartitionId(2).withRecordKey(key).limit(2))
                   .hasSizeGreaterThan(1);
             });
-    RecordingExporter.setMaximumWaitTime(5000);
   }
 
   private MetricSnapshot snapshotMetrics() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -289,9 +289,6 @@ public class ScaleUpTest {
 
   @Test
   public void bootstrappingAPartitionIsIdempotent() {
-
-    // set a lower maximum time as we don't expect to see the SCALED_UP event
-    RecordingExporter.setMaximumWaitTime(200);
     // given
     final var index = 99;
     final var scaleTo3 =
@@ -316,11 +313,14 @@ public class ScaleUpTest {
 
     // then
     // no additional events are added to the log stream
-    final var records =
-        RecordingExporter.scaleRecords()
-            .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
-            .filter(r -> r.getPartitionId() == 1);
-    assertThat(records)
+    final var scaleRecords =
+        RecordingExporter.expectNoMatchingRecords(
+            records ->
+                records
+                    .scaleRecords()
+                    .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
+                    .filter(r -> r.getPartitionId() == 1));
+    assertThat(scaleRecords)
         .hasSize(2)
         .map(Record::getIntent)
         .containsSequence(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.time.Instant;
@@ -35,7 +36,8 @@ public class EngineRuleTest {
     engineRule.awaitProcessingOf(message);
 
     // then
-    final var records = RecordingExporter.messageRecords();
+    final var records =
+        RecordingExporter.messageRecords().limit(r -> r.getIntent() == MessageIntent.PUBLISHED);
     assertThat(records)
         .allSatisfy(
             record ->

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -205,4 +205,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.BATCH_OPERATION_EXECUTION)
             .map(Record.class::cast));
   }
+
+  public ScaleRecordStream scaleRecords() {
+    return new ScaleRecordStream(
+        filter(r -> r.getValueType() == ValueType.SCALE).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -145,7 +145,6 @@ public final class RecordingExporter implements Exporter {
   private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
   private static volatile boolean autoAcknowledge = true;
   private static boolean overrideMaximumWaitTime = false;
-  private static final boolean failOnMaximumWaitTime = true;
 
   private Controller controller;
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -765,9 +765,11 @@ public final class RecordingExporter implements Exporter {
       final Function<RecordStream, T> consumer) {
     final var previousMaximumWaitTime = maximumWaitTime;
     maximumWaitTime = DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME;
-    final var records = consumer.apply(records());
-    maximumWaitTime = previousMaximumWaitTime;
-    return records;
+    try {
+      return consumer.apply(records());
+    } finally {
+      maximumWaitTime = previousMaximumWaitTime;
+    }
   }
 
   public static class AwaitingRecordIterator implements Iterator<Record<?>> {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -141,12 +141,14 @@ public final class RecordingExporter implements Exporter {
       new ConcurrentSkipListMap<Integer, Record<?>>();
   private static final Lock LOCK = new ReentrantLock();
   private static final Condition IS_EMPTY = LOCK.newCondition();
-
   private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
   private static volatile boolean autoAcknowledge = true;
   private static boolean overrideMaximumWaitTime = false;
-
   private Controller controller;
+
+  static long getMaximumWaitTime() {
+    return maximumWaitTime;
+  }
 
   public static void setMaximumWaitTime(final long maximumWaitTime) {
     RecordingExporter.maximumWaitTime = maximumWaitTime;

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -763,9 +763,10 @@ public final class RecordingExporter implements Exporter {
    */
   public static <T extends ExporterRecordStream<?, ?>> T expectNoMatchingRecords(
       final Function<RecordStream, T> consumer) {
+    final var previousMaximumWaitTime = maximumWaitTime;
     maximumWaitTime = DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME;
     final var records = consumer.apply(records());
-    maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
+    maximumWaitTime = previousMaximumWaitTime;
     return records;
   }
 

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -41,7 +41,7 @@ public final class RecordingExporterTest {
 
     // when
     final List<Record<TestValue>> list =
-        records(VALUE_TYPE, TestValue.class).collect(Collectors.toList());
+        records(VALUE_TYPE, TestValue.class).limit(3).collect(Collectors.toList());
 
     // then
     assertThat(list).extracting(Record::getPosition).containsExactly(1L, 2L, 3L);

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -47,6 +47,39 @@ public final class RecordingExporterTest {
     assertThat(list).extracting(Record::getPosition).containsExactly(1L, 2L, 3L);
   }
 
+  @Test
+  public void expectNoMatchingRecordsShouldLowerAndRestoreMaximumWaitTime() {
+    // given
+    final var maximumWaitTime = 123456789L;
+    RecordingExporter.setMaximumWaitTime(maximumWaitTime);
+
+    // when / then
+    RecordingExporter.expectNoMatchingRecords(
+        records -> {
+          assertThat(RecordingExporter.getMaximumWaitTime())
+              .isEqualTo(RecordingExporter.DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME);
+          return records;
+        });
+    assertThat(RecordingExporter.getMaximumWaitTime()).isEqualTo(maximumWaitTime);
+  }
+
+  @Test
+  public void expectNoMatchingRecordsShouldLowerAndRestoreMaximumWaitTimeWhenThrowing() {
+    // when / then
+    try {
+      RecordingExporter.expectNoMatchingRecords(
+          records -> {
+            assertThat(RecordingExporter.getMaximumWaitTime())
+                .isEqualTo(RecordingExporter.DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME);
+            throw new RuntimeException("expected exception");
+          });
+    } catch (final RuntimeException e) {
+      // Ignore expected exception
+    }
+    assertThat(RecordingExporter.getMaximumWaitTime())
+        .isEqualTo(RecordingExporter.DEFAULT_MAX_WAIT_TIME);
+  }
+
   public static class TestRecord implements Record<TestValue> {
 
     private final long position;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Short-circuiting the RecordingExporter in these tests ensures they don't take unnecessarily long. We want to enforce this by failing tests that are not short-circuiting properly. For this we first have to make change the tests that don't do this properly at the moment so they don't suddenly fail. This another batch of these tests 🙂 

For this we had some tests that really really really wanted to assert that a certain record did not exist. For this I've added a new utility method: `expectNoMatchingRecords`. It can be used like so:

```java
    final var scaleRecords =
        RecordingExporter.expectNoMatchingRecords(
            records ->
                records
                    .scaleRecords()
                    .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
                    .filter(r -> r.getPartitionId() == 1));
```

It's nothing more but a wrapper. This will make it so that if you expect no matching records for your filter, it will only find records for 200ms (instead of 5 seconds). This lower number is acceptable, and this utility method will be used later to prevent the test from failing even though it's not technically short-circuited.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42321
