### PR TITLE
Revert "feat: GCS backup store transfers files in parallel"

### DIFF
--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -88,11 +88,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.agrona</groupId>
-      <artifactId>agrona</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>
@@ -143,12 +138,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
@@ -175,18 +164,7 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
-            <ignoredUsedUndeclaredDependency>com.google.api:*</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
-          <ignoredNonTestScopedDependencies>
-            <!--
-                Google libraries are used in whatever version was pulled through the main dependency
-                on google-cloud-core.
-                Explicitly defining dependencies on these libraries doesn't help and only increases
-                the risk that our definitions drift from what google-cloud-core wants to use whenever
-                dependabot updates one of these versions.
-              -->
-            <ignoredNonTestScopedDependency>com.google.api:api-common</ignoredNonTestScopedDependency>
-          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -11,10 +11,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
-import com.google.cloud.storage.transfermanager.ParallelDownloadConfig;
-import com.google.cloud.storage.transfermanager.ParallelUploadConfig;
-import com.google.cloud.storage.transfermanager.TransferManager;
-import com.google.cloud.storage.transfermanager.TransferStatus;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.FileSet;
@@ -23,9 +20,7 @@ import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.stream.Collectors;
-import org.agrona.LangUtil;
 
 final class FileSetManager {
   /**
@@ -43,51 +38,25 @@ final class FileSetManager {
   private static final String PATH_FORMAT = "%scontents/%s/%s/%s/%s/";
 
   private final Storage client;
-  private final TransferManager transferManager;
   private final BucketInfo bucketInfo;
   private final String basePath;
 
-  FileSetManager(
-      final Storage client,
-      final TransferManager transferManager,
-      final BucketInfo bucketInfo,
-      final String basePath) {
+  FileSetManager(final Storage client, final BucketInfo bucketInfo, final String basePath) {
     this.client = client;
-    this.transferManager = transferManager;
     this.bucketInfo = bucketInfo;
     this.basePath = basePath;
   }
 
   void save(final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
-    final var prefix = fileSetPath(id, fileSetName);
-    final var namedFiles = fileSet.namedFiles();
-    final var pathToName =
-        namedFiles.entrySet().stream()
-            .collect(
-                Collectors.toMap(e -> e.getValue().toAbsolutePath().toString(), Map.Entry::getKey));
-    final var paths = namedFiles.values().stream().toList();
-
-    final var uploadConfig =
-        ParallelUploadConfig.newBuilder()
-            .setBucketName(bucketInfo.getName())
-            .setUploadBlobInfoFactory(
-                (bucketName, fileName) ->
-                    BlobInfo.newBuilder(bucketName, prefix + pathToName.get(fileName))
-                        .setContentType("application/octet-stream")
-                        .build())
-            .setSkipIfExists(true)
-            .build();
-
-    try {
-      final var uploadJob = transferManager.uploadFiles(paths, uploadConfig);
-      for (final var result : uploadJob.getUploadResults()) {
-        if (result.getStatus() != TransferStatus.SUCCESS
-            && result.getStatus() != TransferStatus.SKIPPED) {
-          LangUtil.rethrowUnchecked(result.getException());
-        }
+    for (final var namedFile : fileSet.namedFiles().entrySet()) {
+      final var fileName = namedFile.getKey();
+      final var filePath = namedFile.getValue();
+      try {
+        client.createFrom(
+            blobInfo(id, fileSetName, fileName), filePath, BlobWriteOption.doesNotExist());
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
       }
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
     }
   }
 
@@ -105,34 +74,14 @@ final class FileSetManager {
       final String filesetName,
       final FileSet fileSet,
       final Path targetFolder) {
-    final var prefix = fileSetPath(id, filesetName);
     final var pathByName =
         fileSet.files().stream()
-            .collect(Collectors.toMap(NamedFile::name, f -> targetFolder.resolve(f.name())));
+            .collect(Collectors.toMap(NamedFile::name, (f) -> targetFolder.resolve(f.name())));
 
-    final var blobInfos =
-        fileSet.files().stream()
-            .map(NamedFile::name)
-            .map(
-                name ->
-                    BlobInfo.newBuilder(bucketInfo.getName(), prefix + name)
-                        .setContentType("application/octet-stream")
-                        .build())
-            .toList();
-
-    final var downloadConfig =
-        ParallelDownloadConfig.newBuilder()
-            .setBucketName(bucketInfo.getName())
-            .setStripPrefix(prefix)
-            .setDownloadDirectory(targetFolder)
-            .build();
-
-    final var downloadJob = transferManager.downloadBlobs(blobInfos, downloadConfig);
-
-    for (final var result : downloadJob.getDownloadResults()) {
-      if (result.getStatus() != TransferStatus.SUCCESS) {
-        LangUtil.rethrowUnchecked(result.getException());
-      }
+    for (final var entry : pathByName.entrySet()) {
+      final var fileName = entry.getKey();
+      final var filePath = entry.getValue();
+      client.downloadTo(blobInfo(id, filesetName, fileName).getBlobId(), filePath);
     }
 
     return new NamedFileSetImpl(pathByName);
@@ -141,5 +90,12 @@ final class FileSetManager {
   private String fileSetPath(final BackupIdentifier id, final String fileSetName) {
     return PATH_FORMAT.formatted(
         basePath, id.partitionId(), id.checkpointId(), id.nodeId(), fileSetName);
+  }
+
+  private BlobInfo blobInfo(
+      final BackupIdentifier id, final String fileSetName, final String fileName) {
+    return BlobInfo.newBuilder(bucketInfo, fileSetPath(id, fileSetName) + fileName)
+        .setContentType("application/octet-stream")
+        .build();
   }
 }


### PR DESCRIPTION
Reverts camunda/camunda#45294

Backups tend to fail due to being modified during upload. As far as I can tell, there's no way to circumvent this while keeping the `TransferManager`, so let's revert for now and look for a better solution.

```
Caused by: com.google.api.client.http.HttpResponseException: 400 Bad Request
PUT https://storage.googleapis.com/upload/storage/v1/b/zeebe-load-test-backups/o?ifGenerationMatch=0&name=ls-backups/contents/1/1770823800478/1/segments/raft-partition-partition-1-2.log&uploadType=resumable&upload_id=AJRbA5VTR5OO2A5SLCJDcNonLGM1tm24V8ttrEAgLCcpbtt5qTttQglGz1l2a3XOqKivCqyA3jCOzXkV2ljT_U366v8TLgNWFElHiK4dkgeFSbjC
{
  "error": {
    "code": 400,
    "message": "Provided CRC32C \"59tHIg==\" doesn't match calculated CRC32C \"sIKTuA==\".",
    "errors": [
      {
        "message": "Provided CRC32C \"59tHIg==\" doesn't match calculated CRC32C \"sIKTuA==\".",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}
```