### PR TITLE
fix: update nightly search DB test version boundaries

### DIFF
--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -66,15 +66,15 @@ jobs:
             it-database-type: "os"
           # OpenSearch 3 - Supported versions: 3.4.0 (min) to 3.5.0 (max)
           - database-name: "OpenSearch 3.4.0"
-            database-type: "opensearch3_4_0"
-            database-container: "opensearch"
+            database-type: "opensearch"
             database-image-version: "3.4.0"
             it-database-type: "os"
+            job-name-suffix: "3"
           - database-name: "OpenSearch 3.5.0"
-            database-type: "opensearch3_5_0"
-            database-container: "opensearch"
+            database-type: "opensearch"
             database-image-version: "3.5.0"
             it-database-type: "os"
+            job-name-suffix: "3"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Description

Update supported version ranges for Elasticsearch and OpenSearch nightly integration tests to match current support policy:

- ES 8: 8.19.0+ (was 8.16.6+)
- ES 9: 9.2.0+ (was 9.0.0+)
- OS 2: 2.19.0+ (was 2.17.0+)
- OS 3: 3.4.0 to 3.5.0 (newly added)