### PR TITLE
feat: create a batch operation to delete decision definition related data

### DIFF
--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -175,6 +175,13 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if
+        test="filter.decisionRequirementsKeyOperations != null and !filter.decisionRequirementsKeyOperations.isEmpty()">
+        <foreach collection="filter.decisionRequirementsKeyOperations" item="operation">
+          AND di.DECISION_REQUIREMENTS_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.partitionId != null">
         AND di.PARTITION_ID = #{filter.partitionId}
       </if>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -274,6 +274,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getRootDecisionDefinitionKey())
           .map(mapToOperations(Long.class))
           .ifPresent(builder::rootDecisionDefinitionKeyOperations);
+      ofNullable(filter.getDecisionRequirementsKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::decisionRequirementsKeyOperations);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
     return builder.build();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -106,6 +106,7 @@ public class DecisionInstanceSpecificFilterIT {
                     .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
                     .decisionDefinitionId(decisionDefinition.decisionDefinitionId())
                     .rootDecisionDefinitionKey(rootDecisionDefinitionKey)
+                    .decisionRequirementsKey(567L)
                     .evaluationFailure("failure-42")
                     .tenantId("unique-tenant-42")
                     .result("result-42")
@@ -147,6 +148,7 @@ public class DecisionInstanceSpecificFilterIT {
         DecisionInstanceFilter.of(b -> b.evaluationDateOperations(Operation.lte(THEN))),
         DecisionInstanceFilter.of(b -> b.rootDecisionDefinitionKeys(200L)),
         DecisionInstanceFilter.of(b -> b.rootDecisionDefinitionKeyOperations(Operation.eq(200L))),
+        DecisionInstanceFilter.of(b -> b.decisionRequirementsKeyOperations(Operation.eq(567L))),
         DecisionInstanceFilter.of(b -> b.tenantIds("unique-tenant-42", "foo")),
         DecisionInstanceFilter.of(b -> b.partitionId(1)));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -20,6 +20,7 @@ import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PART
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_ID;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_NAME;
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_REQUIREMENTS_KEY;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.ELEMENT_INSTANCE_KEY;
@@ -74,6 +75,7 @@ public final class DecisionInstanceFilterTransformer
     ofNullable(getDecisionDefinitionTypesQuery(filter.decisionTypes())).ifPresent(queries::add);
     queries.addAll(
         getRootDecisionDefinitionKeysQuery(filter.rootDecisionDefinitionKeyOperations()));
+    queries.addAll(getDecisionRequirementsKeysQuery(filter.decisionRequirementsKeyOperations()));
     ofNullable(getTenantIdsQuery(filter.tenantIds())).ifPresent(queries::add);
 
     if (filter.partitionId() != null) {
@@ -168,6 +170,11 @@ public final class DecisionInstanceFilterTransformer
                 })
             .toList();
     return stringOperations(ROOT_DECISION_DEFINITION_ID, stringOperations);
+  }
+
+  private List<SearchQuery> getDecisionRequirementsKeysQuery(
+      final List<Operation<Long>> decisionRequirementsKeyOperations) {
+    return longOperations(DECISION_REQUIREMENTS_KEY, decisionRequirementsKeyOperations);
   }
 
   private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
@@ -36,6 +36,7 @@ public record DecisionInstanceFilter(
     List<Integer> decisionDefinitionVersions,
     List<DecisionDefinitionType> decisionTypes,
     List<Operation<Long>> rootDecisionDefinitionKeyOperations,
+    List<Operation<Long>> decisionRequirementsKeyOperations,
     List<String> tenantIds,
     Integer partitionId)
     implements FilterBase {
@@ -61,6 +62,7 @@ public record DecisionInstanceFilter(
         .decisionDefinitionVersions(decisionDefinitionVersions)
         .decisionTypes(decisionTypes)
         .rootDecisionDefinitionKeyOperations(rootDecisionDefinitionKeyOperations)
+        .decisionRequirementsKeyOperations(decisionRequirementsKeyOperations)
         .tenantIds(tenantIds)
         .partitionId(partitionId);
   }
@@ -81,6 +83,7 @@ public record DecisionInstanceFilter(
     private List<Integer> decisionDefinitionVersions;
     private List<DecisionDefinitionType> decisionTypes;
     private List<Operation<Long>> rootDecisionDefinitionKeyOperations;
+    private List<Operation<Long>> decisionRequirementsKeyOperations;
     private List<String> tenantIds;
     private Integer partitionId;
 
@@ -184,7 +187,8 @@ public record DecisionInstanceFilter(
     }
 
     public Builder decisionDefinitionKeys(final Long value, final Long... values) {
-      return decisionDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+      return decisionDefinitionKeyOperations(
+          List.of(FilterUtil.mapDefaultToOperation(value, values)));
     }
 
     @SafeVarargs
@@ -245,6 +249,22 @@ public record DecisionInstanceFilter(
       return rootDecisionDefinitionKeyOperations(collectValues(operation, operations));
     }
 
+    public Builder decisionRequirementsKeyOperations(final List<Operation<Long>> operations) {
+      decisionRequirementsKeyOperations =
+          addValuesToList(decisionRequirementsKeyOperations, operations);
+      return this;
+    }
+
+    public Builder decisionRequirementsKeys(final Long value, final Long... values) {
+      return decisionRequirementsKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder decisionRequirementsKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return decisionRequirementsKeyOperations(collectValues(operation, operations));
+    }
+
     public Builder tenantIds(final List<String> values) {
       tenantIds = addValuesToList(tenantIds, values);
       return this;
@@ -276,6 +296,7 @@ public record DecisionInstanceFilter(
           Objects.requireNonNullElse(decisionDefinitionVersions, Collections.emptyList()),
           Objects.requireNonNullElse(decisionTypes, Collections.emptyList()),
           Objects.requireNonNullElse(rootDecisionDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionRequirementsKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
           partitionId);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -54,6 +54,7 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
       case PROCESS_INSTANCE -> deleteProcessInstance(command);
       case PROCESS_DEFINITION -> deleteProcessDefinition(command);
       case DECISION_INSTANCE -> deleteDecisionInstance(command);
+      case DECISION_DEFINITION -> deleteDecisionDefinition(command);
       default ->
           throw new UnsupportedOperationException(
               "Unsupported resource type: " + command.getValue().getResourceType());
@@ -121,6 +122,11 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
     return authCheckBehavior
         .isAuthorizedOrInternalCommand(request)
         .map(ignored -> command.getValue());
+  }
+
+  private void deleteDecisionDefinition(final TypedRecord<HistoryDeletionRecord> command) {
+    final var recordValue = command.getValue();
+    writeHistoryDeletionEvent(recordValue, command);
   }
 
   private Either<Rejection, HistoryDeletionRecord> validateProcessInstanceDoesNotExist(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteDecisionDefinitionHistoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/historydeletion/DeleteDecisionDefinitionHistoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.historydeletion;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteDecisionDefinitionHistoryTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeleteDecisionDefinitionHistory() {
+    // given
+    final var decisionRequirementsKey =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DMN_RESOURCE)
+            .deploy()
+            .getValue()
+            .getDecisionsMetadata()
+            .getFirst()
+            .getDecisionRequirementsKey();
+
+    // when
+    final var deletedEvent =
+        ENGINE.historyDeletion().decisionDefinition(decisionRequirementsKey).delete();
+
+    // then
+    assertThat(deletedEvent.getValue())
+        .hasResourceKey(decisionRequirementsKey)
+        .hasResourceType(HistoryDeletionType.DECISION_DEFINITION);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -809,7 +809,7 @@ public class ResourceDeletionTest {
     // then
     verifyProcessIdWithVersionIsDeleted(processId, 1);
     verifyResourceDeletionRecords(processDefinitionKey);
-    verifyBatchOperationIsCreated(
+    followUpCommandHistoryDeletionType(
         processDefinitionKey,
         BatchOperationType.DELETE_PROCESS_INSTANCE,
         HistoryDeletionType.PROCESS_DEFINITION,
@@ -911,7 +911,7 @@ public class ResourceDeletionTest {
     verifyDecisionIdWithVersionIsDeleted(drgKey, "jedi_or_sith", 1);
     verifyDecisionRequirementsIsDeleted(drgKey);
     verifyResourceDeletionRecords(drgKey);
-    verifyBatchOperationIsCreated(
+    followUpCommandHistoryDeletionType(
         drgKey,
         BatchOperationType.DELETE_DECISION_INSTANCE,
         HistoryDeletionType.DECISION_DEFINITION,
@@ -1419,7 +1419,7 @@ public class ResourceDeletionTest {
         .build();
   }
 
-  private static void verifyBatchOperationIsCreated(
+  private static void followUpCommandHistoryDeletionType(
       final long resourceKey,
       final BatchOperationType batchOperationType,
       final HistoryDeletionType historyDeletionType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -15,7 +15,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -807,7 +809,11 @@ public class ResourceDeletionTest {
     // then
     verifyProcessIdWithVersionIsDeleted(processId, 1);
     verifyResourceDeletionRecords(processDefinitionKey);
-    verifyBatchOperationIsCreated(processDefinitionKey);
+    verifyBatchOperationIsCreated(
+        processDefinitionKey,
+        BatchOperationType.DELETE_PROCESS_INSTANCE,
+        HistoryDeletionType.PROCESS_DEFINITION,
+        "\"processDefinitionKeyOperations\":[{\"operator\":\"EQUALS\",\"values\":[%s]}]");
 
     assertThat(RecordingExporter.historyDeletionRecords(HistoryDeletionIntent.DELETED).limit(3))
         .describedAs(
@@ -818,6 +824,109 @@ public class ResourceDeletionTest {
             tuple(processInstanceKey1, HistoryDeletionType.PROCESS_INSTANCE),
             tuple(processInstanceKey2, HistoryDeletionType.PROCESS_INSTANCE),
             tuple(processDefinitionKey, HistoryDeletionType.PROCESS_DEFINITION));
+  }
+
+  @Test
+  public void shouldNotCreateBatchOperationOnDecisionDefinitionDeletionWhenDeleteHistoryIsFalse() {
+    // given
+    final long drgKey = deployDrg(DRG_SINGLE_DECISION);
+
+    // when
+    engine.resourceDeletion().withResourceKey(drgKey).withDeleteHistory(false).delete();
+
+    // then
+    verifyDecisionIdWithVersionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionRequirementsIsDeleted(drgKey);
+    verifyResourceDeletionRecords(drgKey);
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ResourceDeletionIntent.DELETED)
+                .batchOperationCreationRecords()
+                .withIntent(BatchOperationIntent.CREATE)
+                .exists())
+        .describedAs("No batch operation should be created when deleteHistory is false")
+        .isFalse();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ResourceDeletionIntent.DELETED)
+                .historyDeletionRecords()
+                .exists())
+        .describedAs("No history deletion events should be written when deleteHistory is false")
+        .isFalse();
+  }
+
+  @Test
+  public void
+      shouldCreateBatchOperationAndDeleteHistoryOnDecisionDefinitionDeletionWhenDeleteHistoryIsTrue() {
+    // given
+    final long drgKey = deployDrg(DRG_SINGLE_DECISION);
+
+    // Verify decision is deployed
+    assertThat(
+            RecordingExporter.decisionRecords()
+                .withIntent(DecisionIntent.CREATED)
+                .withDecisionRequirementsKey(drgKey)
+                .getFirst())
+        .isNotNull();
+
+    // Evaluate some decision instances
+    final long decisionInstanceKey1 =
+        engine
+            .decision()
+            .ofDecisionId("jedi_or_sith")
+            .withVariable("lightsaberColor", "blue")
+            .evaluate()
+            .getKey();
+    final long decisionInstanceKey2 =
+        engine
+            .decision()
+            .ofDecisionId("jedi_or_sith")
+            .withVariable("lightsaberColor", "red")
+            .evaluate()
+            .getKey();
+
+    // Mock the search client to return the decision instances
+    final var decisionInstanceResult =
+        new SearchQueryResult.Builder<DecisionInstanceEntity>()
+            .items(
+                List.of(
+                    createDecisionInstanceEntity(decisionInstanceKey1),
+                    createDecisionInstanceEntity(decisionInstanceKey2)))
+            .total(2)
+            .build();
+    when(searchClientsProxy.searchDecisionInstances(Mockito.any(DecisionInstanceQuery.class)))
+        .thenReturn(decisionInstanceResult);
+
+    assertThat(
+            RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+                .filter(r -> r.getValue().getDecisionRequirementsKey() == drgKey)
+                .limit(2))
+        .hasSize(2);
+
+    // when
+    engine.resourceDeletion().withResourceKey(drgKey).withDeleteHistory(true).delete();
+
+    // then
+    verifyDecisionIdWithVersionIsDeleted(drgKey, "jedi_or_sith", 1);
+    verifyDecisionRequirementsIsDeleted(drgKey);
+    verifyResourceDeletionRecords(drgKey);
+    verifyBatchOperationIsCreated(
+        drgKey,
+        BatchOperationType.DELETE_DECISION_INSTANCE,
+        HistoryDeletionType.DECISION_DEFINITION,
+        "\"decisionRequirementsKeyOperations\":[{\"operator\":\"EQUALS\",\"values\":[%s]}]");
+
+    // Wait for batch operation to complete
+    assertThat(RecordingExporter.historyDeletionRecords(HistoryDeletionIntent.DELETED).limit(3))
+        .describedAs(
+            "History deletion events should be written for all decision instances and the decision definition")
+        .hasSize(3)
+        .extracting(r -> r.getValue().getResourceKey(), r -> r.getValue().getResourceType())
+        .containsExactlyInAnyOrder(
+            tuple(decisionInstanceKey1, HistoryDeletionType.DECISION_INSTANCE),
+            tuple(decisionInstanceKey2, HistoryDeletionType.DECISION_INSTANCE),
+            tuple(drgKey, HistoryDeletionType.DECISION_DEFINITION));
   }
 
   private long deployDrg(final String drgResource) {
@@ -1303,18 +1412,26 @@ public class ResourceDeletionTest {
         Set.of());
   }
 
-  private static void verifyBatchOperationIsCreated(final long processDefinitionKey) {
+  private DecisionInstanceEntity createDecisionInstanceEntity(final long decisionInstanceKey) {
+    return new DecisionInstanceEntity.Builder()
+        .decisionInstanceKey(decisionInstanceKey)
+        .processInstanceKey(decisionInstanceKey)
+        .build();
+  }
+
+  private static void verifyBatchOperationIsCreated(
+      final long resourceKey,
+      final BatchOperationType batchOperationType,
+      final HistoryDeletionType historyDeletionType,
+      final String entityFilter) {
     final var batchOperationCreated =
         RecordingExporter.batchOperationCreationRecords()
             .withIntent(BatchOperationIntent.CREATE)
             .getFirst()
             .getValue();
-    assertThat(batchOperationCreated.getBatchOperationType())
-        .isEqualTo(BatchOperationType.DELETE_PROCESS_INSTANCE);
+    assertThat(batchOperationCreated.getBatchOperationType()).isEqualTo(batchOperationType);
     assertThat(batchOperationCreated.getEntityFilter())
-        .contains(
-            "\"processDefinitionKeyOperations\":[{\"operator\":\"EQUALS\",\"values\":[%s]}]"
-                .formatted(processDefinitionKey));
+        .contains(entityFilter.formatted(resourceKey));
     assertThat(batchOperationCreated.getFollowUpCommand())
         .isNotNull()
         .extracting(NestedRecordValue::getIntent, NestedRecordValue::getValueType)
@@ -1324,6 +1441,6 @@ public class ResourceDeletionTest {
         .asInstanceOf(InstanceOfAssertFactories.type(HistoryDeletionRecordValue.class))
         .extracting(
             HistoryDeletionRecordValue::getResourceKey, HistoryDeletionRecordValue::getResourceType)
-        .containsExactly(processDefinitionKey, HistoryDeletionType.PROCESS_DEFINITION);
+        .containsExactly(resourceKey, historyDeletionType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/HistoryDeletionClient.java
@@ -54,6 +54,12 @@ public class HistoryDeletionClient {
     return this;
   }
 
+  public HistoryDeletionClient decisionDefinition(final long decisionRequirementsKey) {
+    record.setResourceType(HistoryDeletionType.DECISION_DEFINITION);
+    record.setResourceKey(decisionRequirementsKey);
+    return this;
+  }
+
   public Record<HistoryDeletionRecordValue> delete() {
     final long position = writer.writeCommand(HistoryDeletionIntent.DELETE, record);
     return expectation.apply(position);

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -257,6 +257,10 @@ components:
           description: The key of the root decision definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
+        decisionRequirementsKey:
+          description: The key of the decision requirements definition.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKeyFilterProperty'
 
     DeleteDecisionInstanceRequest:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -162,6 +162,14 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         new TestArguments(
             """
       {
+          "filter": {
+              "decisionRequirementsKey": "123458"
+          }
+      }""",
+            q -> q.filter(f -> f.decisionRequirementsKeys(123458L))),
+        new TestArguments(
+            """
+      {
           "sort": [
                 {
                     "field": "decisionDefinitionName",
@@ -435,6 +443,10 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         "rootDecisionDefinitionKey",
         ops ->
             new DecisionInstanceFilter.Builder().rootDecisionDefinitionKeyOperations(ops).build());
+    keyOperationTestCases(
+        streamBuilder,
+        "decisionRequirementsKey",
+        ops -> new DecisionInstanceFilter.Builder().decisionRequirementsKeyOperations(ops).build());
     basicStringOperationTestCases(
         streamBuilder,
         "decisionEvaluationInstanceKey",


### PR DESCRIPTION
## Description

Create a batch operation for `DELETE_DECISION_INSTANCE` and then follow-up with `HISTORY_DELETION` command, with resourceType `DECISION_DEFINITION` 

## Related issues

closes #42474
