### PR TITLE
ci: split camundaex team in subteams in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,6 @@
 # Each line is a file pattern followed by one or more owners.
 # If you'd like to be added as an owner, don't hesitate to reach out to one of the existing ones.
 
-# C8 REST OpenAPI specification
-/zeebe/gateway-protocol/src/main/proto/v2/ @camunda/c8-api-team
-
 # Testing guide
 /docs/testing.md       @npepinpe @ChrisKujawa
 /docs/assets/testing*  @npepinpe @ChrisKujawa
@@ -17,10 +14,6 @@
 .github/actions/setup-c8run/* @camunda/distribution
 .github/workflows/c8run* @camunda/distribution
 /c8run/ @camunda/distribution
-
-# Camunda Ex Team Clients, SDK and CPT
-/clients/        @camunda/camundaex
-/testing/        @camunda/camundaex
 
 # General Automation, Unified CI and release helpers by Monorepo DevOps team
 /.github/actions/build*/*                                @camunda/monorepo-devops-team
@@ -147,3 +140,13 @@
 
 # MCP gateway
 /gateways/gateway-mcp @camunda/connectors-agentic-ai
+
+#################
+## Camunda Ex  ##
+#################
+/clients/        @camunda/c8-java-sdk
+/library-parent/ @camunda/c8-java-sdk
+/testing/        @camunda/c8-testing
+
+# C8 REST OpenAPI specification
+/zeebe/gateway-protocol/src/main/proto/v2/ @camunda/c8-api-team


### PR DESCRIPTION
## Description

Also corrects wrong ownership assignment across other teams.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

