### PR TITLE
ci: skip creation of failure comment

### DIFF
--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -93,7 +93,13 @@ runs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/${{ github.repository }}/check-runs/$JOB_ID/annotations?per_page=100")
 
-          HAS_PRIORITY_CANCELLATION=$(echo "$ANNOTATIONS" | jq -r '.[] | select(.annotation_level == "failure" and (.message | contains("Canceling since a higher priority waiting request"))) | .message' | wc -l)
+          HAS_PRIORITY_CANCELLATION=$(echo "$ANNOTATIONS" | jq -sR '
+            try (
+              fromjson
+                | [.[]? | select(.annotation_level == "failure" and (.message | contains("Canceling since a higher priority waiting request")))]
+                | length
+              ) catch 0
+          ')
 
           if [ "$HAS_PRIORITY_CANCELLATION" -gt 0 ]; then
             PRIORITY_CANCELLED=true

--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -74,6 +74,8 @@ runs:
         echo "Found **${JOB_COUNT}** unsuccessful job(s)" | tee -a "$COMMENT_FILE"
         echo "" | tee -a "$COMMENT_FILE"
 
+        PRIORITY_CANCELLED=false
+
         # Collect annotations for each unsuccessful job
         for JOB_ID in $UNSUCCESSFUL_JOBS; do
           JOB_INFO=$(echo "$JOBS_JSON" | jq -r ".jobs[] | select(.id == $JOB_ID)")
@@ -90,6 +92,13 @@ runs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/${{ github.repository }}/check-runs/$JOB_ID/annotations?per_page=100")
+
+          HAS_PRIORITY_CANCELLATION=$(echo "$ANNOTATIONS" | jq -r '.[] | select(.annotation_level == "failure" and (.message | contains("Canceling since a higher priority waiting request"))) | .message' | wc -l)
+
+          if [ "$HAS_PRIORITY_CANCELLATION" -gt 0 ]; then
+            PRIORITY_CANCELLED=true
+            break # No need to check further jobs - we will skip comment creation entirely in this case
+          fi
 
           ANNOTATION_COUNT=$(echo "$ANNOTATIONS" | jq '. | length')
 
@@ -115,6 +124,11 @@ runs:
 
         # Set output for next step
         echo "comment-file=$COMMENT_FILE" >> "$GITHUB_OUTPUT"
+
+        if [ "$PRIORITY_CANCELLED" = true ]; then
+          echo "ℹ️ Skipping comment creation due to higher priority workflow cancellations."
+          echo "comment-file=" >> "$GITHUB_OUTPUT"
+        fi
 
         exit 0  # Don't fail the step
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Reduce noise caused by the `🔍 CI Failure Analysis`  comment generation when any of the job annotations indicate that the run was cancelled due to a more recent invocation of the job for that PR - subsequent push/rebases of the PR.

It causes some initial noise when opening a PR that requires minor adjustments. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
