### PR TITLE
feat: inter-partition listens to default- prefixed subjects

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -26,9 +26,10 @@ import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
-final class InterPartitionCommandSenderImpl implements InterPartitionCommandSender {
+public final class InterPartitionCommandSenderImpl implements InterPartitionCommandSender {
 
-  public static final String TOPIC_PREFIX = "inter-partition-";
+  public static final String LEGACY_TOPIC_PREFIX = "inter-partition-";
+  public static final String TOPIC_PREFIX = "%s-inter-partition-";
 
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private final ClusterCommunicationService communicationService;
@@ -36,9 +37,12 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
   private final Int2IntHashMap partitionLeaders = new Int2IntHashMap(-1);
   private long checkpointId = CheckpointState.NO_CHECKPOINT;
   private CheckpointType checkpointType = CheckpointType.MANUAL_BACKUP;
+  private final String sendingSubjectPrefix;
 
-  public InterPartitionCommandSenderImpl(final ClusterCommunicationService communicationService) {
+  public InterPartitionCommandSenderImpl(
+      final ClusterCommunicationService communicationService, final String sendingSubjectPrefix) {
     this.communicationService = communicationService;
+    this.sendingSubjectPrefix = sendingSubjectPrefix;
   }
 
   @Override
@@ -97,7 +101,7 @@ final class InterPartitionCommandSenderImpl implements InterPartitionCommandSend
             authInfo);
 
     communicationService.unicast(
-        TOPIC_PREFIX + receiverPartitionId,
+        sendingSubjectPrefix + receiverPartitionId,
         message,
         DefaultSerializers.BASIC::encode,
         MemberId.from("" + partitionLeader),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -26,8 +26,10 @@ public final class InterPartitionCommandSenderService extends Actor
   final int partitionId;
 
   public InterPartitionCommandSenderService(
-      final ClusterCommunicationService communicationService, final int partitionId) {
-    commandSender = new InterPartitionCommandSenderImpl(communicationService);
+      final ClusterCommunicationService communicationService,
+      final int partitionId,
+      final String sendingSubjectPrefix) {
+    commandSender = new InterPartitionCommandSenderImpl(communicationService, sendingSubjectPrefix);
     this.partitionId = partitionId;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.partitionapi;
 
-import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderImpl.TOPIC_PREFIX;
+import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderImpl.LEGACY_TOPIC_PREFIX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -54,7 +54,7 @@ final class InterPartitionCommandCheckpointTest {
     this.communicationService = communicationService;
     this.logStreamWriter = logStreamWriter;
 
-    sender = new InterPartitionCommandSenderImpl(communicationService);
+    sender = new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
     sender.setCurrentLeader(1, 2);
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
   }
@@ -214,7 +214,7 @@ final class InterPartitionCommandCheckpointTest {
 
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(communicationService)
-        .unicast(eq(TOPIC_PREFIX + 1), messageCaptor.capture(), any(), any(), eq(true));
+        .unicast(eq(LEGACY_TOPIC_PREFIX + 1), messageCaptor.capture(), any(), any(), eq(true));
     receiver.handleMessage(new MemberId("0"), messageCaptor.getValue());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.partitionapi;
 
-import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderImpl.TOPIC_PREFIX;
+import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderImpl.LEGACY_TOPIC_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -329,7 +329,8 @@ final class InterPartitionCommandReceiverTest {
     final ClusterCommunicationService communicationService =
         mock(ClusterCommunicationService.class);
 
-    final var sender = new InterPartitionCommandSenderImpl(communicationService);
+    final var sender =
+        new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
     sender.setCurrentLeader(receiverPartitionId, receiverBrokerId);
 
     sender.sendCommand(receiverPartitionId, valueType, intent, recordKey, recordValue, authInfo);
@@ -337,7 +338,7 @@ final class InterPartitionCommandReceiverTest {
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(communicationService)
         .unicast(
-            eq(TOPIC_PREFIX + receiverPartitionId),
+            eq(LEGACY_TOPIC_PREFIX + receiverPartitionId),
             messageCaptor.capture(),
             any(),
             any(),


### PR DESCRIPTION
## Description

This pull request prepares inter-partition communication to support multiple Raft partition groups in Camunda 8.10 by enabling the listening to both legacy "inter-partition-" and new "default-inter-partition-" prefixed subjects.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45260
