### PR TITLE
feat: include detailed information about Minor release timeline + best practices

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -330,6 +330,46 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 > - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
 > - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
 
+### Feature Freeze vs Code Freeze (Minor Releases)
+
+For C8 monorepo minor releases, we enforce two distinct stages to ensure quality and predictable delivery:
+
+**🔒 Feature Freeze (Minor Releases)**
+- **Purpose**: Lock in the feature scope for the upcoming minor release
+- **Timing**: Occurs with the **last alpha** before the minor release (e.g., for `8.9.0`, this would be `8.9.0-alpha5`)
+- **What Changes**:
+- ✅ All cross-component features targeted for the minor must be fully implemented, documented, and working end-to-end
+- ❌ No new features, scope extensions, or risky changes after this point
+- ✅ Bug fixes, stabilization work, and E2E testing continue
+- **Notification Process**: Send email to engineering teams with:
+- **Subject**: `Camunda repo (Zeebe/Operate/Tasklist/Identity/Optimize) Release Minor <version> - Feature Freeze`
+- **Body**:
+
+```
+Hey all,
+
+        This appointment marks the feature freeze for the camunda/camunda repository: <minor_version> (minor).
+        <last_alpha_version> is the last alpha before the minor and defines the scope of what will ship in <minor_version>. Any new features or scope changes must be merged before this point to make it into the minor.
+
+        After this date, we focus on bug fixing, stabilization, and end-to-end testing for <minor_version>. New features should target future alphas/minors instead.
+
+        Overall release manager is <release_manager_name>
+
+        Have a nice week!
+        ```
+
+**🚫 Code Freeze (Minor Releases)**
+- **Purpose**: Minimize code changes to ensure release stability
+- **Timing**: On the day of the official minor release start date
+- **What Changes**:
+- ✅ Only **critical** changes allowed (release blockers, severe regressions, security issues)
+- ❌ Non-critical changes deferred to future alphas or patch releases
+- **Coordination**: Scheduled via dedicated calendar invite managed by respective teams
+
+**📅 Important References**
+- **Release Dates**: All upcoming alpha, minor, and feature freeze dates are maintained on the [C8 Release Train](https://confluence.camunda.com/spaces/HAN/pages/201853752/C8+Release+Train) page
+- **Detailed Policy**: See [Minor Release Feature Freeze](https://confluence.camunda.com/spaces/HAN/pages/307894801/Minor+Release+Feature+Freeze) for comprehensive guidelines
+
 ## Troubleshooting
 
 ### How to correlate [Git commits](https://github.com/camunda/zeebe-engineering-processes/commits) with deployed process version in C8 Operate?

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -341,7 +341,7 @@ For C8 monorepo minor releases, we enforce two distinct stages to ensure quality
 - ✅ All cross-component features targeted for the minor must be fully implemented, documented, and working end-to-end
 - ❌ No new features, scope extensions, or risky changes after this point
 - ✅ Bug fixes, stabilization work, and E2E testing continue
-- **Notification Process**: Send email to engineering teams with:
+- **Notification Process**: Send calendar invite to engineering teams (Core Features, Orchestration, QA, DevOps/Release, and other relevant teams) with:
 - **Subject**: `Camunda repo (Zeebe/Operate/Tasklist/Identity/Optimize) Release Minor <version> - Feature Freeze`
 - **Body**:
 


### PR DESCRIPTION
## Description

This pull request adds a new section to the release documentation to clarify the process and policies around feature freeze and code freeze for minor releases. The update aims to ensure a predictable and high-quality release process by distinguishing between when new features are locked in and when only critical changes are allowed.

**Release process clarification:**

* Added a detailed explanation of the distinction between "Feature Freeze" and "Code Freeze" for C8 monorepo minor releases, including their purposes, timing, allowed changes, and communication procedures.
* Provided notification templates and references to relevant release dates and policy documentation to help teams coordinate and follow the process.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
