### PR TITLE
fix: LoggingAuthenticationFailureHandlerTest fails when run in Idea

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandlerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/handler/LoggingAuthenticationFailureHandlerTest.java
@@ -65,7 +65,6 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "logging.level.org.springframework.security=TRACE",
     })
 @ActiveProfiles("consolidated-auth")
-@ExtendWith(OutputCaptureExtension.class)
 class LoggingAuthenticationFailureHandlerTest {
   @RegisterExtension
   static WireMockExtension wireMock =
@@ -107,6 +106,7 @@ class LoggingAuthenticationFailureHandlerTest {
   }
 
   @Test
+  @ExtendWith(OutputCaptureExtension.class)
   void shouldNotLogOnErrorLevel(final CapturedOutput capturedOutput) {
     // Given: a random access token
     final String accessToken = accessToken();
@@ -121,8 +121,9 @@ class LoggingAuthenticationFailureHandlerTest {
             .exchange();
     // Then:
     assertThat(apiResult).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
-    assertThat(capturedOutput.getOut()).contains("A technical authentication problem occurred");
-    assertThat(capturedOutput.getOut()).doesNotContain("ERROR");
+    assertThat(capturedOutput.getOut())
+        .contains("A technical authentication problem occurred")
+        .doesNotContain("ERROR");
   }
 
   private static String wellKnownResponse() {


### PR DESCRIPTION
## Description

After the bump to Spring Boot 4, LoggingAuthenticationFailureHandlerTest would cause the running of all tests in the Authentication module to stop executing when reached.
It's likely due to the `OutputCaptureExtension` changing the global System.out/System.err while background threads (e.g., WireMock/logging) are still writing.

Moving the annotation to the individual `@Test` level solved the issue.


