### PR TITLE
fix: set correct default redirect URI

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -23,6 +23,8 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 public final class ClientRegistrationFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientRegistrationFactory.class);
 
+  private static final String DEFAULT_REDIRECT_URI = "{baseUrl}/sso-callback";
+
   private ClientRegistrationFactory() {}
 
   public static ClientRegistration createClientRegistration(
@@ -45,9 +47,13 @@ public final class ClientRegistrationFactory {
     if (configuration.getClientSecret() != null) {
       builder.clientSecret(configuration.getClientSecret());
     }
-    if (configuration.getRedirectUri() != null) {
+
+    if (configuration.getRedirectUri() == null) {
+      builder.redirectUri(DEFAULT_REDIRECT_URI);
+    } else {
       builder.redirectUri(configuration.getRedirectUri());
     }
+
     if (configuration.getAuthorizationUri() != null) {
       builder.authorizationUri(configuration.getAuthorizationUri());
     }

--- a/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClientRegistrationFactory.java
@@ -23,7 +23,7 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 public final class ClientRegistrationFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientRegistrationFactory.class);
 
-  private static final String DEFAULT_REDIRECT_URI = "{baseUrl}/sso-callback";
+  private static final String DEFAULT_REDIRECT_URI = "{baseUrl}" + WebSecurityConfig.REDIRECT_URI;
 
   private ClientRegistrationFactory() {}
 
@@ -48,10 +48,11 @@ public final class ClientRegistrationFactory {
       builder.clientSecret(configuration.getClientSecret());
     }
 
-    if (configuration.getRedirectUri() == null) {
+    final var redirectUri = configuration.getRedirectUri();
+    if (redirectUri == null || redirectUri.isBlank()) {
       builder.redirectUri(DEFAULT_REDIRECT_URI);
     } else {
-      builder.redirectUri(configuration.getRedirectUri());
+      builder.redirectUri(redirectUri);
     }
 
     if (configuration.getAuthorizationUri() != null) {

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -133,6 +133,7 @@ public class WebSecurityConfig {
   public static final String X_CSRF_TOKEN = "X-CSRF-TOKEN";
   public static final String LOGIN_URL = "/login";
   public static final String LOGOUT_URL = "/logout";
+  public static final String REDIRECT_URI = "/sso-callback";
   public static final Set<String> API_PATHS = Set.of("/api/**", "/v1/**", "/v2/**", "/mcp/**");
   public static final Set<String> UNPROTECTED_API_PATHS =
       Set.of(
@@ -952,7 +953,7 @@ public class WebSecurityConfig {
                         .userInfoEndpoint(c -> c.oidcUserService(oidcUserService))
                         .redirectionEndpoint(
                             redirectionEndpointConfig ->
-                                redirectionEndpointConfig.baseUri("/sso-callback"))
+                                redirectionEndpointConfig.baseUri(REDIRECT_URI))
                         .authorizationEndpoint(
                             authorization ->
                                 authorization.authorizationRequestResolver(

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
@@ -98,4 +98,16 @@ class OidcClientRegistrationTest {
           .isNull();
     }
   }
+
+  @Test
+  public void shouldFallbackToValidDefaultRedirectUri() {
+    final var config = new OidcAuthenticationConfiguration();
+    config.setClientId("clientId");
+    config.setAuthorizationUri("authorizationUri");
+    config.setTokenUri("tokenUri");
+    config.setClientAuthenticationMethod("client_secret_basic");
+
+    Assertions.assertThat(ClientRegistrationFactory.createClientRegistration("foo", config))
+        .returns("{baseUrl}/sso-callback", ClientRegistration::getRedirectUri);
+  }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcClientRegistrationTest.java
@@ -10,6 +10,8 @@ package io.camunda.authentication.config;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.Mockito;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
@@ -99,11 +101,13 @@ class OidcClientRegistrationTest {
     }
   }
 
-  @Test
-  public void shouldFallbackToValidDefaultRedirectUri() {
+  @ParameterizedTest
+  @NullAndEmptySource
+  public void shouldFallbackToValidDefaultRedirectUri(final String blankRedirectUri) {
     final var config = new OidcAuthenticationConfiguration();
     config.setClientId("clientId");
     config.setAuthorizationUri("authorizationUri");
+    config.setRedirectUri(blankRedirectUri);
     config.setTokenUri("tokenUri");
     config.setClientAuthenticationMethod("client_secret_basic");
 


### PR DESCRIPTION
## Description

This PR ensures we use an appropriate default redirect URI when none is given, such that we always redirect to `/sso-callback` unless explicitly told not to.

We keep the override to support cases such as reverse proxies and so on.

## Related issues

closes #45555 
