### PR TITLE
feat: add tenantfilter to grpc api

### DIFF
--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
@@ -19,10 +18,10 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
-import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TenantFilter;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -38,149 +37,377 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
-public final class ActivateJobsTest extends GatewayTest {
+@RunWith(Enclosed.class)
+public final class ActivateJobsTest {
 
-  public ActivateJobsTest(final boolean isLongPollingEnabled) {
-    super(getConfig(isLongPollingEnabled), new SecurityConfiguration());
-  }
+  @RunWith(Parameterized.class)
+  public static class MultiTenancyDisabledTest extends GatewayTest {
 
-  @Parameters(name = "{index}: longPolling.enabled[{0}]")
-  public static Iterable<Object[]> data() {
-    return Arrays.asList(new Object[][] {{true}, {false}});
-  }
-
-  private static GatewayCfg getConfig(final boolean isLongPollingEnabled) {
-    final var config = new GatewayCfg();
-    config.getLongPolling().setEnabled(isLongPollingEnabled);
-    return config;
-  }
-
-  @Test
-  public void shouldMapRequestAndResponse() {
-    // given
-    final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.registerWith(brokerClient);
-
-    final String jobType = "testJob";
-    final String worker = "testWorker";
-    final int maxJobsToActivate = 13;
-    final Duration timeout = Duration.ofMinutes(12);
-    final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
-
-    final ActivateJobsRequest request =
-        ActivateJobsRequest.newBuilder()
-            .setType(jobType)
-            .setWorker(worker)
-            .setMaxJobsToActivate(maxJobsToActivate)
-            .setTimeout(timeout.toMillis())
-            .addAllFetchVariable(fetchVariables)
-            .build();
-
-    stub.addAvailableJobs(jobType, maxJobsToActivate);
-
-    // when
-    final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
-
-    // then
-    assertThat(responses.hasNext()).isTrue();
-
-    final ActivateJobsResponse response = responses.next();
-
-    assertThat(response.getJobsCount()).isEqualTo(maxJobsToActivate);
-
-    for (int i = 0; i < maxJobsToActivate; i++) {
-      final ActivatedJob job = response.getJobs(i);
-      assertThat(job.getKey())
-          .isEqualTo(Protocol.encodePartitionId(Protocol.START_PARTITION_ID, i));
-      assertThat(job.getType()).isEqualTo(jobType);
-      assertThat(job.getWorker()).isEqualTo(worker);
-      assertThat(job.getRetries()).isEqualTo(stub.getRetries());
-      assertThat(job.getDeadline()).isEqualTo(stub.getDeadline());
-      assertThat(job.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
-      assertThat(job.getBpmnProcessId()).isEqualTo(stub.getBpmnProcessId());
-      assertThat(job.getProcessDefinitionVersion()).isEqualTo(stub.getProcessDefinitionVersion());
-      assertThat(job.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
-      assertThat(job.getElementId()).isEqualTo(stub.getElementId());
-      assertThat(job.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-      assertThat(job.getElementInstanceKey()).isEqualTo(stub.getElementInstanceKey());
-      JsonUtil.assertEquality(job.getCustomHeaders(), stub.getCustomHeaders());
-      JsonUtil.assertEquality(job.getVariables(), stub.getVariables());
+    public MultiTenancyDisabledTest(final boolean isLongPollingEnabled) {
+      super(
+          cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
+          cfg -> cfg.getMultiTenancy().setChecksEnabled(false));
     }
 
-    final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
-    final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
-    assertThat(brokerRequestValue.getMaxJobsToActivate()).isEqualTo(maxJobsToActivate);
-    assertThat(brokerRequestValue.getTypeBuffer()).isEqualTo(wrapString(jobType));
-    assertThat(brokerRequestValue.getTimeout()).isEqualTo(timeout.toMillis());
-    assertThat(brokerRequestValue.getWorkerBuffer()).isEqualTo(wrapString(worker));
-    assertThat(brokerRequestValue.variables())
-        .extracting(v -> BufferUtil.bufferAsString(v.getValue()))
-        .containsExactlyInAnyOrderElementsOf(fetchVariables);
-    assertThat(brokerRequestValue.getTenantIds())
-        .containsExactly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
+    @Parameters(name = "{index}: longPolling.enabled[{0}]")
+    public static Iterable<Object[]> data() {
+      return Arrays.asList(new Object[][] {{true}, {false}});
+    }
 
-  @Test
-  public void shouldActivateJobsRoundRobin() {
-    // given
-    final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.registerWith(brokerClient);
+    @Test
+    public void shouldMapRequestAndResponse() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
 
-    final String type = "test";
-    final int maxJobsToActivate = 2;
-    final ActivateJobsRequest request =
-        ActivateJobsRequest.newBuilder()
-            .setType(type)
-            .setMaxJobsToActivate(maxJobsToActivate)
-            .build();
+      final String jobType = "testJob";
+      final String worker = "testWorker";
+      final int maxJobsToActivate = 13;
+      final Duration timeout = Duration.ofMinutes(12);
+      final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
 
-    for (int partitionOffset = 0; partitionOffset < 3; partitionOffset++) {
-      stub.addAvailableJobs(type, maxJobsToActivate);
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setWorker(worker)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .setTimeout(timeout.toMillis())
+              .addAllFetchVariable(fetchVariables)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
       // when
       final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
 
       // then
       assertThat(responses.hasNext()).isTrue();
+
       final ActivateJobsResponse response = responses.next();
 
-      for (final ActivatedJob activatedJob : response.getJobsList()) {
-        assertThat(Protocol.decodePartitionId(activatedJob.getKey()))
-            .isEqualTo(Protocol.START_PARTITION_ID + partitionOffset);
+      assertThat(response.getJobsCount()).isEqualTo(maxJobsToActivate);
+
+      for (int i = 0; i < maxJobsToActivate; i++) {
+        final ActivatedJob job = response.getJobs(i);
+        assertThat(job.getKey())
+            .isEqualTo(Protocol.encodePartitionId(Protocol.START_PARTITION_ID, i));
+        assertThat(job.getType()).isEqualTo(jobType);
+        assertThat(job.getWorker()).isEqualTo(worker);
+        assertThat(job.getRetries()).isEqualTo(stub.getRetries());
+        assertThat(job.getDeadline()).isEqualTo(stub.getDeadline());
+        assertThat(job.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
+        assertThat(job.getBpmnProcessId()).isEqualTo(stub.getBpmnProcessId());
+        assertThat(job.getProcessDefinitionVersion()).isEqualTo(stub.getProcessDefinitionVersion());
+        assertThat(job.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
+        assertThat(job.getElementId()).isEqualTo(stub.getElementId());
+        assertThat(job.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        assertThat(job.getElementInstanceKey()).isEqualTo(stub.getElementInstanceKey());
+        JsonUtil.assertEquality(job.getCustomHeaders(), stub.getCustomHeaders());
+        JsonUtil.assertEquality(job.getVariables(), stub.getVariables());
       }
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getMaxJobsToActivate()).isEqualTo(maxJobsToActivate);
+      assertThat(brokerRequestValue.getTypeBuffer()).isEqualTo(wrapString(jobType));
+      assertThat(brokerRequestValue.getTimeout()).isEqualTo(timeout.toMillis());
+      assertThat(brokerRequestValue.getWorkerBuffer()).isEqualTo(wrapString(worker));
+      assertThat(brokerRequestValue.variables())
+          .extracting(v -> BufferUtil.bufferAsString(v.getValue()))
+          .containsExactlyInAnyOrderElementsOf(fetchVariables);
+      assertThat(brokerRequestValue.getTenantIds())
+          .containsExactly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    }
+
+    @Test
+    public void shouldActivateJobsRoundRobin() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String type = "test";
+      final int maxJobsToActivate = 2;
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(type)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .build();
+
+      for (int partitionOffset = 0; partitionOffset < 3; partitionOffset++) {
+        stub.addAvailableJobs(type, maxJobsToActivate);
+        // when
+        final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+        // then
+        assertThat(responses.hasNext()).isTrue();
+        final ActivateJobsResponse response = responses.next();
+
+        for (final ActivatedJob activatedJob : response.getJobsList()) {
+          assertThat(Protocol.decodePartitionId(activatedJob.getKey()))
+              .isEqualTo(Protocol.START_PARTITION_ID + partitionOffset);
+        }
+      }
+    }
+
+    @Test
+    public void shouldSendRejectionWithoutRetrying() {
+      // given
+      final RejectionType rejectionType = RejectionType.INVALID_ARGUMENT;
+      final AtomicInteger callCounter = new AtomicInteger();
+
+      brokerClient.registerHandler(
+          BrokerActivateJobsRequest.class,
+          (RequestHandler<BrokerRequest<?>, BrokerResponse<?>>)
+              request -> {
+                callCounter.incrementAndGet();
+                return new BrokerRejectionResponse<>(
+                    new BrokerRejection(Intent.UNKNOWN, 1, rejectionType, "expected"));
+              });
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder().setType("").setMaxJobsToActivate(1).build();
+
+      // when/then
+      assertThatThrownBy(
+              () -> {
+                final Iterator<ActivateJobsResponse> responseIterator =
+                    client.activateJobs(request);
+                responseIterator.hasNext();
+              })
+          .isInstanceOf(StatusRuntimeException.class)
+          .extracting(t -> ((StatusRuntimeException) t).getStatus().getCode())
+          .isEqualTo(Status.INVALID_ARGUMENT.getCode());
+      assertThat(callCounter).hasValue(1);
+    }
+
+    @Test
+    public void shouldDefaultToProvidedTenantFilterAndDefaultTenantWhenMultiTenancyDisabled() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final int maxJobsToActivate = 5;
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantIds())
+          .describedAs(
+              "When multi-tenancy is disabled and no tenant IDs are provided, the default tenant ID should be used")
+          .containsExactly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      assertThat(brokerRequestValue.getTenantFilter())
+          .describedAs(
+              "When multi-tenancy is disabled and no tenant filter is provided, it should default to PROVIDED")
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED);
     }
   }
 
-  @Test
-  public void shouldSendRejectionWithoutRetrying() {
-    // given
-    final RejectionType rejectionType = RejectionType.INVALID_ARGUMENT;
-    final AtomicInteger callCounter = new AtomicInteger();
+  @RunWith(Parameterized.class)
+  public static class MultiTenancyEnabledTest extends GatewayTest {
 
-    brokerClient.registerHandler(
-        BrokerActivateJobsRequest.class,
-        (RequestHandler<BrokerRequest<?>, BrokerResponse<?>>)
-            request -> {
-              callCounter.incrementAndGet();
-              return new BrokerRejectionResponse<>(
-                  new BrokerRejection(Intent.UNKNOWN, 1, rejectionType, "expected"));
-            });
-    final ActivateJobsRequest request =
-        ActivateJobsRequest.newBuilder().setType("").setMaxJobsToActivate(1).build();
+    public MultiTenancyEnabledTest(final boolean isLongPollingEnabled) {
+      super(
+          cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
+          cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
+    }
 
-    // when/then
-    assertThatThrownBy(
-            () -> {
-              final Iterator<ActivateJobsResponse> responseIterator = client.activateJobs(request);
-              responseIterator.hasNext();
-            })
-        .isInstanceOf(StatusRuntimeException.class)
-        .extracting(t -> ((StatusRuntimeException) t).getStatus().getCode())
-        .isEqualTo(Status.INVALID_ARGUMENT.getCode());
-    assertThat(callCounter).hasValue(1);
+    @Parameters(name = "{index}: longPolling.enabled[{0}]")
+    public static Iterable<Object[]> data() {
+      return Arrays.asList(new Object[][] {{true}, {false}});
+    }
+
+    @Test
+    public void shouldMapProvidedTenantFilterWithTenantIds() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final List<String> tenantIds = Arrays.asList("tenant-a", "tenant-b", "tenant-c");
+      final int maxJobsToActivate = 5;
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .addAllTenantIds(tenantIds)
+              .setTenantFilter(TenantFilter.PROVIDED)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantIds()).containsExactlyElementsOf(tenantIds);
+      assertThat(brokerRequestValue.getTenantFilter())
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED);
+    }
+
+    @Test
+    public void shouldMapAssignedTenantFilterWithoutTenantIds() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final int maxJobsToActivate = 5;
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .setTenantFilter(TenantFilter.ASSIGNED)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantIds())
+          .describedAs(
+              "When ASSIGNED filter is used, tenant IDs should be empty as they will be determined from authorized tenants")
+          .isEmpty();
+      assertThat(brokerRequestValue.getTenantFilter())
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED);
+    }
+
+    @Test
+    public void shouldIgnoreTenantIdsWhenAssignedTenantFilterIsUsed() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final List<String> tenantIds = Arrays.asList("tenant-a", "tenant-b");
+      final int maxJobsToActivate = 5;
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .addAllTenantIds(tenantIds)
+              .setTenantFilter(TenantFilter.ASSIGNED)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantIds())
+          .describedAs(
+              "Provided tenant IDs should be ignored when ASSIGNED filter is used. "
+                  + "Tenant IDs will be determined from authorized tenants instead.")
+          .isEmpty();
+      assertThat(brokerRequestValue.getTenantFilter())
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED);
+    }
+
+    @Test
+    public void shouldDefaultToProvidedTenantFilterWhenNotSpecified() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final int maxJobsToActivate = 5;
+      final List<String> tenantIds = List.of("tenant-a");
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .addAllTenantIds(tenantIds)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantFilter())
+          .describedAs("When no tenant filter is specified, it should default to PROVIDED")
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED);
+      assertThat(brokerRequestValue.getTenantIds()).containsExactlyElementsOf(tenantIds);
+    }
+
+    @Test
+    public void shouldMapProvidedTenantFilterWithSingleTenantId() {
+      // given
+      final ActivateJobsStub stub = new ActivateJobsStub();
+      stub.registerWith(brokerClient);
+
+      final String jobType = "testJob";
+      final String tenantId = "tenant-xyz";
+      final int maxJobsToActivate = 3;
+
+      final ActivateJobsRequest request =
+          ActivateJobsRequest.newBuilder()
+              .setType(jobType)
+              .setMaxJobsToActivate(maxJobsToActivate)
+              .addTenantIds(tenantId)
+              .setTenantFilter(TenantFilter.PROVIDED)
+              .build();
+
+      stub.addAvailableJobs(jobType, maxJobsToActivate);
+
+      // when
+      final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+      // then
+      assertThat(responses.hasNext()).isTrue();
+      responses.next();
+
+      final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+      final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
+      assertThat(brokerRequestValue.getTenantIds()).containsExactly(tenantId);
+      assertThat(brokerRequestValue.getTenantFilter())
+          .isEqualTo(io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED);
+    }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -44,11 +44,21 @@ message ActivateJobsRequest {
   int64 requestTimeout = 6;
   // a list of IDs of tenants for which to activate jobs
   repeated string tenantIds = 7;
+  // the tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs
+  TenantFilter tenantFilter = 8;
 }
 
 message ActivateJobsResponse {
   // list of activated jobs
   repeated ActivatedJob jobs = 1;
+}
+
+// Describes the tenant filtering strategy for job activation
+enum TenantFilter {
+  // Use the tenant IDs provided in the request
+  PROVIDED = 0;
+  // Use the tenant IDs assigned to the authenticated user/identity
+  ASSIGNED = 1;
 }
 
 message ActivatedJob {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import org.agrona.DirectBuffer;
@@ -52,6 +53,11 @@ public final class BrokerActivateJobsRequest extends BrokerExecuteCommand<JobBat
 
   public BrokerActivateJobsRequest setTenantIds(final List<String> tenantIds) {
     requestDto.setTenantIds(tenantIds);
+    return this;
+  }
+
+  public BrokerActivateJobsRequest setTenantFilter(final TenantFilter tenantFilter) {
+    requestDto.setTenantFilter(tenantFilter);
     return this;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR introduces the TenantFilter enum to the gRPC protocol and wires this into the gRPC request mapper.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45341, closes https://github.com/camunda/camunda/issues/45342
