### PR TITLE
feat: Add info message for modifying specific instances in ModificationDropdown

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -19,6 +19,7 @@ import {
   Title,
   Unsupported,
   SelectedInstanceCount,
+  InfoMessage,
   Button,
   InlineLoading,
 } from './styled';
@@ -91,6 +92,10 @@ const ModificationDropdown: React.FC<Props> = observer(
       processDefinitionKey,
     });
 
+    const hasSelectedElementMultipleRunningInstances =
+      selectedElementRunningInstancesCount !== undefined &&
+      selectedElementRunningInstancesCount > 1;
+
     if (
       selectedElementId === null ||
       modificationsStore.state.status === 'moving-token'
@@ -133,6 +138,13 @@ const ModificationDropdown: React.FC<Props> = observer(
                       {`Selected running instances: ${selectedElementRunningInstancesCount ?? 0}`}
                     </SelectedInstanceCount>
                   )}
+                  {hasSelectedElementMultipleRunningInstances && (
+                    <InfoMessage>
+                      To modify a specific instance, select it in the Instance
+                      History below.
+                    </InfoMessage>
+                  )}
+
                   <Stack gap={2}>
                     {availableModifications.includes('add') &&
                       businessObjects && (

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/styled.tsx
@@ -30,8 +30,22 @@ const SelectedInstanceCount = styled.div`
   ${styles.helperText01}
 `;
 
+const InfoMessage = styled.div`
+  ${styles.helperText01}
+  max-width: 20rem;
+  font-style: italic;
+  color: var(--cds-text-secondary);
+`;
+
 const InlineLoading = styled(BaseInlineLoading)`
   justify-content: center;
 `;
 
-export {Title, Unsupported, SelectedInstanceCount, InlineLoading, Button};
+export {
+  Title,
+  Unsupported,
+  SelectedInstanceCount,
+  InfoMessage,
+  InlineLoading,
+  Button,
+};

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
@@ -465,4 +465,62 @@ describe('Modification Dropdown', () => {
     expect(screen.getByText(/Move/)).toBeInTheDocument();
     expect(screen.getByText(/Add/)).toBeInTheDocument();
   });
+
+  it('should display message when there are multiple instances and hide when specific instance is selected', async () => {
+    const {unmount} = renderPopover([
+      `${Paths.processInstance('instance_id')}?elementId=service-task-1`,
+    ]);
+
+    expect(
+      await screen.findByText(/To modify a specific instance/i),
+    ).toBeInTheDocument();
+
+    unmount();
+
+    mockFetchElementInstance('some-instance-key').withSuccess({
+      elementInstanceKey: 'some-instance-key',
+      elementId: 'service-task-1',
+      elementName: 'Service Task 1',
+      type: 'SERVICE_TASK',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      processDefinitionId: 'someKey',
+      processInstanceKey: 'instance_id',
+      processDefinitionKey: '2',
+      hasIncident: false,
+      tenantId: '<default>',
+    });
+
+    mockFetchProcessInstance().withSuccess({
+      processInstanceKey: 'instance_id',
+      state: 'ACTIVE',
+      startDate: '2018-06-21',
+      processDefinitionKey: '2',
+      processDefinitionVersion: 1,
+      processDefinitionId: 'someKey',
+      tenantId: '<default>',
+      processDefinitionName: 'someProcessName',
+      hasIncident: false,
+    });
+
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statisticsData,
+    });
+
+    renderPopover([
+      `${Paths.processInstance('instance_id')}?elementId=service-task-1&elementInstanceKey=some-instance-key`,
+    ]);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('dropdown-spinner'),
+    );
+
+    expect(
+      screen.queryByText(/To modify a specific instance/i),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -389,54 +389,6 @@ describe('TopPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('should display multiple instances banner when a flow node with multiple running instances is selected', async () => {
-    mockSearchElementInstances().withSuccess(searchResult([]));
-    mockSearchElementInstances().withSuccess(searchResult([]));
-
-    modificationsStore.enableModificationMode();
-
-    render(<TopPanel />, {
-      wrapper: getWrapper({elementId: 'service-task-7'}),
-    });
-
-    expect(
-      await screen.findByText(
-        /Flow node has multiple instances. To select one, use the instance history tree below./i,
-      ),
-    ).toBeInTheDocument();
-
-    // Select single-instance element - banner should disappear
-    updateSearchParams({elementId: 'service-task-1'});
-
-    await waitFor(() =>
-      expect(
-        screen.queryByText(
-          /Flow node has multiple instances. To select one, use the instance history tree below./i,
-        ),
-      ).not.toBeInTheDocument(),
-    );
-
-    // Re-select multi-instance element - banner should reappear
-    updateSearchParams({elementId: 'service-task-7'});
-
-    expect(
-      await screen.findByText(
-        /Flow node has multiple instances. To select one, use the instance history tree below./i,
-      ),
-    ).toBeInTheDocument();
-
-    // FIXME: In the new element selection, the "multiple instances" banner no longer disappears.
-    // Tracked here: https://github.com/camunda/camunda/issues/45557
-
-    // Select element instance - banner should disappear
-    // updateSearchParams({elementId: 'service-task-7', elementInstanceKey: 'some-instance-id'});
-    // await waitForElementToBeRemoved(() =>
-    //   screen.queryByText(
-    //     /Flow node has multiple instances. To select one, use the instance history tree below./i,
-    //   ),
-    // );
-  });
-
   it('should display move token banner in moving mode', async () => {
     mockSearchElementInstances().withSuccess(
       searchResult([mockElementInstance]),

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -314,10 +314,6 @@ const TopPanel: React.FC = observer(() => {
             }}
           />
         )}
-      {modificationsStore.isModificationModeEnabled &&
-        hasSelectedElementMultipleRunningInstances && (
-          <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
-        )}
       <DiagramPanel>
         <DiagramShell status={getStatus()}>
           {processDefinitionData?.xml !== undefined &&

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -85,6 +85,7 @@ const TopPanel: React.FC = observer(() => {
   const {
     clearSelection,
     selectedElementId,
+    selectedElementInstanceKey,
     selectElement,
     selectedAnchorElementId,
   } = useProcessInstanceElementSelection();
@@ -125,8 +126,8 @@ const TopPanel: React.FC = observer(() => {
   const {data: selectedElementRunningInstancesCount} =
     useTotalRunningInstancesForFlowNode(selectedElementId ?? undefined);
   const hasSelectedElementMultipleRunningInstances =
-    selectedElementRunningInstancesCount !== undefined &&
-    selectedElementRunningInstancesCount > 1;
+    selectedElementInstanceKey === null &&
+    (selectedElementRunningInstancesCount ?? 0) > 1;
 
   const {
     data: processDefinitionData,


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
Moved the instance-selection message directly into the modification dropdown menu where users interact with modification actions. The message now appears Next to the flow node inside the modification popover.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #41611
