### PR TITLE
test: switch back to running on gcp-perf-core-16-longrunning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,7 +686,7 @@ jobs:
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_IT_EXPORTER_MODULES }}
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-core-32-default
+            runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
             owner: "DataLayer"


### PR DESCRIPTION
looks like 16 higher performance cores (c2d) are much better than 32 lower performance (n1) ones.