### PR TITLE
fix: highlight root in instance history when selected

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -126,16 +126,18 @@ const NonFoldableElementInstancesNode: React.FC<NonFoldableElementInstancesNodeP
         useElementInstanceHistoryTree();
       const isRoot = elementType === 'PROCESS';
       const {processInstance} = useElementInstanceHistoryTree();
-      const {isSelected} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
 
       const rootNode = useRootNode();
 
       const isElementSelected = IS_ELEMENT_SELECTION_V2
-        ? isSelected({
-            elementId: isRoot ? undefined : elementId,
-            elementInstanceKey: scopeKey,
-            isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
-          })
+        ? isRoot
+          ? !hasSelection
+          : isSelected({
+              elementId,
+              elementInstanceKey: scopeKey,
+              isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
+            })
         : flowNodeSelectionStore.isSelected({
             flowNodeId: isRoot ? undefined : elementId,
             flowNodeInstanceId: scopeKey,
@@ -243,14 +245,16 @@ const NonFoldableVirtualElementInstanceNode: React.FC<NonFoldableVirtualElementI
       const businessObject = businessObjects[elementId];
 
       const rootNode = useRootNode();
-      const {isSelected} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
 
       const isElementSelected = IS_ELEMENT_SELECTION_V2
-        ? isSelected({
-            elementId: isRoot ? undefined : elementId,
-            elementInstanceKey: scopeKey,
-            isMultiInstanceBody: isMultiInstance(businessObject),
-          })
+        ? isRoot
+          ? !hasSelection
+          : isSelected({
+              elementId,
+              elementInstanceKey: scopeKey,
+              isMultiInstanceBody: isMultiInstance(businessObject),
+            })
         : flowNodeSelectionStore.isSelected({
             flowNodeId: isRoot ? undefined : elementId,
             flowNodeInstanceId: scopeKey,
@@ -383,14 +387,16 @@ const FoldableVirtualElementInstanceNode: React.FC<FoldableVirtualElementInstanc
 
       const rootNode = useRootNode();
 
-      const {isSelected} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
 
       const isElementSelected = IS_ELEMENT_SELECTION_V2
-        ? isSelected({
-            elementId: isRoot ? undefined : elementId,
-            elementInstanceKey: scopeKey,
-            isMultiInstanceBody: isMultiInstance(businessObject),
-          })
+        ? isRoot
+          ? !hasSelection
+          : isSelected({
+              elementId,
+              elementInstanceKey: scopeKey,
+              isMultiInstanceBody: isMultiInstance(businessObject),
+            })
         : flowNodeSelectionStore.isSelected({
             flowNodeId: isRoot ? undefined : elementId,
             flowNodeInstanceId: scopeKey,
@@ -556,14 +562,16 @@ const FoldableElementInstancesNode: React.FC<FoldableElementInstancesNodeProps> 
 
       const rootNode = useRootNode();
 
-      const {isSelected} = useProcessInstanceElementSelection();
+      const {isSelected, hasSelection} = useProcessInstanceElementSelection();
 
       const isElementSelected = IS_ELEMENT_SELECTION_V2
-        ? isSelected({
-            elementId: isRoot ? undefined : elementId,
-            elementInstanceKey: scopeKey,
-            isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
-          })
+        ? isRoot
+          ? !hasSelection
+          : isSelected({
+              elementId,
+              elementInstanceKey: scopeKey,
+              isMultiInstanceBody: elementType === 'MULTI_INSTANCE_BODY',
+            })
         : flowNodeSelectionStore.isSelected({
             flowNodeId: isRoot ? undefined : elementId,
             flowNodeInstanceId: scopeKey,


### PR DESCRIPTION
## Description

Highlights the root in the instance history when nothing else is selected.
I noticed a visual bug with the `TreeNode` component where the left marker sticks around when something is selected in the list and then deselected by clicking in the diagram. However, it does seem to be an issue with the carbon component or our use of it. Unrelated to this problem.

relates #40425