### PR TITLE
45498 auditlog agent inherit metadata

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -176,7 +176,7 @@ public class Engine implements RecordProcessor {
           processingResultBuilder.withProcessInASeparateBatch();
         }
 
-        currentProcessor.processRecord(record);
+        currentProcessor.processRecord(record, processingResultBuilder);
       }
     }
     return processingResultBuilder.build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -203,9 +203,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private void preCompleteActions(final JobRecord job, final ProcessingContext context) {
     if (job.isAgentic()) {
       context.appendMetadataToAllFollowUps(
-          m ->
-              m.agent(
-                  new AgentInfo().setId(job.getElementInstanceKey()).setName(job.getElementId())));
+          m -> m.agent(new AgentInfo().setElementId(job.getElementId())));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultActivateElementValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.ProcessingContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.EnumSet;
@@ -167,7 +169,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   }
 
   @Override
-  public void processRecord(final TypedRecord<JobRecord> record) {
+  public void processRecord(final TypedRecord<JobRecord> record, final ProcessingContext context) {
     final long jobKey = record.getKey();
     final JobState.State state = jobState.getState(jobKey);
 
@@ -175,14 +177,18 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         .check(state, record)
         .flatMap(job -> checkAuthorization(record, job))
         .ifRightOrLeft(
-            job -> completeJob(record, job),
+            job -> completeJob(record, job, context),
             rejection -> {
               rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
             });
   }
 
-  private void completeJob(final TypedRecord<JobRecord> command, final JobRecord job) {
+  private void completeJob(
+      final TypedRecord<JobRecord> command, final JobRecord job, final ProcessingContext context) {
+
+    preCompleteActions(job, context);
+
     job.setVariables(command.getValue().getVariablesBuffer());
     job.setResult(command.getValue().getResult());
 
@@ -192,6 +198,15 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     jobMetrics.countJobEvent(JobAction.COMPLETED, job.getJobKind(), job.getType());
 
     postCompleteActions(job);
+  }
+
+  private void preCompleteActions(final JobRecord job, final ProcessingContext context) {
+    if (job.isAgentic()) {
+      context.appendMetadataToAllFollowUps(
+          m ->
+              m.agent(
+                  new AgentInfo().setId(job.getElementInstanceKey()).setName(job.getElementId())));
+    }
   }
 
   private void postCompleteActions(final JobRecord value) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -202,8 +202,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
 
   private void preCompleteActions(final JobRecord job, final ProcessingSession session) {
     if (job.isAgentic()) {
-      session.appendMetadataToAllFollowUps(
-          m -> m.agent(new AgentInfo().setElementId(job.getElementId())));
+      session.appendAgentInfoToFollowUps(new AgentInfo().setElementId(job.getElementId()));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.camunda.zeebe.stream.api.ProcessingContext;
+import io.camunda.zeebe.stream.api.ProcessingSession;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
@@ -18,7 +18,7 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
         "A TypedRecordProcessor must implement at least one of the processRecord methods");
   }
 
-  default void processRecord(final TypedRecord<T> record, final ProcessingContext context) {
+  default void processRecord(final TypedRecord<T> record, final ProcessingSession session) {
     processRecord(record);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -8,11 +8,19 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.stream.api.ProcessingContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
 
-  void processRecord(final TypedRecord<T> record);
+  default void processRecord(final TypedRecord<T> record) {
+    throw new UnsupportedOperationException(
+        "A TypedRecordProcessor must implement at least one of the processRecord methods");
+  }
+
+  default void processRecord(final TypedRecord<T> record, final ProcessingContext context) {
+    processRecord(record);
+  }
 
   /**
    * Try to handle an error that occurred during processing.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -41,6 +42,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -1176,6 +1178,31 @@ public class JobBasedAdHocSubProcessTest {
                 .formatted(ahspKey));
   }
 
+  @Test
+  public void shouldCompleteAgenticJobWithFollowupMetadata() {
+    // given
+    final var jobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+    final BpmnModelInstance process =
+        process(jobType, adHocSubProcess -> adHocSubProcess.task("A1").task("A2"));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var jobCompleted = completeJob(jobType, true, Map.of("bar", "foo"));
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .withSourceRecordPosition(jobCompleted.getSourceRecordPosition())
+                .between(
+                    l -> l.getIntent().equals(JobIntent.COMPLETED),
+                    r ->
+                        r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                            && r.getKey() == processInstanceKey))
+        .hasSizeGreaterThan(15)
+        .allMatch(r -> r.getAgent() != null);
+  }
+
   private void completeJob(
       final String jobType,
       final boolean completionConditionFulfilled,
@@ -1189,6 +1216,17 @@ public class JobBasedAdHocSubProcessTest {
             .setCompletionConditionFulfilled(completionConditionFulfilled)
             .setCancelRemainingInstances(cancelRemainingInstances);
     ENGINE.job().withKey(jobKey).withResult(jobResult).complete();
+  }
+
+  private Record<JobRecordValue> completeJob(
+      final String jobType,
+      final boolean completionConditionFulfilled,
+      final Map<String, Object> variables) {
+    final var jobKey =
+        ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().getFirst();
+    final var jobResult =
+        new JobResult().setCompletionConditionFulfilled(completionConditionFulfilled);
+    return ENGINE.job().withKey(jobKey).withResult(jobResult).withVariables(variables).complete();
   }
 
   private JobResultActivateElement activateElement(final String elementId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -1199,8 +1199,8 @@ public class JobBasedAdHocSubProcessTest {
                     r ->
                         r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
                             && r.getKey() == processInstanceKey))
-        .hasSizeGreaterThan(15)
-        .allMatch(r -> r.getAgent() != null);
+        .isNotEmpty()
+        .allMatch(r -> AHSP_ELEMENT_ID.equals(r.getAgent().getElementId()));
   }
 
   private void completeJob(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -20,6 +21,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -29,6 +31,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
@@ -111,6 +114,33 @@ public final class CompleteJobTest {
         .hasDeadline(job.getDeadline())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasResult(new JobResult().setDenied(false));
+  }
+
+  @Test
+  public void shouldCompleteAgenticJobWithFollowupMetadata() {
+    // given
+    final var jobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+
+    // when
+    final Record<JobRecordValue> jobCompletedRecord =
+        ENGINE.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete();
+
+    // then
+    final JobRecordValue recordValue = jobCompletedRecord.getValue();
+    assertThat(
+            RecordingExporter.records()
+                .withSourceRecordPosition(jobCompletedRecord.getSourceRecordPosition())
+                .between(
+                    l -> l.getIntent().equals(JobIntent.COMPLETED),
+                    r ->
+                        r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                            && r.getKey() == recordValue.getProcessInstanceKey()))
+        .hasSizeGreaterThan(15)
+        .allMatch(r -> r.getAgent() != null);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -139,8 +139,8 @@ public final class CompleteJobTest {
                     r ->
                         r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
                             && r.getKey() == recordValue.getProcessInstanceKey()))
-        .hasSizeGreaterThan(15)
-        .allMatch(r -> r.getAgent() != null);
+        .isNotEmpty()
+        .allMatch(r -> "task".equals(r.getAgent().getElementId()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -211,14 +211,17 @@ public final class EngineErrorHandlingTest {
                   .onCommand(
                       ValueType.PROCESS_INSTANCE,
                       ProcessInstanceIntent.ACTIVATE_ELEMENT,
-                      record -> {
-                        processingContext
-                            .getWriters()
-                            .state()
-                            .appendFollowUpEvent(
-                                keyGenerator.getCurrentKey() + 1000,
-                                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                                record.getValue());
+                      new TypedRecordProcessor<UnifiedRecordValue>() {
+                        @Override
+                        public void processRecord(final TypedRecord<UnifiedRecordValue> record) {
+                          processingContext
+                              .getWriters()
+                              .state()
+                              .appendFollowUpEvent(
+                                  keyGenerator.getCurrentKey() + 1000,
+                                  ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                                  record.getValue());
+                        }
                       });
             });
     final AtomicReference<HealthReport> reportRef = new AtomicReference<>();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -57,11 +57,7 @@
         "agent": {
           "type": "object",
           "properties": {
-            "id": {
-              "type": "long",
-              "index": false
-            },
-            "name": {
+            "elementId": {
               "type": "keyword",
               "index": false
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -57,11 +57,7 @@
         "agent": {
           "type": "object",
           "properties": {
-            "id": {
-              "type": "long",
-              "index": false
-            },
-            "name": {
+            "elementId": {
               "type": "keyword",
               "index": false
             }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AgentInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AgentInfo.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.protocol.impl.encoding;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -19,38 +18,26 @@ import org.agrona.concurrent.UnsafeBuffer;
 /** */
 public class AgentInfo extends UnpackedObject implements Agent {
 
-  private final LongProperty idProp = new LongProperty("id", -1L);
-  private final StringProperty nameProp = new StringProperty("name", "");
+  private final StringProperty elementIdProp = new StringProperty("elementId", "");
 
   public AgentInfo() {
-    super(2);
-    declareProperty(idProp).declareProperty(nameProp);
+    super(1);
+    declareProperty(elementIdProp);
   }
 
   @Override
-  public long getId() {
-    return idProp.getValue();
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementIdProp.getValue());
   }
 
-  public AgentInfo setId(final long agentId) {
-    idProp.setValue(agentId);
-    return this;
-  }
-
-  @Override
-  public String getName() {
-    return BufferUtil.bufferAsString(nameProp.getValue());
-  }
-
-  public AgentInfo setName(final String agentName) {
-    nameProp.setValue(agentName);
+  public AgentInfo setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
     return this;
   }
 
   @Override
   public void reset() {
-    idProp.reset();
-    nameProp.setValue("");
+    elementIdProp.setValue("");
   }
 
   @Override
@@ -81,7 +68,7 @@ public class AgentInfo extends UnpackedObject implements Agent {
 
   public static AgentInfo of(final Agent agent) {
     if (agent != null) {
-      return new AgentInfo().setId(agent.getId()).setName(agent.getName());
+      return new AgentInfo().setElementId(agent.getElementId());
     } else {
       return null;
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -103,6 +104,26 @@ public class AuthInfo extends UnpackedObject {
       return new JwtDecoder(token).decode().getClaims();
     }
     return getClaims();
+  }
+
+  public static AuthInfo of(final AuthInfo info) {
+    if (info == null) {
+      return null;
+    }
+
+    final var auth = new AuthInfo();
+    auth.copyFrom(info);
+    return auth;
+  }
+
+  public boolean hasAnyClaims() {
+    switch (getFormat()) {
+      case JWT:
+        return authDataProp.getValue() != null && authDataProp.getValue().capacity() > 0;
+      default:
+        return claimsProp.getValue() != null
+            && !DocumentValue.EMPTY_DOCUMENT.equals(claimsProp.getValue());
+    }
   }
 
   public enum AuthDataFormat {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -39,6 +39,17 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class JobRecord extends UnifiedRecordValue implements JobRecordValue {
 
+  /**
+   * The worker type prefix for Camunda Agentic AI jobs that are set in Camunda Connectors.
+   *
+   * <p>For 8.9 this is accepted as limitation that all agentic jobs must have this prefix in order
+   * to be categorized as agentic jobs.
+   *
+   * <p>In the future, we might want to introduce a more robust way of identifying agentic jobs
+   */
+  public static final String IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX =
+      "io.camunda.agenticai:aiagent";
+
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
   public static final String TIMEOUT = "timeout";
@@ -47,7 +58,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final String CUSTOM_HEADERS = "customHeaders";
   private static final String VARIABLES = "variables";
   private static final String ERROR_MESSAGE = "errorMessage";
-
   // Static StringValue keys to avoid memory waste
   private static final StringValue TYPE_KEY = new StringValue(TYPE);
   private static final StringValue WORKER_KEY = new StringValue("worker");
@@ -535,5 +545,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public JobRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @JsonIgnore
+  public boolean isAgentic() {
+    return getType().startsWith(IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AgentInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AgentInfoTest.java
@@ -11,43 +11,72 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class AgentInfoTest {
 
-  @Test
-  void shouldEncodeDecodeAgentInfo() {
-    // given
-    final AgentInfo info = new AgentInfo().setId(1234L).setName("foo");
+  @Nested
+  class EncodeDecodeTests {
+    @Test
+    void shouldEncodeDecodeAgentInfo() {
+      // given
+      final AgentInfo info = new AgentInfo().setElementId("foo");
 
-    // when
-    encodeDecode(info);
+      // when
+      encodeDecode(info);
 
-    // then
-    assertThat(info.getId()).isEqualTo(1234L);
-    assertThat(info.getName()).isEqualTo("foo");
+      // then
+      assertThat(info.getElementId()).isEqualTo("foo");
+    }
+
+    @Test
+    void shouldEncodeDecodeEmptyAgentInfo() {
+      // given
+      final AgentInfo info = new AgentInfo();
+
+      // when
+      encodeDecode(info);
+
+      // then
+      assertThat(info.getElementId()).isEqualTo("");
+    }
+
+    private void encodeDecode(final AgentInfo info) {
+      // encode
+      final UnsafeBuffer buffer = new UnsafeBuffer(new byte[info.getLength()]);
+      info.write(buffer, 0);
+
+      // decode
+      info.reset();
+      info.wrap(buffer, 0, buffer.capacity());
+    }
   }
 
-  @Test
-  void shouldEncodeDecodeEmptyAgentInfo() {
-    // given
-    final AgentInfo info = new AgentInfo();
+  @Nested
+  class OfTests {
+    @Test
+    void shouldReturnNullWhenOfCalledWithNull() {
+      // when
+      final AgentInfo result = AgentInfo.of(null);
 
-    // when
-    encodeDecode(info);
+      // then
+      assertThat(result).isNull();
+    }
 
-    // then
-    assertThat(info.getId()).isEqualTo(-1L);
-    assertThat(info.getName()).isEqualTo("");
-  }
+    @Test
+    void shouldCopyAgentInfoWhenOfCalledWithNonNull() {
+      // given
+      final AgentInfo original = new AgentInfo();
+      original.setElementId("test-element-id");
 
-  private void encodeDecode(final AgentInfo info) {
-    // encode
-    final UnsafeBuffer buffer = new UnsafeBuffer(new byte[info.getLength()]);
-    info.write(buffer, 0);
+      // when
+      final AgentInfo copy = AgentInfo.of(original);
 
-    // decode
-    info.reset();
-    info.wrap(buffer, 0, buffer.capacity());
+      // then
+      assertThat(copy).isNotNull();
+      assertThat(copy).isNotSameAs(original);
+      assertThat(copy.getElementId()).isEqualTo(original.getElementId());
+    }
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/AuthInfoTest.java
@@ -13,42 +13,10 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class AuthInfoTest {
-
-  @Test
-  void shouldEncodeDecodeAuthInfo() {
-    // given
-    final AuthInfo authInfo = new AuthInfo();
-    final String token = "token";
-    final Map<String, Object> authInfoMap = Map.of("key", "value");
-    authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
-    authInfo.setAuthData(token);
-    authInfo.setClaims(authInfoMap);
-
-    // when
-    encodeDecode(authInfo);
-
-    // then
-    assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
-    assertThat(authInfo.getAuthData()).isEqualTo(token);
-    assertThat(authInfo.getClaims()).isEqualTo(authInfoMap);
-  }
-
-  @Test
-  void shouldEncodeDecodeEmptyAuthInfo() {
-    // given
-    final AuthInfo authInfo = new AuthInfo();
-
-    // when
-    encodeDecode(authInfo);
-
-    // then
-    assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
-    assertThat(authInfo.getAuthData()).isEqualTo("");
-    assertThat(authInfo.getClaims()).isEqualTo(Map.of());
-  }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/35177")
   void shouldSanitizeOnToString() {
@@ -69,13 +37,150 @@ final class AuthInfoTest {
         {"format":"JWT","authData":"***","claims":"***"}""");
   }
 
-  private void encodeDecode(final AuthInfo authInfo) {
-    // encode
-    final UnsafeBuffer buffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
-    authInfo.write(buffer, 0);
+  @Nested
+  class EncodeDecodeTests {
+    @Test
+    void shouldEncodeDecodeAuthInfo() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      final String token = "token";
+      final Map<String, Object> authInfoMap = Map.of("key", "value");
+      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
+      authInfo.setAuthData(token);
+      authInfo.setClaims(authInfoMap);
 
-    // decode
-    authInfo.reset();
-    authInfo.wrap(buffer, 0, buffer.capacity());
+      // when
+      encodeDecode(authInfo);
+
+      // then
+      assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.JWT);
+      assertThat(authInfo.getAuthData()).isEqualTo(token);
+      assertThat(authInfo.getClaims()).isEqualTo(authInfoMap);
+    }
+
+    @Test
+    void shouldEncodeDecodeEmptyAuthInfo() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+
+      // when
+      encodeDecode(authInfo);
+
+      // then
+      assertThat(authInfo.getFormat()).isEqualTo(AuthInfo.AuthDataFormat.UNKNOWN);
+      assertThat(authInfo.getAuthData()).isEqualTo("");
+      assertThat(authInfo.getClaims()).isEqualTo(Map.of());
+    }
+
+    private void encodeDecode(final AuthInfo authInfo) {
+      // encode
+      final UnsafeBuffer buffer = new UnsafeBuffer(new byte[authInfo.getLength()]);
+      authInfo.write(buffer, 0);
+
+      // decode
+      authInfo.reset();
+      authInfo.wrap(buffer, 0, buffer.capacity());
+    }
+  }
+
+  @Nested
+  class HasAnyClaimsTests {
+
+    @Test
+    void shouldReturnTrueWhenJwtFormatHasAuthData() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
+      authInfo.setAuthData("valid-token");
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenJwtFormatHasEmptyAuthData() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.JWT);
+      authInfo.setAuthData("");
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenPreAuthorizedFormatHasClaims() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of("key", "value"));
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenPreAuthorizedFormatHasEmptyClaims() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.PRE_AUTHORIZED);
+      authInfo.setClaims(Map.of());
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenUnknownFormatHasEmptyClaims() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.UNKNOWN);
+      authInfo.setClaims(Map.of());
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenUnknownFormatHasClaims() {
+      // given
+      final AuthInfo authInfo = new AuthInfo();
+      authInfo.setFormat(AuthInfo.AuthDataFormat.UNKNOWN);
+      authInfo.setClaims(Map.of("key", "value"));
+
+      // when / then
+      assertThat(authInfo.hasAnyClaims()).isTrue();
+    }
+  }
+
+  @Nested
+  class OfTests {
+    @Test
+    void shouldReturnNullWhenOfCalledWithNull() {
+      // when
+      final AuthInfo result = AuthInfo.of(null);
+
+      // then
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldCopyAuthInfoWhenOfCalledWithNonNull() {
+      // given
+      final AuthInfo original = new AuthInfo();
+      original.setFormat(AuthInfo.AuthDataFormat.JWT);
+      original.setAuthData("test-token");
+      original.setClaims(Map.of("claim1", "value1", "claim2", "value2"));
+
+      // when
+      final AuthInfo copy = AuthInfo.of(original);
+
+      // then
+      assertThat(copy).isNotNull();
+      assertThat(copy).isNotSameAs(original);
+      assertThat(copy.getFormat()).isEqualTo(original.getFormat());
+      assertThat(copy.getAuthData()).isEqualTo(original.getAuthData());
+      assertThat(copy.getClaims()).isEqualTo(original.getClaims());
+    }
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -188,7 +188,7 @@ final class JsonSerializableToJsonTest {
               final int requestStreamId = 1;
 
               final AuthInfo authInfo = new AuthInfo().setClaims(Map.of("foo", "bar"));
-              final AgentInfo agentInfo = new AgentInfo().setId(123L).setName("agent-name");
+              final AgentInfo agentInfo = new AgentInfo().setElementId("agent-element");
 
               recordMetadata
                   .intent(intent)
@@ -252,8 +252,7 @@ final class JsonSerializableToJsonTest {
                     "foo" : "bar"
                   },
                   "agent": {
-                    "id": 123,
-                    "name": "agent-name"
+                    "elementId": "agent-element"
                   },
                   "recordVersion": 10,
                   "operationReference": 1234,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Agent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Agent.java
@@ -38,16 +38,11 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableAgent.Builder.class)
 public interface Agent {
   /**
-   * Returns the unique identifier of this agent.
+   * Returns the elementId that the agent is associated with
    *
-   * @return the agent's unique ID
-   */
-  long getId();
-
-  /**
-   * Returns the name of this agent.
+   * <p>for example, the id of the adhoc subprocess that represents the agent in the process model.
    *
-   * @return the agent's name
+   * @return the elementId
    */
-  String getName();
+  String getElementId();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingContext.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import java.util.function.Consumer;
+
+public interface ProcessingContext {
+
+  default void appendMetadataToAllFollowUps(final Consumer<RecordMetadata> decorator) {}
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.util.Either;
 
 /** Builder to compose the processing result */
-public interface ProcessingResultBuilder extends ProcessingContext {
+public interface ProcessingResultBuilder extends ProcessingSession {
 
   /**
    * Appends a record to the result

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.util.Either;
 
 /** Builder to compose the processing result */
-public interface ProcessingResultBuilder {
+public interface ProcessingResultBuilder extends ProcessingContext {
 
   /**
    * Appends a record to the result

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.stream.api;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import java.util.function.Consumer;
 
-public interface ProcessingContext {
+public interface ProcessingSession {
 
   default void appendMetadataToAllFollowUps(final Consumer<RecordMetadata> decorator) {}
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -7,10 +7,51 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.Agent;
 import java.util.function.Consumer;
 
 public interface ProcessingSession {
 
-  default void appendMetadataToAllFollowUps(final Consumer<RecordMetadata> decorator) {}
+  default void appendMetadataToFollowUps(final Consumer<RecordMetadata> decorator) {}
+
+  default void appendOperationReferenceToFollowUps(final long operationReference) {
+    if (operationReference != operationReferenceNullValue()) {
+      appendMetadataToFollowUps(
+          metadata -> {
+            // `operationReference` from `metadata` should have a higher precedence
+            if (metadata.getOperationReference() == operationReferenceNullValue()) {
+              metadata.operationReference(operationReference);
+            }
+          });
+    }
+  }
+
+  default void appendBatchOperationReferenceToFollowUps(final long batchOperationReference) {
+    if (batchOperationReference != batchOperationReferenceNullValue()) {
+      appendMetadataToFollowUps(
+          metadata -> metadata.batchOperationReference(batchOperationReference));
+    }
+  }
+
+  default void appendAuthInfoToFollowUps(final AuthInfo authInfo) {
+    if (authInfo != null && authInfo.hasAnyClaims()) {
+      // make a copy to rule out any side effects
+      final var authorization = AuthInfo.of(authInfo);
+      appendMetadataToFollowUps(metadata -> metadata.authorization(authorization));
+    }
+  }
+
+  default void appendAgentInfoToFollowUps(final Agent agentInfo) {
+    if (agentInfo != null) {
+      // make a copy to rule out any side effects
+      final var agent = AgentInfo.of(agentInfo);
+      appendMetadataToFollowUps(metadata -> metadata.agent(agent));
+    }
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -7,11 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
-
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
@@ -31,7 +27,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Implementation of {@code ProcessingResultBuilder} that buffers the processing results. After
@@ -44,44 +40,21 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   private final RecordBatch mutableRecordBatch;
   private ProcessingResponseImpl processingResponse;
-  private final long operationReference;
   private boolean processInASeparateBatch = false;
-  private final long batchOperationReference;
-  private final Map<String, Object> authorizationClaims;
 
-  BufferedProcessingResultBuilder(final RecordBatchSizePredicate predicate) {
-    this(predicate, operationReferenceNullValue(), batchOperationReferenceNullValue(), Map.of());
-  }
+  private final List<Consumer<RecordMetadata>> metadataDecorators = new ArrayList<>();
 
   BufferedProcessingResultBuilder(
-      final RecordBatchSizePredicate predicate,
-      final long operationReference,
-      final long batchOperationReference,
-      final Map<String, Object> authorizationClaims) {
+      final RecordBatchSizePredicate predicate, final Consumer<RecordMetadata>... decorators) {
     mutableRecordBatch = new RecordBatch(predicate);
-    this.operationReference = operationReference;
-    this.batchOperationReference = batchOperationReference;
-    this.authorizationClaims = authorizationClaims;
+    metadataDecorators.addAll(List.of(decorators));
   }
 
   @Override
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
       final long key, final RecordValue value, final RecordMetadata metadata) {
 
-    // `operationReference` from `metadata` should have a higher precedence
-    if (metadata.getOperationReference() == operationReferenceNullValue()) {
-      if (operationReference != operationReferenceNullValue()) {
-        metadata.operationReference(operationReference);
-      }
-    }
-
-    if (batchOperationReference != batchOperationReferenceNullValue()) {
-      metadata.batchOperationReference(batchOperationReference);
-    }
-
-    if (authorizationClaims != null && !authorizationClaims.isEmpty()) {
-      metadata.authorization(new AuthInfo().setClaims(authorizationClaims));
-    }
+    metadataDecorators.forEach(m -> m.accept(metadata));
 
     if (value instanceof final UnifiedRecordValue unifiedRecordValue) {
       final var valueType = unifiedRecordValue.valueType();
@@ -126,9 +99,11 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
             .intent(intent)
             .rejectionType(rejectionType)
             .rejectionReason(rejectionReason)
-            .valueType(valueType)
-            .operationReference(operationReference)
-            .batchOperationReference(batchOperationReference);
+            .valueType(valueType);
+
+    metadataDecorators.forEach(m -> m.accept(metadata));
+    metadata.getAuthorization().reset(); // don't expose the authorization data in the response
+
     final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);
     return this;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -138,6 +138,11 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
   }
 
+  @Override
+  public void appendMetadataToAllFollowUps(final Consumer<RecordMetadata> decorator) {
+    metadataDecorators.add(decorator);
+  }
+
   record ProcessingResponseImpl(RecordBatchEntry responseValue, long requestId, int requestStreamId)
       implements ProcessingResponse {}
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -139,7 +139,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   }
 
   @Override
-  public void appendMetadataToAllFollowUps(final Consumer<RecordMetadata> decorator) {
+  public void appendMetadataToFollowUps(final Consumer<RecordMetadata> decorator) {
     metadataDecorators.add(decorator);
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -820,6 +821,12 @@ public final class ProcessingStateMachine {
 
           if (command.getAuthorizations() != null && !command.getAuthorizations().isEmpty()) {
             metadata.authorization(new AuthInfo().setClaims(command.getAuthorizations()));
+          }
+
+          // make sure the agent information is forwarded also to follow up commands/events that
+          // will be processed in a separate batch
+          if (command.getAgent() != null) {
+            metadata.agent(AgentInfo.of(command.getAgent()));
           }
         });
   }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilderTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo.AuthDataFormat;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.stream.api.records.RecordBatchSizePredicate;
+import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class BufferedProcessingResultBuilderTest {
+
+  private static final RecordBatchSizePredicate LARGE_BATCH_PREDICATE =
+      (count, size) -> size < 100_000;
+
+  @Test
+  void shouldWriteRecordWithEnhancedMetadata() {
+    // given
+    final var builder =
+        new BufferedProcessingResultBuilder(
+            LARGE_BATCH_PREDICATE, metadata -> metadata.batchOperationReference(12345L));
+    final var record = new ProcessInstanceCreationRecord();
+    final var metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(ProcessInstanceCreationIntent.CREATE);
+
+    // when
+    builder.appendRecordReturnEither(1L, record, metadata);
+
+    // then
+    final var result = builder.build();
+    final var entries = result.getRecordBatch().entries();
+    assertThat(entries).hasSize(1);
+    final var entry = (RecordBatchEntry) entries.get(0);
+    assertThat(entry.recordMetadata().getBatchOperationReference()).isEqualTo(12345L);
+  }
+
+  @Test
+  void shouldEnhanceMetadataOnWithResponse() {
+    // given
+    final var builder =
+        new BufferedProcessingResultBuilder(
+            LARGE_BATCH_PREDICATE, metadata -> metadata.batchOperationReference(12345L));
+    final var record = new ProcessInstanceCreationRecord();
+
+    // when
+    builder.withResponse(
+        RecordType.EVENT,
+        1L,
+        ProcessInstanceCreationIntent.CREATED,
+        record,
+        ValueType.PROCESS_INSTANCE_CREATION,
+        RejectionType.NULL_VAL,
+        "",
+        123L,
+        456);
+
+    // then
+    final var result = builder.build();
+    final var response = result.getProcessingResponse().orElseThrow();
+    final var responseEntry = response.responseValue();
+    assertThat(responseEntry.recordMetadata().getBatchOperationReference()).isEqualTo(12345L);
+  }
+
+  @Test
+  void shouldResetAuthorizationWhenSetByDecorator() {
+    // given
+    final Consumer<RecordMetadata> authorizationDecorator =
+        metadata -> {
+          final var authInfo = new AuthInfo();
+          authInfo.setFormat(AuthDataFormat.JWT);
+          authInfo.setAuthData("secret-token");
+          metadata.authorization(authInfo);
+        };
+    final var builder =
+        new BufferedProcessingResultBuilder(LARGE_BATCH_PREDICATE, authorizationDecorator);
+    final var record = new ProcessInstanceCreationRecord();
+
+    // when
+    builder.withResponse(
+        RecordType.EVENT,
+        1L,
+        ProcessInstanceCreationIntent.CREATED,
+        record,
+        ValueType.PROCESS_INSTANCE_CREATION,
+        RejectionType.NULL_VAL,
+        "",
+        123L,
+        456);
+
+    // then
+    final var result = builder.build();
+    final var response = result.getProcessingResponse().orElseThrow();
+    final var responseEntry = response.responseValue();
+    final var authorization = responseEntry.recordMetadata().getAuthorization();
+    assertThat(authorization.getFormat()).isEqualTo(AuthDataFormat.UNKNOWN);
+    assertThat(authorization.getAuthData()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

Splitted into 4 nicely reviewable commits
- refactor the `BufferedProcessingResultBuilder` to generically allow metadata decorators
- allow command processors to register metadata decorators
- apply metadata decoration from (agentic) job completions
- refactor the agent to only contain `elementId`

## Related issues

closes #45498
