### PR TITLE
fix: increase operate import entity buffer for size based batching

### DIFF
--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -111,11 +111,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
     </dependency>

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.zeebeimport;
 
-import static org.apache.commons.io.output.NullOutputStream.INSTANCE;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -24,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-import org.apache.commons.io.output.CountingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -174,7 +172,7 @@ public class ImportJob implements Callable<Boolean> {
       long subBatchSize = 0;
       for (final HitEntity hit : importBatch.getHits()) {
         final String indexName = hit.getIndex();
-        final long hitSize = EntitySizeEstimator.estimateEntitySize(hit);
+        final int hitSize = EntitySizeEstimator.estimateEntitySize(hit);
         final boolean indexChanged =
             previousIndexName != null && !indexName.equals(previousIndexName);
         final boolean sizeExceeded = subBatchSize + hitSize > maxBatchSizeBytes;
@@ -284,26 +282,22 @@ public class ImportJob implements Callable<Boolean> {
     return creationTime;
   }
 
-  private static final class EntitySizeEstimator {
-    private static final ThreadLocal<Kryo> THREAD_LOCAL_KRYO =
+  protected static class EntitySizeEstimator {
+    private static final int INITIAL_BUFFER_SIZE = 1024;
+    private static final int MAX_BUFFER_SIZE = 5 * 1024 * 1024; // 5 MB
+    private static final ThreadLocal<Kryo> KYRO_THREAD_LOCAL =
         ThreadLocal.withInitial(
             () -> {
               final Kryo kryo = new Kryo();
               kryo.setRegistrationRequired(false);
-              kryo.setReferences(false);
               return kryo;
             });
 
-    public static long estimateEntitySize(final HitEntity entity) {
-      final Kryo kryo = THREAD_LOCAL_KRYO.get();
-      try (final CountingOutputStream countingStream = new CountingOutputStream(INSTANCE);
-          final Output output = new Output(countingStream, 8192)) {
-        kryo.writeObject(output, entity);
-        output.flush();
-        kryo.reset();
-        return countingStream.getByteCount();
-      } catch (final Exception e) {
-        throw new RuntimeException("Failed to estimate object size", e);
+    public static int estimateEntitySize(final HitEntity entity) {
+      final Kryo kryo = KYRO_THREAD_LOCAL.get();
+      try (final Output output = new Output(INITIAL_BUFFER_SIZE, MAX_BUFFER_SIZE)) {
+        kryo.writeClassAndObject(output, entity);
+        return output.position();
       }
     }
   }

--- a/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportListenerTest.java
+++ b/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportListenerTest.java
@@ -10,6 +10,7 @@ package io.camunda.operate.zeebeimport;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.esotericsoftware.kryo.io.KryoBufferOverflowException;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -194,6 +196,80 @@ public class ImportListenerTest extends NoBeansTest {
     final List<Integer> batchSizes =
         batches.stream().map(b -> b.getHits().size()).collect(Collectors.toList());
     assertEquals(List.of(2, 2, 1), batchSizes);
+  }
+
+  @Test
+  public void testFinishedWithLargeVariableUnderBufferLimit() {
+    final HitEntity hit = new HitEntity();
+    hit.setIndex("test_index");
+    hit.setSourceAsString(
+        "{ \"fieldName\": \"" + "x".repeat(4 * 1024 * 1024) + "\"}"); // <5MB buffer limit
+
+    final ImportBatch importBatch =
+        new ImportBatch(1, ImportValueType.PROCESS_INSTANCE, List.of(hit), "some_name");
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity()
+            .setAliasName("alias")
+            .setPartitionId(1)
+            .setPosition(0)
+            .setSequence(0L);
+    final ImportJob importJob = beanFactory.getBean(ImportJob.class, importBatch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(elasticsearchBulkProcessor);
+      doNothing().when(elasticsearchBulkProcessor).performImport(importBatch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // when the job is executed
+    importJob.call();
+
+    // then
+    assertTrue(importListener.isFinishedCalled());
+    assertFalse(importListener.isFailedCalled());
+    assertEquals(importListener.getImportBatch(), importBatch);
+  }
+
+  @Test
+  public void testFailedWithLargeVariableOverBufferLimit() throws PersistenceException {
+    final HitEntity largeHit = new HitEntity();
+    largeHit.setIndex("test_index");
+    largeHit.setSourceAsString(
+        "{ \"fieldName\": \"" + "x".repeat(5 * 1024 * 1024) + "\"}"); // >5MB buffer limit
+    final HitEntity smallHit = new HitEntity();
+    smallHit.setIndex("test_index");
+    smallHit.setSourceAsString("{ \"fieldName\": \"" + "x".repeat(5) + "\"}");
+
+    final ImportBatch importBatch =
+        new ImportBatch(
+            1, ImportValueType.PROCESS_INSTANCE, List.of(largeHit, smallHit), "some_name");
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity()
+            .setAliasName("alias")
+            .setPartitionId(1)
+            .setPosition(0)
+            .setSequence(0L);
+    final ImportJob importJob = beanFactory.getBean(ImportJob.class, importBatch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(elasticsearchBulkProcessor);
+      doNothing().when(elasticsearchBulkProcessor).performImport(importBatch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // when the job is executed
+    assertThrows(
+        KryoBufferOverflowException.class,
+        () -> {
+          importJob.call();
+        });
+    verify(elasticsearchBulkProcessor, times(0)).performImport(importBatch);
   }
 
   @Component

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerElasticsearchTest.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerElasticsearchTest.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.tasklist.zeebeimport;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerElasticsearchTest.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerElasticsearchTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.zeebeimport;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.esotericsoftware.kryo.io.KryoBufferOverflowException;
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.entities.meta.ImportPositionEntity;
 import io.camunda.tasklist.exceptions.PersistenceException;
@@ -28,13 +30,18 @@ import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.zeebe.ImportValueType;
 import io.camunda.tasklist.zeebeimport.es.ImportBatchElasticSearch;
 import io.camunda.tasklist.zeebeimport.es.ImportJobElasticsearch;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchShardTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -246,6 +253,94 @@ public class ImportListenerElasticsearchTest extends NoBeansTest {
     final List<Integer> batchSizes =
         batches.stream().map(b -> b.getHits().size()).collect(Collectors.toList());
     assertEquals(List.of(2, 2, 1), batchSizes);
+  }
+
+  @Test
+  public void testLargeVarSmallerThanEstimationBufferIsSuccessful() throws Exception {
+    // given
+    final String indexName = "some_name-8.7.0_";
+
+    // Create a real SearchHit with a large variable, but lower than limit (<5MB)
+    final StringBuilder sb = new StringBuilder();
+    sb.append("{\"fieldA\":12345,\"fieldB\":67890,\"variables\":\"");
+    for (int i = 0; i < 4.5 * 1024 * 1024; i++) {
+      sb.append("a");
+    }
+    sb.append("\"}");
+    final byte[] sourceBytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+    final SearchHit largeHit = new SearchHit(0);
+    largeHit.sourceRef(new BytesArray(sourceBytes));
+    largeHit.shard(
+        new SearchShardTarget(
+            "someId", new ShardId(indexName, UUID.randomUUID().toString(), 1), "clusterAlias"));
+
+    final List<SearchHit> hits = List.of(largeHit);
+    final ImportBatch importBatchElasticSearch =
+        new ImportBatchElasticSearch(1, ImportValueType.PROCESS_INSTANCE, hits, indexName);
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity().setAliasName("alias").setPartitionId(1).setPosition(0);
+    final ImportJob importJob =
+        beanFactory.getBean(
+            ImportJobElasticsearch.class, importBatchElasticSearch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(elasticsearchBulkProcessor);
+      doNothing().when(elasticsearchBulkProcessor).performImport(importBatchElasticSearch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // when the job is executed
+    importJob.call();
+
+    // then
+    assertFalse(importListener.isFailedCalled());
+    assertTrue(importListener.isFinishedCalled());
+  }
+
+  @Test
+  public void testVarsLargerThanEstimationBufferFails() throws Exception {
+    // given
+    final String indexName = "some_name-8.7.0_";
+
+    // Create a real SearchHit with a large variable (>5MB)
+    final StringBuilder sb = new StringBuilder();
+    sb.append("{\"fieldA\":12345,\"fieldB\":67890,\"variables\":\"");
+    for (int i = 0; i < 5.5 * 1024 * 1024; i++) {
+      sb.append("a");
+    }
+    sb.append("\"}");
+    final byte[] sourceBytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+    final SearchHit largeHit = new SearchHit(0);
+    largeHit.sourceRef(new BytesArray(sourceBytes));
+
+    final List<SearchHit> hits = List.of(largeHit);
+    final ImportBatch importBatchElasticSearch =
+        new ImportBatchElasticSearch(1, ImportValueType.PROCESS_INSTANCE, hits, indexName);
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity().setAliasName("alias").setPartitionId(1).setPosition(0);
+    final ImportJob importJob =
+        beanFactory.getBean(
+            ImportJobElasticsearch.class, importBatchElasticSearch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(elasticsearchBulkProcessor);
+      doNothing().when(elasticsearchBulkProcessor).performImport(importBatchElasticSearch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // then
+    assertThrows(
+        KryoBufferOverflowException.class,
+        () -> {
+          importJob.call();
+        });
+    verify(elasticsearchBulkProcessor, times(0)).performImport(importBatchElasticSearch);
   }
 
   @Component

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerOpenSearchTest.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerOpenSearchTest.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.zeebeimport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.esotericsoftware.kryo.io.KryoBufferOverflowException;
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.entities.meta.ImportPositionEntity;
 import io.camunda.tasklist.exceptions.PersistenceException;
@@ -242,6 +244,90 @@ public class ImportListenerOpenSearchTest extends NoBeansTest {
     final List<Integer> batchSizes =
         batches.stream().map(b -> b.getHits().size()).collect(Collectors.toList());
     assertEquals(List.of(2, 2, 1), batchSizes);
+  }
+
+  @Test
+  public void testLargeVarSmallerThanEstimationBufferIsSuccessful() throws Exception {
+    final String indexName = "some_name-8.7.0_";
+    final StringBuilder sb = new StringBuilder();
+    // Create a real Hit with a large variable, but lower than limit (<5MB)
+    for (int i = 0; i < 4.5 * 1024 * 1024; i++) {
+      sb.append("a");
+    }
+    // Use a Map for the source, not a JSON string
+    final Map<String, Object> sourceMap =
+        Map.of(
+            "position", 12345,
+            "sequence", 67890,
+            "variables", sb.toString());
+    final Hit largeHit = new Hit.Builder<>().index(indexName).source(sourceMap).build();
+
+    final ImportBatch importBatchOpenSearch =
+        new ImportBatchOpenSearch(
+            1, ImportValueType.PROCESS_INSTANCE, Arrays.asList(largeHit), indexName);
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity().setAliasName("alias").setPartitionId(1).setPosition(0);
+    final ImportJob importJob =
+        beanFactory.getBean(ImportJobOpenSearch.class, importBatchOpenSearch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(importBatchProcessor);
+      doNothing().when(importBatchProcessor).performImport(importBatchOpenSearch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // when the job is executed
+    importJob.call();
+
+    // then
+    assertTrue(importListener.isFinishedCalled());
+    assertFalse(importListener.isFailedCalled());
+    assertEquals(importListener.getImportBatch(), importBatchOpenSearch);
+  }
+
+  @Test
+  public void testVarsLargerThanEstimationBufferFails() throws Exception {
+    final String indexName = "some_name-8.7.0_";
+    final StringBuilder sb = new StringBuilder();
+    // Create a real SearchHit with a large variable (>5MB)
+    for (int i = 0; i < 5.5 * 1024 * 1024; i++) {
+      sb.append("a");
+    }
+    // Use a Map for the source, not a JSON string
+    final Map<String, Object> sourceMap =
+        Map.of(
+            "position", 12345,
+            "sequence", 67890,
+            "variables", sb.toString());
+    final Hit largeHit = new Hit.Builder<>().index(indexName).source(sourceMap).build();
+
+    final ImportBatch importBatchOpenSearch =
+        new ImportBatchOpenSearch(
+            1, ImportValueType.PROCESS_INSTANCE, Arrays.asList(largeHit), indexName);
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity().setAliasName("alias").setPartitionId(1).setPosition(0);
+    final ImportJob importJob =
+        beanFactory.getBean(ImportJobOpenSearch.class, importBatchOpenSearch, previousPosition);
+
+    // mock import methods
+    try {
+      when(importBatchProcessorFactory.getImportBatchProcessor(anyString()))
+          .thenReturn(importBatchProcessor);
+      doNothing().when(importBatchProcessor).performImport(importBatchOpenSearch);
+    } catch (final PersistenceException e) {
+      // ignore
+    }
+
+    // then
+    assertThrows(
+        KryoBufferOverflowException.class,
+        () -> {
+          importJob.call();
+        });
+    verify(importBatchProcessor, times(0)).performImport(importBatchOpenSearch);
   }
 
   @Component


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Copies the approach that Tasklist uses and was observed in https://github.com/camunda/camunda/issues/44825.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #44825 
