### PR TITLE
feat: add agent to RecordMetadata

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.zeebe;
 
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -103,6 +104,11 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
   @Override
   public Map<String, Object> getAuthorizations() {
     return authorizations;
+  }
+
+  @Override
+  public Agent getAgent() {
+    return null;
   }
 
   @Override

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -94,6 +95,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public Agent getAgent() {
+    return null;
+  }
+
+  @Override
   public int getRecordVersion() {
     return 1;
   }
@@ -124,6 +130,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public AuthInfo getAuthInfo() {
+    return null;
+  }
+
+  @Override
   public int getRequestStreamId() {
     return requestStreamId;
   }
@@ -136,10 +147,5 @@ record MockTypedCheckpointRecord(
   @Override
   public int getLength() {
     return 0;
-  }
-
-  @Override
-  public AuthInfo getAuthInfo() {
-    return null;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.incident;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -98,6 +99,11 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   }
 
   @Override
+  public Agent getAgent() {
+    return null;
+  }
+
+  @Override
   public int getRecordVersion() {
     return 1;
   }
@@ -133,6 +139,11 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   }
 
   @Override
+  public AuthInfo getAuthInfo() {
+    return null;
+  }
+
+  @Override
   public int getRequestStreamId() {
     return RecordMetadataEncoder.requestStreamIdNullValue();
   }
@@ -145,10 +156,5 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   @Override
   public int getLength() {
     return 0;
-  }
-
-  @Override
-  public AuthInfo getAuthInfo() {
-    return null;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -47,6 +48,15 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
     return value;
   }
 
+  public void setValue(final T value) {
+    this.value = value;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
+  }
+
   @Override
   public int getRequestStreamId() {
     return metadata.getRequestStreamId();
@@ -60,10 +70,6 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public int getLength() {
     return metadata.getLength() + value.getLength();
-  }
-
-  public void setValue(final T value) {
-    this.value = value;
   }
 
   public void setMetadata(final RecordMetadata metadata) {
@@ -121,6 +127,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
+  public Agent getAgent() {
+    return metadata.getAgent();
+  }
+
+  @Override
   public int getRecordVersion() {
     return metadata.getRecordVersion();
   }
@@ -148,10 +159,5 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("not yet implemented");
-  }
-
-  @Override
-  public AuthInfo getAuthInfo() {
-    return metadata.getAuthorization();
   }
 }

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -233,6 +234,11 @@ public final class ExporterTest {
     @Override
     public Map<String, Object> getAuthorizations() {
       return Map.of();
+    }
+
+    @Override
+    public Agent getAgent() {
+      return null;
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.protocol;
 
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -69,6 +70,11 @@ public record TestRecord(long position, ValueType valueType) implements Record<T
   @Override
   public Map<String, Object> getAuthorizations() {
     return Map.of();
+  }
+
+  @Override
+  public Agent getAgent() {
+    return null;
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -53,6 +53,19 @@
         },
         "batchOperationReference": {
           "type": "long"
+        },
+        "agent": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "long",
+              "index": false
+            },
+            "name": {
+              "type": "keyword",
+              "index": false
+            }
+          }
         }
       }
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -53,6 +53,19 @@
         },
         "batchOperationReference": {
           "type": "long"
+        },
+        "agent": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "long",
+              "index": false
+            },
+            "name": {
+              "type": "keyword",
+              "index": false
+            }
+          }
         }
       }
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AgentInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AgentInfo.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** */
+public class AgentInfo extends UnpackedObject implements Agent {
+
+  private final LongProperty idProp = new LongProperty("id", -1L);
+  private final StringProperty nameProp = new StringProperty("name", "");
+
+  public AgentInfo() {
+    super(2);
+    declareProperty(idProp).declareProperty(nameProp);
+  }
+
+  @Override
+  public long getId() {
+    return idProp.getValue();
+  }
+
+  public AgentInfo setId(final long agentId) {
+    idProp.setValue(agentId);
+    return this;
+  }
+
+  @Override
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
+  }
+
+  public AgentInfo setName(final String agentName) {
+    nameProp.setValue(agentName);
+    return this;
+  }
+
+  @Override
+  public void reset() {
+    idProp.reset();
+    nameProp.setValue("");
+  }
+
+  @Override
+  @JsonIgnore
+  public int getEncodedLength() {
+    return super.getEncodedLength();
+  }
+
+  @Override
+  @JsonIgnore
+  public boolean isEmpty() {
+    return super.isEmpty();
+  }
+
+  @Override
+  @JsonIgnore
+  public int getLength() {
+    return super.getLength();
+  }
+
+  public DirectBuffer toDirectBuffer() {
+    final var bytes = new byte[getLength()];
+    final var buffer = new UnsafeBuffer(bytes);
+    write(buffer, 0);
+
+    return buffer;
+  }
+
+  public static AgentInfo of(final Agent agent) {
+    if (agent != null) {
+      return new AgentInfo().setId(agent.getId()).setName(agent.getName());
+    } else {
+      return null;
+    }
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.protocol.impl.record;
 
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -33,6 +35,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String rejectionReason;
   private final String brokerVersion;
   private final AuthInfo authorization;
+  private final Agent agent;
   private final int recordVersion;
   private final long operationReference;
   private final long batchOperationReference;
@@ -62,6 +65,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = metadata.getRecordVersion();
     operationReference = metadata.getOperationReference();
     batchOperationReference = metadata.getBatchOperationReference();
+    agent = AgentInfo.of(metadata.getAgent());
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -98,6 +102,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = copiedRecord.recordVersion;
     operationReference = copiedRecord.operationReference;
     batchOperationReference = copiedRecord.batchOperationReference;
+    agent = AgentInfo.of(copiedRecord.agent);
   }
 
   @Override
@@ -153,6 +158,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public Map<String, Object> getAuthorizations() {
     return authorization.toDecodedMap();
+  }
+
+  @Override
+  public Agent getAgent() {
+    return agent;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
@@ -50,6 +51,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final AuthInfo authorization = new AuthInfo();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
+  private Optional<AgentInfo> agent = Optional.empty();
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -117,6 +119,17 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     } else {
       decoder.skipAuthorization();
     }
+
+    final int agentLength = decoder.agentLength();
+    if (agentLength > 0) {
+      final var agentBuffer = new UnsafeBuffer();
+      decoder.wrapAgent(agentBuffer);
+      final var agentInfo = agent.orElseGet(AgentInfo::new);
+      agentInfo.wrap(agentBuffer);
+      agent = Optional.of(agentInfo);
+    } else {
+      decoder.skipAgent();
+    }
   }
 
   @Override
@@ -125,7 +138,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorization.getLength();
+        + authorization.getLength()
+        + RecordMetadataEncoder.agentHeaderLength()
+        + agent.map(AgentInfo::getLength).orElse(0);
   }
 
   @Override
@@ -163,6 +178,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
     encoder.putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+
+    agent.ifPresentOrElse(
+        a -> encoder.putAgent(a.toDirectBuffer(), 0, a.getLength()), () -> encoder.agent(""));
   }
 
   public long getRequestId() {
@@ -258,6 +276,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return authorization;
   }
 
+  public AgentInfo getAgent() {
+    return agent.orElse(null);
+  }
+
+  public RecordMetadata agent(final AgentInfo agent) {
+    this.agent = Optional.ofNullable(agent);
+    return this;
+  }
+
   public RecordMetadata brokerVersion(final VersionInfo brokerVersion) {
     this.brokerVersion = brokerVersion;
     return this;
@@ -305,6 +332,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
     authorization.reset();
+    agent = Optional.empty();
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -327,7 +355,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         brokerVersion,
         recordVersion,
         operationReference,
-        batchOperationReference);
+        batchOperationReference,
+        agent);
   }
 
   @Override
@@ -348,6 +377,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
         && authorization.equals(that.authorization)
+        && agent.equals(that.agent)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -384,6 +414,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (batchOperationReference != RecordMetadataEncoder.batchOperationReferenceNullValue()) {
       builder.append(", batchOperationReference=").append(batchOperationReference);
+    }
+    if (agent.isPresent()) {
+      builder.append(", agent=").append(agent);
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AgentInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AgentInfoTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class AgentInfoTest {
+
+  @Test
+  void shouldEncodeDecodeAgentInfo() {
+    // given
+    final AgentInfo info = new AgentInfo().setId(1234L).setName("foo");
+
+    // when
+    encodeDecode(info);
+
+    // then
+    assertThat(info.getId()).isEqualTo(1234L);
+    assertThat(info.getName()).isEqualTo("foo");
+  }
+
+  @Test
+  void shouldEncodeDecodeEmptyAgentInfo() {
+    // given
+    final AgentInfo info = new AgentInfo();
+
+    // when
+    encodeDecode(info);
+
+    // then
+    assertThat(info.getId()).isEqualTo(-1L);
+    assertThat(info.getName()).isEqualTo("");
+  }
+
+  private void encodeDecode(final AgentInfo info) {
+    // encode
+    final UnsafeBuffer buffer = new UnsafeBuffer(new byte[info.getLength()]);
+    info.write(buffer, 0);
+
+    // decode
+    info.reset();
+    info.wrap(buffer, 0, buffer.capacity());
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
@@ -187,6 +188,7 @@ final class JsonSerializableToJsonTest {
               final int requestStreamId = 1;
 
               final AuthInfo authInfo = new AuthInfo().setClaims(Map.of("foo", "bar"));
+              final AgentInfo agentInfo = new AgentInfo().setId(123L).setName("agent-name");
 
               recordMetadata
                   .intent(intent)
@@ -200,6 +202,7 @@ final class JsonSerializableToJsonTest {
                   .requestId(requestId)
                   .requestStreamId(requestStreamId)
                   .authorization(authInfo)
+                  .agent(agentInfo)
                   .operationReference(1234)
                   .batchOperationReference(5678);
 
@@ -247,6 +250,10 @@ final class JsonSerializableToJsonTest {
                   "brokerVersion": "1.2.3",
                   "authorizations": {
                     "foo" : "bar"
+                  },
+                  "agent": {
+                    "id": 123,
+                    "name": "agent-name"
                   },
                   "recordVersion": 10,
                   "operationReference": 1234,
@@ -315,6 +322,7 @@ final class JsonSerializableToJsonTest {
                   "rejectionReason": "",
                   "brokerVersion": "0.0.0",
                   "authorizations": {},
+                  "agent": null,
                   "recordVersion": 1,
                   "operationReference": -1,
                   "batchOperationReference": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/RecordMetadataTest.java
@@ -39,6 +39,7 @@ final class RecordMetadataTest {
     assertThat(metadata.getRejectionType()).isEqualTo(RejectionType.NULL_VAL);
     assertThat(metadata.getRejectionReason()).isEmpty();
     assertThat(metadata.getAuthorization()).isEqualTo(new AuthInfo());
+    assertThat(metadata.getAgent()).isNull();
     assertThat(metadata.getBrokerVersion()).isEqualTo(RecordMetadata.CURRENT_BROKER_VERSION);
     assertThat(metadata.getRecordVersion()).isEqualTo(RecordMetadata.DEFAULT_RECORD_VERSION);
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CopiedRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CopiedRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record;
 
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -33,6 +34,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String rejectionReason;
   private final String brokerVersion;
   private final AuthInfo authorization;
+  private final Agent agent;
   private final int recordVersion;
   private final long operationReference;
   private final long batchOperationReference;
@@ -62,6 +64,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = metadata.getRecordVersion();
     operationReference = metadata.getOperationReference();
     batchOperationReference = metadata.getBatchOperationReference();
+    agent = metadata.getAgent();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -98,6 +101,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = copiedRecord.recordVersion;
     operationReference = copiedRecord.operationReference;
     batchOperationReference = copiedRecord.batchOperationReference;
+    agent = copiedRecord.agent;
   }
 
   @Override
@@ -153,6 +157,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public Map<String, Object> getAuthorizations() {
     return authorization.toDecodedMap();
+  }
+
+  @Override
+  public Agent getAgent() {
+    return agent;
   }
 
   @Override

--- a/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
+++ b/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.protocol.jackson;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -42,4 +45,7 @@ abstract class RecordMixin<T extends RecordValue> {
   @JsonTypeInfo(use = Id.CUSTOM, include = As.EXTERNAL_PROPERTY, property = "valueType")
   @JsonTypeIdResolver(RecordValueTypeIdResolver.class)
   private T recordValue;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private Agent agent;
 }

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <protocol.version>6</protocol.version>
+    <protocol.version>7</protocol.version>
   </properties>
 
   <dependencies>

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Agent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Agent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record;
+
+import org.immutables.value.Value;
+
+/**
+ * Represents an agent that can trigger events and commands within the system.
+ *
+ * <p>This interface is used to trace events and commands that were issued directly or indirectly
+ * through agentic interactions. It enables capturing the complete trail of changes that occurred as
+ * a result of an agent's actions, providing full traceability of which agent (process) triggered
+ * all subsequent changes in the system.
+ *
+ * <p>By associating an {@code Agent} with records, the system can:
+ *
+ * <ul>
+ *   <li>Track the origin of events and commands back to the initiating agent
+ *   <li>Build a complete audit trail of all changes triggered by an agent
+ *   <li>Understand the causal chain of events resulting from agentic interactions
+ *   <li>Enable debugging and analysis of agent-driven workflows
+ * </ul>
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAgent.Builder.class)
+public interface Agent {
+  /**
+   * Returns the unique identifier of this agent.
+   *
+   * @return the agent's unique ID
+   */
+  long getId();
+
+  /**
+   * Returns the name of this agent.
+   *
+   * @return the agent's name
+   */
+  String getName();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -109,6 +110,7 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    *
    * @return the agent information associated with this record, or {@code null} if no agent
    */
+  @Nullable
   Agent getAgent();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -104,6 +104,14 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   Map<String, Object> getAuthorizations();
 
   /**
+   * Provides agent information that is associated with the record, e.g. the id and name of the
+   * agent that produced the record within an adhoc subprocess
+   *
+   * @return the agent information associated with this record, or {@code null} if no agent
+   */
+  Agent getAgent();
+
+  /**
    * A record version is an integer starting from 1. The version of a record is defined when it is
    * written. It allows different versions of the same record to be processed or applied
    * differently.

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -125,7 +125,6 @@
       <type name="minorVersion" primitiveType="int32"/>
       <type name="patchVersion" primitiveType="int32"/>
     </composite>
-
   </types>
 
   <!-- L1 General Messages 0 - 99 -->
@@ -193,6 +192,7 @@
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="11" type="varDataEncoding" sinceVersion="4"/>
+    <data name="agent" id="14" type="varDataEncoding" sinceVersion="7"/>
   </sbe:message>
 
   <sbe:message name="BrokerInfo" id="201" description="Broker topology information">

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -95,8 +96,8 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
-  public AuthInfo getAuthInfo() {
-    return metadata.getAuthorization();
+  public Agent getAgent() {
+    return metadata.getAgent();
   }
 
   @Override
@@ -132,6 +133,11 @@ public final class TypedRecordImpl implements TypedRecord {
   @Override
   public UnifiedRecordValue getValue() {
     return value;
+  }
+
+  @Override
+  public AuthInfo getAuthInfo() {
+    return metadata.getAuthorization();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.stream.impl.records;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -83,6 +84,11 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public Map<String, Object> getAuthorizations() {
     return metadata.getAuthorization().toDecodedMap();
+  }
+
+  @Override
+  public Agent getAgent() {
+    return metadata.getAgent();
   }
 
   @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 460]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 464]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 461);
+    final var recordBatch = new RecordBatch((count, size) -> size < 465);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.test.util.record;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -108,6 +109,11 @@ public final class RecordingExporterTest {
     @Override
     public Map<String, Object> getAuthorizations() {
       return Map.of();
+    }
+
+    @Override
+    public Agent getAgent() {
+      return null;
     }
 
     @Override


### PR DESCRIPTION
## Description

Add `agent` information to `RecordMetaData`

- Expresses `agent` as a first level concept for Camunda/C8
- Extra null handling to keep memory footprint low

## Related issues

closes #45497 
