### PR TITLE
fix: fix instance modification bug in undo operation

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
@@ -7,6 +7,7 @@
  */
 
 import {Form as ReactFinalForm} from 'react-final-form';
+import {useMemo} from 'react';
 import {type VariableFormValues} from 'modules/types/variables';
 
 import arrayMutators from 'final-form-arrays';
@@ -17,6 +18,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {queryKeys} from 'modules/queries/queryKeys';
 import {useElementInstanceVariables} from 'modules/mutations/elementInstances/useElementInstanceVariables';
 import {handleMutationError} from 'modules/utils/notifications';
+import {modificationsStore} from 'modules/stores/modifications';
 
 type Props = {
   scopeKey: string;
@@ -30,6 +32,20 @@ const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
     processInstanceId,
   );
 
+  const initialValues = useMemo<Partial<VariableFormValues> | undefined>(() => {
+    if (!modificationsStore.isModificationModeEnabled) {
+      return undefined;
+    }
+    const addVariableModifications =
+      modificationsStore.getAddVariableModifications(scopeKey);
+    if (addVariableModifications.length === 0) {
+      return undefined;
+    }
+    return {
+      newVariables: addVariableModifications,
+    } as Partial<VariableFormValues>;
+  }, [scopeKey]);
+
   return (
     <ReactFinalForm<VariableFormValues>
       mutators={{
@@ -41,6 +57,7 @@ const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
         },
       }}
       key={scopeKey}
+      initialValues={initialValues}
       render={(props) => <VariablesForm {...props} />}
       onSubmit={async (values, form) => {
         const {initialValues} = form.getState();

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesFinalForm.tsx
@@ -32,18 +32,18 @@ const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
     processInstanceId,
   );
 
-  const initialValues = useMemo<Partial<VariableFormValues> | undefined>(() => {
+  const initialValues = useMemo(() => {
     if (!modificationsStore.isModificationModeEnabled) {
-      return undefined;
+      return {};
     }
     const addVariableModifications =
       modificationsStore.getAddVariableModifications(scopeKey);
     if (addVariableModifications.length === 0) {
-      return undefined;
+      return {};
     }
     return {
       newVariables: addVariableModifications,
-    } as Partial<VariableFormValues>;
+    };
   }, [scopeKey]);
 
   return (

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
@@ -14,7 +14,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -124,7 +124,7 @@ describe.skip('VariablePanel', () => {
     );
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {totalItems: 1},
     });
 
@@ -138,13 +138,13 @@ describe.skip('VariablePanel', () => {
 
   it('should display correct state for a flow node that has only one running token on it', async () => {
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -337,13 +337,13 @@ describe.skip('VariablePanel', () => {
 
   it('should display correct state for a flow node that has no running or finished tokens on it', async () => {
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -562,19 +562,19 @@ describe.skip('VariablePanel', () => {
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -19,7 +19,7 @@ import {LastModification} from 'App/ProcessInstance/LastModification';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import {createInstance, createvariable} from 'modules/testUtils';
+import {createInstance, createVariable} from 'modules/testUtils';
 import {
   modificationsStore,
   type FlowNodeModification,
@@ -155,7 +155,7 @@ describe.skip('New Variable Modifications', () => {
       items: statisticsData,
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -249,19 +249,19 @@ describe.skip('New Variable Modifications', () => {
     );
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -656,7 +656,7 @@ describe.skip('New Variable Modifications', () => {
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/editVariable.test.tsx
@@ -19,7 +19,7 @@ import {
   mockProcessInstance,
   mockProcessInstanceDeprecated,
 } from './mocks';
-import {createInstance, createvariable} from 'modules/testUtils';
+import {createInstance, createVariable} from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
 import {notificationsStore} from 'modules/stores/notifications';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -58,12 +58,12 @@ describe('Edit variable', () => {
 
     const mockVariables = {
       items: [
-        createvariable({
+        createVariable({
           name: 'firstVariable',
           value: '"initial-value"',
           isTruncated: false,
         }),
-        createvariable({
+        createVariable({
           name: 'secondVariable',
           value: '"another-value"',
           isTruncated: false,
@@ -300,12 +300,12 @@ describe('Edit variable', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           name: 'clientNo',
           value: '"value-preview"',
           isTruncated: true,
         }),
-        createvariable({
+        createVariable({
           name: 'mwst',
           value: '"124.26"',
         }),
@@ -316,12 +316,12 @@ describe('Edit variable', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           name: 'clientNo',
           value: '"value-preview"',
           isTruncated: true,
         }),
-        createvariable({
+        createVariable({
           name: 'mwst',
           value: '"124.26"',
         }),
@@ -344,7 +344,7 @@ describe('Edit variable', () => {
     });
 
     mockGetVariable().withSuccess(
-      createvariable({
+      createVariable({
         name: 'clientNo',
         value: '"full-value"',
         isTruncated: false,
@@ -378,7 +378,7 @@ describe('Edit variable', () => {
   it('should display notification if error occurs when getting single variable details', async () => {
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '"value-preview"',
           isTruncated: true,
         }),
@@ -389,7 +389,7 @@ describe('Edit variable', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '"value-preview"',
           isTruncated: true,
         }),
@@ -439,7 +439,7 @@ describe('Edit variable', () => {
   it('should not get variable details on edit button click if the variables value was not a preview', async () => {
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '"full-value"',
           isTruncated: false,
         }),
@@ -450,7 +450,7 @@ describe('Edit variable', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '"full-value"',
           isTruncated: false,
         }),
@@ -503,7 +503,7 @@ describe('Edit variable', () => {
 
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '123',
           isTruncated: true,
         }),
@@ -514,7 +514,7 @@ describe('Edit variable', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '123',
           isTruncated: true,
         }),
@@ -524,7 +524,7 @@ describe('Edit variable', () => {
       },
     });
     mockGetVariable().withSuccess(
-      createvariable({
+      createVariable({
         value: '123456',
         isTruncated: false,
       }),
@@ -569,7 +569,7 @@ describe('Edit variable', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '123',
           isTruncated: true,
         }),
@@ -580,7 +580,7 @@ describe('Edit variable', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({
+        createVariable({
           value: '123',
           isTruncated: true,
         }),
@@ -590,7 +590,7 @@ describe('Edit variable', () => {
       },
     });
     mockGetVariable().withSuccess(
-      createvariable({
+      createVariable({
         value: '123456',
         isTruncated: false,
       }),
@@ -624,7 +624,7 @@ describe('Edit variable', () => {
     });
 
     mockGetVariable().withSuccess(
-      createvariable({
+      createVariable({
         value: '123456',
         isTruncated: false,
       }),
@@ -645,13 +645,13 @@ describe('Edit variable', () => {
     processInstanceDetailsStore.setProcessInstance(instanceMock);
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -697,15 +697,15 @@ describe('Edit variable', () => {
 
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({name: 'a.b', value: '"old"', isTruncated: false}),
-        createvariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
       ],
       page: {totalItems: 2},
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable({name: 'a.b', value: '"old"', isTruncated: false}),
-        createvariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b', value: '"old"', isTruncated: false}),
+        createVariable({name: 'a.b.c', value: '"old"', isTruncated: false}),
       ],
       page: {totalItems: 2},
     });
@@ -752,7 +752,7 @@ describe('Edit variable', () => {
     });
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -20,7 +20,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -136,7 +136,7 @@ describe('VariablePanel', () => {
     });
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -163,7 +163,7 @@ describe('VariablePanel', () => {
 
   it('should render variables', async () => {
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -232,8 +232,8 @@ describe('VariablePanel', () => {
 
     mockSearchVariables().withSuccess({
       items: [
-        createvariable(),
-        createvariable({
+        createVariable(),
+        createVariable({
           variableKey: '2251799813725337-foo',
           name: 'foo',
           value: '"bar"',
@@ -243,8 +243,8 @@ describe('VariablePanel', () => {
     });
     mockSearchVariables().withSuccess({
       items: [
-        createvariable(),
-        createvariable({
+        createVariable(),
+        createVariable({
           variableKey: '2251799813725337-foo',
           name: 'foo',
           value: '"bar"',
@@ -396,7 +396,7 @@ describe('VariablePanel', () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {totalItems: 1},
     });
 
@@ -469,7 +469,7 @@ describe('VariablePanel', () => {
   it.skip('should select correct tab when navigating between flow nodes', async () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {totalItems: 1},
     });
 
@@ -483,7 +483,7 @@ describe('VariablePanel', () => {
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockSearchVariables().withSuccess({
-      items: [createvariable({name: 'test2'})],
+      items: [createVariable({name: 'test2'})],
       page: {totalItems: 1},
     });
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
@@ -503,7 +503,7 @@ describe('VariablePanel', () => {
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockSearchVariables().withSuccess({
-      items: [createvariable({name: 'test2'})],
+      items: [createVariable({name: 'test2'})],
       page: {totalItems: 1},
     });
     mockFetchProcessDefinitionXml().withSuccess('');
@@ -523,7 +523,7 @@ describe('VariablePanel', () => {
     expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
 
     mockSearchVariables().withSuccess({
-      items: [createvariable({name: 'test2'})],
+      items: [createVariable({name: 'test2'})],
       page: {totalItems: 1},
     });
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/notification.test.tsx
@@ -14,7 +14,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -125,7 +125,7 @@ describe.skip('VariablePanel', () => {
       items: statistics,
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
@@ -14,7 +14,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -120,13 +120,13 @@ describe.skip('VariablePanel', () => {
     });
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
@@ -14,7 +14,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
   searchResult,
 } from 'modules/testUtils';
@@ -128,7 +128,7 @@ describe('VariablePanel', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
-    mockSearchVariables().withSuccess(searchResult([createvariable()]));
+    mockSearchVariables().withSuccess(searchResult([createVariable()]));
 
     mockFetchFlowNodeMetadata().withSuccess({
       ...singleInstanceMetadata,
@@ -162,7 +162,7 @@ describe('VariablePanel', () => {
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
-    mockSearchVariables().withSuccess(searchResult([createvariable()]));
+    mockSearchVariables().withSuccess(searchResult([createVariable()]));
 
     mockFetchFlowNodeMetadata().withSuccess({
       ...singleInstanceMetadata,
@@ -217,7 +217,7 @@ describe('VariablePanel', () => {
       await screen.findByText('The Flow Node has no Variables'),
     ).toBeInTheDocument();
 
-    mockSearchVariables().withSuccess(searchResult([createvariable()]));
+    mockSearchVariables().withSuccess(searchResult([createVariable()]));
     mockSearchJobs().withSuccess(searchResult([]));
 
     act(() => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
@@ -19,7 +19,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {
   createInstance,
-  createvariable,
+  createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -151,7 +151,7 @@ describe.skip('VariablePanel spinner', () => {
 
   it('should display spinner for variables tab when switching between tabs', async () => {
     mockSearchVariables().withDelay({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -167,7 +167,7 @@ describe.skip('VariablePanel spinner', () => {
 
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withDelay({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -193,11 +193,11 @@ describe.skip('VariablePanel spinner', () => {
   it('should display spinner on second variable fetch', async () => {
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchVariables().withDelay({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {totalItems: 1},
     });
     mockSearchVariables().withDelay({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {totalItems: 1},
     });
     render(<VariablePanel setListenerTabVisibility={vi.fn()} />, {
@@ -224,13 +224,13 @@ describe.skip('VariablePanel spinner', () => {
   it('should not display spinner for variables tab when switching between tabs if scope does not exist', async () => {
     modificationsStore.enableModificationMode();
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
@@ -1,0 +1,370 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor, type UserEvent} from 'modules/testing-library';
+
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {createInstance, createvariable} from 'modules/testUtils';
+import {
+  modificationsStore,
+  type FlowNodeModification,
+} from 'modules/stores/modifications';
+import {singleInstanceMetadata} from 'modules/mocks/metadata';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {useEffect, act} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {selectFlowNode} from 'modules/utils/flowNodeSelection';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
+import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
+
+const INITIAL_ADD_MODIFICATION: FlowNodeModification = {
+  type: 'token',
+  payload: {
+    affectedTokenCount: 1,
+    flowNode: {
+      id: 'flow_node_0',
+      name: 'flow node 0',
+    },
+    operation: 'ADD_TOKEN',
+    parentScopeIds: {},
+    scopeId: 'random-scope-id-0',
+    visibleAffectedTokenCount: 1,
+  },
+};
+
+const editExistingVariableValue = async (
+  user: UserEvent,
+  variableName: string,
+  newValue: string,
+) => {
+  const variableRow = screen.getByTestId(`variable-${variableName}`);
+  const valueField = variableRow.querySelector('input');
+
+  if (!valueField) {
+    throw new Error(`No value field found for variable ${variableName}`);
+  }
+
+  await user.click(valueField);
+  await user.keyboard('{Control>}a{/Control}');
+  await user.keyboard('{Backspace}');
+  await user.type(valueField, newValue);
+  await user.tab();
+};
+
+const editLastNewVariableName = async (user: UserEvent, value: string) => {
+  const nameField = screen.getAllByTestId('new-variable-name').at(-1);
+
+  if (!nameField) {
+    throw new Error('No name field found');
+  }
+
+  await user.click(nameField);
+  await user.type(nameField, value);
+  await user.tab();
+};
+
+const editLastNewVariableValue = async (user: UserEvent, value: string) => {
+  const valueField = screen.getAllByTestId('new-variable-value').at(-1);
+
+  if (!valueField) {
+    throw new Error('No value field found');
+  }
+
+  await user.click(valueField);
+  await user.type(valueField, value);
+  await user.tab();
+};
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        flowNodeSelectionStore.reset();
+        flowNodeMetaDataStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('Undo variable modifications from different scope', () => {
+  const mockProcessInstance: ProcessInstance = {
+    processInstanceKey: 'instance_id',
+    state: 'ACTIVE',
+    startDate: '2018-06-21',
+    processDefinitionKey: '2',
+    processDefinitionVersion: 1,
+    processDefinitionId: 'someKey',
+    tenantId: '<default>',
+    processDefinitionName: 'someProcessName',
+    hasIncident: false,
+  };
+  const mockProcessInstanceDeprecated = createInstance({id: 'instance_id'});
+
+  beforeEach(async () => {
+    const statisticsData = [
+      {
+        elementId: 'TEST_FLOW_NODE',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statisticsData,
+    });
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+
+    flowNodeSelectionStore.init();
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+  });
+
+  describe('Scenario 1: Editing existing variables', () => {
+    it('should preserve earlier edit modifications after undoing from a different scope', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true});
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+      mockFetchProcessInstanceDeprecated().withSuccess(
+        mockProcessInstanceDeprecated,
+      );
+      mockFetchProcessInstanceDeprecated().withSuccess(
+        mockProcessInstanceDeprecated,
+      );
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+
+      mockSearchVariables().withSuccess({
+        items: [
+          createvariable({name: 'foo', value: '"bar"', isTruncated: false}),
+          createvariable({name: 'test', value: '123', isTruncated: false}),
+        ],
+        page: {totalItems: 2},
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('"bar"')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+      });
+
+      await editExistingVariableValue(user, 'foo', '1');
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+      });
+
+      await editExistingVariableValue(user, 'test', '2');
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+      });
+
+      await editExistingVariableValue(user, 'foo', '3');
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+      });
+
+      act(() => {
+        modificationsStore.removeLastModification();
+      });
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+      });
+
+      mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+      mockSearchVariables().withSuccess({
+        items: [],
+        page: {totalItems: 0},
+      });
+
+      act(() => {
+        selectFlowNode(
+          {flowNodeInstanceId: 'different_instance_id', isMultiInstance: false},
+          {
+            flowNodeInstanceId: 'different_instance_id',
+            isMultiInstance: false,
+          },
+        );
+      });
+
+      act(() => {
+        modificationsStore.removeLastModification();
+      });
+
+      mockSearchVariables().withSuccess({
+        items: [
+          createvariable({name: 'foo', value: '"bar"', isTruncated: false}),
+          createvariable({name: 'test', value: '123', isTruncated: false}),
+        ],
+        page: {totalItems: 2},
+      });
+
+      act(() => {
+        selectFlowNode(
+          {flowNodeInstanceId: 'instance_id', isMultiInstance: false},
+          {
+            flowNodeInstanceId: 'instance_id',
+            isMultiInstance: false,
+          },
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+      });
+
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('Scenario 2: Adding new variables', () => {
+    it('should preserve earlier added variable modifications after undoing from a different scope', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true});
+      modificationsStore.enableModificationMode();
+      modificationsStore.addModification(INITIAL_ADD_MODIFICATION);
+
+      mockFetchProcessInstanceDeprecated().withSuccess(
+        mockProcessInstanceDeprecated,
+      );
+      mockFetchProcessInstanceDeprecated().withSuccess(
+        mockProcessInstanceDeprecated,
+      );
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+      mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
+
+      mockSearchVariables().withSuccess({
+        items: [],
+        page: {totalItems: 0},
+      });
+
+      const {user} = render(
+        <VariablePanel setListenerTabVisibility={vi.fn()} />,
+        {wrapper: getWrapper()},
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {name: /add variable/i}),
+        ).toBeEnabled();
+      });
+
+      await user.click(screen.getByRole('button', {name: /add variable/i}));
+      expect(
+        await screen.findByTestId('new-variable-name'),
+      ).toBeInTheDocument();
+      await editLastNewVariableName(user, 'test2');
+      await editLastNewVariableValue(user, '1');
+
+      expect(screen.getByDisplayValue('test2')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: /add variable/i}));
+      await waitFor(() => {
+        expect(screen.getAllByTestId('new-variable-name')).toHaveLength(2);
+      });
+      await editLastNewVariableName(user, 'test3');
+      await editLastNewVariableValue(user, '2');
+
+      expect(screen.getByDisplayValue('test3')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+
+      mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+      mockSearchVariables().withSuccess({
+        items: [],
+        page: {totalItems: 0},
+      });
+
+      act(() => {
+        selectFlowNode(
+          {flowNodeInstanceId: 'different_instance_id', isMultiInstance: false},
+          {
+            flowNodeInstanceId: 'different_instance_id',
+            isMultiInstance: false,
+          },
+        );
+      });
+
+      act(() => {
+        modificationsStore.removeLastModification();
+      });
+
+      mockSearchVariables().withSuccess({
+        items: [],
+        page: {totalItems: 0},
+      });
+
+      act(() => {
+        selectFlowNode(
+          {flowNodeInstanceId: 'instance_id', isMultiInstance: false},
+          {
+            flowNodeInstanceId: 'instance_id',
+            isMultiInstance: false,
+          },
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('test2')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByDisplayValue('test3')).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue('2')).not.toBeInTheDocument();
+
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    });
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/undoFromDifferentScope.test.tsx
@@ -9,7 +9,7 @@
 import {VariablePanel} from '../index';
 import {render, screen, waitFor, type UserEvent} from 'modules/testing-library';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
-import {createvariable} from 'modules/testUtils';
+import {createVariable} from 'modules/testUtils';
 import {
   modificationsStore,
   type FlowNodeModification,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -124,8 +124,21 @@ const ExistingVariableValue: React.FC<Props> = observer(
 
     const isValid = !validating && valid;
 
-    const getInitialValue = (variable?: Variable) =>
-      variable?.value ?? variableValue;
+    const pendingEditModification =
+      isModificationModeEnabled && variableScopeKey !== null
+        ? modificationsStore.getLastVariableModification(
+            variableScopeKey,
+            variableName,
+            'EDIT_VARIABLE',
+          )
+        : undefined;
+
+    const getInitialValue = (variable?: Variable) => {
+      if (pendingEditModification !== undefined) {
+        return pendingEditModification.newValue;
+      }
+      return variable?.value ?? variableValue;
+    };
 
     const isVariableValueUndefined = variable?.value === undefined;
     const pauseValidation = isPreview && isVariableValueUndefined;

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/Footer/CopyVariablesButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/Footer/CopyVariablesButton.test.tsx
@@ -8,7 +8,7 @@
 
 import {CopyVariablesButton} from './CopyVariablesButton';
 import {render, screen, waitFor} from 'modules/testing-library';
-import {createvariable, createProcessInstance} from 'modules/testUtils';
+import {createVariable, createProcessInstance} from 'modules/testUtils';
 import type {QueryVariablesResponseBody} from '@camunda/camunda-api-zod-schemas/8.8';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
@@ -72,7 +72,7 @@ describe('CopyVariableButton', () => {
 
   it('should be disabled (too many variables)', () => {
     const variables = [...Array(50)].map((_, i) =>
-      createvariable({
+      createVariable({
         name: i.toString(),
         value: 'value',
       }),
@@ -111,7 +111,7 @@ describe('CopyVariableButton', () => {
 
   it('should be disabled (truncated values)', () => {
     const response: QueryVariablesResponseBody = {
-      items: [createvariable({isTruncated: true})],
+      items: [createVariable({isTruncated: true})],
       page: {
         totalItems: 1,
       },
@@ -144,15 +144,15 @@ describe('CopyVariableButton', () => {
   it('should copy variables to clipboard', async () => {
     const response: QueryVariablesResponseBody = {
       items: [
-        createvariable({
+        createVariable({
           name: 'jsonVariable',
           value: JSON.stringify({a: 123, b: [1, 2, 3], c: 'text'}),
         }),
-        createvariable({
+        createVariable({
           name: 'numberVariable',
           value: '666',
         }),
-        createvariable({
+        createVariable({
           name: 'stringVariable',
           value: '"text"',
         }),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ViewFullVariableButton/index.test.tsx
@@ -15,7 +15,7 @@ import {ViewFullVariableButton} from './index';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
-import {createvariable} from 'modules/testUtils';
+import {createVariable} from 'modules/testUtils';
 
 const createWrapper = () => {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
@@ -33,7 +33,7 @@ describe('<ViewFullVariableButton />', () => {
     const mockVariableValue = '{"foo": "bar", "test": 123}';
 
     mockGetVariable().withSuccess(
-      createvariable({
+      createVariable({
         variableKey: mockVariableKey,
         name: mockVariableName,
         value: mockVariableValue,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/createVariableFieldName.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const createVariableFieldName = (name: string) => {
+const createVariableFieldName = (name: string): `#${string}` => {
   return `#${encodeURIComponent(name).replace(/\./g, '%2E')}`;
 };
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/validators.test.ts
@@ -18,7 +18,7 @@ import {
   validateValueValid,
 } from './validators';
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.8';
-import {createvariable} from 'modules/testUtils';
+import {createVariable} from 'modules/testUtils';
 
 const MOCK_FIELD_META_STATE = {
   blur: vi.fn(),
@@ -29,12 +29,12 @@ const MOCK_FIELD_META_STATE = {
 
 describe('validators with allVariables', () => {
   const allVariables: Variable[] = [
-    createvariable({
+    createVariable({
       variableKey: '1',
       name: 'existingName1',
       value: 'value1',
     }),
-    createvariable({
+    createVariable({
       variableKey: '2',
       name: 'existingName2',
       value: 'value2',

--- a/operate/client/src/App/ProcessInstance/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/index.test.tsx
@@ -15,7 +15,7 @@ import {getProcessName} from 'modules/utils/instance';
 import {getWrapper, mockRequests} from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
-import {createvariable} from 'modules/testUtils';
+import {createVariable} from 'modules/testUtils';
 
 vi.mock('modules/utils/bpmn');
 
@@ -27,7 +27,7 @@ describe('ProcessInstance', () => {
   it('should render and set the page title', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -8,7 +8,7 @@
 
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {testData} from './index.setup';
-import {createUser, createvariable} from 'modules/testUtils';
+import {createUser, createVariable} from 'modules/testUtils';
 import {createMemoryRouter, RouterProvider} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {LocationLog} from 'modules/utils/LocationLog';
@@ -107,7 +107,7 @@ const mockRequests = () => {
     ],
   });
   mockSearchVariables().withSuccess({
-    items: [createvariable()],
+    items: [createVariable()],
     page: {
       totalItems: 1,
     },

--- a/operate/client/src/App/ProcessInstance/tests/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/modifications.test.tsx
@@ -14,7 +14,7 @@ import {
   fireEvent,
 } from 'modules/testing-library';
 import {ProcessInstance} from '../index';
-import {createUser, createvariable} from 'modules/testUtils';
+import {createUser, createVariable} from 'modules/testUtils';
 import {storeStateLocally} from 'modules/utils/localStorage';
 import {singleInstanceMetadata} from 'modules/mocks/metadata';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
@@ -172,13 +172,13 @@ describe('ProcessInstance - modification mode', () => {
   // TODO: fix test with #45539
   it.skip('should display summary modifications modal when apply modifications is clicked during the modification mode', async () => {
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
     });
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -210,7 +210,7 @@ describe('ProcessInstance - modification mode', () => {
     await user.click(screen.getByRole('button', {name: 'Select flow node'}));
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },
@@ -223,7 +223,7 @@ describe('ProcessInstance - modification mode', () => {
     );
 
     mockSearchVariables().withSuccess({
-      items: [createvariable()],
+      items: [createVariable()],
       page: {
         totalItems: 1,
       },

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -168,7 +168,7 @@ const createProcessDefinition = (
   };
 };
 
-const createvariable = (options: Partial<Variable> = {}): Variable => {
+const createVariable = (options: Partial<Variable> = {}): Variable => {
   const name = options.name ?? 'testVariableName';
   return {
     variableKey: `2251799813725337-${name}`,
@@ -1027,7 +1027,7 @@ export {
   multiInstanceProcess,
   eventSubProcess,
   mockProcessInstancesV2,
-  createvariable,
+  createVariable,
   createBatchOperation,
   createUser,
   createProcessInstance,

--- a/operate/client/src/modules/types/variables.ts
+++ b/operate/client/src/modules/types/variables.ts
@@ -7,9 +7,10 @@
  */
 
 type VariableFormValues = {
-  [key: string]: string;
-} & {
+  name: string;
+  value: string;
   newVariables?: {id: string; name: string; value: string}[];
+  [key: `#${string}`]: string;
 };
 
 export type {VariableFormValues};


### PR DESCRIPTION
## Description

### Issue

In Operate's process instance modification mode, when a user undoes a variable modification while viewing a different flow node scope, then navigates back to the original scope, the variable displays an incorrect value. The undo operation correctly removes the last modification from the store, but earlier modifications for the same variable are also visually lost.

### Solution

The fix ensures that when navigating between scopes in modification mode, the variable form properly initializes its values from the modifications store rather than solely from the API response.

### Technical Details

**Root Cause**: When undoing a modification while viewing a different scope, the OnLastVariableModificationRemoved reaction fires but returns early (since scopes don't match). This is correct behavior—the modification is properly removed from the store. However, when the user navigates back to the original scope, the form remounts and initializes field values from the API response, ignoring any remaining modifications in the store.

#### Fix Applied:

- `ExistingVariableValue.tsx`: Added a lookup for pending EDIT_VARIABLE modifications when computing the field's initial value. If a modification exists in the store for the current scope and variable, that value is used; otherwise, the API value is used. The lookup is performed at the component level to ensure proper MobX dependency tracking.
- `VariablesFinalForm.tsx`: Added initialization of newVariables from the store using useMemo. When the form mounts in modification mode, it checks for ADD_VARIABLE modifications for the current scope and uses them as initial values.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/42546
