### PR TITLE
perf: use original message size to estimate memory usage

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -281,10 +281,6 @@
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-stream-platform</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -281,6 +281,10 @@
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -15,7 +15,7 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import io.camunda.zeebe.protocol.record.WrittenRecord;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -141,8 +141,8 @@ public final class ExporterBatchWriter {
   }
 
   private long recordSize(final Record<?> record) {
-    if (record instanceof final TypedRecordImpl typedRecord) {
-      return typedRecord.getRawLength();
+    if (record instanceof final WrittenRecord writtenRecord) {
+      return writtenRecord.getRawLength();
     } else if (record instanceof final BufferWriter writer) {
       return writer.getLength();
     } else {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -15,8 +15,10 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,19 +27,22 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Caches exporter entities of different types and provide the method to flush them in a batch. */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class ExporterBatchWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterBatchWriter.class);
+  private boolean warnAboutMessageSizeEstimation = false;
   private final Map<EntityIdAndEntityType, ExporterEntity> cachedEntities = new HashMap<>();
   private final Map<EntityIdTypeAndHandler, ExporterEntity> cachedEntitiesToFlush =
       new LinkedHashMap<>();
-  private final Map<EntityIdAndEntityType, Long> cachedEntitySizes = new HashMap<>();
   private final Map<Long, Long> cachedRecordTimestamps = new HashMap<>();
-
   private final Map<ValueType, List<ExportHandler>> handlers;
   private final BiConsumer<String, Error> customErrorHandler;
   private final CamundaExporterMetrics metrics;
+  private long memoryEstimation = 0L;
 
   private ExporterBatchWriter(
       final Map<ValueType, List<ExportHandler>> handlers,
@@ -51,28 +56,36 @@ public final class ExporterBatchWriter {
   public void addRecord(final Record<?> record) {
     final ValueType valueType = record.getValueType();
 
+    final var serializedSize = recordSize(record);
+
     handlers
         .getOrDefault(valueType, Collections.emptyList())
         .forEach(
             handler -> {
               if (handler.handlesRecord(record)) {
                 final List<String> entityIds = handler.generateIds(record);
-                entityIds.forEach(id -> updateAndCacheEntity(record, handler, id));
+                entityIds.forEach(
+                    id -> {
+                      updateAndCacheEntity(record, handler, id, serializedSize);
+                    });
               }
             });
   }
 
   private void updateAndCacheEntity(
-      final Record<?> record, final ExportHandler handler, final String id) {
+      final Record<?> record, final ExportHandler handler, final String id, final long length) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
     final ExporterEntity entity =
-        cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
+        cachedEntities.computeIfAbsent(
+            cacheKey,
+            (k) -> {
+              memoryEstimation += length;
+              return handler.createNewEntity(id);
+            });
 
     handler.updateEntity(record, entity);
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
-
-    cachedEntitySizes.put(cacheKey, ObjectSizeEstimator.estimateSize(entity));
 
     // we store all handlers for an entity to make sure not to miss any flushes.
     // we flush them in the same order as they were originally run.
@@ -103,8 +116,7 @@ public final class ExporterBatchWriter {
   }
 
   public int getBatchMemoryEstimateInMb() {
-    return (int) cachedEntitySizes.values().stream().mapToLong(Long::longValue).sum()
-        / (1024 * 1024);
+    return (int) (memoryEstimation / (1024 * 1024));
   }
 
   private void observeRecordTimestamps() {
@@ -125,7 +137,23 @@ public final class ExporterBatchWriter {
   private void reset() {
     cachedEntities.clear();
     cachedEntitiesToFlush.clear();
-    cachedEntitySizes.clear();
+    memoryEstimation = 0;
+  }
+
+  private long recordSize(final Record<?> record) {
+    if (record instanceof final TypedRecordImpl typedRecord) {
+      return typedRecord.getRawLength();
+    } else if (record instanceof final BufferWriter writer) {
+      return writer.getLength();
+    } else {
+      if (!warnAboutMessageSizeEstimation) {
+        LOG.debug(
+            "Message size estimation is not supported for record type: {}, using ObjectSizeEstimator",
+            record.getClass().getSimpleName());
+        warnAboutMessageSizeEstimation = true;
+      }
+      return ObjectSizeEstimator.estimateSize(record);
+    }
   }
 
   public static final class Builder {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/WrittenRecord.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/WrittenRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record;
+
+/** A record that has been written to the log, hence it is immutable. */
+public interface WrittenRecord {
+
+  /**
+   * @return the length of the event i.e. the number of bytes it occupies in the log
+   */
+  int getRawLength();
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -18,12 +18,13 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.WrittenRecord;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.Map;
 
-public final class TypedRecordImpl implements TypedRecord {
+public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   private final int partitionId;
   private LoggedEvent rawEvent;
   private RecordMetadata metadata;
@@ -158,6 +159,7 @@ public final class TypedRecordImpl implements TypedRecord {
     return metadata.getLength() + value.getLength();
   }
 
+  @Override
   @JsonIgnore
   public int getRawLength() {
     return rawEvent.getLength();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -158,6 +158,11 @@ public final class TypedRecordImpl implements TypedRecord {
     return metadata.getLength() + value.getLength();
   }
 
+  @JsonIgnore
+  public int getRawLength() {
+    return rawEvent.getLength();
+  }
+
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);


### PR DESCRIPTION
## Description
Previously we were using `ObjectSizeEstimator` to estimate the size of a record. However, the exporter reads "immutable" records from the log, so we can use the size on disk as an estimation of how much space that record takes. 

Moreover, a large chunk of time was spenting recomputing the size of the entities. 
In the same batch, an entity can appear multiple times, which requires saving that space in the map.
However, we can have a good approximation by just keeping track of the size of the first time an entity is added to the batch. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44131
