### PR TITLE
Update modify variable test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -21,6 +21,7 @@ import {OperateDashboardPage} from '@pages/OperateDashboardPage';
 import {OperateDiagramPage} from '@pages/OperateDiagramPage';
 import {OperateProcessMigrationModePage} from '@pages/OperateProcessMigrationModePage';
 import {OperateProcessModificationModePage} from '@pages/OperateProcessModificationModePage';
+import {OperateProcessInstanceViewModificationModePage} from '@pages/OperateProcessInstanceViewModificationMode';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
@@ -57,6 +58,7 @@ type PlaywrightFixtures = {
   operateDiagramPage: OperateDiagramPage;
   operateProcessMigrationModePage: OperateProcessMigrationModePage;
   operateProcessModificationModePage: OperateProcessModificationModePage;
+  operateProcessInstanceViewModificationModePage: OperateProcessInstanceViewModificationModePage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
   tasklistProcessesPage: TasklistProcessesPage;
@@ -120,6 +122,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateFiltersPanelPage: async ({page}, use) => {
     await use(new OperateFiltersPanelPage(page));
+  },
+  operateProcessInstanceViewModificationModePage: async ({page}, use) => {
+    await use(new OperateProcessInstanceViewModificationModePage(page));
   },
   taskDetailsPage: async ({page}, use) => {
     await use(new TaskDetailsPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -1,0 +1,628 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+
+export class OperateProcessInstanceViewModificationModePage {
+  private page: Page;
+  readonly modifyModeHeader: Locator;
+  readonly flowNodeModificationsPopup: Locator;
+  readonly addModificationButtononPopup: Locator;
+  readonly moveAllButtononPopup: Locator;
+  readonly cancelButtonPopup: Locator;
+  readonly cancelAllButtonPopup: Locator;
+  readonly applyModificationsButton: Locator;
+  readonly discardAllModificationsButton: Locator;
+  readonly cancelButtonModificationDialog: Locator;
+  readonly applyButtonModificationsDialog: Locator;
+  readonly moveTokensMessage: Locator;
+  readonly diagram: Locator;
+  readonly multipleInstancesAlert: Locator;
+  readonly history: Locator;
+  readonly continueButton: Locator;
+  readonly addSingleFlowNodeInstanceButton: Locator;
+  readonly moveSelectedInstanceButton: Locator;
+  readonly modificationModeText: Locator;
+  readonly lastAddedModificationText: Locator;
+  readonly undoModificationButton: Locator;
+  readonly deleteVariableModificationButton: Locator;
+  readonly cancelButton: Locator;
+  readonly addVariableModificationButton: Locator;
+  readonly modalDialog: Locator;
+  readonly noVariablesText: Locator;
+  readonly newVariableByIndex: (index: number) => {
+    name: Locator;
+    value: Locator;
+    jsonEditorButton: Locator;
+    deleteButton: Locator;
+    jsonEditorModal: {
+      header: Locator;
+      cancelButton: Locator;
+      applyButton: Locator;
+      inputField: Locator;
+    };
+    valueErrorMessage?: Locator;
+    nameErrorMessage?: Locator;
+  };
+  readonly editableExistingVariableByName: (name: string) => {
+    name: Locator;
+    value: Locator;
+    jsonEditorButton: Locator;
+    jsonEditorModal: {
+      header: Locator;
+      cancelButton: Locator;
+      applyButton: Locator;
+      inputField: Locator;
+    };
+    valueErrorMessage?: Locator;
+  };
+  readonly applyModificationDialog: Locator;
+  readonly applyModificationDialogFlowNodeModificationRowByIndex: (
+    index: number,
+  ) => {
+    operation: Locator;
+    flowNode: Locator;
+    instanceKey: Locator;
+    affectedTokens: Locator;
+    deleteFlowNodeModificationButton: Locator;
+  };
+  readonly applyModificationDialogVariableModificationRowByIndex: (
+    index: number,
+  ) => {
+    expandChangesButton: Locator;
+    operation: Locator;
+    scope: Locator;
+    nameValue: Locator;
+    childRow: Locator;
+    deleteVariableModificationButton: Locator;
+  };
+
+  constructor(page: Page) {
+    this.page = page;
+    this.modifyModeHeader = page
+      .getByText('Process Instance Modification Mode')
+      .first();
+    this.flowNodeModificationsPopup = page.getByText('Flow Node Modifications');
+    this.addModificationButtononPopup = page.getByTitle(
+      'Add single flow node instance',
+    );
+    this.moveAllButtononPopup = page.getByTitle(
+      'Move all running instances in this flow node to another target',
+    );
+    this.cancelButtonPopup = page.getByTitle(
+      'Cancel selected instance in this flow node',
+    );
+    this.cancelAllButtonPopup = page.getByTitle(
+      'Cancel all running flow node instances in this flow node',
+    );
+    this.applyModificationsButton = page.getByTestId(
+      'apply-modifications-button',
+    );
+    this.discardAllModificationsButton = page.getByTestId('discard-all-button');
+    this.cancelButtonModificationDialog = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Cancel'});
+    this.applyButtonModificationsDialog = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Apply'});
+    this.moveTokensMessage = page.getByText(
+      'Select the target flow node in the diagram',
+    );
+    this.diagram = this.page.getByTestId('diagram');
+    this.multipleInstancesAlert = page.getByText(
+      'Flow node has multiple instances. To select one, use the instance history tree below.',
+    );
+    this.history = page.getByTestId('instance-history');
+
+    this.continueButton = page.getByRole('button', {name: 'Continue'});
+    this.addSingleFlowNodeInstanceButton = page.getByRole('button', {
+      name: 'Add single flow node instance',
+    });
+    this.moveSelectedInstanceButton = page.getByRole('button', {
+      name: 'Move selected instance in this flow node to another target',
+    });
+    this.modificationModeText = page.getByText(
+      'Process Instance Modification Mode',
+    );
+    this.lastAddedModificationText = page.getByText('Last added modification:');
+    this.undoModificationButton = page.getByRole('button', {name: 'undo'});
+    this.deleteVariableModificationButton = page.getByRole('button', {
+      name: /delete variable modification/i,
+    });
+    this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+    this.addVariableModificationButton = page.getByRole('button', {
+      name: /add variable/i,
+    });
+    this.modalDialog = page.getByRole('dialog');
+    this.noVariablesText = page.getByText(/The Flow Node has no Variables/i);
+    this.newVariableByIndex = (index: number) => ({
+      name: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .locator(`[id="newVariables[${index}].name"]`),
+      value: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .locator(`[id="newVariables[${index}].value"]`),
+      jsonEditorButton: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .getByRole('cell')
+        .nth(1)
+        .getByRole('button'),
+      deleteButton: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .getByRole('cell')
+        .nth(2)
+        .getByRole('button'),
+      jsonEditorModal: {
+        header: this.page
+          .getByTestId(`variable-newVariables[${index}]`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByText('Edit a new Variable'),
+        cancelButton: this.page
+          .getByTestId(`variable-newVariables[${index}]`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('button', {name: 'Cancel'}),
+        applyButton: this.page
+          .getByTestId(`variable-newVariables[${index}]`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('button', {name: 'Apply'}),
+        inputField: this.page
+          .getByTestId(`variable-newVariables[${index}]`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('textbox'),
+      },
+      valueErrorMessage: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .getByRole('cell')
+        .nth(1)
+        .locator(`[id="newVariables[${index}].value-error-msg"]`),
+      nameErrorMessage: this.page
+        .getByTestId(`variable-newVariables[${index}]`)
+        .getByRole('cell')
+        .nth(0)
+        .locator(`[id="newVariables[${index}].name-error-msg"]`),
+    });
+
+    this.editableExistingVariableByName = (name: string) => ({
+      name: this.page.getByTestId(`variable-${name}`).getByTitle(name),
+      value: this.page
+        .getByTestId(`variable-${name}`)
+        .getByTestId('edit-variable-value'),
+      jsonEditorButton: this.page
+        .getByTestId(`variable-${name}`)
+        .getByRole('cell')
+        .nth(1)
+        .getByRole('button'),
+      jsonEditorModal: {
+        header: this.page
+          .getByTestId(`variable-${name}`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByText(`Edit Variable "${name}"`),
+        cancelButton: this.page
+          .getByTestId(`variable-${name}`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('button', {name: 'Cancel'}),
+        applyButton: this.page
+          .getByTestId(`variable-${name}`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('button', {name: 'Apply'}),
+        inputField: this.page
+          .getByTestId(`variable-${name}`)
+          .getByRole('cell')
+          .nth(1)
+          .getByRole('presentation')
+          .getByRole('dialog')
+          .getByRole('textbox'),
+      },
+      valueErrorMessage: this.page
+        .getByTestId(`variable-${name}`)
+        .locator(`[id="#${name}-error-msg"]`),
+    });
+    ((this.applyModificationDialog = this.page.getByRole('dialog', {
+      name: 'Apply Modifications',
+    })),
+      (this.applyModificationDialogFlowNodeModificationRowByIndex = (
+        index: number,
+      ) => ({
+        operation: this.applyModificationDialog
+          .getByRole('table')
+          .nth(0)
+          .locator('tbody')
+          .getByRole('row')
+          .nth(index)
+          .getByRole('cell')
+          .nth(1),
+        flowNode: this.applyModificationDialog
+          .getByRole('table')
+          .nth(0)
+          .locator('tbody')
+          .getByRole('row')
+          .nth(index)
+          .getByRole('cell')
+          .nth(2),
+        instanceKey: this.applyModificationDialog
+          .getByRole('table')
+          .nth(0)
+          .locator('tbody')
+          .getByRole('row')
+          .nth(index)
+          .getByRole('cell')
+          .nth(3),
+        affectedTokens: this.applyModificationDialog
+          .getByRole('table')
+          .nth(0)
+          .locator('tbody')
+          .getByRole('row')
+          .nth(index)
+          .getByTestId('affected-token-count'),
+        deleteFlowNodeModificationButton: this.applyModificationDialog
+          .getByRole('table')
+          .nth(0)
+          .locator('tbody')
+          .getByRole('row')
+          .nth(index)
+          .getByRole('cell')
+          .nth(5)
+          .getByRole('button', {name: 'Delete flow node modification'}),
+      })));
+    this.applyModificationDialogVariableModificationRowByIndex = (
+      index: number,
+    ) => ({
+      expandChangesButton: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-parent-row="true"]')
+        .nth(index)
+        .getByRole('cell')
+        .nth(0)
+        .getByRole('button'),
+      operation: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-parent-row="true"]')
+        .nth(index)
+        .getByRole('cell')
+        .nth(1),
+      scope: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-parent-row="true"]')
+        .nth(index)
+        .getByRole('cell')
+        .nth(2),
+      nameValue: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-parent-row="true"]')
+        .nth(index)
+        .getByRole('cell')
+        .nth(3),
+      childRow: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-child-row="true"]')
+        .nth(index),
+      deleteVariableModificationButton: this.applyModificationDialog
+        .getByRole('table')
+        .nth(1)
+        .locator('tr[data-parent-row="true"]')
+        .nth(index)
+        .getByRole('cell')
+        .nth(5),
+    });
+  }
+
+  async clickAddModificationButtononPopup(): Promise<void> {
+    await this.addModificationButtononPopup.click();
+  }
+
+  async clickMoveAllButtononPopup(): Promise<void> {
+    await this.moveAllButtononPopup.click();
+  }
+
+  async clickCancelButtononPopup(): Promise<void> {
+    await this.cancelButtonPopup.click();
+  }
+
+  async clickCancelAllButtononPopup(): Promise<void> {
+    await this.cancelAllButtonPopup.click();
+  }
+
+  async clickApplyModificationsButton(): Promise<void> {
+    await this.applyModificationsButton.click();
+  }
+
+  async clickDiscardAllModificationsButton(): Promise<void> {
+    await this.discardAllModificationsButton.click();
+  }
+
+  async clickCancelButtonDialog(): Promise<void> {
+    await this.cancelButtonModificationDialog.click();
+  }
+
+  async clickApplyButtonModificationsDialog(): Promise<void> {
+    await this.applyButtonModificationsDialog.click();
+  }
+
+  clickFlowNode(flowNodeName: string) {
+    return this.getFlowNode(flowNodeName).first().click({timeout: 20000});
+  }
+
+  clickSubProcess(subProcessName: string) {
+    return this.getFlowNode(subProcessName).click({
+      position: {x: 5, y: 5},
+      force: true,
+    });
+  }
+
+  getFlowNode(flowNodeName: string) {
+    return this.diagram
+      .locator('.djs-group')
+      .locator(`[data-element-id="${flowNodeName}"]`);
+  }
+
+  async addTokenToFlowNodeAndApplyChanges(flowNodeName: string): Promise<void> {
+    await this.clickFlowNode(flowNodeName);
+    await this.clickAddModificationButtononPopup();
+    await this.applyChanges();
+  }
+
+  async addTokenToSubprocessAndApplyChanges(
+    flowNodeName: string,
+  ): Promise<void> {
+    await this.clickSubProcess(flowNodeName);
+    await this.clickAddModificationButtononPopup();
+    await this.applyChanges();
+  }
+
+  async moveAllTokensFromSelectedFlowNodeToTarget(
+    sourceFlowNodeName: string,
+    targetFlowNodeName: string,
+  ): Promise<void> {
+    await this.clickFlowNode(sourceFlowNodeName);
+    await this.clickMoveAllButtononPopup();
+    await expect(this.moveTokensMessage).toBeVisible();
+    await this.clickFlowNode(targetFlowNodeName);
+  }
+
+  async addTokenToFlowNode(flowNodeName: string): Promise<void> {
+    await this.clickFlowNode(flowNodeName);
+    await this.clickAddModificationButtononPopup();
+  }
+
+  async applyChanges(): Promise<void> {
+    await this.clickApplyModificationsButton();
+    await this.clickApplyButtonModificationsDialog();
+  }
+
+  async getBadgeLocatorForModificationOverlay(elementLocator: Locator) {
+    const badgeLocator = elementLocator.getByTestId(/^badge-/);
+    return await badgeLocator.getAttribute('data-testid');
+  }
+
+  async getModificationOverlayLocatorByElementName(elementName: string) {
+    return this.page
+      .locator(`[data-container-id=${elementName}]`)
+      .getByTestId('modifications-overlay');
+  }
+
+  async verifyModificationOverlay(
+    flowNodeName: string,
+    tokenChange: number,
+  ): Promise<void> {
+    const flowNodeModificationOverlay =
+      await this.getModificationOverlayLocatorByElementName(flowNodeName);
+    await expect(flowNodeModificationOverlay).toBeVisible();
+
+    const flowNodeModificationOverlayText =
+      await flowNodeModificationOverlay.innerText();
+    const flowNodeModificationOverlayBadgeValue =
+      await this.getBadgeLocatorForModificationOverlay(
+        flowNodeModificationOverlay,
+      );
+
+    if (tokenChange < 0) {
+      tokenChange = -tokenChange;
+      expect(flowNodeModificationOverlayBadgeValue).toContain('minus');
+    } else {
+      expect(flowNodeModificationOverlayBadgeValue).toContain('plus');
+    }
+
+    expect(flowNodeModificationOverlayText).toContain(tokenChange.toString());
+  }
+
+  async cancelOneTokenUsingHistory(flowNodeName: string): Promise<void> {
+    await this.clickFlowNode(flowNodeName);
+    await expect(this.multipleInstancesAlert).toBeVisible();
+    const meow = this.history
+      .getByTestId(/^tree-node-/)
+      .locator('[aria-current="true"]')
+      .first();
+    await meow.click();
+    await expect(
+      this.page
+        .getByTestId('popover')
+        .getByText('Selected running instances: 1'),
+    ).toBeVisible();
+    await this.clickCancelButtononPopup();
+    await this.verifyModificationOverlay(flowNodeName, -1);
+    await this.applyChanges();
+  }
+
+  getNewVariableNameFieldSelector = (variableIndex: string) => {
+    return this.page
+      .getByTestId(`variable-newVariables[${variableIndex}]`)
+      .locator(`[id="newVariables[${variableIndex}].name"]`);
+  };
+
+  getNewVariableValueFieldSelector = (variableIndex: string) => {
+    return this.page
+      .getByTestId(`variable-newVariables[${variableIndex}]`)
+      .locator(`[id="newVariables[${variableIndex}].value"]`);
+  };
+
+  getEditVariableFieldSelector(variableName: string) {
+    return this.page
+      .getByTestId(`variable-${variableName}`)
+      .getByRole('textbox', {
+        name: 'value',
+      });
+  }
+
+  async undoModification() {
+    await this.undoModificationButton.click();
+  }
+
+  async clickAddVariable() {
+    await this.addVariableModificationButton.click();
+  }
+
+  async clickDeleteVariableModification() {
+    await this.deleteVariableModificationButton.click();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+  }
+
+  getEditVariableModificationText(variableName: string) {
+    return this.page.getByText(
+      new RegExp(`edit variable "${variableName}"`, 'i'),
+    );
+  }
+
+  getAddVariableModificationText(variableName: string) {
+    return this.page.getByText(
+      new RegExp(`add new variable "${variableName}"`, 'i'),
+    );
+  }
+
+  getVariableModificationSummaryText(variableName: string, value: string) {
+    return this.page.getByText(`${variableName}: ${value}`);
+  }
+
+  getDialogVariableModificationSummaryText(
+    variableName: string,
+    value: string,
+  ) {
+    return this.modalDialog.getByText(`${variableName}: ${value}`);
+  }
+
+  getDialogDeleteVariableModificationButton(index?: number) {
+    const button = this.modalDialog.getByRole('button', {
+      name: 'Delete variable modification',
+    });
+    return index !== undefined ? button.nth(index) : button;
+  }
+
+  getDialogCancelButton() {
+    return this.modalDialog.getByRole('button', {name: 'Cancel'});
+  }
+
+  async clickDialogDeleteVariableModification(index?: number) {
+    await this.getDialogDeleteVariableModificationButton(index).click();
+  }
+
+  async clickDialogCancel() {
+    await this.getDialogCancelButton().click();
+  }
+
+  async addNewVariable(variableIndex: string, name: string, value: string) {
+    await this.addVariableModificationButton.click();
+    await expect(
+      this.page.getByTestId(`variable-newVariables[${variableIndex}]`),
+    ).toBeVisible();
+
+    await this.getNewVariableNameFieldSelector(variableIndex).clear();
+    await this.getNewVariableNameFieldSelector(variableIndex).type(name);
+    await this.page.keyboard.press('Tab');
+
+    await this.getNewVariableValueFieldSelector(variableIndex).type(value);
+    await this.page.keyboard.press('Tab');
+  }
+
+  async editVariableValue(variableName: string, value: string) {
+    await this.getEditVariableFieldSelector(variableName).clear();
+    await this.getEditVariableFieldSelector(variableName).type(value);
+    await this.page.keyboard.press('Tab');
+  }
+
+  async applyModifications(): Promise<void> {
+    await expect(this.applyModificationsButton).toBeEnabled();
+    await this.applyModificationsButton.click();
+    await this.applyButtonModificationsDialog.click();
+  }
+
+  async checkNewVariableErrorMessageText(
+    variableIndex: number,
+    message:
+      | 'Name should be unique'
+      | 'Value has to be filled'
+      | 'Name has to be filled'
+      | 'Value has to be JSON',
+    field: 'name' | 'value',
+  ) {
+    const errorMessage =
+      field === 'name'
+        ? this.newVariableByIndex(variableIndex).nameErrorMessage
+        : this.newVariableByIndex(variableIndex).valueErrorMessage;
+    await expect(errorMessage!).toHaveText(message);
+  }
+
+  async deleteNewVariableModification(variableIndex: number) {
+    await this.newVariableByIndex(variableIndex).deleteButton.click();
+  }
+
+  async editNewVariableJSONInModal(variableIndex: number, json: string) {
+    await this.newVariableByIndex(variableIndex).jsonEditorButton.click();
+    const jsonEditorModal =
+      this.newVariableByIndex(variableIndex).jsonEditorModal;
+    await expect(jsonEditorModal.header).toBeVisible();
+    await jsonEditorModal.inputField.clear();
+    await jsonEditorModal.inputField.fill(json);
+    await jsonEditorModal.applyButton.click();
+    await this.page.keyboard.press('Tab');
+  }
+
+  async editExistingVariableJSONInModal(variableName: string, json: string) {
+    await this.editableExistingVariableByName(variableName).value.clear();
+    await this.editableExistingVariableByName(
+      variableName,
+    ).jsonEditorButton.click();
+    const jsonEditorModal =
+      this.editableExistingVariableByName(variableName).jsonEditorModal;
+    await expect(jsonEditorModal.header).toBeVisible();
+    await jsonEditorModal.inputField.clear();
+    await jsonEditorModal.inputField.fill(json);
+    await jsonEditorModal.applyButton.click();
+    await this.editableExistingVariableByName(
+      'testVariableString',
+    ).value.click();
+    await this.page.keyboard.press('Tab');
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -241,55 +241,55 @@ export class OperateProcessInstanceViewModificationModePage {
       },
       valueErrorMessage: this.page
         .getByTestId(`variable-${name}`)
-        .locator(`[id="#${name}-error-msg"]`),
+        .locator(`[id="${name}-error-msg"]`),
     });
-    ((this.applyModificationDialog = this.page.getByRole('dialog', {
+    this.applyModificationDialog = this.page.getByRole('dialog', {
       name: 'Apply Modifications',
-    })),
-      (this.applyModificationDialogFlowNodeModificationRowByIndex = (
-        index: number,
-      ) => ({
-        operation: this.applyModificationDialog
-          .getByRole('table')
-          .nth(0)
-          .locator('tbody')
-          .getByRole('row')
-          .nth(index)
-          .getByRole('cell')
-          .nth(1),
-        flowNode: this.applyModificationDialog
-          .getByRole('table')
-          .nth(0)
-          .locator('tbody')
-          .getByRole('row')
-          .nth(index)
-          .getByRole('cell')
-          .nth(2),
-        instanceKey: this.applyModificationDialog
-          .getByRole('table')
-          .nth(0)
-          .locator('tbody')
-          .getByRole('row')
-          .nth(index)
-          .getByRole('cell')
-          .nth(3),
-        affectedTokens: this.applyModificationDialog
-          .getByRole('table')
-          .nth(0)
-          .locator('tbody')
-          .getByRole('row')
-          .nth(index)
-          .getByTestId('affected-token-count'),
-        deleteFlowNodeModificationButton: this.applyModificationDialog
-          .getByRole('table')
-          .nth(0)
-          .locator('tbody')
-          .getByRole('row')
-          .nth(index)
-          .getByRole('cell')
-          .nth(5)
-          .getByRole('button', {name: 'Delete flow node modification'}),
-      })));
+    });
+    this.applyModificationDialogFlowNodeModificationRowByIndex = (
+      index: number,
+    ) => ({
+      operation: this.applyModificationDialog
+        .getByRole('table')
+        .nth(0)
+        .locator('tbody')
+        .getByRole('row')
+        .nth(index)
+        .getByRole('cell')
+        .nth(1),
+      flowNode: this.applyModificationDialog
+        .getByRole('table')
+        .nth(0)
+        .locator('tbody')
+        .getByRole('row')
+        .nth(index)
+        .getByRole('cell')
+        .nth(2),
+      instanceKey: this.applyModificationDialog
+        .getByRole('table')
+        .nth(0)
+        .locator('tbody')
+        .getByRole('row')
+        .nth(index)
+        .getByRole('cell')
+        .nth(3),
+      affectedTokens: this.applyModificationDialog
+        .getByRole('table')
+        .nth(0)
+        .locator('tbody')
+        .getByRole('row')
+        .nth(index)
+        .getByTestId('affected-token-count'),
+      deleteFlowNodeModificationButton: this.applyModificationDialog
+        .getByRole('table')
+        .nth(0)
+        .locator('tbody')
+        .getByRole('row')
+        .nth(index)
+        .getByRole('cell')
+        .nth(5)
+        .getByRole('button', {name: 'Delete flow node modification'}),
+    });
     this.applyModificationDialogVariableModificationRowByIndex = (
       index: number,
     ) => ({
@@ -333,7 +333,8 @@ export class OperateProcessInstanceViewModificationModePage {
         .locator('tr[data-parent-row="true"]')
         .nth(index)
         .getByRole('cell')
-        .nth(5),
+        .nth(5)
+        .getByRole('button', {name: 'Delete variable modification'}),
     });
   }
 
@@ -427,7 +428,7 @@ export class OperateProcessInstanceViewModificationModePage {
 
   async getModificationOverlayLocatorByElementName(elementName: string) {
     return this.page
-      .locator(`[data-container-id=${elementName}]`)
+      .locator(`[data-container-id="${elementName}"]`)
       .getByTestId('modifications-overlay');
   }
 
@@ -621,7 +622,7 @@ export class OperateProcessInstanceViewModificationModePage {
     await jsonEditorModal.inputField.fill(json);
     await jsonEditorModal.applyButton.click();
     await this.editableExistingVariableByName(
-      'testVariableString',
+      variableName,
     ).value.click();
     await this.page.keyboard.press('Tab');
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -185,7 +185,8 @@ export class OperateProcessInstanceViewModificationModePage {
           .nth(1)
           .getByRole('presentation')
           .getByRole('dialog')
-          .getByRole('textbox'),
+          .getByRole('code')
+          .getByRole('textbox', { name: 'Editor content' }),
       },
       valueErrorMessage: this.page
         .getByTestId(`variable-newVariables[${index}]`)
@@ -237,7 +238,8 @@ export class OperateProcessInstanceViewModificationModePage {
           .nth(1)
           .getByRole('presentation')
           .getByRole('dialog')
-          .getByRole('textbox'),
+          .getByRole('code')
+          .getByRole('textbox', { name: 'Editor content' }),
       },
       valueErrorMessage: this.page
         .getByTestId(`variable-${name}`)
@@ -600,12 +602,15 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async editNewVariableJSONInModal(variableIndex: number, json: string) {
+    await this.newVariableByIndex(variableIndex)
+      .value.clear();
     await this.newVariableByIndex(variableIndex).jsonEditorButton.click();
     const jsonEditorModal =
       this.newVariableByIndex(variableIndex).jsonEditorModal;
     await expect(jsonEditorModal.header).toBeVisible();
-    await jsonEditorModal.inputField.clear();
-    await jsonEditorModal.inputField.fill(json);
+    await expect(jsonEditorModal.inputField).toBeVisible();
+    await expect(jsonEditorModal.inputField).toBeEnabled();
+    await this.fillMonacoEditor(jsonEditorModal.inputField, json);
     await jsonEditorModal.applyButton.click();
     await this.page.keyboard.press('Tab');
   }
@@ -618,12 +623,17 @@ export class OperateProcessInstanceViewModificationModePage {
     const jsonEditorModal =
       this.editableExistingVariableByName(variableName).jsonEditorModal;
     await expect(jsonEditorModal.header).toBeVisible();
-    await jsonEditorModal.inputField.clear();
-    await jsonEditorModal.inputField.fill(json);
+    await expect(jsonEditorModal.inputField).toBeVisible();
+    await expect(jsonEditorModal.inputField).toBeEnabled();
+    await this.fillMonacoEditor(jsonEditorModal.inputField, json);
     await jsonEditorModal.applyButton.click();
     await this.editableExistingVariableByName(
       variableName,
     ).value.click();
     await this.page.keyboard.press('Tab');
+  }
+
+  async fillMonacoEditor(editor: Locator, value: string) {
+    await this.page.keyboard.type(value, {delay: 0});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/EmbeddedSubprocess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/EmbeddedSubprocess.bpmn
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="bb4fb0c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_EmbeddedSubprocess" name="EmbeddedSubprocess" isExecutable="true">
+    <bpmn:startEvent id="StartGlobal" name="StartGlobal">
+      <bpmn:outgoing>Flow_0g7rbn8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="FirstSubprocess" name="FirstSubprocess">
+      <bpmn:incoming>Flow_07amn95</bpmn:incoming>
+      <bpmn:outgoing>Flow_0kpkair</bpmn:outgoing>
+      <bpmn:startEvent id="StartFirstSubProcess">
+        <bpmn:outgoing>Flow_06dbvp3</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_06dbvp3" sourceRef="StartFirstSubProcess" targetRef="CollectMoney" />
+      <bpmn:sequenceFlow id="Flow_09r7m0m" sourceRef="CollectMoney" targetRef="FetchItems" />
+      <bpmn:endEvent id="EndFirstSubProcess">
+        <bpmn:incoming>Flow_1lrsb76</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1lrsb76" sourceRef="FetchItems" targetRef="EndFirstSubProcess" />
+      <bpmn:userTask id="FetchItems" name="FetchItems">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_09r7m0m</bpmn:incoming>
+        <bpmn:outgoing>Flow_1lrsb76</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:userTask id="CollectMoney" name="CollectMoney">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_06dbvp3</bpmn:incoming>
+        <bpmn:outgoing>Flow_09r7m0m</bpmn:outgoing>
+      </bpmn:userTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="OrderCanceled" name="OrderCanceled" attachedToRef="FirstSubprocess">
+      <bpmn:outgoing>Flow_0mv2lgu</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1b83q3n" messageRef="Message_308hg45" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="OrderCancelledEnd">
+      <bpmn:incoming>Flow_0mv2lgu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mv2lgu" sourceRef="OrderCanceled" targetRef="OrderCancelledEnd" />
+    <bpmn:sequenceFlow id="Flow_0g7rbn8" sourceRef="StartGlobal" targetRef="Node" />
+    <bpmn:sequenceFlow id="Flow_07amn95" sourceRef="Node" targetRef="FirstSubprocess" />
+    <bpmn:userTask id="Node" name="Node">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0g7rbn8</bpmn:incoming>
+      <bpmn:outgoing>Flow_07amn95</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0kpkair" sourceRef="FirstSubprocess" targetRef="SecondSubprocess" />
+    <bpmn:subProcess id="SecondSubprocess" name="SecondSubprocess">
+      <bpmn:incoming>Flow_0kpkair</bpmn:incoming>
+      <bpmn:outgoing>Flow_1reshi7</bpmn:outgoing>
+      <bpmn:startEvent id="StartSecondSubProcess">
+        <bpmn:outgoing>Flow_1l6c623</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1l6c623" sourceRef="StartSecondSubProcess" targetRef="SendItems" />
+      <bpmn:userTask id="SendItems" name="SendItems">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1l6c623</bpmn:incoming>
+        <bpmn:outgoing>Flow_09o62lp</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="EndSecondSubProcess">
+        <bpmn:incoming>Flow_09o62lp</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_09o62lp" sourceRef="SendItems" targetRef="EndSecondSubProcess" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1reshi7" sourceRef="SecondSubprocess" targetRef="EndGlobal" />
+    <bpmn:endEvent id="EndGlobal" name="EndGlobal">
+      <bpmn:incoming>Flow_1reshi7</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_308hg45" name="order canceled">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=meow" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_EmbeddedSubprocess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartGlobal">
+        <dc:Bounds x="-18" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-27" y="143" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1irq61y_di" bpmnElement="FirstSubprocess" isExpanded="true">
+        <dc:Bounds x="260" y="18" width="590" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xff6k0_di" bpmnElement="StartFirstSubProcess">
+        <dc:Bounds x="300" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bv0a08_di" bpmnElement="EndFirstSubProcess">
+        <dc:Bounds x="712" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0skvzsk_di" bpmnElement="FetchItems">
+        <dc:Bounds x="550" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0la24vn_di" bpmnElement="CollectMoney">
+        <dc:Bounds x="390" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06dbvp3_di" bpmnElement="Flow_06dbvp3">
+        <di:waypoint x="336" y="118" />
+        <di:waypoint x="390" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09r7m0m_di" bpmnElement="Flow_09r7m0m">
+        <di:waypoint x="490" y="118" />
+        <di:waypoint x="550" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lrsb76_di" bpmnElement="Flow_1lrsb76">
+        <di:waypoint x="650" y="118" />
+        <di:waypoint x="712" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0oh1ygw_di" bpmnElement="OrderCancelledEnd">
+        <dc:Bounds x="632" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dyu342_di" bpmnElement="Node">
+        <dc:Bounds x="90" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w8qele_di" bpmnElement="SecondSubprocess" isExpanded="true">
+        <dc:Bounds x="920" y="18" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0qn7lba_di" bpmnElement="StartSecondSubProcess">
+        <dc:Bounds x="960" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d0nwks_di" bpmnElement="SendItems">
+        <dc:Bounds x="1050" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_096gam2_di" bpmnElement="EndSecondSubProcess">
+        <dc:Bounds x="1212" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l6c623_di" bpmnElement="Flow_1l6c623">
+        <di:waypoint x="996" y="118" />
+        <di:waypoint x="1050" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09o62lp_di" bpmnElement="Flow_09o62lp">
+        <di:waypoint x="1150" y="118" />
+        <di:waypoint x="1212" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ri4nye_di" bpmnElement="EndGlobal">
+        <dc:Bounds x="1362" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1355" y="143" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jkbwqi_di" bpmnElement="OrderCanceled">
+        <dc:Bounds x="537" y="200" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="519" y="243" width="75" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0mv2lgu_di" bpmnElement="Flow_0mv2lgu">
+        <di:waypoint x="555" y="236" />
+        <di:waypoint x="555" y="300" />
+        <di:waypoint x="632" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g7rbn8_di" bpmnElement="Flow_0g7rbn8">
+        <di:waypoint x="18" y="118" />
+        <di:waypoint x="90" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07amn95_di" bpmnElement="Flow_07amn95">
+        <di:waypoint x="190" y="118" />
+        <di:waypoint x="260" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kpkair_di" bpmnElement="Flow_0kpkair">
+        <di:waypoint x="850" y="118" />
+        <di:waypoint x="920" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1reshi7_di" bpmnElement="Flow_1reshi7">
+        <di:waypoint x="1270" y="118" />
+        <di:waypoint x="1362" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -12,15 +12,56 @@ import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp, hideModificationHelperModal} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
 };
 
 let instanceWithoutAnIncident: ProcessInstance;
+let embeddedSubprocessInstance: ProcessInstance;
+
+const activityNode = 'Node';
+const activityFirstSubprocess = 'FirstSubprocess';
+const activityCollectMoney = 'CollectMoney';
+const validJSONValue1 = {
+  employeeId: {
+    value: 'E123',
+    type: 'String',
+  },
+  employeeName: {
+    value: 'Alice Smith',
+    type: 'String',
+  },
+  employeeEmail: {
+    value: 'alice@example.com',
+    type: 'String',
+  },
+  employeeRole: {
+    value: 'Developer',
+    type: 'String',
+  },
+  documentsVerified: {
+    value: true,
+    type: 'Boolean',
+  },
+  startDate: {
+    value: '2025-08-01',
+    type: 'String',
+  },
+};
+const validJSONValue2 = {
+  employeeId: {
+    value: 'E123',
+    type: 'String',
+  },
+};
 
 test.beforeAll(async () => {
-  await deploy(['./resources/withoutIncidentsProcess_v_1.bpmn']);
+  await deploy([
+    './resources/withoutIncidentsProcess_v_1.bpmn',
+    './resources/EmbeddedSubprocess.bpmn',
+  ]);
 
   instanceWithoutAnIncident = await createSingleInstance(
     'withoutIncidentsProcess',
@@ -28,6 +69,16 @@ test.beforeAll(async () => {
     {
       test: 123,
       foo: 'bar',
+    },
+  );
+
+  embeddedSubprocessInstance = await createSingleInstance(
+    'Process_EmbeddedSubprocess',
+    1,
+    {
+      meow: 0,
+      testVariableNumber: 123,
+      testVariableString: 'bar',
     },
   );
 
@@ -201,6 +252,361 @@ test.describe('Process Instance Modifications', () => {
       await expect(
         operateProcessInstancePage.getEditVariableFieldSelector('foo'),
       ).toHaveValue('"bar"');
+    });
+  });
+
+  test('Verify Variables functionality in Modification mode', async ({
+    operateProcessInstancePage,
+    page,
+    operateProcessInstanceViewModificationModePage,
+  }) => {
+    await test.step('Navigate to embedded subprocess instance', async () => {
+      await operateProcessInstancePage.gotoProcessInstancePage({
+        id: embeddedSubprocessInstance.processInstanceKey,
+      });
+    });
+
+    await test.step('Verify initial variables are visible', async () => {
+      await expect(
+        operateProcessInstancePage.getVariableTestId('testVariableString'),
+      ).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getVariableTestId('testVariableNumber'),
+      ).toBeVisible();
+    });
+
+    await test.step('Enter modification mode and verify variables are not editable', async () => {
+      await operateProcessInstancePage.enterModificationMode();
+      await expect(operateProcessInstancePage.addVariableButton).toBeHidden();
+      await expect(operateProcessInstancePage.existingVariableByName('testVariableString').editVariableModal.button).toBeHidden();
+    });
+
+    await test.step('Select an element from the process diagram and verify variables are not addable', async () => {
+      await operateProcessInstanceViewModificationModePage.clickFlowNode(
+        activityNode,
+      );
+      await expect(operateProcessInstancePage.addVariableButton).toBeHidden();
+    });
+
+    await test.step('Add a token to the element and verify variable are changable', async () => {
+      await operateProcessInstanceViewModificationModePage.addTokenToFlowNode(
+        activityCollectMoney,
+      );
+      await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
+        activityCollectMoney,
+        1,
+      );
+
+      await expect(operateProcessInstancePage.addVariableButton).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableFieldSelector(
+          'testVariableString',
+        ),
+      ).toBeEnabled();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableFieldSelector(
+          'testVariableNumber',
+        ),
+      ).toBeEnabled();
+    });
+
+    await test.step('Change process-level variable and undo changes and verify results', async () => {
+      await operateProcessInstanceViewModificationModePage.editVariableValue(
+        'testVariableNumber',
+        '1',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableModificationText(
+          'testVariableNumber',
+        ),
+      ).toBeVisible();
+
+      await operateProcessInstanceViewModificationModePage.undoModification();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableFieldSelector(
+          'testVariableNumber',
+        ),
+      ).toHaveValue('123');
+    });
+
+    await test.step('Add variable on process-level and verify warning appeared', async () => {
+      await operateProcessInstanceViewModificationModePage.addNewVariable(
+        '0',
+        'testVariableNumber',
+        '7',
+      );
+      await operateProcessInstanceViewModificationModePage.checkNewVariableErrorMessageText(
+        0,
+        'Name should be unique',
+        'name',
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.newVariableByIndex(0)
+          .nameErrorMessage!,
+      ).toBeVisible();
+      await operateProcessInstanceViewModificationModePage
+        .newVariableByIndex(0)
+        .name.fill('testNewMeowVariable');
+      await page.keyboard.press('Tab');
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getAddVariableModificationText(
+          'testNewMeowVariable',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Select the newly added token from the Instance History and verify the Add Variable button is visible in the Variables panel for the selected token (element level).', async () => {
+      const newNestedParentName = `${activityFirstSubprocess}, this flow node instance is planned to be added`;
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        newNestedParentName,
+      );
+      const addedTokenInHistory = `${activityCollectMoney}, this flow node instance is planned to be added`;
+      await operateProcessInstancePage.clickTreeItem(addedTokenInHistory);
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.noVariablesText,
+      ).toBeVisible();
+      await expect(operateProcessInstancePage.addVariableButton).toBeVisible();
+
+      await operateProcessInstanceViewModificationModePage.addNewVariable(
+        '0',
+        '',
+        '"addedValue"',
+      );
+      await operateProcessInstanceViewModificationModePage.checkNewVariableErrorMessageText(
+        0,
+        'Name has to be filled',
+        'name',
+      );
+      await operateProcessInstanceViewModificationModePage
+        .newVariableByIndex(0)
+        .name.fill('testLocalVariable');
+      await page.keyboard.press('Tab');
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getAddVariableModificationText(
+          'testLocalVariable',
+        ),
+      ).toBeVisible();
+
+      await operateProcessInstanceViewModificationModePage.addNewVariable(
+        '1',
+        'testEmptyVariable',
+        '',
+      );
+      await operateProcessInstanceViewModificationModePage.checkNewVariableErrorMessageText(
+        1,
+        'Value has to be filled',
+        'value',
+      );
+    });
+
+    await test.step('Update variable value in JSON editor modal window and verify results', async () => {
+      await operateProcessInstanceViewModificationModePage
+        .newVariableByIndex(1)
+        .value.fill('meow');
+      await operateProcessInstanceViewModificationModePage.checkNewVariableErrorMessageText(
+        1,
+        'Value has to be JSON',
+        'value',
+      );
+      await operateProcessInstanceViewModificationModePage
+        .newVariableByIndex(1)
+        .value.clear();
+
+      await operateProcessInstanceViewModificationModePage.editNewVariableJSONInModal(
+        1,
+        JSON.stringify(validJSONValue1),
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.newVariableByIndex(1)
+          .value,
+      ).toHaveValue(JSON.stringify(validJSONValue1));
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getAddVariableModificationText(
+          'testEmptyVariable',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Update variable value for existing variable in JSON editor modal window and verify results', async () => {
+      await operateProcessInstancePage.navigateToRootScope();
+
+      await operateProcessInstanceViewModificationModePage.editExistingVariableJSONInModal(
+        'testVariableString',
+        JSON.stringify(validJSONValue2),
+      );
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableFieldSelector(
+          'testVariableString',
+        ),
+      ).toHaveValue(JSON.stringify(validJSONValue2));
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getEditVariableModificationText(
+          'testVariableString',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Check that a variable that hasn\'t been added yet can be removed with "trash bin" icon', async () => {
+      await operateProcessInstanceViewModificationModePage.addNewVariable(
+        '0',
+        'testVariableToRemove',
+        '"to be removed"',
+      );
+      await operateProcessInstanceViewModificationModePage
+        .newVariableByIndex(0)
+        .deleteButton.click();
+
+      await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
+      for (let i = 0; i < 4; i++) {
+        const variableName =
+          await operateProcessInstanceViewModificationModePage
+            .applyModificationDialogVariableModificationRowByIndex(i)
+            .nameValue.innerText();
+        expect(variableName).not.toContain('testVariableToRemove');
+      }
+      await operateProcessInstanceViewModificationModePage.clickCancelButtonDialog();
+    });
+
+    await test.step('Check that a variable that hasn\'t been added yet can be removed from "Apply Modifications" window', async () => {
+      await operateProcessInstanceViewModificationModePage.addNewVariable(
+        '0',
+        'testVariableToMeow',
+        '"meow"',
+      );
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.lastAddedModificationText,
+      ).toBeVisible();
+      await expect(
+        operateProcessInstanceViewModificationModePage.getAddVariableModificationText(
+          'testVariableToMeow',
+        ),
+      ).toBeVisible();
+
+      await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
+          4,
+        ).nameValue,
+      ).toHaveText('testVariableToMeow: "meow"');
+      await operateProcessInstanceViewModificationModePage
+        .applyModificationDialogVariableModificationRowByIndex(4)
+        .deleteVariableModificationButton.click();
+      for (let i = 0; i < 4; i++) {
+        const variableName =
+          await operateProcessInstanceViewModificationModePage
+            .applyModificationDialogVariableModificationRowByIndex(i)
+            .nameValue.innerText();
+        expect(variableName).not.toContain('testVariableToMeow');
+      }
+    });
+
+    await test.step('Apply modifications and verify variable values in the instance', async () => {
+      await operateProcessInstanceViewModificationModePage.clickApplyButtonModificationsDialog();
+
+      await expect(
+        operateProcessInstanceViewModificationModePage.modificationModeText,
+      ).toBeHidden();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.existingVariableByName(
+              'testNewMeowVariable',
+            ).name,
+          ).toBeVisible({timeout: 5000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      expect(
+        await operateProcessInstancePage
+          .existingVariableByName('testNewMeowVariable')
+          .value.innerText(),
+      ).toContain('7');
+      expect(
+        await operateProcessInstancePage
+          .existingVariableByName('testVariableString')
+          .value.innerText(),
+      ).toContain(JSON.stringify(validJSONValue2));
+
+      const newNestedParentName = activityFirstSubprocess;
+      await operateProcessInstancePage.expandTreeItemInHistory(
+        newNestedParentName,
+      );
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        activityCollectMoney,
+      );
+      await expect(
+        operateProcessInstancePage.existingVariableByName('testLocalVariable')
+          .name,
+      ).toBeVisible();
+      expect(
+        await operateProcessInstancePage
+          .existingVariableByName('testLocalVariable')
+          .value.innerText(),
+      ).toContain('"addedValue"');
+      await expect(
+        operateProcessInstancePage.existingVariableByName('testLocalVariable')
+          .name,
+      ).toBeVisible();
+      expect(
+        await operateProcessInstancePage
+          .existingVariableByName('testEmptyVariable')
+          .value.innerText(),
+      ).toContain(JSON.stringify(validJSONValue1));
+    });
+
+    await test.step("Check that an existing variable can't be deleted:", async () => {
+      await operateProcessInstancePage.navigateToRootScope();
+      await operateProcessInstancePage.clickEditVariableButton(
+        'testVariableNumber',
+      );
+      await operateProcessInstancePage.clearVariableValueInput();
+      await page.keyboard.press('Tab');
+      await operateProcessInstancePage.checkExistingVariableErrorMessageText(
+        'testVariableNumber',
+        'Value has to be JSON',
+      );
+      await expect(
+        operateProcessInstancePage.saveVariableButton,
+      ).toBeDisabled();
+      await operateProcessInstancePage.fillVariableValueInput('1');
+      await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
+      await operateProcessInstancePage.saveVariableButton.click();
+
+      await page.reload();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessInstancePage.existingVariableByName(
+              'testVariableNumber',
+            ).value,
+          ).toHaveText('1', {timeout: 5000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -476,11 +476,6 @@ test.describe('Process Instance Modifications', () => {
 
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
       for (let i = 0; ; i++) {
-        // const variableName =
-        //   await operateProcessInstanceViewModificationModePage
-        //     .applyModificationDialogVariableModificationRowByIndex(i)
-        //     .nameValue.innerText();
-        // expect(variableName).not.toContain('testVariableToRemove');
         const row =
           operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
             i,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -418,14 +418,11 @@ test.describe('Process Instance Modifications', () => {
         'Value has to be JSON',
         'value',
       );
-      await operateProcessInstanceViewModificationModePage
-        .newVariableByIndex(1)
-        .value.clear();
-
       await operateProcessInstanceViewModificationModePage.editNewVariableJSONInModal(
         1,
         JSON.stringify(validJSONValue1),
       );
+      
       await expect(
         operateProcessInstanceViewModificationModePage.newVariableByIndex(1)
           .value,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -288,7 +288,7 @@ test.describe('Process Instance Modifications', () => {
       await expect(operateProcessInstancePage.addVariableButton).toBeHidden();
     });
 
-    await test.step('Add a token to the element and verify variable are changable', async () => {
+    await test.step('Add a token to the element and verify variables are changeable', async () => {
       await operateProcessInstanceViewModificationModePage.addTokenToFlowNode(
         activityCollectMoney,
       );
@@ -475,11 +475,20 @@ test.describe('Process Instance Modifications', () => {
         .deleteButton.click();
 
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
-      for (let i = 0; i < 4; i++) {
-        const variableName =
-          await operateProcessInstanceViewModificationModePage
-            .applyModificationDialogVariableModificationRowByIndex(i)
-            .nameValue.innerText();
+      for (let i = 0; ; i++) {
+        // const variableName =
+        //   await operateProcessInstanceViewModificationModePage
+        //     .applyModificationDialogVariableModificationRowByIndex(i)
+        //     .nameValue.innerText();
+        // expect(variableName).not.toContain('testVariableToRemove');
+        const row =
+          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
+            i,
+          );
+        if (!(await row.nameValue.isVisible())) {
+          break;
+        }
+        const variableName = await row.nameValue.innerText();
         expect(variableName).not.toContain('testVariableToRemove');
       }
       await operateProcessInstanceViewModificationModePage.clickCancelButtonDialog();
@@ -503,24 +512,44 @@ test.describe('Process Instance Modifications', () => {
 
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
 
-      await expect(
-        operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-          4,
-        ).nameValue,
-      ).toHaveText('testVariableToMeow: "meow"');
-      await operateProcessInstanceViewModificationModePage
-        .applyModificationDialogVariableModificationRowByIndex(4)
-        .deleteVariableModificationButton.click();
-      for (let i = 0; i < 4; i++) {
-        const variableName =
-          await operateProcessInstanceViewModificationModePage
-            .applyModificationDialogVariableModificationRowByIndex(i)
-            .nameValue.innerText();
+      let variableModificationFound = false;
+
+      for (let i = 0; ; i++) {
+        const row =
+          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
+            i,
+          );
+        if (!(await row.nameValue.isVisible())) {
+          break;
+        }
+        const variableNameValue = await row.nameValue.innerText();
+        if (variableNameValue === 'testVariableToMeow: "meow"') {
+          await expect(row.nameValue).toHaveText('testVariableToMeow: "meow"');
+          await row.deleteVariableModificationButton.click();
+          variableModificationFound = true;
+          break;
+        }
+      }
+      expect(variableModificationFound).toBeTruthy();
+
+      for (let i = 0; ; i++) {
+        const row =
+          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
+            i,
+        );
+        if (!(await row.nameValue.isVisible())) {
+          break;
+        }
+        const variableName = await row.nameValue.innerText();
+    
         expect(variableName).not.toContain('testVariableToMeow');
       }
+
+      await operateProcessInstanceViewModificationModePage.clickCancelButtonDialog();
     });
 
     await test.step('Apply modifications and verify variable values in the instance', async () => {
+      await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
       await operateProcessInstanceViewModificationModePage.clickApplyButtonModificationsDialog();
 
       await expect(


### PR DESCRIPTION
## Description

This PR introduces new test for Verify Variables functionality in Modification mode (manual [TestRail](https://camunda.testrail.com/index.php?/cases/view/783945) test case). That was required as new functionality for Single instance modification was introduced (see related issue).

- For that was introduced "new" `OperateProcessInstanceViewModificationModePage` object. I used one from stable/8.8 as it will be needed for other regression tests.
- New Test in `operate/processInstanceModifications.spec.ts`
- New locators in `OperateProcessInstancePage.ts`

## Related issues
#41143 

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/21874143616)

[latest run](https://github.com/camunda/camunda/actions/runs/21982174196) is not all green. Same tests are [failing on main](https://github.com/camunda/camunda/actions/runs/21982855795)

