### PR TITLE
Introduce bpmn process filter

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilter.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Filters records by BPMN process id using simple inclusion/exclusion lists.
+ *
+ * <p>These are the values allowed by the shouldIndexValueType configuration
+ *
+ * <p>Supported record values (all of which expose a BPMN process id) are:
+ *
+ * <ul>
+ *   <li>{@link ConditionalSubscriptionRecordValue}
+ *   <li>{@link DecisionEvaluationRecordValue}
+ *   <li>{@link IncidentRecordValue}
+ *   <li>{@link JobRecordValue}
+ *   <li>{@link MessageStartEventSubscriptionRecordValue}
+ *   <li>{@link MessageSubscriptionRecordValue}
+ *   <li>{@link ProcessInstanceCreationRecordValue}
+ *   <li>{@link ProcessInstanceRecordValue}
+ *   <li>{@link ProcessInstanceResultRecordValue}
+ *   <li>{@link ProcessMessageSubscriptionRecordValue}
+ *   <li>{@link ProcessMetadataValue}
+ *   <li>{@link SignalSubscriptionRecordValue}
+ *   <li>{@link UserTaskRecordValue}
+ *   <li>{@link VariableRecordValue}
+ * </ul>
+ *
+ * <p>Non-supported record values are always accepted (filter is a no-op for them).
+ */
+public final class BpmnProcessFilter implements ExporterRecordFilter, RecordVersionFilter {
+
+  private static final SemanticVersion MIN_BROKER_VERSION =
+      new SemanticVersion(8, 9, 0, null, null);
+
+  private final Set<String> allowedBpmnProcesses;
+  private final Set<String> excludedBpmnProcesses;
+
+  public BpmnProcessFilter(final List<String> inclusion, final List<String> exclusion) {
+    final Set<String> inc = normalize(inclusion);
+    final Set<String> exc = normalize(exclusion);
+
+    final Set<String> allowed = new HashSet<>(inc);
+    allowed.removeAll(exc);
+
+    allowedBpmnProcesses = Collections.unmodifiableSet(allowed);
+    excludedBpmnProcesses = Collections.unmodifiableSet(exc);
+  }
+
+  private static Set<String> normalize(final List<String> raw) {
+    if (raw == null || raw.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Set.copyOf(raw);
+  }
+
+  @Override
+  public boolean accept(final Record<?> record) {
+    final String bpmnProcessId = bpmnProcessIdOf(record.getValue());
+
+    if (bpmnProcessId == null || bpmnProcessId.isEmpty()) {
+      return true;
+    }
+
+    if (allowedBpmnProcesses.isEmpty()) {
+      return !excludedBpmnProcesses.contains(bpmnProcessId);
+    }
+
+    return allowedBpmnProcesses.contains(bpmnProcessId);
+  }
+
+  @Override
+  public SemanticVersion minRecordBrokerVersion() {
+    return MIN_BROKER_VERSION;
+  }
+
+  private static String bpmnProcessIdOf(final RecordValue value) {
+    return switch (value) {
+      case final ConditionalSubscriptionRecordValue v -> v.getBpmnProcessId();
+      case final DecisionEvaluationRecordValue v -> v.getBpmnProcessId();
+      case final IncidentRecordValue v -> v.getBpmnProcessId();
+      case final JobRecordValue v -> v.getBpmnProcessId();
+      case final MessageStartEventSubscriptionRecordValue v -> v.getBpmnProcessId();
+      case final MessageSubscriptionRecordValue v -> v.getBpmnProcessId();
+      case final ProcessInstanceCreationRecordValue v -> v.getBpmnProcessId();
+      case final ProcessInstanceRecordValue v -> v.getBpmnProcessId();
+      case final ProcessInstanceResultRecordValue v -> v.getBpmnProcessId();
+      case final ProcessMessageSubscriptionRecordValue v -> v.getBpmnProcessId();
+      case final ProcessMetadataValue v -> v.getBpmnProcessId();
+      case final SignalSubscriptionRecordValue v -> v.getBpmnProcessId();
+      case final UserTaskRecordValue v -> v.getBpmnProcessId();
+      case final VariableRecordValue v -> v.getBpmnProcessId();
+      default -> null;
+    };
+  }
+}

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilter.java
@@ -77,6 +77,17 @@ public final class DefaultRecordFilter implements Context.RecordFilter {
       filters.add(new VariableTypeFilter(valueTypeInclusion, valueTypeExclusion));
     }
 
+    if (!index.getBpmnProcessIdInclusion().isEmpty()
+        || !index.getBpmnProcessIdExclusion().isEmpty()) {
+      LOG.info(
+          "Bpmn process id filters configured. Inclusion ids: {}, Exclusion ids: {}.",
+          index.getBpmnProcessIdInclusion(),
+          index.getBpmnProcessIdExclusion());
+      filters.add(
+          new BpmnProcessFilter(
+              index.getBpmnProcessIdInclusion(), index.getBpmnProcessIdExclusion()));
+    }
+
     return List.copyOf(filters);
   }
 

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/FilterConfiguration.java
@@ -46,6 +46,10 @@ public interface FilterConfiguration {
 
     List<String> getVariableValueTypeExclusion();
 
+    List<String> getBpmnProcessIdInclusion();
+
+    List<String> getBpmnProcessIdExclusion();
+
     boolean isOptimizeModeEnabled();
   }
 }

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilterTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ConditionalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.util.SemanticVersion;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.stubbing.Answer;
+
+final class BpmnProcessFilterTest {
+
+  private static final String INCLUDED_ID = "order-process";
+  private static final String EXCLUDED_ID = "deprecated-process";
+  private static final String OTHER_ID = "other-process";
+
+  // ---------------------------------------------------------------------------
+  // Basic behavior
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldAcceptAllWhenNoInclusionOrExclusionConfigured() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(), List.of());
+
+    final var recordWithProcess =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, INCLUDED_ID));
+
+    // when / then
+    assertThat(filter.accept(recordWithProcess))
+        .as("No inclusion/exclusion configured -> record should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldFilterByInclusionOnly() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(INCLUDED_ID), List.of());
+
+    final var includedRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, INCLUDED_ID));
+    final var otherRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, OTHER_ID));
+
+    // when / then
+    assertThat(filter.accept(includedRecord))
+        .as("Record for included BPMN process id should be accepted")
+        .isTrue();
+    assertThat(filter.accept(otherRecord))
+        .as("Record for non-included BPMN process id should be rejected")
+        .isFalse();
+  }
+
+  @Test
+  void shouldFilterByExclusionOnly() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(), List.of(EXCLUDED_ID));
+
+    final var excludedRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, EXCLUDED_ID));
+    final var otherRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, OTHER_ID));
+
+    // when / then
+    assertThat(filter.accept(excludedRecord))
+        .as("Record for excluded BPMN process id should be rejected")
+        .isFalse();
+    assertThat(filter.accept(otherRecord))
+        .as("Record for other BPMN process ids should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldLetExclusionOverrideInclusionWhenBothPresent() {
+    // given
+    final var filter =
+        new BpmnProcessFilter(
+            /* inclusion */ List.of(INCLUDED_ID, EXCLUDED_ID), /* exclusion */
+            List.of(EXCLUDED_ID));
+
+    final var includedRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, INCLUDED_ID));
+    final var excludedRecord =
+        recordWithValue(valueWithBpmnProcessId(ProcessInstanceRecordValue.class, EXCLUDED_ID));
+
+    // when / then
+    assertThat(filter.accept(includedRecord))
+        .as("ID present in inclusion but not in exclusion should remain allowed")
+        .isTrue();
+    assertThat(filter.accept(excludedRecord))
+        .as(
+            "ID present in both inclusion and exclusion should be removed from allowed set "
+                + "and therefore rejected")
+        .isFalse();
+  }
+
+  @Test
+  void shouldAcceptSupportedRecordsWithNullBpmnProcessId() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(INCLUDED_ID), List.of());
+
+    final var value = valueWithBpmnProcessId(ProcessInstanceRecordValue.class, null);
+    final var record = recordWithValue(value);
+
+    // when / then
+    assertThat(filter.accept(record))
+        .as("Records with null BPMN process id should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldAcceptSupportedRecordsWithEmptyBpmnProcessId() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(INCLUDED_ID), List.of());
+
+    final var value = valueWithBpmnProcessId(ProcessInstanceRecordValue.class, "");
+    final var record = recordWithValue(value);
+
+    // when / then
+    assertThat(filter.accept(record))
+        .as("Records with empty BPMN process id should be accepted")
+        .isTrue();
+  }
+
+  @Test
+  void shouldAcceptUnsupportedRecordValues() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(), List.of(EXCLUDED_ID));
+
+    // A plain RecordValue that does not implement any of the supported interfaces
+    final RecordValue unsupportedValue = mock(RecordValue.class);
+    final var record = recordWithValue(unsupportedValue);
+
+    // when / then
+    assertThat(filter.accept(record))
+        .as("Unsupported record values should always be accepted (filter is no-op)")
+        .isTrue();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Coverage for all supported value types
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExtractBpmnProcessIdFromAllSupportedRecordValues() {
+    // given
+    final var filter = new BpmnProcessFilter(List.of(), List.of(EXCLUDED_ID));
+
+    final var values =
+        List.of(
+            valueWithBpmnProcessId(ConditionalSubscriptionRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(DecisionEvaluationRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(IncidentRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(JobRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(MessageStartEventSubscriptionRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(MessageSubscriptionRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(ProcessInstanceCreationRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(ProcessInstanceRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(ProcessInstanceResultRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(ProcessMessageSubscriptionRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(ProcessMetadataValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(SignalSubscriptionRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(UserTaskRecordValue.class, EXCLUDED_ID),
+            valueWithBpmnProcessId(VariableRecordValue.class, EXCLUDED_ID));
+
+    // when / then
+    for (final RecordValue value : values) {
+      final Record<?> record = recordWithValue(value);
+
+      assertThat(filter.accept(record))
+          .as(
+              "Record for %s should be rejected when its BPMN process id is excluded",
+              value.getClass().getSimpleName())
+          .isFalse();
+    }
+  }
+
+  @Test
+  void shouldExposeMinimumBrokerVersion() {
+    final var filter = new BpmnProcessFilter(List.of(), List.of());
+
+    assertThat(filter.minRecordBrokerVersion()).isEqualTo(new SemanticVersion(8, 9, 0, null, null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> recordWithValue(final T value) {
+    final Record<T> record = (Record<T>) mock(Record.class);
+    when(record.getValue()).thenReturn(value);
+    return record;
+  }
+
+  private static <T extends RecordValue> T valueWithBpmnProcessId(
+      final Class<T> type, final String bpmnProcessId) {
+
+    final Answer<Object> defaults = Answers.RETURNS_DEFAULTS;
+
+    return mock(
+        type,
+        invocation -> {
+          if ("getBpmnProcessId".equals(invocation.getMethod().getName())
+              && invocation.getArguments().length == 0) {
+            return bpmnProcessId;
+          }
+          return defaults.answer(invocation);
+        });
+  }
+}

--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/config/TestIndexConfig.java
@@ -29,6 +29,9 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   private List<String> variableValueTypeInclusion = List.of();
   private List<String> variableValueTypeExclusion = List.of();
 
+  private List<String> bpmnProcessIdInclusion = List.of();
+  private List<String> bpmnProcessIdExclusion = List.of();
+
   private boolean optimizeModeEnabled = false;
 
   // --- fluent setters -------------------------------------------------------
@@ -78,6 +81,16 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
     return this;
   }
 
+  public TestIndexConfig withBpmnProcessIdInclusion(final List<String> bpmnProcessIds) {
+    bpmnProcessIdInclusion = bpmnProcessIds != null ? bpmnProcessIds : List.of();
+    return this;
+  }
+
+  public TestIndexConfig withBpmnProcessIdExclusion(final List<String> bpmnProcessIds) {
+    bpmnProcessIdExclusion = bpmnProcessIds != null ? bpmnProcessIds : List.of();
+    return this;
+  }
+
   // --- FilterConfiguration.IndexConfig -------------------------------------
 
   @Override
@@ -118,6 +131,16 @@ public final class TestIndexConfig implements FilterConfiguration.IndexConfig {
   @Override
   public List<String> getVariableValueTypeExclusion() {
     return variableValueTypeExclusion;
+  }
+
+  @Override
+  public List<String> getBpmnProcessIdInclusion() {
+    return bpmnProcessIdInclusion;
+  }
+
+  @Override
+  public List<String> getBpmnProcessIdExclusion() {
+    return bpmnProcessIdExclusion;
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -271,6 +271,10 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     // optimize mode
     private boolean optimizeModeEnabled = false;
 
+    // BPMN process id filters
+    private List<String> bpmnProcessIdInclusion = new ArrayList<>();
+    private List<String> bpmnProcessIdExclusion = new ArrayList<>();
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -336,12 +340,30 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     }
 
     @Override
+    public List<String> getBpmnProcessIdInclusion() {
+      return List.copyOf(bpmnProcessIdInclusion);
+    }
+
+    @Override
+    public List<String> getBpmnProcessIdExclusion() {
+      return List.copyOf(bpmnProcessIdExclusion);
+    }
+
+    @Override
     public boolean isOptimizeModeEnabled() {
       return optimizeModeEnabled;
     }
 
     public void setOptimizeModeEnabled(final boolean optimizeModeEnabled) {
       this.optimizeModeEnabled = optimizeModeEnabled;
+    }
+
+    public void setBpmnProcessIdExclusion(final List<String> bpmnProcessIdExclusion) {
+      this.bpmnProcessIdExclusion = bpmnProcessIdExclusion;
+    }
+
+    public void setBpmnProcessIdInclusion(final List<String> bpmnProcessIdInclusion) {
+      this.bpmnProcessIdInclusion = bpmnProcessIdInclusion;
     }
 
     public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
@@ -491,6 +513,10 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeExclusion
           + ", optimizeModeEnabled="
           + optimizeModeEnabled
+          + ", bpmnProcessIdInclusion="
+          + bpmnProcessIdInclusion
+          + ", bpmnProcessIdExclusion="
+          + bpmnProcessIdExclusion
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -262,6 +262,10 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     // optimize mode
     private boolean optimizeModeEnabled = false;
 
+    // BPMN process id filters
+    private List<String> bpmnProcessIdInclusion = new ArrayList<>();
+    private List<String> bpmnProcessIdExclusion = new ArrayList<>();
+
     public Integer getNumberOfShards() {
       return numberOfShards;
     }
@@ -327,12 +331,30 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     }
 
     @Override
+    public List<String> getBpmnProcessIdInclusion() {
+      return List.copyOf(bpmnProcessIdInclusion);
+    }
+
+    @Override
+    public List<String> getBpmnProcessIdExclusion() {
+      return List.copyOf(bpmnProcessIdExclusion);
+    }
+
+    @Override
     public boolean isOptimizeModeEnabled() {
       return optimizeModeEnabled;
     }
 
     public void setOptimizeModeEnabled(final boolean optimizeModeEnabled) {
       this.optimizeModeEnabled = optimizeModeEnabled;
+    }
+
+    public void setBpmnProcessIdExclusion(final List<String> bpmnProcessIdExclusion) {
+      this.bpmnProcessIdExclusion = bpmnProcessIdExclusion;
+    }
+
+    public void setBpmnProcessIdInclusion(final List<String> bpmnProcessIdInclusion) {
+      this.bpmnProcessIdInclusion = bpmnProcessIdInclusion;
     }
 
     public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
@@ -480,6 +502,10 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeExclusion
           + ", optimizeModeEnabled="
           + optimizeModeEnabled
+          + ", bpmnProcessIdInclusion="
+          + bpmnProcessIdInclusion
+          + ", bpmnProcessIdExclusion="
+          + bpmnProcessIdExclusion
           + '}';
     }
   }


### PR DESCRIPTION
## Description

Introduce a shared BpmnProcessFilter that filters exporter records by BPMN process id using inclusion and exclusion lists.

Extend FilterConfiguration and the Elasticsearch/OpenSearch exporter index configurations with BPMN process id inclusion/exclusion settings.

Wire the BPMN process filter into DefaultRecordFilter so it is applied when BPMN filter configuration is present.

Add unit tests to cover BPMN process id filtering behavior and its integration with the default record filter.

## Related issues

closes https://github.com/camunda/camunda/issues/44140
