### PR TITLE
Improve dry run for stable branches

### DIFF
--- a/.github/workflows/camunda-platform-release-stable-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-stable-dry-run.yml
@@ -1,8 +1,7 @@
 # type: Release
 # owner: @camunda/monorepo-devops-team
 ---
-# NOTE: This workflow is not just for Zeebe, but also for 8.6+ monorepo release!
-name: Zeebe Release Dry Run from stable branches
+name: Camunda Platform Release Dry Run from stable branches
 
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -5,25 +5,36 @@
 name: Zeebe Release Dry Run from stable branches
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      releaseBranch88:
+        description: 'Specifies the branch for 8.8 release dry run'
+        default: 'stable/8.8'
+        required: false
+        type: string
+      includeOptimize88:
+        description: 'Whether to include Optimize in the 8.8 dry run. Defaults to true.'
+        type: boolean
+        default: true
   schedule:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
 jobs:
   dry-run-release-88:
-    name: "Release from stable/8.8"
+    name: "Release from ${{ inputs.releaseBranch88 || 'stable/8.8' }}"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.8
     secrets: inherit
     strategy:
       fail-fast: false
     with:
-      releaseBranch: stable/8.8
+      releaseBranch: ${{ inputs.releaseBranch88 || 'stable/8.8' }}
       # Uses fake tag for dry run testing without affecting real releases
       releaseVersion: 0.0.0-dryrun-88
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
+      includeOptimize: ${{ github.event_name == 'schedule' || inputs.includeOptimize88 || true }}
   dry-run-release-87:
     name: "Release from stable/8.7"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7


### PR DESCRIPTION
## Description

This pull request updates the release dry run workflow for Camunda Platform, renaming the workflow file and enhancing its configurability for the 8.8 release. The changes primarily focus on improving flexibility for triggering dry runs and including Optimize as an option.

Workflow enhancements for configurability:

* Introduced workflow dispatch inputs `releaseBranch88` and `includeOptimize88` to allow specifying the branch and whether to include Optimize in the 8.8 dry run, making the workflow more flexible for manual runs.
* Updated job naming and parameters to use the provided input values, ensuring the dry run can be customized per invocation.
* Required to properly test this configurations: https://github.com/camunda/camunda/pull/45437
* Also related to https://github.com/camunda/camunda/issues/40184?reload=1

File and naming updates:

* Renamed `.github/workflows/zeebe-release-stable-dry-run.yml` to `.github/workflows/camunda-platform-release-stable-dry-run.yml` and changed the workflow name to "Camunda Platform Release Dry Run from stable branches" to better reflect its scope.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
