### PR TITLE
ci: move Operate frontend unit tests to a self-hosted runner

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -133,6 +133,8 @@ jobs:
         name: Install dependencies
       - run: npm run test -- --no-file-parallelism --maxWorkers 1 --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         name: Unit & Integration tests
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
       - name: Upload blob report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -108,7 +108,7 @@ jobs:
   fe-unit-tests:
     if: inputs.runFeTests
     name: "Unit - Front End [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job
     strategy:
@@ -157,7 +157,7 @@ jobs:
     if: ${{ !cancelled() && inputs.runFeTests }}
     needs: [fe-unit-tests]
     name: "Unit - Front End - Merge Reports"
-    runs-on: ubuntu-latest
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 5
     permissions: {} # GITHUB_TOKEN unused in this job
     env:


### PR DESCRIPTION
This was already done in #41074 to avoid Out Of Memory errors, but was then reverted in #44047 when vitest sharding was added, thinking it was no longer necessary.
Since OOM error are presenting again, the use of the more powerful runner is required.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45526
