### PR TITLE
Short-circuit `RecordingExporter` in Zeebe Unit General Processing tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
@@ -400,6 +400,7 @@ public final class BpmnElementTypeTest {
               return Bpmn.createExecutableProcess(processId())
                   .startEvent()
                   .adHocSubProcess(elementId(), adHocSubProcess -> adHocSubProcess.task("task"))
+                  .zeebeActiveElementsCollectionExpression("[\"task\"]")
                   .endEvent()
                   .done();
             }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/StartEventFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/StartEventFormTest.java
@@ -57,7 +57,7 @@ public class StartEventFormTest {
   }
 
   @Test
-  public void shouldStartAncCompleteProcessWithForm() {
+  public void shouldStartAndCompleteProcessWithForm() {
     // given
     deployForm();
     deployProcess(FORM_ID);
@@ -87,7 +87,9 @@ public class StartEventFormTest {
   }
 
   private void assertProcessDeployed() {
-    assertThat(RecordingExporter.deploymentRecords())
+    assertThat(
+            RecordingExporter.deploymentRecords()
+                .limit(r -> r.getIntent() == DeploymentIntent.CREATED))
         .extracting(Record::getRecordType, Record::getIntent)
         .containsSequence(
             tuple(RecordType.COMMAND, DeploymentIntent.CREATE),
@@ -96,7 +98,9 @@ public class StartEventFormTest {
 
   private void assertProcessInstanceCompleted(final long processInstanceKey) {
     assertThat(
-            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
         .extracting(Record::getRecordType, Record::getIntent)
         .containsSequence(
             tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
@@ -200,7 +200,10 @@ public class NativeUserTaskFormTest {
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
 
     // then
-    assertThat(RecordingExporter.incidentRecords().onlyEvents())
+    assertThat(
+            RecordingExporter.incidentRecords()
+                .onlyEvents()
+                .limit(r -> r.getIntent() == IncidentIntent.RESOLVED))
         .extracting(Record::getKey, Record::getIntent)
         .describedAs("form not found incident is resolved and no new incident is created")
         .containsExactly(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableMultiPartitionTest.java
@@ -57,7 +57,7 @@ public final class DeleteClusterVariableMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.CLUSTER_VARIABLE
@@ -124,7 +124,7 @@ public final class DeleteClusterVariableMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.CLUSTER_VARIABLE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -123,7 +123,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -870,8 +869,7 @@ public class CommandDistributionIdempotencyTest {
     interceptor.enable(distributionCommand);
 
     // then we expect the command will written to the target partition twice (retry)
-    RecordingExporter.setMaximumWaitTime(100);
-    Awaitility.await()
+    RecordingExporter.await()
         .untilAsserted(
             () -> {
               // wait for retry mechanism to trigger second distribution
@@ -890,7 +888,6 @@ public class CommandDistributionIdempotencyTest {
                           .limit(2))
                   .hasSize(2);
             });
-    RecordingExporter.setMaximumWaitTime(5000);
 
     // then we expect the distribution still finishes based on the second (retried) acknowledgement
     if (scenario.assertDistributionFinishes) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -265,13 +265,17 @@ public class TenantAwareBusinessRuleTaskTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords()
-                .onlyEvents()
-                .withProcessInstanceKey(processInstanceKey)
-                .withTenantId(tenantTwo)
-                .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
-                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
-        .isEmpty();
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .onlyEvents()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withTenantId(tenantTwo)
+                        .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+                        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                        .exists()))
+        .isFalse();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
@@ -119,13 +119,17 @@ public class TenantAwareCallActivityTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords()
-                .onlyEvents()
-                .withProcessInstanceKey(processInstanceKey)
-                .withTenantId(tenantTwo)
-                .withElementId("call")
-                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
-        .isEmpty();
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .onlyEvents()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withTenantId(tenantTwo)
+                        .withElementId("call")
+                        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                        .exists()))
+        .isFalse();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -168,9 +168,12 @@ public class TenantAwareResourceDeletionTest {
             "Expected to delete resource but no resource found with key `%d`"
                 .formatted(resourceKey));
     assertThat(
-            RecordingExporter.resourceDeletionRecords()
-                .withIntent(ResourceDeletionIntent.DELETED)
-                .exists())
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .resourceDeletionRecords()
+                        .withIntent(ResourceDeletionIntent.DELETED)
+                        .exists()))
         .isFalse();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -430,11 +430,15 @@ public class TenantAwareSignalEventTest {
         .describedAs("Expect that signal is thrown")
         .isNotNull();
     assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withBpmnProcessId(signalCatchingProcess)
-                .withElementId("signal-start")
-                .withTenantId(tenantIdB)
-                .exists())
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    records
+                        .processInstanceRecords()
+                        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                        .withBpmnProcessId(signalCatchingProcess)
+                        .withElementId("signal-start")
+                        .withTenantId(tenantIdB)
+                        .exists()))
         .describedAs("Expect that process instance was not created")
         .isFalse();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -224,12 +224,7 @@ public final class CreateProcessInstanceTest {
     // given
     ENGINE
         .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess("process")
-                .startEvent()
-                .serviceTask("my-task", t -> t.zeebeJobType("my-job"))
-                .endEvent()
-                .done())
+        .withXmlResource(Bpmn.createExecutableProcess("process").startEvent().endEvent().done())
         .deploy();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -110,6 +110,7 @@ public class TenantDeleteProcessorTest {
         RecordingExporter.tenantRecords()
             .withIntents(TenantIntent.ENTITY_REMOVED, TenantIntent.DELETED)
             .withTenantId(tenantId)
+            .limit(2)
             .asList();
 
     assertThat(deletedTenant).hasTenantKey(tenantKey);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -762,8 +762,7 @@ public final class RecordingExporter implements Exporter {
    * RecordingExporter#DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME} to speed up the test execution, and
    * resets it after.
    */
-  public static <T extends ExporterRecordStream<?, ?>> T expectNoMatchingRecords(
-      final Function<RecordStream, T> consumer) {
+  public static <T> T expectNoMatchingRecords(final Function<RecordStream, T> consumer) {
     final var previousMaximumWaitTime = maximumWaitTime;
     maximumWaitTime = DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME;
     try {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I had to change the return type of `expectNoMatchingRecords` to `T`, as sometime it would be desirable to return a list, or a boolean instead of a record stream.

Requires #45420 to be merged first

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42320
