### PR TITLE
perf: do not serialize LoggedEvent everytime in StreamProcessor & ReplayStateMachine

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -9,53 +9,74 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class EventDescription {
+  private static final int WRITE_ACQUIRE_LOCK_TIMEOUT = 1;
+  private static final int READ_ACQUIRE_LOCK_TIMEOUT = 100;
+  private static final String FAILED_TO_ACQUIRE_LOCK = "failed to acquire lock";
   private long position;
   private Intent intent;
   private ValueType valueType;
   private String status;
-  private final Lock rwLock = new ReentrantLock();
+  private final Lock lock = new ReentrantLock();
 
   public EventDescription(final String status) {
     status(status);
   }
 
   public void status(final String status) {
-    rwLock.lock();
-    // this cannot fail, try/finally is not needed
-    this.status = status;
-    position = 0;
-    intent = null;
-    valueType = null;
-    rwLock.unlock();
+    try {
+      if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        // this cannot fail, try/finally is not needed
+        this.status = status;
+        position = 0;
+        intent = null;
+        valueType = null;
+      }
+    } catch (final InterruptedException e) {
+      // ignore it, it's just for reporting
+    } finally {
+      lock.unlock();
+    }
   }
 
   public void set(
       final String status, final long position, final Intent intent, final ValueType valueType) {
-    // this cannot fail, try/finally is not needed
-    rwLock.lock();
-    this.status = status;
-    this.position = position;
-    this.intent = intent;
-    this.valueType = valueType;
-    rwLock.unlock();
+    try {
+      if (lock.tryLock(WRITE_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        this.status = status;
+        this.position = position;
+        this.intent = intent;
+        this.valueType = valueType;
+      }
+    } catch (final InterruptedException e) {
+      // ignore it, it's just for reporting
+    } finally {
+      lock.unlock();
+    }
   }
 
   @Override
   public String toString() {
-    rwLock.lock();
     try {
-      if (position == 0) {
-        return status;
+      if (lock.tryLock(READ_ACQUIRE_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+        if (position == 0) {
+          return status;
+        } else {
+          return String.format(
+              "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+        }
       } else {
-        return String.format(
-            "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+        return FAILED_TO_ACQUIRE_LOCK;
       }
+    } catch (final InterruptedException e) {
+      // ignore it, it's just for reporting
+      return FAILED_TO_ACQUIRE_LOCK;
     } finally {
-      rwLock.unlock();
+      lock.unlock();
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -38,6 +38,7 @@ public class EventDescription {
       }
     } catch (final InterruptedException e) {
       // ignore it, it's just for reporting
+      Thread.currentThread().interrupt();
     } finally {
       lock.unlock();
     }
@@ -54,6 +55,7 @@ public class EventDescription {
       }
     } catch (final InterruptedException e) {
       // ignore it, it's just for reporting
+      Thread.currentThread().interrupt();
     } finally {
       lock.unlock();
     }
@@ -74,6 +76,7 @@ public class EventDescription {
       }
     } catch (final InterruptedException e) {
       // ignore it, it's just for reporting
+      Thread.currentThread().interrupt();
       return FAILED_TO_ACQUIRE_LOCK;
     } finally {
       lock.unlock();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -9,44 +9,44 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class EventDescription {
   private long position;
   private Intent intent;
   private ValueType valueType;
   private String status;
-  private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+  private final Lock rwLock = new ReentrantLock();
 
   public EventDescription(final String status) {
     status(status);
   }
 
   public void status(final String status) {
-    rwLock.writeLock().lock();
+    rwLock.lock();
     // this cannot fail, try/finally is not needed
     this.status = status;
     position = 0;
     intent = null;
     valueType = null;
-    rwLock.writeLock().unlock();
+    rwLock.unlock();
   }
 
   public void set(
       final String status, final long position, final Intent intent, final ValueType valueType) {
     // this cannot fail, try/finally is not needed
-    rwLock.writeLock().lock();
+    rwLock.lock();
     this.status = status;
     this.position = position;
     this.intent = intent;
     this.valueType = valueType;
-    rwLock.writeLock().unlock();
+    rwLock.unlock();
   }
 
   @Override
   public String toString() {
-    rwLock.readLock().lock();
+    rwLock.lock();
     try {
       if (position == 0) {
         return status;
@@ -55,7 +55,7 @@ public class EventDescription {
             "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
       }
     } finally {
-      rwLock.readLock().unlock();
+      rwLock.unlock();
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/EventDescription.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class EventDescription {
+  private long position;
+  private Intent intent;
+  private ValueType valueType;
+  private String status;
+  private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+
+  public EventDescription(final String status) {
+    status(status);
+  }
+
+  public void status(final String status) {
+    rwLock.writeLock().lock();
+    // this cannot fail, try/finally is not needed
+    this.status = status;
+    position = 0;
+    intent = null;
+    valueType = null;
+    rwLock.writeLock().unlock();
+  }
+
+  public void set(
+      final String status, final long position, final Intent intent, final ValueType valueType) {
+    // this cannot fail, try/finally is not needed
+    rwLock.writeLock().lock();
+    this.status = status;
+    this.position = position;
+    this.intent = intent;
+    this.valueType = valueType;
+    rwLock.writeLock().unlock();
+  }
+
+  @Override
+  public String toString() {
+    rwLock.readLock().lock();
+    try {
+      if (position == 0) {
+        return status;
+      } else {
+        return String.format(
+            "%s @ position=%d, intent=%s, valueType=%s", status, position, intent, valueType);
+      }
+    } finally {
+      rwLock.readLock().unlock();
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -163,7 +163,7 @@ public final class ProcessingStateMachine {
   private final ScheduledCommandCache scheduledCommandCache;
   private volatile ErrorHandlingPhase errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
   private final ControllableStreamClock clock;
-  private String currentStateDescription = "idle";
+  private final EventDescription currentStateDescription = new EventDescription("idle");
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
@@ -201,7 +201,7 @@ public final class ProcessingStateMachine {
   }
 
   String describeCurrentState() {
-    return currentStateDescription;
+    return currentStateDescription.toString();
   }
 
   private void skipRecord() {
@@ -212,7 +212,11 @@ public final class ProcessingStateMachine {
   }
 
   void markProcessingCompleted() {
-    currentStateDescription = String.format("finished processing '%s %s'", currentRecord, metadata);
+    currentStateDescription.set(
+        "finished processing",
+        currentRecord.getPosition(),
+        metadata.getIntent(),
+        metadata.getValueType());
     inProcessing = false;
     if (onErrorRetries > 0) {
       onErrorRetries = 0;
@@ -268,7 +272,8 @@ public final class ProcessingStateMachine {
 
     metadata.reset();
     loggedEvent.readMetadata(metadata);
-    currentStateDescription = String.format("processing '%s %s'", currentRecord, metadata);
+    currentStateDescription.set(
+        "processing", currentRecord.getPosition(), metadata.getIntent(), metadata.getValueType());
 
     try {
       // Here we need to get the current time, since we want to calculate
@@ -796,10 +801,11 @@ public final class ProcessingStateMachine {
 
   private void updateErrorHandlingPhase(final ErrorHandlingPhase errorHandlingPhase) {
     if (errorHandlingPhase != ErrorHandlingPhase.NO_ERROR) {
-      currentStateDescription =
-          String.format(
-              "in error handling phase %s for '%s %s'",
-              errorHandlingPhase, currentRecord, metadata);
+      currentStateDescription.set(
+          "in error handling phase " + errorHandlingPhase,
+          currentRecord.getPosition(),
+          metadata.getIntent(),
+          metadata.getValueType());
     }
     this.errorHandlingPhase = errorHandlingPhase;
     processingMetrics.errorHandlingPhase(errorHandlingPhase);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -255,6 +255,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
     // source position (pointer). This means the last source position is equal to the last processed
     // position by the processing state machine, which we can backfill after replay.
     final var lastProcessedPosition = lastSourceEventPosition;
+    currentStateDescription = () -> "replay finished";
 
     // The replay state machine reads all records, but only applies the events.
     // The last read record position can be used as lastWrittenPosition in order to
@@ -275,6 +276,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
    */
   private void onRecordReplayed(final LoggedEvent currentEvent) {
     replayMetrics.event();
+    // release the reference to the event as soon as possible
     final var sourceEventPosition = currentEvent.getSourceEventPosition();
     final var currentPosition = currentEvent.getPosition();
     final var currentRecordKey = currentEvent.getKey();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -484,7 +484,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       if (processingStateMachine != null) {
         message.append(processingStateMachine.describeCurrentState());
       } else if (replayStateMachine != null) {
-        message.append(replayStateMachine.describeCurrentState().get());
+        message.append(replayStateMachine.describeCurrentState());
       } else {
         message.append("in phase ").append(streamProcessorContext.getStreamProcessorPhase());
       }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -484,7 +484,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       if (processingStateMachine != null) {
         message.append(processingStateMachine.describeCurrentState());
       } else if (replayStateMachine != null) {
-        message.append(replayStateMachine.describeCurrentState());
+        message.append(replayStateMachine.describeCurrentState().get());
       } else {
         message.append("in phase ").append(streamProcessorContext.getStreamProcessorPhase());
       }


### PR DESCRIPTION
## Description
We were serializing every record when replaying, while we could make it "lazy".
The lambda keeps a reference to the written event which is immutable. 
When replay finishes, the reference to the last event is dropped and it returns "replay finished".

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #42728
