### PR TITLE
test: retention acceptance stabilization

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -149,13 +149,11 @@ public interface BackupActuator {
     public Exception decode(final String methodKey, final Response response) {
       if (response.status() == 500) {
         try {
-          final var payload = (Payload) decoder.decode(response, Payload.class);
+          final var body = response.body().asInputStream().readAllBytes();
+          final var bufferedResponse = response.toBuilder().body(body).build();
+          final var payload = (Payload) decoder.decode(bufferedResponse, Payload.class);
           return new ErrorResponse(
-              payload.failure(),
-              response.request(),
-              response.body().asInputStream().readAllBytes(),
-              response.headers(),
-              payload);
+              payload.failure(), response.request(), body, response.headers(), payload);
         } catch (final IOException e) {
           throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Stabilize backup store retention acceptance scenario:
- Use `BackupActuator.state()` instead of `.list()` to retrieve latest backup when awaiting. Using `list()` can have mismatch in eTag hashes that result in 404 errors
- Separate the scheduled backup creation and retention execution with a cluster restart. Expected state is defined better
- Fix an issue in the `BackupActuator` error decoder, where the response stream was consumed twice

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
