### PR TITLE
test: RdbmRestoreRangeIT to test restore of backups ranges w/ exporter positions

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -88,12 +88,11 @@ import org.springframework.context.annotation.Profile;
 @DependsOn("unifiedConfigurationHelper")
 public class BrokerBasedPropertiesOverride {
 
+  public static final String RDBMS_EXPORTER_NAME = "rdbms";
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerBasedPropertiesOverride.class);
   private static final String CAMUNDA_EXPORTER_CLASS_NAME = "io.camunda.exporter.CamundaExporter";
   private static final String CAMUNDA_EXPORTER_NAME = "camundaexporter";
   private static final String RDBMS_EXPORTER_CLASS_NAME = "io.camunda.exporter.rdbms.RdbmsExporter";
-  private static final String RDBMS_EXPORTER_NAME = "rdbms";
-
   private final UnifiedConfiguration unifiedConfiguration;
   private final LegacyBrokerBasedProperties legacyBrokerBasedProperties;
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -11,6 +11,8 @@ import io.camunda.application.MainSupport;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration;
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
@@ -77,6 +79,7 @@ public class RestoreApp implements ApplicationRunner {
 
   @Autowired
   public RestoreApp(
+      final Camunda camunda,
       final BrokerBasedProperties configuration,
       final BackupStore backupStore,
       @Autowired(required = false) final ExporterPositionMapper exporterPositionMapper,
@@ -90,6 +93,10 @@ public class RestoreApp implements ApplicationRunner {
       final PreRestoreAction preRestoreAction) {
     this.configuration = configuration;
     this.backupStore = backupStore;
+    if (exporterPositionMapper == null
+        && camunda.getData().getSecondaryStorage().getType() == SecondaryStorageType.rdbms) {
+      throw new IllegalStateException("RDBMS-aware restore requires ExporterPositionMapper");
+    }
     this.exporterPositionMapper = exporterPositionMapper;
     this.restoreConfiguration = restoreConfiguration;
     this.meterRegistry = meterRegistry;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRange.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 
@@ -16,6 +18,12 @@ public sealed interface BackupRange {
   long lastCheckpointId();
 
   boolean contains(Interval<Long> other);
+
+  Interval<Long> checkpointInterval();
+
+  default Interval<Instant> timeInterval(final CheckpointIdGenerator generator) {
+    return checkpointInterval().map(generator::toInstant);
+  }
 
   /** A complete backup range without deletions. */
   record Complete(Interval<Long> checkpointInterval) implements BackupRange {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -229,8 +229,8 @@ public record Interval<T extends Comparable<T>>(
    * <ul>
    *   <li>Interval [3, 7], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (exact matches at both
    *       boundaries)
-   *   <li>Interval [4, 6], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (3 is last before 4, 7 is first
-   *       after 6)
+   *   <li>Interval [4, 6], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (3 is last before 4, 7 is
+   *       first after 6)
    *   <li>Interval [4, 6], points [1, 3, 7, 9] &rarr; [3, 7] (no points within, neighbors cover)
    *   <li>Interval [10, 20], points [1, 3, 5] &rarr; [] (no coverage at end)
    * </ul>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -229,8 +229,8 @@ public record Interval<T extends Comparable<T>>(
    * <ul>
    *   <li>Interval [3, 7], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (exact matches at both
    *       boundaries)
-   *   <li>Interval [4, 6], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (3 is last before 4, 7 is
-   *       first after 6)
+   *   <li>Interval [4, 6], points [1, 3, 5, 7, 9] &rarr; [3, 5, 7] (3 is last before 4, 7 is first
+   *       after 6)
    *   <li>Interval [4, 6], points [1, 3, 7, 9] &rarr; [3, 7] (no points within, neighbors cover)
    *   <li>Interval [10, 20], points [1, 3, 5] &rarr; [] (no coverage at end)
    * </ul>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/CheckpointIdGenerator.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/CheckpointIdGenerator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.common;
 
+import java.time.Instant;
 import java.time.InstantSource;
 
 /**
@@ -63,5 +64,9 @@ public final class CheckpointIdGenerator {
       return timestamp + offset;
     }
     return timestamp;
+  }
+
+  public Instant toInstant(final long checkpointId) {
+    return Instant.ofEpochMilli(checkpointId - offset);
   }
 }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -617,6 +617,12 @@
       <artifactId>zeebe-backup-store-filesystem</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -106,6 +106,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-db-rdbms</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * tests verify that backups follow a rolling window pattern and that old backups and range markers
  * are properly deleted.
  */
-public interface BackupRetentionAcceptance {
+public interface BackupRetentionAcceptance extends ClockSupport {
   int PARTITION_COUNT = 3;
   int BROKER_COUNT = 3;
   int REPLICATION_FACTOR = 3;
@@ -60,6 +60,7 @@ public interface BackupRetentionAcceptance {
   @Test
   default void shouldMaintainRollingWindowAndDeleteOldBackupsWithRangeMarkers() {
 
+    pinClock(getTestCluster());
     final var actuator = BackupActuator.of(getTestCluster().availableGateway());
     final List<Long> backupIds = new ArrayList<>();
 
@@ -92,6 +93,7 @@ public interface BackupRetentionAcceptance {
   }
 
   default long awaitNewBackup(final long previousBackup) {
+    progressClock(getTestCluster(), BACKUP_INTERVAL.toMillis());
     final var actuator = BackupActuator.of(getTestCluster().availableGateway());
     Awaitility.await("Backup is created")
         .atMost(Duration.ofSeconds(30))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClockSupport.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ClockSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.backup;
+
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.PinTimeRequest;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Instant;
+
+public interface ClockSupport {
+
+  default Instant currentTime(final TestStandaloneBroker broker) {
+    final var clockActuator = ActorClockActuator.of(broker);
+    return clockActuator.getCurrentClock().instant();
+  }
+
+  default void progressClock(final TestStandaloneBroker broker, final long millis) {
+    final var clockActuator = ActorClockActuator.of(broker);
+    clockActuator.addTime(new AddTimeRequest(millis));
+  }
+
+  default void progressClock(final TestCluster cluster, final long millis) {
+    cluster.brokers().values().forEach(broker -> progressClock(broker, millis));
+  }
+
+  default void resetTime(final TestStandaloneBroker broker) {
+    final var clockActuator = ActorClockActuator.of(broker);
+    clockActuator.resetTime();
+  }
+
+  default void resetTime(final TestCluster cluster) {
+    cluster.brokers().values().forEach(this::resetTime);
+  }
+
+  default void pinClock(final TestStandaloneBroker broker) {
+    final var clock = ActorClockActuator.of(broker);
+    clock.pinClock(new PinTimeRequest(clock.getCurrentClock().epochMilli()));
+  }
+
+  default void pinClock(final TestCluster cluster) {
+    cluster.brokers().values().forEach(this::pinClock);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RdbmsRangeRestoreIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RdbmsRangeRestoreIT.java
@@ -168,7 +168,6 @@ final class RdbmsRangeRestoreIT implements ClockSupport {
     try (final var client = broker.newClientBuilder().build()) {
       processKey = deployTestProcess(client);
       interval = deployProcessAndTakeBackups(client, processKey);
-      client.newCreateInstanceCommand().processDefinitionKey(processKey).send().join();
     }
     takeAndAwaitBackup();
 
@@ -222,7 +221,7 @@ final class RdbmsRangeRestoreIT implements ClockSupport {
       // The exact count depends on which backups were selected by the RDBMS-aware range resolver,
       // but we should have at least 2 jobs (from the first two instances created before any
       // backup).
-      assertThat(jobs.getJobs()).hasSizeGreaterThanOrEqualTo(2);
+      assertThat(jobs.getJobs()).hasSize(4);
 
       for (final var job : jobs.getJobs()) {
         client.newCompleteCommand(job.getKey()).send().join();

--- a/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
+++ b/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
@@ -16,6 +16,7 @@
     <Logger name="io.atomix.cluster.messaging" level="info"/>
     <Logger name="io.atomix.cluster.protocol" level="debug"/>
     <Logger name="io.atomix.raft" level="debug"/>
+    <logger name="io.camunda.zeebe.restore" level="debug"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -129,17 +129,20 @@ public class RestoreManager implements CloseableSilently {
     final var partitionCount = configuration.getCluster().getPartitionsCount();
 
     final var exportedPositions = exportedPositions(partitionCount).join();
+    LOG.info("Exported positions for all partitions: {}", exportedPositions);
     final var interval = Interval.closed(from, to);
     final var restoreInfos =
         rangeResolver
-            .getRestoreInfoForAllPartitions(interval, partitionCount, exportedPositions, executor)
+            .getRestoreInfoForAllPartitions(
+                interval, partitionCount, exportedPositions, checkpointIdGenerator, executor)
             .join();
 
     LOG.info(
-        "Restoring RDBMS backups in range [{},{}] to global checkpoint {}",
+        "Restoring RDBMS backups in range [{},{}] to global checkpoint {}: {}",
         from,
         to,
-        restoreInfos.globalCheckpointId());
+        restoreInfos.globalCheckpointId(),
+        restoreInfos.backupsByPartitionId());
 
     restore(restoreInfos.backupsByPartitionId(), validateConfig, ignoreFilesInTarget);
   }


### PR DESCRIPTION
## Description
Added `RdbmsRestoreRangeIT` that verifies that we can take a few backups (3) and restore with a time range. 

To verify that the exported position from the RDBMS is taken into account, I added also a test that verifies that the restore fails if there's no backup with `checkpointPosition >= exportedPosition`. 

H2 is used in PostgreSQL mode in in-memory mode. The database is kept open between broker restarts to make the test simpler: 
we assume that that the RDBMS has been restored to the exact same position before the shutdown. 

A filesystem `BackupStore` is used for zeebe instead.

## Related issues

closes #40233
