### PR TITLE
[Backport stable/8.8] [CPT] Wait until remote engine is ready

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
@@ -23,7 +23,11 @@ import io.camunda.client.api.response.PartitionInfo;
 import io.camunda.client.api.response.Topology;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +73,20 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
         connectorsRestApiAddress);
 
     // check connection to remote runtime
-    checkConnectionToRemoteRuntime();
+    //    checkConnectionToRemoteRuntime();
+    try {
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofSeconds(1))
+          .pollDelay(Duration.ZERO)
+          .ignoreExceptions()
+          .untilAsserted(this::checkConnectionToRemoteRuntime);
+    } catch (final ConditionTimeoutException timeout) {
+      throw new RuntimeException(
+          Optional.ofNullable(timeout.getCause())
+              .map(Throwable::getMessage)
+              .orElse("Failed to connect to remote Camunda runtime."));
+    }
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntime.java
@@ -40,12 +40,14 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
   private final URI camundaGrpcApiAddress;
   private final URI camundaMonitoringApiAddress;
   private final URI connectorsRestApiAddress;
+  private final Duration runtimeConnectionTimeout;
   private final CamundaClientBuilderFactory camundaClientBuilderFactory;
 
   public CamundaProcessTestRemoteRuntime(final CamundaProcessTestRuntimeBuilder runtimeBuilder) {
     camundaClientBuilderFactory = runtimeBuilder.getRemoteCamundaClientBuilderFactory();
     camundaMonitoringApiAddress = runtimeBuilder.getRemoteCamundaMonitoringApiAddress();
     connectorsRestApiAddress = runtimeBuilder.getRemoteConnectorsRestApiAddress();
+    runtimeConnectionTimeout = runtimeBuilder.getRemoteRuntimeConnectionTimeout();
 
     final CamundaClientConfiguration clientConfiguration =
         getClientConfiguration(camundaClientBuilderFactory);
@@ -73,10 +75,9 @@ public class CamundaProcessTestRemoteRuntime implements CamundaProcessTestRuntim
         connectorsRestApiAddress);
 
     // check connection to remote runtime
-    //    checkConnectionToRemoteRuntime();
     try {
       Awaitility.await()
-          .atMost(Duration.ofSeconds(5))
+          .atMost(runtimeConnectionTimeout)
           .pollInterval(Duration.ofSeconds(1))
           .pollDelay(Duration.ZERO)
           .ignoreExceptions()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -19,6 +19,7 @@ import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +80,9 @@ public class CamundaProcessTestRuntimeBuilder {
       CamundaProcessTestRuntimeDefaults.REMOTE_CAMUNDA_MONITORING_API_ADDRESS;
   private URI remoteConnectorsRestApiAddress =
       CamundaProcessTestRuntimeDefaults.REMOTE_CONNECTORS_REST_API_ADDRESS;
+
+  private Duration remoteRuntimeConnectionTimeout =
+      CamundaProcessTestRuntimeDefaults.REMOTE_RUNTIME_CONNECTION_TIMEOUT;
 
   private boolean isMultiTenancyEnabled = CamundaProcessTestRuntimeDefaults.MULTI_TENANCY_ENABLED;
 
@@ -233,6 +237,12 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
+  public CamundaProcessTestRuntimeBuilder withRemoteRuntimeConnectionTimeout(
+      final Duration remoteRuntimeConnectionTimeout) {
+    this.remoteRuntimeConnectionTimeout = remoteRuntimeConnectionTimeout;
+    return this;
+  }
+
   public CamundaProcessTestRuntimeBuilder withMultiTenancyEnabled(final boolean enabled) {
     isMultiTenancyEnabled = enabled;
     return this;
@@ -352,6 +362,10 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public URI getRemoteConnectorsRestApiAddress() {
     return remoteConnectorsRestApiAddress;
+  }
+
+  public Duration getRemoteRuntimeConnectionTimeout() {
+    return remoteRuntimeConnectionTimeout;
   }
 
   public String getCoverageReportDirectory() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -42,6 +42,8 @@ public class CamundaProcessTestRuntimeDefaults {
       URI.create("http://0.0.0.0:" + ContainerRuntimePorts.CAMUNDA_MONITORING_API);
   public static final URI LOCAL_CONNECTORS_REST_API_ADDRESS = URI.create("http://0.0.0.0:8085");
 
+  public static final Duration DEFAULT_REMOTE_RUNTIME_CONNECTION_TIMEOUT = Duration.ofMinutes(1);
+
   public static final String DEFAULT_COVERAGE_REPORT_DIRECTORY = "target/coverage-report";
 
   private static final ContainerRuntimePropertiesUtil PROPERTIES_UTIL =
@@ -79,6 +81,9 @@ public class CamundaProcessTestRuntimeDefaults {
       PROPERTIES_UTIL.getRemoteCamundaMonitoringApiAddress();
   public static final URI REMOTE_CONNECTORS_REST_API_ADDRESS =
       PROPERTIES_UTIL.getRemoteConnectorsRestApiAddress();
+
+  public static final Duration REMOTE_RUNTIME_CONNECTION_TIMEOUT =
+      PROPERTIES_UTIL.getRemoteRuntimeConnectionTimeout();
 
   public static final URI REMOTE_CLIENT_GRPC_ADDRESS = PROPERTIES_UTIL.getRemoteClientGrpcAddress();
   public static final URI REMOTE_CLIENT_REST_ADDRESS = PROPERTIES_UTIL.getRemoteClientRestAddress();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -27,6 +27,7 @@ import io.camunda.process.test.impl.runtime.util.VersionedPropertiesUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -207,6 +208,10 @@ public final class ContainerRuntimePropertiesUtil {
 
   public URI getRemoteClientRestAddress() {
     return remoteRuntimeProperties.getRemoteClientProperties().getRestAddress();
+  }
+
+  public Duration getRemoteRuntimeConnectionTimeout() {
+    return remoteRuntimeProperties.getRuntimeConnectionTimeout();
   }
 
   public CamundaProcessTestRuntimeMode getRuntimeMode() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/RemoteRuntimeProperties.java
@@ -19,6 +19,7 @@ import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getProper
 
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Properties;
 
 public class RemoteRuntimeProperties {
@@ -26,9 +27,12 @@ public class RemoteRuntimeProperties {
       "remote.camundaMonitoringApiAddress";
   public static final String PROPERTY_NAME_CONNECTORS_REST_API_ADDRESS =
       "remote.connectorsRestApiAddress";
+  public static final String PROPERTY_NAME_RUNTIME_CONNECTION_TIMEOUT =
+      "remote.runtimeConnectionTimeout";
 
   private final URI camundaMonitoringApiAddress;
   private final URI connectorsRestApiAddress;
+  private final Duration runtimeConnectionTimeout;
 
   private final RemoteRuntimeClientProperties remoteClientProperties;
 
@@ -59,6 +63,13 @@ public class RemoteRuntimeProperties {
             },
             CamundaProcessTestRuntimeDefaults.LOCAL_CONNECTORS_REST_API_ADDRESS);
 
+    runtimeConnectionTimeout =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_RUNTIME_CONNECTION_TIMEOUT,
+            Duration::parse,
+            CamundaProcessTestRuntimeDefaults.DEFAULT_REMOTE_RUNTIME_CONNECTION_TIMEOUT);
+
     remoteClientProperties = new RemoteRuntimeClientProperties(properties);
   }
 
@@ -68,6 +79,10 @@ public class RemoteRuntimeProperties {
 
   public URI getConnectorsRestApiAddress() {
     return connectorsRestApiAddress;
+  }
+
+  public Duration getRuntimeConnectionTimeout() {
+    return runtimeConnectionTimeout;
   }
 
   public RemoteRuntimeClientProperties getRemoteClientProperties() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
@@ -33,6 +33,7 @@ import io.camunda.client.api.response.Topology;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -175,6 +176,7 @@ public class CamundaProcessTestRemoteRuntimeTest {
         CamundaProcessTestContainerRuntime.newBuilder()
             .withRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE)
             .withRemoteCamundaClientBuilderFactory(() -> camundaClientBuilder)
+            .withRemoteRuntimeConnectionTimeout(Duration.ofSeconds(1))
             .build();
 
     // when/then
@@ -206,6 +208,7 @@ public class CamundaProcessTestRemoteRuntimeTest {
         CamundaProcessTestContainerRuntime.newBuilder()
             .withRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE)
             .withRemoteCamundaClientBuilderFactory(() -> camundaClientBuilder)
+            .withRemoteRuntimeConnectionTimeout(Duration.ofSeconds(1))
             .build();
 
     // when/then
@@ -229,6 +232,7 @@ public class CamundaProcessTestRemoteRuntimeTest {
         CamundaProcessTestContainerRuntime.newBuilder()
             .withRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE)
             .withRemoteCamundaClientBuilderFactory(() -> camundaClientBuilder)
+            .withRemoteRuntimeConnectionTimeout(Duration.ofSeconds(1))
             .build();
 
     // when/then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -61,6 +61,8 @@ public class ContainerRuntimePropertiesUtilTest {
 
     assertThat(propertiesUtil.getCoverageReportProperties().getCoverageReportDirectory())
         .isEqualTo("target/coverage-report");
+
+    assertThat(propertiesUtil.getRemoteRuntimeConnectionTimeout()).isEqualTo(Duration.ofMinutes(1));
   }
 
   @Test
@@ -492,6 +494,8 @@ public class ContainerRuntimePropertiesUtilTest {
           .isEqualTo(URI.create("http://0.0.0.0:8088"));
       assertThat(propertiesUtil.getRemoteClientRestAddress())
           .isEqualTo(URI.create("http://0.0.0.0:8089"));
+      assertThat(propertiesUtil.getRemoteRuntimeConnectionTimeout())
+          .isEqualTo(Duration.ofSeconds(30));
 
       assertThat(propertiesUtil.isMultiTenancyEnabled()).isTrue();
 

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -41,6 +41,7 @@ runtimeMode=remote
 remote.client.mode=saas
 remote.camundaMonitoringApiAddress=http://0.0.0.0:8080
 remote.connectorsRestApiAddress=http://0.0.0.0:8085
+remote.runtimeConnectionTimeout=PT30S
 remote.client.grpcAddress=http://0.0.0.0:8088
 remote.client.restAddress=http://0.0.0.0:8089
 remote.client.cloud.clusterId=clusterId

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/RemoteConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/RemoteConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.impl.configuration;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -31,6 +32,9 @@ public class RemoteConfiguration {
 
   private URI connectorsRestApiAddress =
       CamundaProcessTestRuntimeDefaults.LOCAL_CONNECTORS_REST_API_ADDRESS;
+
+  private Duration runtimeConnectionTimeout =
+      CamundaProcessTestRuntimeDefaults.DEFAULT_REMOTE_RUNTIME_CONNECTION_TIMEOUT;
 
   public CamundaClientProperties getClient() {
     return client;
@@ -56,6 +60,20 @@ public class RemoteConfiguration {
     this.connectorsRestApiAddress = connectorsRestApiAddress;
   }
 
+  public Duration getRuntimeConnectionTimeout() {
+    return runtimeConnectionTimeout;
+  }
+
+  public void setRuntimeConnectionTimeout(final Duration runtimeConnectionTimeout) {
+    this.runtimeConnectionTimeout = runtimeConnectionTimeout;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        camundaMonitoringApiAddress, connectorsRestApiAddress, runtimeConnectionTimeout);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (o == null || getClass() != o.getClass()) {
@@ -63,11 +81,7 @@ public class RemoteConfiguration {
     }
     final RemoteConfiguration that = (RemoteConfiguration) o;
     return Objects.equals(camundaMonitoringApiAddress, that.camundaMonitoringApiAddress)
-        && Objects.equals(connectorsRestApiAddress, that.connectorsRestApiAddress);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(camundaMonitoringApiAddress, connectorsRestApiAddress);
+        && Objects.equals(connectorsRestApiAddress, that.connectorsRestApiAddress)
+        && Objects.equals(runtimeConnectionTimeout, that.runtimeConnectionTimeout);
   }
 }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -80,7 +80,9 @@ public class CamundaSpringProcessTestRuntimeBuilder {
         .withRemoteCamundaMonitoringApiAddress(
             runtimeConfiguration.getRemote().getCamundaMonitoringApiAddress())
         .withRemoteConnectorsRestApiAddress(
-            runtimeConfiguration.getRemote().getConnectorsRestApiAddress());
+            runtimeConfiguration.getRemote().getConnectorsRestApiAddress())
+        .withRemoteRuntimeConnectionTimeout(
+            runtimeConfiguration.getRemote().getRuntimeConnectionTimeout());
 
     final CamundaClientBuilderFactory remoteClientBuilderFactory =
         createRemoteClientBuilderFactory(runtimeConfiguration);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -152,6 +152,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         .isEqualTo(CamundaProcessTestRuntimeDefaults.LOCAL_CAMUNDA_MONITORING_API_ADDRESS);
     assertThat(runtimeBuilder.getRemoteConnectorsRestApiAddress())
         .isEqualTo(CamundaProcessTestRuntimeDefaults.LOCAL_CONNECTORS_REST_API_ADDRESS);
+    assertThat(runtimeBuilder.getRemoteRuntimeConnectionTimeout())
+        .isEqualTo(CamundaProcessTestRuntimeDefaults.REMOTE_RUNTIME_CONNECTION_TIMEOUT);
 
     final CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =
         runtimeBuilder.getRemoteCamundaClientBuilderFactory();
@@ -181,6 +183,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     final URI remoteCamundaGrpcApiAddress = URI.create("http://camunda.com:2000");
     final URI remoteCamundaMonitoringApiAddress = URI.create("http://camunda.com:3000");
     final URI remoteConnectorsRestApiAddress = URI.create("http://camunda.com:4000");
+    final Duration remoteRuntimeConnectionTimeout = Duration.ofSeconds(30);
 
     runtimeConfiguration.setRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE);
     runtimeConfiguration.getRemote().getClient().setRequestTimeout(Duration.ofHours(1));
@@ -188,6 +191,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     final RemoteConfiguration remoteConfiguration = runtimeConfiguration.getRemote();
     remoteConfiguration.setCamundaMonitoringApiAddress(remoteCamundaMonitoringApiAddress);
     remoteConfiguration.setConnectorsRestApiAddress(remoteConnectorsRestApiAddress);
+    remoteConfiguration.setRuntimeConnectionTimeout(remoteRuntimeConnectionTimeout);
 
     final CamundaClientProperties remoteClientProperties = remoteConfiguration.getClient();
     remoteClientProperties.setRestAddress(remoteCamundaRestApiAddress);
@@ -201,6 +205,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         .isEqualTo(remoteCamundaMonitoringApiAddress);
     assertThat(runtimeBuilder.getRemoteConnectorsRestApiAddress())
         .isEqualTo(remoteConnectorsRestApiAddress);
+    assertThat(runtimeBuilder.getRemoteRuntimeConnectionTimeout())
+        .isEqualTo(remoteRuntimeConnectionTimeout);
 
     final CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =
         runtimeBuilder.getRemoteCamundaClientBuilderFactory();


### PR DESCRIPTION
# Description
Backport of #45256 to `stable/8.8`.

relates to #44995