### PR TITLE
Tenantfilter enum and record property with first usage

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -77,18 +78,19 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   @Override
   public void processRecord(final TypedRecord<JobBatchRecord> record) {
-    final var validationResult = isValid(record);
+    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(record);
+    final var validationResult = isValid(record, authorizedTenantIds);
     if (validationResult.isRight()) {
-      activateJobs(record);
+      activateJobs(record, authorizedTenantIds);
     } else {
       rejectCommand(record, validationResult.getLeft());
     }
   }
 
-  private Either<Rejection, Void> isValid(final TypedRecord<JobBatchRecord> command) {
+  private Either<Rejection, Void> isValid(
+      final TypedRecord<JobBatchRecord> command, final AuthorizedTenants authorizedTenantIds) {
     final var record = command.getValue();
     final var tenantIds = record.getTenantIds();
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
 
     if (!authorizedTenantIds.isAuthorizedForTenantIds(tenantIds)) {
       return Either.left(
@@ -120,11 +122,13 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     return Either.right(null);
   }
 
-  private void activateJobs(final TypedRecord<JobBatchRecord> record) {
+  private void activateJobs(
+      final TypedRecord<JobBatchRecord> record, final AuthorizedTenants authorizedTenants) {
     final JobBatchRecord value = record.getValue();
     final long jobBatchKey = keyGenerator.nextKey();
 
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = jobBatchCollector.collectJobs(record);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+        jobBatchCollector.collectJobs(record, authorizedTenants);
     final var activatedJobCountPerJobKind = result.getOrElse(Collections.emptyMap());
     result.ifLeft(
         largeJob ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -23,8 +22,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import io.camunda.zeebe.protocol.record.value.TenantFilter;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -81,12 +78,12 @@ final class JobBatchCollector {
    * key. On success, it will return the amount of jobs activated.
    *
    * @param record the batch activate command; jobs and their keys will be added directly into it
-   * @param authorizedTenants the authorized tenants for the requesting identity
+   * @param tenantIds the tenant IDs to use for filtering jobs
    * @return the amount of activated jobs per jobKind on success, or a job which was too large to
    *     activate on failure
    */
   public Either<TooLargeJob, Map<JobKind, Integer>> collectJobs(
-      final TypedRecord<JobBatchRecord> record, final AuthorizedTenants authorizedTenants) {
+      final TypedRecord<JobBatchRecord> record, final List<String> tenantIds) {
     final JobBatchRecord value = record.getValue();
     final ValueArray<JobRecord> jobIterator = value.jobs();
     final ValueArray<LongValue> jobKeyIterator = value.jobKeys();
@@ -94,7 +91,6 @@ final class JobBatchCollector {
     final var maxActivatedCount = value.getMaxJobsToActivate();
     final var activatedCount = new MutableInteger(0);
     final var unwritableJob = new MutableReference<TooLargeJob>();
-    final var tenantIds = computeTenantIds(value, authorizedTenants);
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
     // the tenant check is performed earlier in the JobBatchActivateProcessor, so we can skip it
     // here and only check if the requester has the correct permissions to access the jobs
@@ -156,17 +152,6 @@ final class JobBatchCollector {
     }
 
     return Either.right(jobCountPerJobKind);
-  }
-
-  private List<String> computeTenantIds(
-      final JobBatchRecord value, final AuthorizedTenants authorizedTenants) {
-    if (value.getTenantFilter() == TenantFilter.ASSIGNED) {
-      return authorizedTenants.getAuthorizedTenantIds();
-    } else if (value.getTenantIds().isEmpty()) {
-      return List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    } else {
-      return value.getTenantIds();
-    }
   }
 
   private boolean isAuthorizedForJob(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -79,11 +81,12 @@ final class JobBatchCollector {
    * key. On success, it will return the amount of jobs activated.
    *
    * @param record the batch activate command; jobs and their keys will be added directly into it
+   * @param authorizedTenants the authorized tenants for the requesting identity
    * @return the amount of activated jobs per jobKind on success, or a job which was too large to
    *     activate on failure
    */
   public Either<TooLargeJob, Map<JobKind, Integer>> collectJobs(
-      final TypedRecord<JobBatchRecord> record) {
+      final TypedRecord<JobBatchRecord> record, final AuthorizedTenants authorizedTenants) {
     final JobBatchRecord value = record.getValue();
     final ValueArray<JobRecord> jobIterator = value.jobs();
     final ValueArray<LongValue> jobKeyIterator = value.jobKeys();
@@ -91,10 +94,7 @@ final class JobBatchCollector {
     final var maxActivatedCount = value.getMaxJobsToActivate();
     final var activatedCount = new MutableInteger(0);
     final var unwritableJob = new MutableReference<TooLargeJob>();
-    final var tenantIds =
-        value.getTenantIds().isEmpty()
-            ? List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-            : value.getTenantIds();
+    final var tenantIds = computeTenantIds(value, authorizedTenants);
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
     // the tenant check is performed earlier in the JobBatchActivateProcessor, so we can skip it
     // here and only check if the requester has the correct permissions to access the jobs
@@ -156,6 +156,17 @@ final class JobBatchCollector {
     }
 
     return Either.right(jobCountPerJobKind);
+  }
+
+  private List<String> computeTenantIds(
+      final JobBatchRecord value, final AuthorizedTenants authorizedTenants) {
+    if (value.getTenantFilter() == TenantFilter.ASSIGNED) {
+      return authorizedTenants.getAuthorizedTenantIds();
+    } else if (value.getTenantIds().isEmpty()) {
+      return List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    } else {
+      return value.getTenantIds();
+    }
   }
 
   private boolean isAuthorizedForJob(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -87,7 +86,7 @@ final class JobBatchCollectorTest {
     // when - set up the evaluator to only accept the first job
     lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
     final Either<TooLargeJob, Map<JobKind, Integer>> result =
-        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+        collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -110,7 +109,7 @@ final class JobBatchCollectorTest {
     // when - set up the evaluator to accept no jobs
     lengthEvaluator.canWriteEventOfLength = (length) -> false;
     final Either<TooLargeJob, Map<JobKind, Integer>> result =
-        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+        collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -133,7 +132,7 @@ final class JobBatchCollectorTest {
     createJobWithVariables(secondScopeKey, secondJobVariables);
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -156,7 +155,7 @@ final class JobBatchCollectorTest {
     final List<Job> jobs = Arrays.asList(createJob(scopeKey), createJob(scopeKey));
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -173,7 +172,7 @@ final class JobBatchCollectorTest {
 
     // when
     final Either<TooLargeJob, Map<JobKind, Integer>> result =
-        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+        collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -198,7 +197,7 @@ final class JobBatchCollectorTest {
     createJob(scopeKey);
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -226,7 +225,7 @@ final class JobBatchCollectorTest {
     record.getValue().setWorker(expectedWorker);
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -256,7 +255,7 @@ final class JobBatchCollectorTest {
     record.getValue().variables().add().wrap(BufferUtil.wrapString("foo"));
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -296,7 +295,7 @@ final class JobBatchCollectorTest {
           estimatedLength.set(length);
           return true;
         };
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     // the expected length is then the length of the initial record + the length of the activated
@@ -321,7 +320,7 @@ final class JobBatchCollectorTest {
     createJob(secondScopeKey, tenantB);
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(tenantA, tenantB));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -347,7 +346,7 @@ final class JobBatchCollectorTest {
     createJob(secondScopeKey, tenantB);
 
     // when
-    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    collector.collectJobs(record, List.of(tenantA));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -378,7 +377,7 @@ final class JobBatchCollectorTest {
 
     // when - user is authorized for tenantA and tenantB only
     final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of(tenantA, tenantB));
-    collector.collectJobs(record, authorizedTenants);
+    collector.collectJobs(record, authorizedTenants.getAuthorizedTenantIds());
 
     // then - only jobs from tenantA and tenantB should be collected
     final JobBatchRecord batchRecord = record.getValue();
@@ -413,7 +412,7 @@ final class JobBatchCollectorTest {
 
     // when - user is authorized for tenantA and tenantB, record specifies tenantC
     final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of(tenantA, tenantB));
-    collector.collectJobs(record, authorizedTenants);
+    collector.collectJobs(record, authorizedTenants.getAuthorizedTenantIds());
 
     // then - should use authorized tenants (A, B) and ignore provided tenant (C)
     final JobBatchRecord batchRecord = record.getValue();
@@ -447,7 +446,7 @@ final class JobBatchCollectorTest {
 
     // when - user is authorized for tenantA only, record has empty tenant IDs
     final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantA);
-    collector.collectJobs(record, authorizedTenants);
+    collector.collectJobs(record, authorizedTenants.getAuthorizedTenantIds());
 
     // then - should use assigned tenants (A) and not default tenant
     final JobBatchRecord batchRecord = record.getValue();
@@ -474,7 +473,7 @@ final class JobBatchCollectorTest {
 
     // when - user is authorized for tenantB only, but job exists for tenantA
     final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantB);
-    collector.collectJobs(record, authorizedTenants);
+    collector.collectJobs(record, authorizedTenants.getAuthorizedTenantIds());
 
     // then - no jobs should be collected
     final JobBatchRecord batchRecord = record.getValue();
@@ -504,7 +503,7 @@ final class JobBatchCollectorTest {
 
     // when - user is authorized for tenantB, but record specifies tenantA
     final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantB);
-    collector.collectJobs(record, authorizedTenants);
+    collector.collectJobs(record, List.of(tenantA));
 
     // then - should use provided tenant (A) from record
     final JobBatchRecord batchRecord = record.getValue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -83,7 +84,7 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to only accept the first job
     lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -105,7 +106,7 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to accept no jobs
     lengthEvaluator.canWriteEventOfLength = (length) -> false;
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -128,7 +129,7 @@ final class JobBatchCollectorTest {
     createJobWithVariables(secondScopeKey, secondJobVariables);
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -151,7 +152,7 @@ final class JobBatchCollectorTest {
     final List<Job> jobs = Arrays.asList(createJob(scopeKey), createJob(scopeKey));
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -167,7 +168,7 @@ final class JobBatchCollectorTest {
     record.getValue().setMaxJobsToActivate(1);
 
     // when
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -192,7 +193,7 @@ final class JobBatchCollectorTest {
     createJob(scopeKey);
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -220,7 +221,7 @@ final class JobBatchCollectorTest {
     record.getValue().setWorker(expectedWorker);
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -250,7 +251,7 @@ final class JobBatchCollectorTest {
     record.getValue().variables().add().wrap(BufferUtil.wrapString("foo"));
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -290,7 +291,7 @@ final class JobBatchCollectorTest {
           estimatedLength.set(length);
           return true;
         };
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     // the expected length is then the length of the initial record + the length of the activated
@@ -315,7 +316,7 @@ final class JobBatchCollectorTest {
     createJob(secondScopeKey, tenantB);
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -341,7 +342,7 @@ final class JobBatchCollectorTest {
     createJob(secondScopeKey, tenantB);
 
     // when
-    collector.collectJobs(record);
+    collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.JobBatchRecordValueAssert;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValueAssert;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -358,6 +360,163 @@ final class JobBatchCollectorTest {
             });
   }
 
+  @Test
+  public void shouldCollectJobsBasedOnAssignedTenantsWhenFilterIsAssigned() {
+    // given
+    final String tenantA = "tenant-a";
+    final String tenantB = "tenant-b";
+    final String tenantC = "tenant-c";
+    final TypedRecord<JobBatchRecord> record = createRecordWithTenantFilter(TenantFilter.ASSIGNED);
+
+    final long scopeKeyA = state.getKeyGenerator().nextKey();
+    final long scopeKeyB = state.getKeyGenerator().nextKey();
+    final long scopeKeyC = state.getKeyGenerator().nextKey();
+
+    createJob(scopeKeyA, tenantA);
+    createJob(scopeKeyB, tenantB);
+    createJob(scopeKeyC, tenantC);
+
+    // when - user is authorized for tenantA and tenantB only
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of(tenantA, tenantB));
+    collector.collectJobs(record, authorizedTenants);
+
+    // then - only jobs from tenantA and tenantB should be collected
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              assertThat(activatedJobs).hasSize(2);
+              assertThat(activatedJobs.stream().map(JobRecordValue::getTenantId).toList())
+                  .containsExactlyInAnyOrder(tenantA, tenantB);
+            });
+  }
+
+  @Test
+  public void shouldIgnoreProvidedTenantIdsWhenFilterIsAssigned() {
+    // given
+    final String tenantA = "tenant-a";
+    final String tenantB = "tenant-b";
+    final String tenantC = "tenant-c";
+
+    // Create record with tenantC in the tenant IDs list but ASSIGNED filter
+    final TypedRecord<JobBatchRecord> record =
+        createRecordWithTenantFilter(TenantFilter.ASSIGNED, tenantC);
+
+    final long scopeKeyA = state.getKeyGenerator().nextKey();
+    final long scopeKeyB = state.getKeyGenerator().nextKey();
+    final long scopeKeyC = state.getKeyGenerator().nextKey();
+
+    createJob(scopeKeyA, tenantA);
+    createJob(scopeKeyB, tenantB);
+    createJob(scopeKeyC, tenantC);
+
+    // when - user is authorized for tenantA and tenantB, record specifies tenantC
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of(tenantA, tenantB));
+    collector.collectJobs(record, authorizedTenants);
+
+    // then - should use authorized tenants (A, B) and ignore provided tenant (C)
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              assertThat(activatedJobs).hasSize(2);
+              assertThat(activatedJobs.stream().map(JobRecordValue::getTenantId).toList())
+                  .containsExactlyInAnyOrder(tenantA, tenantB)
+                  .doesNotContain(tenantC);
+            });
+  }
+
+  @Test
+  public void shouldUseAssignedTenantsEvenWhenProvidedTenantIdsIsEmpty() {
+    // given
+    final String tenantA = "tenant-a";
+    final String tenantB = "tenant-b";
+
+    // Create record with empty tenant IDs but ASSIGNED filter
+    final TypedRecord<JobBatchRecord> record = createRecordWithTenantFilter(TenantFilter.ASSIGNED);
+
+    final long scopeKeyA = state.getKeyGenerator().nextKey();
+    final long scopeKeyB = state.getKeyGenerator().nextKey();
+    final long scopeKeyDefault = state.getKeyGenerator().nextKey();
+
+    createJob(scopeKeyA, tenantA);
+    createJob(scopeKeyB, tenantB);
+    createJob(scopeKeyDefault, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // when - user is authorized for tenantA only, record has empty tenant IDs
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantA);
+    collector.collectJobs(record, authorizedTenants);
+
+    // then - should use assigned tenants (A) and not default tenant
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              assertThat(activatedJobs).hasSize(1);
+              JobRecordValueAssert.assertThat(activatedJobs.get(0)).hasTenantId(tenantA);
+            });
+  }
+
+  @Test
+  public void shouldCollectNoJobsWhenAssignedTenantsHaveNoMatchingJobs() {
+    // given
+    final String tenantA = "tenant-a";
+    final String tenantB = "tenant-b";
+
+    final TypedRecord<JobBatchRecord> record = createRecordWithTenantFilter(TenantFilter.ASSIGNED);
+
+    final long scopeKeyA = state.getKeyGenerator().nextKey();
+
+    createJob(scopeKeyA, tenantA);
+
+    // when - user is authorized for tenantB only, but job exists for tenantA
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantB);
+    collector.collectJobs(record, authorizedTenants);
+
+    // then - no jobs should be collected
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              assertThat(activatedJobs).isEmpty();
+            });
+  }
+
+  @Test
+  public void shouldUseProvidedTenantsWhenFilterIsProvided() {
+    // given
+    final String tenantA = "tenant-a";
+    final String tenantB = "tenant-b";
+
+    // Create record with tenantA in tenant IDs and PROVIDED filter (default)
+    final TypedRecord<JobBatchRecord> record =
+        createRecordWithTenantFilter(TenantFilter.PROVIDED, tenantA);
+
+    final long scopeKeyA = state.getKeyGenerator().nextKey();
+    final long scopeKeyB = state.getKeyGenerator().nextKey();
+
+    createJob(scopeKeyA, tenantA);
+    createJob(scopeKeyB, tenantB);
+
+    // when - user is authorized for tenantB, but record specifies tenantA
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(tenantB);
+    collector.collectJobs(record, authorizedTenants);
+
+    // then - should use provided tenant (A) from record
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              assertThat(activatedJobs).hasSize(1);
+              JobRecordValueAssert.assertThat(activatedJobs.get(0)).hasTenantId(tenantA);
+            });
+  }
+
   private TypedRecord<JobBatchRecord> createRecord(final String... tenantIds) {
     final RecordMetadata metadata =
         new RecordMetadata()
@@ -374,6 +533,30 @@ final class JobBatchCollectorTest {
     final List<String> tenantIdsList =
         tenantIds.length > 0 ? List.of(tenantIds) : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     batchRecord.setTenantIds(tenantIdsList);
+
+    return new MockTypedRecord<>(state.getKeyGenerator().nextKey(), metadata, batchRecord);
+  }
+
+  private TypedRecord<JobBatchRecord> createRecordWithTenantFilter(
+      final TenantFilter tenantFilter, final String... tenantIds) {
+    final RecordMetadata metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(JobBatchIntent.ACTIVATE)
+            .valueType(ValueType.JOB_BATCH);
+    final var batchRecord =
+        new JobBatchRecord()
+            .setTimeout(Duration.ofSeconds(10).toMillis())
+            .setMaxJobsToActivate(10)
+            .setType(JOB_TYPE)
+            .setWorker("test")
+            .setTenantFilter(tenantFilter);
+
+    if (tenantIds.length > 0) {
+      batchRecord.setTenantIds(List.of(tenantIds));
+    } else {
+      batchRecord.setTenantIds(List.of());
+    }
 
     return new MockTypedRecord<>(state.getKeyGenerator().nextKey(), metadata, batchRecord);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -84,7 +84,8 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to only accept the first job
     lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -106,7 +107,8 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to accept no jobs
     lengthEvaluator.canWriteEventOfLength = (length) -> false;
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -168,7 +170,8 @@ final class JobBatchCollectorTest {
     record.getValue().setMaxJobsToActivate(1);
 
     // when
-    final Either<TooLargeJob, Map<JobKind, Integer>> result = collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
+    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+        collector.collectJobs(record, AuthorizedTenants.DEFAULT_TENANTS);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -171,6 +171,9 @@
             },
             "tenantIds": {
               "type": "keyword"
+            },
+            "tenantFilter": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -171,6 +171,9 @@
             },
             "tenantIds": {
               "type": "keyword"
+            },
+            "tenantFilter": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.job;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,6 +40,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private static final StringValue TENANT_IDS_KEY = new StringValue("tenantIds");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
+  private static final StringValue TENANT_FILTER_KEY = new StringValue("tenantFilter");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, "");
@@ -52,9 +55,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final ArrayProperty<StringValue> variablesProp =
       new ArrayProperty<>(VARIABLES_KEY, StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty(TRUNCATED_KEY, false);
+  private final EnumProperty<TenantFilter> tenantFilterProp =
+      new EnumProperty<>(TENANT_FILTER_KEY, TenantFilter.class, TenantFilter.PROVIDED);
 
   public JobBatchRecord() {
-    super(9);
+    super(10);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -63,7 +68,8 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(jobsProp)
         .declareProperty(variablesProp)
         .declareProperty(truncatedProp)
-        .declareProperty(tenantIdsProp);
+        .declareProperty(tenantIdsProp)
+        .declareProperty(tenantFilterProp);
   }
 
   public JobBatchRecord setType(final DirectBuffer buf, final int offset, final int length) {
@@ -147,6 +153,16 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public TenantFilter getTenantFilter() {
+    return tenantFilterProp.getValue();
+  }
+
+  public JobBatchRecord setTenantFilter(final TenantFilter tenantFilter) {
+    tenantFilterProp.setValue(tenantFilter);
+    return this;
   }
 
   public JobBatchRecord setTenantIds(final List<String> tenantIds) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -903,7 +903,8 @@ final class JsonSerializableToJsonTest {
                     }
                   ],
                   "timeout": 2,
-                  "tenantIds": []
+                  "tenantIds": [],
+                  "tenantFilter": "PROVIDED"
                 }
                 """
       },
@@ -928,7 +929,8 @@ final class JsonSerializableToJsonTest {
                   "jobKeys": [],
                   "jobs": [],
                   "timeout": -1,
-                  "tenantIds": []
+                  "tenantIds": [],
+                  "tenantFilter": "PROVIDED"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecordTenantFilterTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecordTenantFilterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the TenantFilter property on JobBatchRecord to verify getter/setter functionality and
+ * default value behavior.
+ */
+final class JobBatchRecordTenantFilterTest {
+
+  @Test
+  void shouldHaveDefaultTenantFilterOfProvided() {
+    // given
+    final var record = new JobBatchRecord();
+
+    // when
+    final var tenantFilter = record.getTenantFilter();
+
+    // then
+    assertThat(tenantFilter).isEqualTo(TenantFilter.PROVIDED);
+  }
+
+  @Test
+  void shouldSetTenantFilterToAssigned() {
+    // given
+    final var record = new JobBatchRecord();
+
+    // when
+    record.setTenantFilter(TenantFilter.ASSIGNED);
+
+    // then
+    assertThat(record.getTenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+  }
+
+  @Test
+  void shouldSetTenantFilterToProvided() {
+    // given
+    final var record = new JobBatchRecord();
+
+    // when
+    record.setTenantFilter(TenantFilter.PROVIDED);
+
+    // then
+    assertThat(record.getTenantFilter()).isEqualTo(TenantFilter.PROVIDED);
+  }
+
+  @Test
+  void shouldMaintainTenantFilterAfterOtherPropertiesSet() {
+    // given
+    final var record = new JobBatchRecord();
+    record.setTenantFilter(TenantFilter.ASSIGNED);
+
+    // when - set other properties
+    record.setType("test-type");
+    record.setWorker("test-worker");
+    record.setTimeout(1000L);
+    record.setMaxJobsToActivate(5);
+
+    // then - tenant filter should remain unchanged
+    assertThat(record.getTenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+  }
+
+  @Test
+  void shouldSerializeAndDeserializeTenantFilter() {
+    // given
+    final var original = new JobBatchRecord();
+    original.setType("test-type");
+    original.setWorker("test-worker");
+    original.setTimeout(1000L);
+    original.setMaxJobsToActivate(5);
+    original.setTenantFilter(TenantFilter.ASSIGNED);
+
+    // when - serialize to buffer
+    final var buffer = new org.agrona.concurrent.UnsafeBuffer(new byte[original.getLength()]);
+    original.write(buffer, 0);
+
+    // and - deserialize from buffer
+    final var deserialized = new JobBatchRecord();
+    deserialized.wrap(buffer, 0, original.getLength());
+
+    // then
+    assertThat(deserialized.getTenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+    assertThat(deserialized.getType()).isEqualTo("test-type");
+    assertThat(deserialized.getWorker()).isEqualTo("test-worker");
+    assertThat(deserialized.getTimeout()).isEqualTo(1000L);
+    assertThat(deserialized.getMaxJobsToActivate()).isEqualTo(5);
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobBatchRecord.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.job;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,6 +40,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private static final StringValue TENANT_IDS_KEY = new StringValue("tenantIds");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
+  private static final StringValue TENANT_FILTER_KEY = new StringValue("tenantFilter");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, "");
@@ -52,9 +55,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final ArrayProperty<StringValue> variablesProp =
       new ArrayProperty<>(VARIABLES_KEY, StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty(TRUNCATED_KEY, false);
+  private final EnumProperty<TenantFilter> tenantFilterProp =
+      new EnumProperty<>(TENANT_FILTER_KEY, TenantFilter.class, TenantFilter.PROVIDED);
 
   public JobBatchRecord() {
-    super(9);
+    super(10);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -63,7 +68,8 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(jobsProp)
         .declareProperty(variablesProp)
         .declareProperty(truncatedProp)
-        .declareProperty(tenantIdsProp);
+        .declareProperty(tenantIdsProp)
+        .declareProperty(tenantFilterProp);
   }
 
   public JobBatchRecord setType(final DirectBuffer buf, final int offset, final int length) {
@@ -147,6 +153,16 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public TenantFilter getTenantFilter() {
+    return tenantFilterProp.getValue();
+  }
+
+  public JobBatchRecord setTenantFilter(final TenantFilter tenantFilter) {
+    tenantFilterProp.setValue(tenantFilter);
+    return this;
   }
 
   public JobBatchRecord setTenantIds(final List<String> tenantIds) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
@@ -79,8 +79,5 @@ public interface JobBatchRecordValue extends RecordValue {
   /**
    * @return the tenant filtering strategy used for job activation
    */
-  @Value.Default
-  default TenantFilter getTenantFilter() {
-    return TenantFilter.PROVIDED;
-  }
+  TenantFilter getTenantFilter();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
@@ -75,4 +75,12 @@ public interface JobBatchRecordValue extends RecordValue {
    * @return the identifiers of the tenants that this job batch may contain jobs for
    */
   List<String> getTenantIds();
+
+  /**
+   * @return the tenant filtering strategy used for job activation
+   */
+  @Value.Default
+  default TenantFilter getTenantFilter() {
+    return TenantFilter.PROVIDED;
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantFilter.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/** Enumerates the tenant filtering strategies for job activation */
+public enum TenantFilter {
+  /**
+   * Indicates that the tenant IDs provided in the request should be used to filter jobs. This is
+   * the default behavior where jobs are filtered based on explicitly provided tenant identifiers.
+   */
+  PROVIDED,
+
+  /**
+   * Indicates that jobs should be filtered based on tenants assigned to the requesting identity.
+   * When this filter is used, the system will automatically determine which tenants the requester
+   * has access to and filter jobs accordingly.
+   */
+  ASSIGNED
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR is a little larger than I had planned however a large portion are tests and an addition of some boilerplate however strictly speaking this PR:

- Introduces the new `TenantFilter` enum with two values `PROVIDED` and `ASSIGNED` that will be use to signal to the engine whether to use the tenantIds on a command, or the tenants assigned to the principle making the request.
- Adds this TenantFilter to the JobBatchRecord class (and related Value class)
- Includes a usage of the TenantFilter in the JobBatchCollector class where we use the value to compute the tenantIds that should be sent on and used.

You could argue that I could have just performed the first two steps but they felt a bit hollow to include in one PR, this way, although larger, we have a concrete usage of the value of that field.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45329, closes https://github.com/camunda/camunda/issues/45330, closes https://github.com/camunda/camunda/issues/45333, closes https://github.com/camunda/camunda/issues/45332
