### PR TITLE
[Backport stable/8.6] fix: add configuration for maximum incident search groups

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -31,6 +31,13 @@ public class OperateProperties {
 
   private static final String UNKNOWN_VERSION = "unknown-version";
 
+  /**
+   * Maximum number of groups to search for when searching for incidents. For the backward
+   * compatibility reasons we must keep it as 10000 to keep the behavior unchanged for the most of
+   * the users. For some users we need to override it to a smaller value to avoid Operate UI crash.
+   */
+  private int maxIncidentSearchGroups = 10000;
+
   private boolean importerEnabled = true;
   private boolean archiverEnabled = true;
   private boolean webappEnabled = true;
@@ -395,5 +402,13 @@ public class OperateProperties {
         return null;
       }
     }
+  }
+
+  public int getMaxIncidentSearchGroups() {
+    return maxIncidentSearchGroups;
+  }
+
+  public void setMaxIncidentSearchGroups(final int maxIncidentSearchGroups) {
+    this.maxIncidentSearchGroups = maxIncidentSearchGroups;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -154,7 +154,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     assertThat(response).hasSize(1);
     final IncidentsByErrorMsgStatisticsDto incidentsByErrorStat = response.get(0);
     assertThat(incidentsByErrorStat.getErrorMessage()).isEqualTo(TestUtil.ERROR_MSG);
-    assertThat(incidentsByErrorStat.getProcesses()).hasSize(1);
+    assertThat(incidentsByErrorStat.getProcesses()).hasSize(2);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -22,6 +22,7 @@ import io.camunda.operate.entities.ProcessEntity;
 import io.camunda.operate.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceState;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
 import io.camunda.operate.util.SearchTestRule;
 import io.camunda.operate.util.TestUtil;
@@ -38,9 +39,12 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 public class IncidentStatisticsIT extends OperateAbstractIT {
 
@@ -58,10 +62,16 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
   private static final String QUERY_INCIDENTS_BY_ERROR_URL = INCIDENT_URL + "/byError";
   @Rule public SearchTestRule searchTestRule = new SearchTestRule();
   @MockBean private PermissionsService permissionsService;
-  private Random random = new Random();
+  @MockitoSpyBean private OperateProperties operateProperties;
+  private final Random random = new Random();
 
-  private String tenantId1 = "tenant1";
-  private String tenantId2 = "tenant2";
+  private final String tenantId1 = "tenant1";
+  private final String tenantId2 = "tenant2";
+
+  @After
+  public void resetMock() {
+    Mockito.reset(operateProperties);
+  }
 
   @Test
   public void testAbsentProcessDoesntThrowExceptions() throws Exception {
@@ -129,6 +139,22 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
                     && s.getTenantId().equals(tenantId1)
                     && s.getInstancesWithActiveIncidentsCount() == 1L
                     && (s.getVersion() == 1 || s.getVersion() == 2));
+  }
+
+  @Test
+  public void testIncidentStatisticsByErrorWithLimit() throws Exception {
+    // Given
+    when(operateProperties.getMaxIncidentSearchGroups()).thenReturn(1);
+    createData();
+
+    // When
+    final List<IncidentsByErrorMsgStatisticsDto> response = requestIncidentsByError();
+
+    // Then
+    assertThat(response).hasSize(1);
+    final IncidentsByErrorMsgStatisticsDto incidentsByErrorStat = response.get(0);
+    assertThat(incidentsByErrorStat.getErrorMessage()).isEqualTo(TestUtil.ERROR_MSG);
+    assertThat(incidentsByErrorStat.getProcesses()).hasSize(1);
   }
 
   @Test
@@ -344,7 +370,8 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
         .containsExactly(ORDER_BPMN_PROCESS_ID);
   }
 
-  private void assertNoInstancesProcess(IncidentByProcessStatisticsDto process, int version) {
+  private void assertNoInstancesProcess(
+      final IncidentByProcessStatisticsDto process, final int version) {
     assertThat(process.getVersion()).isEqualTo(version);
     assertThat(process.getActiveInstancesCount()).isEqualTo(0);
     assertThat(process.getInstancesWithActiveIncidentsCount()).isEqualTo(0);
@@ -353,7 +380,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     assertThat(process.getName()).isEqualTo(NO_INSTANCES_PROCESS_NAME + version);
   }
 
-  private void assertLoanProcess(IncidentsByProcessGroupStatisticsDto loanProcessGroup) {
+  private void assertLoanProcess(final IncidentsByProcessGroupStatisticsDto loanProcessGroup) {
     assertThat(loanProcessGroup.getBpmnProcessId()).isEqualTo(LOAN_BPMN_PROCESS_ID);
     assertThat(loanProcessGroup.getTenantId()).isEqualTo(tenantId1);
     assertThat(loanProcessGroup.getProcessName()).isEqualTo(LOAN_PROCESS_NAME + "1");
@@ -373,7 +400,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     assertThat(loanProcessProcessStatistic.getInstancesWithActiveIncidentsCount()).isEqualTo(0);
   }
 
-  private void assertOrderProcess(IncidentsByProcessGroupStatisticsDto orderProcessGroup) {
+  private void assertOrderProcess(final IncidentsByProcessGroupStatisticsDto orderProcessGroup) {
     // assert Order process group
     assertThat(orderProcessGroup.getBpmnProcessId()).isEqualTo(ORDER_BPMN_PROCESS_ID);
     assertThat(orderProcessGroup.getTenantId()).isEqualTo(tenantId2);
@@ -392,7 +419,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     assertThat(orderProcess.getInstancesWithActiveIncidentsCount()).isEqualTo(1);
   }
 
-  private void assertDemoProcess(IncidentsByProcessGroupStatisticsDto demoProcessGroup) {
+  private void assertDemoProcess(final IncidentsByProcessGroupStatisticsDto demoProcessGroup) {
     // assert Demo process group
     assertThat(demoProcessGroup.getBpmnProcessId()).isEqualTo(DEMO_BPMN_PROCESS_ID);
     assertThat(demoProcessGroup.getTenantId()).isEqualTo(tenantId1);
@@ -543,7 +570,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     searchTestRule.persistNew(entities.toArray(new OperateEntity[entities.size()]));
   }
 
-  private void createNoInstancesProcessData(int versionCount) {
+  private void createNoInstancesProcessData(final int versionCount) {
     createProcessVersions(
             NO_INSTANCES_PROCESS_ID, NO_INSTANCES_PROCESS_NAME, versionCount, tenantId2)
         .forEach(processVersion -> searchTestRule.persistNew(processVersion));
@@ -573,16 +600,16 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
 
   private List<OperateEntity> createIncidents(
       final ProcessInstanceForListViewEntity processInstance,
-      int activeIncidentsCount,
-      int resolvedIncidentsCount) {
+      final int activeIncidentsCount,
+      final int resolvedIncidentsCount) {
     return createIncidents(processInstance, activeIncidentsCount, resolvedIncidentsCount, false);
   }
 
   private List<OperateEntity> createIncidents(
       final ProcessInstanceForListViewEntity processInstance,
-      int activeIncidentsCount,
-      int resolvedIncidentsCount,
-      boolean withOtherMsg) {
+      final int activeIncidentsCount,
+      final int resolvedIncidentsCount,
+      final boolean withOtherMsg) {
     final List<OperateEntity> entities = new ArrayList<>();
     for (int i = 0; i < activeIncidentsCount; i++) {
       final FlowNodeInstanceForListViewEntity activityInstance =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
@@ -19,6 +19,7 @@ import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.entities.ProcessEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceState;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.ProcessIndex;
 import io.camunda.operate.schema.templates.IncidentTemplate;
 import io.camunda.operate.schema.templates.ListViewTemplate;
@@ -79,6 +80,8 @@ public class IncidentStatisticsReader extends AbstractReader
   @Autowired(required = false)
   private PermissionsService permissionsService;
 
+  @Autowired private OperateProperties operateProperties;
+
   @Override
   public Set<IncidentsByProcessGroupStatisticsDto> getProcessAndIncidentsStatistics() {
     final Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap =
@@ -91,6 +94,8 @@ public class IncidentStatisticsReader extends AbstractReader
     final Set<IncidentsByErrorMsgStatisticsDto> result =
         new TreeSet<>(IncidentsByErrorMsgStatisticsDto.COMPARATOR);
 
+    final int termsAggSize = operateProperties.getMaxIncidentSearchGroups();
+
     final Map<Long, ProcessEntity> processes =
         processReader.getProcessesWithFields(
             ProcessIndex.KEY,
@@ -102,7 +107,7 @@ public class IncidentStatisticsReader extends AbstractReader
     final TermsAggregationBuilder aggregation =
         terms(GROUP_BY_ERROR_MESSAGE_HASH)
             .field(IncidentTemplate.ERROR_MSG_HASH)
-            .size(ElasticsearchUtil.TERMS_AGG_SIZE)
+            .size(termsAggSize)
             .subAggregation(
                 topHits(ERROR_MESSAGE)
                     .size(1)
@@ -133,10 +138,10 @@ public class IncidentStatisticsReader extends AbstractReader
 
       final Terms errorMessageAggregation =
           searchResponse.getAggregations().get(GROUP_BY_ERROR_MESSAGE_HASH);
-      for (Bucket bucket : errorMessageAggregation.getBuckets()) {
+      for (final Bucket bucket : errorMessageAggregation.getBuckets()) {
         result.add(getIncidentsByErrorMsgStatistic(processes, bucket));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining incidents by error message: %s", e.getMessage());
@@ -162,7 +167,7 @@ public class IncidentStatisticsReader extends AbstractReader
 
       final List<? extends Bucket> buckets =
           ((Terms) searchResponse.getAggregations().get(PROCESS_KEYS)).getBuckets();
-      for (Bucket bucket : buckets) {
+      for (final Bucket bucket : buckets) {
         final Long processDefinitionKey = (Long) bucket.getKey();
         final long incidents = bucket.getDocCount();
         results.put(
@@ -170,7 +175,7 @@ public class IncidentStatisticsReader extends AbstractReader
             new IncidentByProcessStatisticsDto(processDefinitionKey.toString(), incidents, 0));
       }
       return results;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining incidents by process: %s", e.getMessage());
@@ -180,7 +185,7 @@ public class IncidentStatisticsReader extends AbstractReader
   }
 
   private Map<Long, IncidentByProcessStatisticsDto> updateActiveInstances(
-      Map<Long, IncidentByProcessStatisticsDto> statistics) {
+      final Map<Long, IncidentByProcessStatisticsDto> statistics) {
     final QueryBuilder runningInstanceQuery =
         joinWithAnd(
             termQuery(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE.toString()),
@@ -199,7 +204,7 @@ public class IncidentStatisticsReader extends AbstractReader
 
       final List<? extends Bucket> buckets =
           ((Terms) searchResponse.getAggregations().get(PROCESS_KEYS)).getBuckets();
-      for (Bucket bucket : buckets) {
+      for (final Bucket bucket : buckets) {
         final Long processDefinitionKey = (Long) bucket.getKey();
         final long runningCount = bucket.getDocCount();
         IncidentByProcessStatisticsDto statistic = results.get(processDefinitionKey);
@@ -213,7 +218,7 @@ public class IncidentStatisticsReader extends AbstractReader
         results.put(processDefinitionKey, statistic);
       }
       return results;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining active processes: %s", e.getMessage());
       LOGGER.error(message, e);
@@ -222,7 +227,7 @@ public class IncidentStatisticsReader extends AbstractReader
   }
 
   private Set<IncidentsByProcessGroupStatisticsDto> collectStatisticsForProcessGroups(
-      Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap) {
+      final Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap) {
 
     final Set<IncidentsByProcessGroupStatisticsDto> result =
         new TreeSet<>(IncidentsByProcessGroupStatisticsDto.COMPARATOR);
@@ -230,7 +235,7 @@ public class IncidentStatisticsReader extends AbstractReader
     final var processGroups = processReader.getProcessesGrouped(new ProcessRequestDto());
 
     // iterate over process groups (bpmnProcessId)
-    for (List<ProcessEntity> processes : processGroups.values()) {
+    for (final List<ProcessEntity> processes : processGroups.values()) {
       final IncidentsByProcessGroupStatisticsDto stat = new IncidentsByProcessGroupStatisticsDto();
       stat.setBpmnProcessId(processes.get(0).getBpmnProcessId());
       stat.setTenantId(processes.get(0).getTenantId());
@@ -243,7 +248,7 @@ public class IncidentStatisticsReader extends AbstractReader
       long maxVersion = 0;
 
       // iterate over process versions
-      for (ProcessEntity processEntity : processes) {
+      for (final ProcessEntity processEntity : processes) {
         IncidentByProcessStatisticsDto statForProcess =
             incidentsByProcessMap.get(processEntity.getKey());
         if (statForProcess != null) {
@@ -280,7 +285,7 @@ public class IncidentStatisticsReader extends AbstractReader
    *
    * @return query that matches the processes for which the user has the given permission
    */
-  private QueryBuilder createQueryForProcessesByPermission(IdentityPermission permission) {
+  private QueryBuilder createQueryForProcessesByPermission(final IdentityPermission permission) {
     final PermissionsService.ResourcesAllowed allowed =
         permissionsService.getProcessesWithPermission(permission);
     if (allowed == null) {
@@ -292,7 +297,7 @@ public class IncidentStatisticsReader extends AbstractReader
   }
 
   private IncidentsByErrorMsgStatisticsDto getIncidentsByErrorMsgStatistic(
-      Map<Long, ProcessEntity> processes, Bucket errorMessageBucket) {
+      final Map<Long, ProcessEntity> processes, final Bucket errorMessageBucket) {
     final SearchHits searchHits =
         ((TopHits) errorMessageBucket.getAggregations().get(ERROR_MESSAGE)).getHits();
     final SearchHit searchHit = searchHits.getHits()[0];
@@ -305,7 +310,7 @@ public class IncidentStatisticsReader extends AbstractReader
 
     final Terms processDefinitionKeyAggregation =
         (Terms) errorMessageBucket.getAggregations().get(GROUP_BY_PROCESS_KEYS);
-    for (Bucket processDefinitionKeyBucket : processDefinitionKeyAggregation.getBuckets()) {
+    for (final Bucket processDefinitionKeyBucket : processDefinitionKeyAggregation.getBuckets()) {
       final Long processDefinitionKey = (Long) processDefinitionKeyBucket.getKey();
       final long incidentsCount =
           ((Cardinality) processDefinitionKeyBucket.getAggregations().get(UNIQ_PROCESS_INSTANCES))

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -25,12 +25,14 @@ import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBu
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.entities.ProcessEntity;
 import io.camunda.operate.entities.listview.ProcessInstanceState;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.ProcessIndex;
 import io.camunda.operate.schema.templates.IncidentTemplate;
 import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.store.ProcessStore;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.ConversionUtils;
+import io.camunda.operate.util.ElasticsearchUtil;
 import io.camunda.operate.webapp.reader.IncidentStatisticsReader;
 import io.camunda.operate.webapp.reader.ProcessReader;
 import io.camunda.operate.webapp.rest.dto.ProcessRequestDto;
@@ -75,6 +77,8 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   @Autowired(required = false)
   private PermissionsService permissionsService;
 
+  @Autowired private OperateProperties operateProperties;
+
   @Override
   public Set<IncidentsByProcessGroupStatisticsDto> getProcessAndIncidentsStatistics() {
     final Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap =
@@ -86,6 +90,8 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   public Set<IncidentsByErrorMsgStatisticsDto> getIncidentStatisticsByError() {
     final Set<IncidentsByErrorMsgStatisticsDto> result =
         new TreeSet<>(IncidentsByErrorMsgStatisticsDto.COMPARATOR);
+
+    final int termsAggSize = operateProperties.getMaxIncidentSearchGroups();
 
     final Map<Long, ProcessEntity> processes =
         processReader.getProcessesWithFields(
@@ -105,11 +111,11 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
     final var groupByProcessKeys =
-        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, TERMS_AGG_SIZE);
+        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, ElasticsearchUtil.TERMS_AGG_SIZE);
     final var errorMessage =
         topHitsAggregation(List.of(IncidentTemplate.ERROR_MSG, IncidentTemplate.ERROR_MSG_HASH), 1);
     final var groupByErrorMessageHash =
-        termAggregation(IncidentTemplate.ERROR_MSG_HASH, TERMS_AGG_SIZE);
+        termAggregation(IncidentTemplate.ERROR_MSG_HASH, termsAggSize);
 
     final var searchRequestBuilder =
         searchRequestBuilder(incidentTemplate, ONLY_RUNTIME)
@@ -139,7 +145,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     return result;
   }
 
-  private List<LongTermsBucket> searchAggBuckets(Query query) {
+  private List<LongTermsBucket> searchAggBuckets(final Query query) {
     final var searchRequestBuilder =
         searchRequestBuilder(processInstanceTemplate, ONLY_RUNTIME)
             .query(withTenantCheck(query))
@@ -163,7 +169,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   }
 
   private Map<Long, IncidentByProcessStatisticsDto> updateActiveInstances(
-      Map<Long, IncidentByProcessStatisticsDto> statistics) {
+      final Map<Long, IncidentByProcessStatisticsDto> statistics) {
     final Map<Long, IncidentByProcessStatisticsDto> results = new HashMap<>(statistics);
     final Query query =
         withTenantCheck(
@@ -190,7 +196,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   }
 
   private Set<IncidentsByProcessGroupStatisticsDto> collectStatisticsForProcessGroups(
-      Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap) {
+      final Map<Long, IncidentByProcessStatisticsDto> incidentsByProcessMap) {
     final Set<IncidentsByProcessGroupStatisticsDto> result =
         new TreeSet<>(IncidentsByProcessGroupStatisticsDto.COMPARATOR);
 
@@ -198,7 +204,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
         processReader.getProcessesGrouped(new ProcessRequestDto());
 
     // iterate over process groups (bpmnProcessId)
-    for (List<ProcessEntity> processes : processGroups.values()) {
+    for (final List<ProcessEntity> processes : processGroups.values()) {
       final IncidentsByProcessGroupStatisticsDto stat = new IncidentsByProcessGroupStatisticsDto();
       stat.setBpmnProcessId(processes.get(0).getBpmnProcessId());
       stat.setTenantId(processes.get(0).getTenantId());
@@ -211,7 +217,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
       long maxVersion = 0;
 
       // iterate over process versions
-      for (ProcessEntity processEntity : processes) {
+      for (final ProcessEntity processEntity : processes) {
         IncidentByProcessStatisticsDto statForProcess =
             incidentsByProcessMap.get(processEntity.getKey());
         if (statForProcess != null) {
@@ -243,7 +249,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     return result;
   }
 
-  private Query createQueryForProcessesByPermission(IdentityPermission permission) {
+  private Query createQueryForProcessesByPermission(final IdentityPermission permission) {
     final PermissionsService.ResourcesAllowed allowed =
         permissionsService.getProcessesWithPermission(permission);
     if (allowed == null) {
@@ -255,7 +261,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
   }
 
   private IncidentsByErrorMsgStatisticsDto getIncidentsByErrorMsgStatistic(
-      Map<Long, ProcessEntity> processes, LongTermsBucket errorMessageBucket) {
+      final Map<Long, ProcessEntity> processes, final LongTermsBucket errorMessageBucket) {
     record ErrorMessage(String errorMessage, Integer errorMessageHash) {}
 
     final ErrorMessage errorMessage =

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -32,7 +32,6 @@ import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.store.ProcessStore;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.ConversionUtils;
-import io.camunda.operate.util.ElasticsearchUtil;
 import io.camunda.operate.webapp.reader.IncidentStatisticsReader;
 import io.camunda.operate.webapp.reader.ProcessReader;
 import io.camunda.operate.webapp.rest.dto.ProcessRequestDto;
@@ -111,7 +110,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
     final var groupByProcessKeys =
-        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, ElasticsearchUtil.TERMS_AGG_SIZE);
+        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, TERMS_AGG_SIZE);
     final var errorMessage =
         topHitsAggregation(List.of(IncidentTemplate.ERROR_MSG, IncidentTemplate.ERROR_MSG_HASH), 1);
     final var groupByErrorMessageHash =


### PR DESCRIPTION
# Description
Backport of #45022 to `stable/8.6`.

relates to #44596