### PR TITLE
[Backport stable/8.8] 39746 add tests for tenant initialization

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeInvalidTenantIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.identity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.security.configuration.ConfiguredTenant;
+import io.camunda.security.validation.IdentityInitializationException;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+
+@ZeebeIntegration
+public class InitializeInvalidTenantIT {
+
+  private static final ConfiguredTenant INVALID_TENANT =
+      new ConfiguredTenant(
+          null,
+          "Tenant 1",
+          "something to test",
+          List.of(),
+          List.of(),
+          List.of(),
+          List.of(),
+          List.of());
+
+  @Test
+  void shouldFailToStartWithInvalidTenant() {
+    // given - An invalid configured authorization
+    final var broker =
+        new TestStandaloneBroker()
+            .withBasicAuth()
+            .withSecurityConfig(
+                conf -> conf.getInitialization().setTenants(List.of(INVALID_TENANT)));
+
+    // when/then - application startup should fail with the expected exception
+    assertThatThrownBy(broker::start)
+        .isInstanceOf(BeanCreationException.class)
+        .hasRootCauseInstanceOf(IdentityInitializationException.class);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeTenantIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.identity;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.DELETE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.ResourceType.TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.configuration.ConfiguredTenant;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class InitializeTenantIT {
+
+  private static final String ADMIN = "admin";
+  private static final String DEFAULT_PASSWORD = "password";
+  private static final String TEST_CLIENT_ID = "test-client";
+
+  private static final ConfiguredTenant CONFIGURED_TENANT_1 =
+      new ConfiguredTenant(
+          "tenant1",
+          "Tenant 1",
+          "something to test",
+          List.of(ADMIN),
+          List.of(TEST_CLIENT_ID),
+          List.of(),
+          List.of(),
+          List.of());
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withSecurityConfig(
+              conf -> conf.getInitialization().setTenants(List.of(CONFIGURED_TENANT_1)));
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          DEFAULT_PASSWORD,
+          List.of(
+              new Permissions(TENANT, READ, List.of("*")),
+              new Permissions(TENANT, CREATE, List.of("*")),
+              new Permissions(TENANT, DELETE, List.of("*"))));
+
+  @Test
+  void searchShouldReturnTenantsFromInitialization(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var response = adminClient.newTenantsSearchRequest().send().join();
+
+    // then:
+    assertThat(response.items()).hasSize(2);
+    assertThat(response.items())
+        .anyMatch(
+            actual ->
+                actual.getTenantId().equals(CONFIGURED_TENANT_1.tenantId())
+                    && actual.getName().equals(CONFIGURED_TENANT_1.name())
+                    && actual.getDescription().equals(CONFIGURED_TENANT_1.description()));
+  }
+
+  @Test
+  void searchShouldReturnTenantUsersMembersFromInitialization(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var membersResponse =
+        adminClient.newUsersByTenantSearchRequest(CONFIGURED_TENANT_1.tenantId()).send().join();
+
+    // then:
+    assertThat(membersResponse.items()).hasSize(1);
+    assertThat(membersResponse.items()).anyMatch(actual -> actual.getUsername().equals(ADMIN));
+  }
+
+  @Test
+  void searchShouldReturnTenantClientMembersFromInitialization(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when:
+    final var membersResponse =
+        adminClient.newClientsByTenantSearchRequest(CONFIGURED_TENANT_1.tenantId()).send().join();
+
+    // then:
+    assertThat(membersResponse.items()).hasSize(1);
+    assertThat(membersResponse.items())
+        .anyMatch(actual -> actual.getClientId().equals(TEST_CLIENT_ID));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/identity/InitializeTenantIT.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+// RDBMS is not fully implemented in 8.8, so we disable this test.
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 class InitializeTenantIT {
 
   private static final String ADMIN = "admin";


### PR DESCRIPTION
# Description
Backport of #43479 to `stable/8.8`.

relates to #39746