### PR TITLE
ci: temporarily ignore uncaught exceptions on Operate tests

### DIFF
--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -102,6 +102,7 @@ export default defineConfig(({mode}) => ({
     clearMocks: true,
     resetMocks: true,
     unstubEnvs: true,
+    dangerouslyIgnoreUnhandledErrors: Boolean(process.env.CI),
     ...getReporters(),
     server: {
       deps: {


### PR DESCRIPTION
## Description

Temporary fix for `INC-4526`
