### PR TITLE
feat: populate primary audit log details

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AuditLogEntityTypeEnum.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AuditLogEntityTypeEnum.java
@@ -29,5 +29,6 @@ public enum AuditLogEntityTypeEnum {
   USER_TASK,
   RESOURCE,
   VARIABLE,
+  CLIENT,
   UNKNOWN_ENUM_VALUE
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -979,7 +979,7 @@
       <column name="RESOURCE_KEY" type="BIGINT"/>
       <column name="RELATED_ENTITY_TYPE" type="VARCHAR(50)"/>
       <column name="RELATED_ENTITY_KEY" type="VARCHAR(${userCharColumnSize})"/>
-      <column name="ENTITY_DESCRIPTION" type="VARCHAR(255)"/>
+      <column name="ENTITY_DESCRIPTION" type="VARCHAR(${userCharColumnSize})"/>
       <column name="PARTITION_ID" type="NUMBER"/>
       <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
     </createTable>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
@@ -221,11 +221,10 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.TENANT, AuditLogOperationTypeEnum.ASSIGN, tenantId);
 
     // then
+    final var result = findByEntityKey(auditLogs, tenantId);
     assertAuditLog(
-        findByEntityKey(auditLogs, tenantId),
-        AuditLogEntityTypeEnum.TENANT,
-        AuditLogOperationTypeEnum.ASSIGN,
-        tenantId);
+        result, AuditLogEntityTypeEnum.TENANT, AuditLogOperationTypeEnum.ASSIGN, tenantId);
+    assertRelatedEntity(result, username, AuditLogEntityTypeEnum.USER);
   }
 
   @Test
@@ -247,11 +246,10 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.TENANT, AuditLogOperationTypeEnum.UNASSIGN, tenantId);
 
     // then
+    final var result = findByEntityKey(auditLogs, tenantId);
     assertAuditLog(
-        findByEntityKey(auditLogs, tenantId),
-        AuditLogEntityTypeEnum.TENANT,
-        AuditLogOperationTypeEnum.UNASSIGN,
-        tenantId);
+        result, AuditLogEntityTypeEnum.TENANT, AuditLogOperationTypeEnum.UNASSIGN, tenantId);
+    assertRelatedEntity(result, username, AuditLogEntityTypeEnum.USER);
   }
 
   // ==================== ROLE TESTS ====================
@@ -328,11 +326,10 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.ROLE, AuditLogOperationTypeEnum.ASSIGN, ROLE_A_ID);
 
     // then
+    final var result = findByEntityKey(auditLogs, ROLE_A_ID);
     assertAuditLog(
-        findByEntityKey(auditLogs, ROLE_A_ID),
-        AuditLogEntityTypeEnum.ROLE,
-        AuditLogOperationTypeEnum.ASSIGN,
-        ROLE_A_ID);
+        result, AuditLogEntityTypeEnum.ROLE, AuditLogOperationTypeEnum.ASSIGN, ROLE_A_ID);
+    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.USER);
   }
 
   @Test
@@ -354,11 +351,9 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.ROLE, AuditLogOperationTypeEnum.UNASSIGN, roleId);
 
     // then
-    assertAuditLog(
-        findByEntityKey(auditLogs, roleId),
-        AuditLogEntityTypeEnum.ROLE,
-        AuditLogOperationTypeEnum.UNASSIGN,
-        roleId);
+    final var result = findByEntityKey(auditLogs, roleId);
+    assertAuditLog(result, AuditLogEntityTypeEnum.ROLE, AuditLogOperationTypeEnum.UNASSIGN, roleId);
+    assertRelatedEntity(result, username, AuditLogEntityTypeEnum.USER);
   }
 
   // ==================== GROUP TESTS ====================
@@ -435,11 +430,10 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.ASSIGN, GROUP_A_ID);
 
     // then
+    final var result = findByEntityKey(auditLogs, GROUP_A_ID);
     assertAuditLog(
-        findByEntityKey(auditLogs, GROUP_A_ID),
-        AuditLogEntityTypeEnum.GROUP,
-        AuditLogOperationTypeEnum.ASSIGN,
-        GROUP_A_ID);
+        result, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.ASSIGN, GROUP_A_ID);
+    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.USER);
   }
 
   @Test
@@ -462,11 +456,10 @@ public class AuditLogIdentityOperationsIT {
     // then
     final var auditLogs =
         findAuditLogs(client, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN);
+    final var result = findByEntityKey(auditLogs, groupId);
     assertAuditLog(
-        findByEntityKey(auditLogs, groupId),
-        AuditLogEntityTypeEnum.GROUP,
-        AuditLogOperationTypeEnum.UNASSIGN,
-        groupId);
+        result, AuditLogEntityTypeEnum.GROUP, AuditLogOperationTypeEnum.UNASSIGN, groupId);
+    assertRelatedEntity(result, username, AuditLogEntityTypeEnum.USER);
   }
 
   // ==================== MAPPING RULE TESTS ====================
@@ -482,11 +475,13 @@ public class AuditLogIdentityOperationsIT {
             MAPPING_RULE_A.id());
 
     // then
+    final var result = findByEntityKey(auditLogs, MAPPING_RULE_A.id());
     assertAuditLog(
-        findByEntityKey(auditLogs, MAPPING_RULE_A.id()),
+        result,
         AuditLogEntityTypeEnum.MAPPING_RULE,
         AuditLogOperationTypeEnum.CREATE,
         MAPPING_RULE_A.id());
+    assertThat(result.getEntityDescription()).isNotBlank();
   }
 
   @Test
@@ -525,11 +520,13 @@ public class AuditLogIdentityOperationsIT {
     final var auditLogs =
         findAuditLogs(
             client, AuditLogEntityTypeEnum.MAPPING_RULE, AuditLogOperationTypeEnum.UPDATE);
+    final var result = findByEntityKey(auditLogs, mappingRuleId);
     assertAuditLog(
-        findByEntityKey(auditLogs, mappingRuleId),
+        result,
         AuditLogEntityTypeEnum.MAPPING_RULE,
         AuditLogOperationTypeEnum.UPDATE,
         mappingRuleId);
+    assertThat(result.getEntityDescription()).isEqualTo("Updated Name");
   }
 
   @Test
@@ -567,6 +564,7 @@ public class AuditLogIdentityOperationsIT {
         AuditLogEntityTypeEnum.MAPPING_RULE,
         AuditLogOperationTypeEnum.DELETE,
         mappingRuleId);
+    // Currently, mapping rule delete does not set the mapping rule name in the record
   }
 
   // ==================== AUTHORIZATION TESTS ====================
@@ -587,11 +585,13 @@ public class AuditLogIdentityOperationsIT {
             client, AuditLogEntityTypeEnum.AUTHORIZATION, AuditLogOperationTypeEnum.CREATE);
 
     // then
+    final var result = findByEntityKey(auditLogs, authorizationKey);
     assertAuditLog(
-        findByEntityKey(auditLogs, authorizationKey),
+        result,
         AuditLogEntityTypeEnum.AUTHORIZATION,
         AuditLogOperationTypeEnum.CREATE,
         authorizationKey);
+    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.USER);
   }
 
   @Test
@@ -635,11 +635,13 @@ public class AuditLogIdentityOperationsIT {
     final var auditLogs =
         findAuditLogs(
             client, AuditLogEntityTypeEnum.AUTHORIZATION, AuditLogOperationTypeEnum.UPDATE);
+    final var result = findByEntityKey(auditLogs, authorizationKey);
     assertAuditLog(
-        findByEntityKey(auditLogs, authorizationKey),
+        result,
         AuditLogEntityTypeEnum.AUTHORIZATION,
         AuditLogOperationTypeEnum.UPDATE,
         authorizationKey);
+    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.USER);
   }
 
   @Test
@@ -677,6 +679,7 @@ public class AuditLogIdentityOperationsIT {
         AuditLogEntityTypeEnum.AUTHORIZATION,
         AuditLogOperationTypeEnum.DELETE,
         authorizationKey);
+    // Currently, authorization delete does not set the owner in the record
   }
 
   // ==================== HELPER METHODS ====================
@@ -715,6 +718,21 @@ public class AuditLogIdentityOperationsIT {
     assertThat(auditLog.getCategory()).isEqualTo(AuditLogCategoryEnum.ADMIN);
     assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
     assertThat(auditLog.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
+  }
+
+  /**
+   * Asserts the related entity information in the audit log.
+   *
+   * @param auditLog the audit log entry
+   * @param relatedEntityKey the expected related entity key
+   * @param relatedEntityType the expected related entity type
+   */
+  private void assertRelatedEntity(
+      final AuditLogResult auditLog,
+      final String relatedEntityKey,
+      final AuditLogEntityTypeEnum relatedEntityType) {
+    assertThat(auditLog.getRelatedEntityKey()).isEqualTo(relatedEntityKey);
+    assertThat(auditLog.getRelatedEntityType()).isEqualTo(relatedEntityType);
   }
 
   private List<AuditLogResult> awaitAuditLogEntry(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogIdentityOperationsIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.search.enums.AuditLogCategoryEnum;
 import io.camunda.client.api.search.enums.AuditLogEntityTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogOperationTypeEnum;
 import io.camunda.client.api.search.enums.AuditLogResultEnum;
+import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.AuditLogResult;
@@ -577,7 +578,8 @@ public class AuditLogIdentityOperationsIT {
             client,
             DEFAULT_USERNAME,
             ResourceType.PROCESS_DEFINITION,
-            PermissionType.READ_PROCESS_INSTANCE);
+            PermissionType.READ_PROCESS_INSTANCE,
+            OwnerType.CLIENT);
 
     // when
     final var auditLogs =
@@ -591,7 +593,7 @@ public class AuditLogIdentityOperationsIT {
         AuditLogEntityTypeEnum.AUTHORIZATION,
         AuditLogOperationTypeEnum.CREATE,
         authorizationKey);
-    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.USER);
+    assertRelatedEntity(result, DEFAULT_USERNAME, AuditLogEntityTypeEnum.CLIENT);
   }
 
   @Test
@@ -755,12 +757,13 @@ public class AuditLogIdentityOperationsIT {
       final CamundaClient client,
       final String username,
       final ResourceType authorizationResourceType,
-      final PermissionType permission) {
+      final PermissionType permission,
+      final OwnerType ownerType) {
     final var authorization =
         client
             .newCreateAuthorizationCommand()
             .ownerId(username)
-            .ownerType(io.camunda.client.api.search.enums.OwnerType.USER)
+            .ownerType(ownerType)
             .resourceId("*")
             .resourceType(authorizationResourceType)
             .permissionTypes(permission)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogResourceOperationsIT.java
@@ -95,7 +95,10 @@ public class AuditLogResourceOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(processDefinitionKey));
     assertResourceAuditLog(
-        auditLog, AuditLogOperationTypeEnum.CREATE, String.valueOf(processDefinitionKey));
+        auditLog,
+        AuditLogOperationTypeEnum.CREATE,
+        String.valueOf(processDefinitionKey),
+        deployment.getProcesses().getFirst().getResourceName());
   }
 
   @Test
@@ -131,7 +134,10 @@ public class AuditLogResourceOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(processDefinitionKey));
     assertResourceAuditLog(
-        auditLog, AuditLogOperationTypeEnum.DELETE, String.valueOf(processDefinitionKey));
+        auditLog,
+        AuditLogOperationTypeEnum.DELETE,
+        String.valueOf(processDefinitionKey),
+        deployment.getProcesses().getFirst().getResourceName());
   }
 
   // ========================================================================================
@@ -161,7 +167,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(decisionKey));
-    assertDecisionAuditLog(auditLog, AuditLogOperationTypeEnum.CREATE, String.valueOf(decisionKey));
+    assertDecisionAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.CREATE,
+        String.valueOf(decisionKey),
+        deployment.getDecisions().getFirst().getDmnDecisionName());
   }
 
   @Test
@@ -198,7 +208,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(decisionKey));
-    assertDecisionAuditLog(auditLog, AuditLogOperationTypeEnum.DELETE, String.valueOf(decisionKey));
+    assertDecisionAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.DELETE,
+        String.valueOf(decisionKey),
+        deployment.getDecisions().getFirst().getDmnDecisionName());
   }
 
   // ========================================================================================
@@ -231,7 +245,10 @@ public class AuditLogResourceOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(decisionRequirementsKey));
     assertResourceAuditLog(
-        auditLog, AuditLogOperationTypeEnum.CREATE, String.valueOf(decisionRequirementsKey));
+        auditLog,
+        AuditLogOperationTypeEnum.CREATE,
+        String.valueOf(decisionRequirementsKey),
+        deployment.getDecisionRequirements().getFirst().getResourceName());
   }
 
   @Test
@@ -269,7 +286,10 @@ public class AuditLogResourceOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(decisionRequirementsKey));
     assertResourceAuditLog(
-        auditLog, AuditLogOperationTypeEnum.DELETE, String.valueOf(decisionRequirementsKey));
+        auditLog,
+        AuditLogOperationTypeEnum.DELETE,
+        String.valueOf(decisionRequirementsKey),
+        deployment.getDecisionRequirements().getFirst().getResourceName());
   }
 
   // ========================================================================================
@@ -299,7 +319,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(formKey));
-    assertResourceAuditLog(auditLog, AuditLogOperationTypeEnum.CREATE, String.valueOf(formKey));
+    assertResourceAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.CREATE,
+        String.valueOf(formKey),
+        deployment.getForm().getFirst().getResourceName());
   }
 
   @Test
@@ -334,7 +358,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(formKey));
-    assertResourceAuditLog(auditLog, AuditLogOperationTypeEnum.DELETE, String.valueOf(formKey));
+    assertResourceAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.DELETE,
+        String.valueOf(formKey),
+        deployment.getForm().getFirst().getResourceName());
   }
 
   // ========================================================================================
@@ -364,7 +392,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(resourceKey));
-    assertResourceAuditLog(auditLog, AuditLogOperationTypeEnum.CREATE, String.valueOf(resourceKey));
+    assertResourceAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.CREATE,
+        String.valueOf(resourceKey),
+        deployment.getResource().getFirst().getResourceName());
   }
 
   @Test
@@ -399,7 +431,11 @@ public class AuditLogResourceOperationsIT {
 
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = findByEntityKey(auditLogItems, String.valueOf(resourceKey));
-    assertResourceAuditLog(auditLog, AuditLogOperationTypeEnum.DELETE, String.valueOf(resourceKey));
+    assertResourceAuditLog(
+        auditLog,
+        AuditLogOperationTypeEnum.DELETE,
+        String.valueOf(resourceKey),
+        deployment.getResource().getFirst().getResourceName());
   }
 
   // ========================================================================================
@@ -438,9 +474,11 @@ public class AuditLogResourceOperationsIT {
   private void assertResourceAuditLog(
       final AuditLogResult auditLog,
       final AuditLogOperationTypeEnum operationType,
-      final String resourceKey) {
+      final String resourceKey,
+      final String resourceName) {
     assertCommonAuditLogFields(auditLog, AuditLogEntityTypeEnum.RESOURCE, operationType);
     assertThat(auditLog.getEntityKey()).isEqualTo(resourceKey);
+    assertThat(auditLog.getEntityDescription()).isEqualTo(resourceName);
   }
 
   /**
@@ -453,9 +491,26 @@ public class AuditLogResourceOperationsIT {
   private void assertDecisionAuditLog(
       final AuditLogResult auditLog,
       final AuditLogOperationTypeEnum operationType,
-      final String decisionKey) {
+      final String decisionKey,
+      final String decisionName) {
     assertCommonAuditLogFields(auditLog, AuditLogEntityTypeEnum.DECISION, operationType);
     assertThat(auditLog.getEntityKey()).isEqualTo(decisionKey);
+    assertThat(auditLog.getEntityDescription()).isEqualTo(decisionName);
+  }
+
+  /**
+   * Asserts the related entity information in the audit log.
+   *
+   * @param auditLog the audit log entry
+   * @param relatedEntityKey the expected related entity key
+   * @param relatedEntityType the expected related entity type
+   */
+  private void assertRelatedEntity(
+      final AuditLogResult auditLog,
+      final String relatedEntityKey,
+      final AuditLogEntityTypeEnum relatedEntityType) {
+    assertThat(auditLog.getRelatedEntityKey()).isEqualTo(relatedEntityKey);
+    assertThat(auditLog.getRelatedEntityType()).isEqualTo(relatedEntityType);
   }
 
   private List<AuditLogResult> awaitAuditLogEntry(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -99,6 +99,8 @@ public class AuditLogUserTaskOperationsIT {
     final var auditLog = auditLogItems.items().getFirst();
     assertThat(auditLog).isNotNull();
     assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+    assertThat(auditLog.getRelatedEntityKey()).isEqualTo(DEFAULT_USERNAME);
+    assertThat(auditLog.getRelatedEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER);
     assertUserTaskAuditLog(
         auditLog, AuditLogOperationTypeEnum.ASSIGN, userTask.getProcessDefinitionKey());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -41,6 +41,7 @@ public class AuditLogUserTaskOperationsIT {
           .withAuthenticatedAccess();
 
   private static UserTaskRecordValue userTask;
+  private static UserTaskRecordValue unassignedUserTask;
   private static CamundaClient adminClient;
   private static AuditLogUtils utils;
 
@@ -50,6 +51,8 @@ public class AuditLogUserTaskOperationsIT {
     userTask = utils.getUserTasks().getFirst();
     updateUserTask(userTask);
     completeUserTask(userTask);
+    unassignedUserTask = utils.getUserTasks().get(1);
+    unassignUserTask(unassignedUserTask);
   }
 
   @Test
@@ -103,6 +106,30 @@ public class AuditLogUserTaskOperationsIT {
     assertThat(auditLog.getRelatedEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER);
     assertUserTaskAuditLog(
         auditLog, AuditLogOperationTypeEnum.ASSIGN, userTask.getProcessDefinitionKey());
+  }
+
+  @Test
+  void shouldSearchUserTaskAuditLogByKeyWithUnassignOperation(
+      @Authenticated final CamundaClient client) {
+    // given
+    final long userTaskKey = unassignedUserTask.getUserTaskKey();
+
+    // when
+    final var auditLogItems =
+        client
+            .newUserTaskAuditLogSearchRequest(userTaskKey)
+            .filter(f -> f.operationType(AuditLogOperationTypeEnum.UNASSIGN))
+            .send()
+            .join();
+
+    // then
+    final var auditLog = auditLogItems.items().getFirst();
+    assertThat(auditLog).isNotNull();
+    assertThat(auditLog.getUserTaskKey()).isEqualTo(String.valueOf(userTaskKey));
+    assertThat(auditLog.getRelatedEntityKey()).isBlank();
+    assertThat(auditLog.getRelatedEntityType()).isEqualTo(AuditLogEntityTypeEnum.USER);
+    assertUserTaskAuditLog(
+        auditLog, AuditLogOperationTypeEnum.UNASSIGN, unassignedUserTask.getProcessDefinitionKey());
   }
 
   @Test
@@ -171,6 +198,29 @@ public class AuditLogUserTaskOperationsIT {
     assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
     assertThat(auditLog.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
     assertThat(auditLog.getProcessDefinitionKey()).isEqualTo(String.valueOf(processDefinitionKey));
+  }
+
+  public static void unassignUserTask(final UserTaskRecordValue userTask) {
+    adminClient.newUnassignUserTaskCommand(userTask.getUserTaskKey()).send().join();
+
+    Awaitility.await("Audit log entry is created for the updated user task")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var auditLogItems =
+                  adminClient
+                      .newAuditLogSearchRequest()
+                      .filter(
+                          fn ->
+                              fn.processInstanceKey(
+                                      String.valueOf(userTask.getProcessInstanceKey()))
+                                  .entityType(AuditLogEntityTypeEnum.USER_TASK)
+                                  .operationType(AuditLogOperationTypeEnum.UNASSIGN))
+                      .send()
+                      .join();
+              assertThat(auditLogItems.items()).hasSize(1);
+            });
   }
 
   public static void updateUserTask(final UserTaskRecordValue userTask) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -310,7 +310,8 @@ public record AuditLogEntity(
     GROUP,
     TENANT,
     AUTHORIZATION,
-    RESOURCE
+    RESOURCE,
+    CLIENT
   }
 
   public enum AuditLogOperationCategory {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/auditlog/AuditLogEntityType.java
@@ -21,5 +21,6 @@ public enum AuditLogEntityType {
   GROUP,
   TENANT,
   AUTHORIZATION,
-  RESOURCE
+  RESOURCE,
+  CLIENT
 }

--- a/zeebe/exporter-common/pom.xml
+++ b/zeebe/exporter-common/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
@@ -55,11 +60,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-security-protocol</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogEntry.java
@@ -30,6 +30,9 @@ public class AuditLogEntry {
   // the type of the affected entity
   private io.camunda.search.entities.AuditLogEntity.AuditLogEntityType entityType;
 
+  // the description of the affected entity
+  private String entityDescription;
+
   // the type of operation that was performed, i.e. the Zeebe record intent
   private io.camunda.search.entities.AuditLogEntity.AuditLogOperationType operationType;
 
@@ -97,6 +100,10 @@ public class AuditLogEntry {
 
   private Long rootProcessInstanceKey;
 
+  private String relatedEntityKey;
+
+  private AuditLogEntityType relatedEntityType;
+
   public String getEntityKey() {
     return entityKey;
   }
@@ -112,6 +119,15 @@ public class AuditLogEntry {
 
   public AuditLogEntry setEntityType(final AuditLogEntityType auditLogEntityType) {
     entityType = auditLogEntityType;
+    return this;
+  }
+
+  public String getEntityDescription() {
+    return entityDescription;
+  }
+
+  public AuditLogEntry setEntityDescription(final String entityDescription) {
+    this.entityDescription = entityDescription;
     return this;
   }
 
@@ -355,6 +371,24 @@ public class AuditLogEntry {
 
   public AuditLogEntry setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
     this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  public String getRelatedEntityKey() {
+    return relatedEntityKey;
+  }
+
+  public AuditLogEntry setRelatedEntityKey(final String relatedEntityKey) {
+    this.relatedEntityKey = relatedEntityKey;
+    return this;
+  }
+
+  public AuditLogEntityType getRelatedEntityType() {
+    return relatedEntityType;
+  }
+
+  public AuditLogEntry setRelatedEntityType(final AuditLogEntityType relatedEntityType) {
+    this.relatedEntityType = relatedEntityType;
     return this;
   }
 

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -26,6 +26,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent.MODIFIED;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer.TransformerConfig;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -48,6 +49,8 @@ import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Map;
 
 public class AuditLogTransformerConfigs {
   public static final TransformerConfig AUTHORIZATION_CONFIG =
@@ -158,4 +161,19 @@ public class AuditLogTransformerConfigs {
 
   public static final TransformerConfig VARIABLE_ADD_UPDATE_CONFIG =
       TransformerConfig.with(VARIABLE).withIntents(VariableIntent.CREATED, VariableIntent.UPDATED);
+
+  private static final Map<EntityType, AuditLogEntityType> ENTITY_TYPE_AUDIT_LOG_ENTITY_TYPE_MAP =
+      Map.ofEntries(
+          Map.entry(EntityType.USER, AuditLogEntityType.USER),
+          Map.entry(EntityType.CLIENT, AuditLogEntityType.USER),
+          Map.entry(EntityType.GROUP, AuditLogEntityType.GROUP),
+          Map.entry(EntityType.ROLE, AuditLogEntityType.ROLE),
+          Map.entry(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE));
+
+  public static AuditLogEntityType mapEntityTypeToAuditLogEntityType(final EntityType entityType) {
+    if (entityType == null) {
+      return null;
+    }
+    return ENTITY_TYPE_AUDIT_LOG_ENTITY_TYPE_MAP.getOrDefault(entityType, null);
+  }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
@@ -25,7 +25,8 @@ public class AuthorizationAuditLogTransformer
     final AuthorizationRecordValue value = record.getValue();
     log.setRelatedEntityKey(value.getOwnerId());
     switch (value.getOwnerType()) {
-      case USER, CLIENT -> log.setRelatedEntityType(AuditLogEntityType.USER);
+      case USER -> log.setRelatedEntityType(AuditLogEntityType.USER);
+      case CLIENT -> log.setRelatedEntityType(AuditLogEntityType.CLIENT);
       case GROUP -> log.setRelatedEntityType(AuditLogEntityType.GROUP);
       case ROLE -> log.setRelatedEntityType(AuditLogEntityType.ROLE);
       case MAPPING_RULE -> log.setRelatedEntityType(AuditLogEntityType.MAPPING_RULE);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformer.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 
 public class AuthorizationAuditLogTransformer
@@ -15,5 +18,21 @@ public class AuthorizationAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.AUTHORIZATION_CONFIG;
+  }
+
+  @Override
+  public void transform(final Record<AuthorizationRecordValue> record, final AuditLogEntry log) {
+    final AuthorizationRecordValue value = record.getValue();
+    log.setRelatedEntityKey(value.getOwnerId());
+    switch (value.getOwnerType()) {
+      case USER, CLIENT -> log.setRelatedEntityType(AuditLogEntityType.USER);
+      case GROUP -> log.setRelatedEntityType(AuditLogEntityType.GROUP);
+      case ROLE -> log.setRelatedEntityType(AuditLogEntityType.ROLE);
+      case MAPPING_RULE -> log.setRelatedEntityType(AuditLogEntityType.MAPPING_RULE);
+      case TENANT -> log.setRelatedEntityType(AuditLogEntityType.TENANT);
+      case null, default -> {
+        // do nothing
+      }
+    }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformer.java
@@ -21,11 +21,12 @@ public class DecisionAuditLogTransformer implements AuditLogTransformer<Decision
   @Override
   public void transform(final Record<DecisionRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(String.valueOf(value.getDecisionKey()));
-    log.setDeploymentKey(value.getDeploymentKey());
-    log.setDecisionRequirementsKey(value.getDecisionRequirementsKey());
-    log.setDecisionDefinitionKey(value.getDecisionKey());
-    log.setDecisionRequirementsId(value.getDecisionRequirementsId());
-    log.setDecisionDefinitionId(value.getDecisionId());
+    log.setEntityKey(String.valueOf(value.getDecisionKey()))
+        .setDeploymentKey(value.getDeploymentKey())
+        .setDecisionRequirementsKey(value.getDecisionRequirementsKey())
+        .setDecisionDefinitionKey(value.getDecisionKey())
+        .setDecisionRequirementsId(value.getDecisionRequirementsId())
+        .setDecisionDefinitionId(value.getDecisionId())
+        .setEntityDescription(value.getDecisionName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformer.java
@@ -27,17 +27,18 @@ public class DecisionEvaluationAuditLogTransformer
   public void transform(
       final Record<DecisionEvaluationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setDecisionDefinitionId(value.getDecisionId());
-    log.setDecisionDefinitionKey(value.getDecisionKey());
-    log.setDecisionRequirementsId(value.getDecisionRequirementsId());
-    log.setDecisionRequirementsKey(value.getDecisionRequirementsKey());
-    log.setDecisionEvaluationKey(
-        Optional.ofNullable(value.getEvaluatedDecisions())
-            .filter(list -> !list.isEmpty())
-            .map(List::getFirst)
-            .map(EvaluatedDecisionValue::getDecisionKey)
-            .orElse(null));
+    log.setDecisionDefinitionId(value.getDecisionId())
+        .setDecisionDefinitionKey(value.getDecisionKey())
+        .setDecisionRequirementsId(value.getDecisionRequirementsId())
+        .setDecisionRequirementsKey(value.getDecisionRequirementsKey())
+        .setDecisionEvaluationKey(
+            Optional.ofNullable(value.getEvaluatedDecisions())
+                .filter(list -> !list.isEmpty())
+                .map(List::getFirst)
+                .map(EvaluatedDecisionValue::getDecisionKey)
+                .orElse(null));
     if (record.getIntent() == DecisionEvaluationIntent.FAILED) {
+      log.setEntityDescription(record.getRejectionType().name());
       log.setResult(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
     }
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformer.java
@@ -23,9 +23,10 @@ public class DecisionRequirementsRecordAuditLogTransformer
   public void transform(
       final Record<DecisionRequirementsRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(String.valueOf(value.getDecisionRequirementsKey()));
-    log.setDecisionRequirementsKey(value.getDecisionRequirementsKey());
-    log.setDecisionRequirementsId(value.getDecisionRequirementsId());
-    log.setDeploymentKey(value.getDeploymentKey());
+    log.setEntityKey(String.valueOf(value.getDecisionRequirementsKey()))
+        .setDecisionRequirementsKey(value.getDecisionRequirementsKey())
+        .setDecisionRequirementsId(value.getDecisionRequirementsId())
+        .setDeploymentKey(value.getDeploymentKey())
+        .setEntityDescription(value.getResourceName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformer.java
@@ -21,8 +21,9 @@ public class FormAuditLogTransformer implements AuditLogTransformer<Form> {
   @Override
   public void transform(final Record<Form> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(String.valueOf(value.getFormKey()));
-    log.setDeploymentKey(value.getDeploymentKey());
-    log.setFormKey(value.getFormKey());
+    log.setEntityKey(String.valueOf(value.getFormKey()))
+        .setDeploymentKey(value.getDeploymentKey())
+        .setFormKey(value.getFormKey())
+        .setEntityDescription(value.getResourceName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformer.java
@@ -20,6 +20,7 @@ public class GroupAuditLogTransformer implements AuditLogTransformer<GroupRecord
 
   @Override
   public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
-    log.setEntityKey(record.getValue().getGroupId());
+    final GroupRecordValue value = record.getValue();
+    log.setEntityKey(value.getGroupId()).setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformer.java
@@ -20,6 +20,10 @@ public class GroupEntityAuditLogTransformer implements AuditLogTransformer<Group
 
   @Override
   public void transform(final Record<GroupRecordValue> record, final AuditLogEntry log) {
-    log.setEntityKey(record.getValue().getGroupId());
+    final GroupRecordValue value = record.getValue();
+    log.setEntityKey(value.getGroupId())
+        .setRelatedEntityKey(value.getEntityId())
+        .setRelatedEntityType(
+            AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformer.java
@@ -21,6 +21,6 @@ public class MappingRuleAuditLogTransformer implements AuditLogTransformer<Mappi
   @Override
   public void transform(final Record<MappingRuleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(value.getMappingRuleId());
+    log.setEntityKey(value.getMappingRuleId()).setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformer.java
@@ -21,9 +21,10 @@ public class ProcessAuditLogTransformer implements AuditLogTransformer<Process> 
   @Override
   public void transform(final Record<Process> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(String.valueOf(value.getProcessDefinitionKey()));
-    log.setDeploymentKey(value.getDeploymentKey());
-    log.setProcessDefinitionKey(value.getProcessDefinitionKey());
-    log.setProcessDefinitionId(value.getBpmnProcessId());
+    log.setEntityKey(String.valueOf(value.getProcessDefinitionKey()))
+        .setDeploymentKey(value.getDeploymentKey())
+        .setProcessDefinitionKey(value.getProcessDefinitionKey())
+        .setProcessDefinitionId(value.getBpmnProcessId())
+        .setEntityDescription(value.getResourceName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformer.java
@@ -21,8 +21,9 @@ public class ResourceAuditLogTransformer implements AuditLogTransformer<Resource
   @Override
   public void transform(final Record<Resource> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(String.valueOf(value.getResourceKey()));
-    log.setDeploymentKey(value.getDeploymentKey());
-    log.setResourceKey(value.getResourceKey());
+    log.setEntityKey(String.valueOf(value.getResourceKey()))
+        .setDeploymentKey(value.getDeploymentKey())
+        .setResourceKey(value.getResourceKey())
+        .setEntityDescription(value.getResourceName());
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformer.java
@@ -21,6 +21,9 @@ public class RoleEntityAuditLogTransformer implements AuditLogTransformer<RoleRe
   @Override
   public void transform(final Record<RoleRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
-    log.setEntityKey(value.getRoleId());
+    log.setEntityKey(value.getRoleId())
+        .setRelatedEntityKey(value.getEntityId())
+        .setRelatedEntityType(
+            AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformer.java
@@ -20,6 +20,10 @@ public class TenantEntityAuditLogTransformer implements AuditLogTransformer<Tena
 
   @Override
   public void transform(final Record<TenantRecordValue> record, final AuditLogEntry log) {
-    log.setEntityKey(record.getValue().getTenantId());
+    final TenantRecordValue value = record.getValue();
+    log.setEntityKey(value.getTenantId())
+        .setRelatedEntityKey(value.getEntityId())
+        .setRelatedEntityType(
+            AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(value.getEntityType()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformer.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 
 public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTaskRecordValue> {
@@ -25,6 +27,10 @@ public class UserTaskAuditLogTransformer implements AuditLogTransformer<UserTask
     final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);
+    }
+    if (record.getIntent() == UserTaskIntent.ASSIGNED) {
+      log.setRelatedEntityKey(value.getAssignee());
+      log.setRelatedEntityType(AuditLogEntityType.USER);
     }
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformer.java
@@ -21,9 +21,11 @@ public class VariableAddUpdateAuditLogTransformer
 
   @Override
   public void transform(final Record<VariableRecordValue> record, final AuditLogEntry log) {
-    final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
+    final VariableRecordValue value = record.getValue();
+    final long rootProcessInstanceKey = value.getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
       log.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
+    log.setEntityDescription(value.getName());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
@@ -15,10 +15,16 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration.ActorAuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogActor;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AuditLogConfigurationTest {
 
@@ -240,6 +246,25 @@ class AuditLogConfigurationTest {
       final var config = ActorAuditLogConfiguration.logAll();
 
       assertThat(config.getExcludes()).isEmpty();
+    }
+
+    private static Stream<Arguments> entityTypeToRelatedEntityTypeProvider() {
+      return Stream.of(
+          Arguments.of(EntityType.USER, AuditLogEntityType.USER),
+          Arguments.of(EntityType.GROUP, AuditLogEntityType.GROUP),
+          Arguments.of(EntityType.ROLE, AuditLogEntityType.ROLE),
+          Arguments.of(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),
+          Arguments.of(EntityType.UNSPECIFIED, null),
+          Arguments.of(null, null));
+    }
+
+    @MethodSource("entityTypeToRelatedEntityTypeProvider")
+    @ParameterizedTest
+    void shouldMapOwnerTypeToEntityType(
+        final EntityType ownerType, final AuditLogEntityType expectedEntityType) {
+      final var entityType =
+          AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(ownerType);
+      assertThat(entityType).isEqualTo(expectedEntityType);
     }
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogConfigurationTest.java
@@ -15,16 +15,10 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration.ActorAuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogInfo.AuditLogActor;
-import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class AuditLogConfigurationTest {
 
@@ -246,25 +240,6 @@ class AuditLogConfigurationTest {
       final var config = ActorAuditLogConfiguration.logAll();
 
       assertThat(config.getExcludes()).isEmpty();
-    }
-
-    private static Stream<Arguments> entityTypeToRelatedEntityTypeProvider() {
-      return Stream.of(
-          Arguments.of(EntityType.USER, AuditLogEntityType.USER),
-          Arguments.of(EntityType.GROUP, AuditLogEntityType.GROUP),
-          Arguments.of(EntityType.ROLE, AuditLogEntityType.ROLE),
-          Arguments.of(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),
-          Arguments.of(EntityType.UNSPECIFIED, null),
-          Arguments.of(null, null));
-    }
-
-    @MethodSource("entityTypeToRelatedEntityTypeProvider")
-    @ParameterizedTest
-    void shouldMapOwnerTypeToEntityType(
-        final EntityType ownerType, final AuditLogEntityType expectedEntityType) {
-      final var entityType =
-          AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(ownerType);
-      assertThat(entityType).isEqualTo(expectedEntityType);
     }
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogTransformerConfigsTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogTransformerConfigsTest.java
@@ -9,12 +9,14 @@ package io.camunda.zeebe.exporter.common.auditlog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer.TransformerConfig;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -167,5 +169,23 @@ class AuditLogTransformerConfigsTest {
       }
     }
     return config.valueType().name();
+  }
+
+  private static Stream<Arguments> entityTypeToRelatedEntityTypeProvider() {
+    return Stream.of(
+        Arguments.of(EntityType.USER, AuditLogEntityType.USER),
+        Arguments.of(EntityType.GROUP, AuditLogEntityType.GROUP),
+        Arguments.of(EntityType.ROLE, AuditLogEntityType.ROLE),
+        Arguments.of(EntityType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),
+        Arguments.of(EntityType.UNSPECIFIED, null),
+        Arguments.of(null, null));
+  }
+
+  @MethodSource("entityTypeToRelatedEntityTypeProvider")
+  @ParameterizedTest
+  void shouldMapOwnerTypeToEntityType(
+      final EntityType ownerType, final AuditLogEntityType expectedEntityType) {
+    final var entityType = AuditLogTransformerConfigs.mapEntityTypeToAuditLogEntityType(ownerType);
+    assertThat(entityType).isEqualTo(expectedEntityType);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerTest.java
@@ -157,7 +157,7 @@ class AuditLogTransformerTest {
   class CreateTest {
     @Test
     void shouldCreateAuditLogEntryWithSuccess() {
-      final Record record =
+      final var record =
           factory.generateRecord(
               ValueType.PROCESS_INSTANCE_MODIFICATION,
               r -> r.withIntent(ProcessInstanceModificationIntent.MODIFIED));
@@ -199,11 +199,12 @@ class AuditLogTransformerTest {
 
       assertThat(log).isNotNull();
       assertThat(log.getResult()).isEqualTo(AuditLogOperationResult.FAIL);
+      assertThat(log.getEntityDescription()).isEqualTo(record.getRejectionType().name());
     }
 
     @Test
     void shouldCreateAuditLogEntryWithCustomTransformerResult() {
-      final Record record =
+      final var record =
           factory.generateRecord(
               ValueType.PROCESS_INSTANCE_MODIFICATION,
               r -> r.withIntent(ProcessInstanceModificationIntent.MODIFIED));

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
@@ -9,15 +9,20 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AuthorizationAuditLogTransformerTest {
 
@@ -25,12 +30,27 @@ class AuthorizationAuditLogTransformerTest {
   private final AuthorizationAuditLogTransformer transformer =
       new AuthorizationAuditLogTransformer();
 
-  @Test
-  void shouldTransformAuthorizationRecord() {
+  private static Stream<Arguments> ownerTypeToEntityTypeProvider() {
+    return Stream.of(
+        Arguments.of(AuthorizationOwnerType.USER, AuditLogEntityType.USER),
+        Arguments.of(AuthorizationOwnerType.CLIENT, AuditLogEntityType.USER),
+        Arguments.of(AuthorizationOwnerType.GROUP, AuditLogEntityType.GROUP),
+        Arguments.of(AuthorizationOwnerType.ROLE, AuditLogEntityType.ROLE),
+        Arguments.of(AuthorizationOwnerType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),
+        Arguments.of(AuthorizationOwnerType.UNSPECIFIED, null),
+        Arguments.of(null, null));
+  }
+
+  @MethodSource("ownerTypeToEntityTypeProvider")
+  @ParameterizedTest
+  void shouldTransformAuthorizationRecord(
+      final AuthorizationOwnerType ownerType, final AuditLogEntityType expectedRelatedEntityType) {
     // given
     final AuthorizationRecordValue recordValue =
         ImmutableAuthorizationRecordValue.builder()
             .from(factory.generateObject(AuthorizationRecordValue.class))
+            .withOwnerId("owner-id")
+            .withOwnerType(ownerType)
             .withAuthorizationKey(123L)
             .build();
 
@@ -45,5 +65,7 @@ class AuthorizationAuditLogTransformerTest {
 
     // then
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getRelatedEntityKey()).isEqualTo("owner-id");
+    assertThat(entity.getRelatedEntityType()).isEqualTo(expectedRelatedEntityType);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuthorizationAuditLogTransformerTest.java
@@ -33,7 +33,7 @@ class AuthorizationAuditLogTransformerTest {
   private static Stream<Arguments> ownerTypeToEntityTypeProvider() {
     return Stream.of(
         Arguments.of(AuthorizationOwnerType.USER, AuditLogEntityType.USER),
-        Arguments.of(AuthorizationOwnerType.CLIENT, AuditLogEntityType.USER),
+        Arguments.of(AuthorizationOwnerType.CLIENT, AuditLogEntityType.CLIENT),
         Arguments.of(AuthorizationOwnerType.GROUP, AuditLogEntityType.GROUP),
         Arguments.of(AuthorizationOwnerType.ROLE, AuditLogEntityType.ROLE),
         Arguments.of(AuthorizationOwnerType.MAPPING_RULE, AuditLogEntityType.MAPPING_RULE),

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionAuditLogTransformerTest.java
@@ -33,6 +33,7 @@ class DecisionAuditLogTransformerTest {
             .withDeploymentKey(123L)
             .withDecisionRequirementsKey(456L)
             .withDecisionKey(789L)
+            .withDecisionName("decisionName")
             .withDecisionRequirementsId("decisionRequirementsId")
             .withDecisionId("decisionId")
             .withTenantId("tenant-1")
@@ -54,5 +55,6 @@ class DecisionAuditLogTransformerTest {
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("decisionRequirementsId");
     assertThat(entity.getDecisionDefinitionId()).isEqualTo("decisionId");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getEntityDescription()).isEqualTo("decisionName");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionEvaluationAuditLogTransformerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
@@ -190,7 +191,10 @@ class DecisionEvaluationAuditLogTransformerTest {
     final Record<DecisionEvaluationRecordValue> record =
         factory.generateRecord(
             ValueType.DECISION_EVALUATION,
-            r -> r.withIntent(DecisionEvaluationIntent.FAILED).withValue(recordValue));
+            r ->
+                r.withIntent(DecisionEvaluationIntent.FAILED)
+                    .withRejectionType(RejectionType.INVALID_STATE)
+                    .withValue(recordValue));
 
     // when
     final var entity = AuditLogEntry.of(record);
@@ -199,5 +203,6 @@ class DecisionEvaluationAuditLogTransformerTest {
     // then
     assertThat(entity.getResult())
         .isEqualTo(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
+    assertThat(entity.getEntityDescription()).isEqualTo(RejectionType.INVALID_STATE.name());
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/DecisionRequirementsRecordAuditLogTransformerTest.java
@@ -30,6 +30,7 @@ class DecisionRequirementsRecordAuditLogTransformerTest {
     final DecisionRequirementsRecordValue recordValue =
         ImmutableDecisionRequirementsRecordValue.builder()
             .from(factory.generateObject(DecisionRequirementsRecordValue.class))
+            .withResourceName("resourceName")
             .withDecisionRequirementsKey(123L)
             .withDecisionRequirementsId("decision-requirements-1")
             .withTenantId("tenant-1")
@@ -50,6 +51,7 @@ class DecisionRequirementsRecordAuditLogTransformerTest {
     assertThat(entity.getDecisionRequirementsKey()).isEqualTo(123L);
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("decision-requirements-1");
     assertThat(entity.getDeploymentKey()).isEqualTo(1234L);
+    assertThat(entity.getEntityDescription()).isEqualTo("resourceName");
   }
 
   @Test
@@ -58,6 +60,7 @@ class DecisionRequirementsRecordAuditLogTransformerTest {
     final DecisionRequirementsRecordValue recordValue =
         ImmutableDecisionRequirementsRecordValue.builder()
             .from(factory.generateObject(DecisionRequirementsRecordValue.class))
+            .withResourceName("resourceName")
             .withDecisionRequirementsKey(456L)
             .withDecisionRequirementsId("decision-requirements-2")
             .withTenantId("tenant-2")
@@ -78,5 +81,6 @@ class DecisionRequirementsRecordAuditLogTransformerTest {
     assertThat(entity.getDecisionRequirementsKey()).isEqualTo(456L);
     assertThat(entity.getDecisionRequirementsId()).isEqualTo("decision-requirements-2");
     assertThat(entity.getDeploymentKey()).isEqualTo(1234L);
+    assertThat(entity.getEntityDescription()).isEqualTo("resourceName");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/FormAuditLogTransformerTest.java
@@ -29,6 +29,7 @@ class FormAuditLogTransformerTest {
     final Form recordValue =
         ImmutableForm.builder()
             .from(factory.generateObject(Form.class))
+            .withResourceName("formResource")
             .withDeploymentKey(123L)
             .withFormKey(456L)
             .withTenantId("tenant-1")
@@ -46,5 +47,6 @@ class FormAuditLogTransformerTest {
     assertThat(entity.getEntityKey()).isEqualTo("456");
     assertThat(entity.getDeploymentKey()).isEqualTo(123L);
     assertThat(entity.getFormKey()).isEqualTo(456L);
+    assertThat(entity.getEntityDescription()).isEqualTo("formResource");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupAuditLogTransformerTest.java
@@ -30,6 +30,7 @@ class GroupAuditLogTransformerTest {
     final GroupRecordValue recordValue =
         ImmutableGroupRecordValue.builder()
             .from(factory.generateObject(GroupRecordValue.class))
+            .withName("groupName")
             .withGroupId("test-group")
             .withGroupKey(789L)
             .build();
@@ -45,5 +46,6 @@ class GroupAuditLogTransformerTest {
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-group");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getEntityDescription()).isEqualTo("groupName");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/GroupEntityAuditLogTransformerTest.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -30,6 +32,7 @@ class GroupEntityAuditLogTransformerTest {
     final GroupRecordValue recordValue =
         ImmutableGroupRecordValue.builder()
             .from(factory.generateObject(GroupRecordValue.class))
+            .withEntityType(EntityType.MAPPING_RULE)
             .withGroupId("test-group")
             .withGroupKey(789L)
             .build();
@@ -45,5 +48,7 @@ class GroupEntityAuditLogTransformerTest {
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-group");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
+    assertThat(entity.getRelatedEntityKey()).isEqualTo(recordValue.getEntityId());
+    assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.MAPPING_RULE);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/MappingRuleAuditLogTransformerTest.java
@@ -49,5 +49,6 @@ class MappingRuleAuditLogTransformerTest {
     // then
     assertThat(entity.getEntityKey()).isEqualTo("mapping-rule-1");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getEntityDescription()).isEqualTo("Engineering Mapping");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessAuditLogTransformerTest.java
@@ -30,6 +30,7 @@ class ProcessAuditLogTransformerTest {
     final Process recordValue =
         ImmutableProcess.builder()
             .from(factory.generateObject(Process.class))
+            .withResourceName("processResource")
             .withDeploymentKey(123L)
             .withProcessDefinitionKey(456L)
             .withBpmnProcessId("process-id")
@@ -51,5 +52,6 @@ class ProcessAuditLogTransformerTest {
     assertThat(entity.getProcessDefinitionId()).isEqualTo("process-id");
     assertThat(entity.getTenant().orElseThrow().tenantId()).isEqualTo("tenant-1");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);
+    assertThat(entity.getEntityDescription()).isEqualTo("processResource");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ResourceAuditLogTransformerTest.java
@@ -29,6 +29,7 @@ class ResourceAuditLogTransformerTest {
     final Resource recordValue =
         ImmutableResource.builder()
             .from(factory.generateObject(Resource.class))
+            .withResourceName("resourceName")
             .withDeploymentKey(123L)
             .withResourceKey(456L)
             .withTenantId("tenant-1")
@@ -46,5 +47,6 @@ class ResourceAuditLogTransformerTest {
     assertThat(entity.getEntityKey()).isEqualTo("456");
     assertThat(entity.getDeploymentKey()).isEqualTo(123L);
     assertThat(entity.getResourceKey()).isEqualTo(456L);
+    assertThat(entity.getEntityDescription()).isEqualTo("resourceName");
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/RoleEntityAuditLogTransformerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -31,6 +32,7 @@ class RoleEntityAuditLogTransformerTest {
         ImmutableRoleRecordValue.builder()
             .from(factory.generateObject(RoleRecordValue.class))
             .withRoleId("role-123")
+            .withEntityId("entity-id")
             .withEntityType(EntityType.USER)
             .build();
 
@@ -44,5 +46,7 @@ class RoleEntityAuditLogTransformerTest {
 
     // then
     assertThat(entity.getEntityKey()).isEqualTo("role-123");
+    assertThat(entity.getRelatedEntityKey()).isEqualTo("entity-id");
+    assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.USER);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/TenantEntityAuditLogTransformerTest.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -32,6 +34,7 @@ class TenantEntityAuditLogTransformerTest {
             .from(factory.generateObject(TenantRecordValue.class))
             .withTenantId("test-tenant")
             .withTenantKey(456L)
+            .withEntityType(EntityType.GROUP)
             .build();
 
     final Record<TenantRecordValue> record =
@@ -45,5 +48,7 @@ class TenantEntityAuditLogTransformerTest {
     // then
     assertThat(entity.getEntityKey()).isEqualTo("test-tenant");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.ASSIGN);
+    assertThat(entity.getRelatedEntityKey()).isEqualTo(recordValue.getEntityId());
+    assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.GROUP);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/UserTaskAuditLogTransformerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,5 +57,45 @@ class UserTaskAuditLogTransformerTest {
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());
+    assertThat(entity.getRelatedEntityKey()).isNullOrEmpty();
+    assertThat(entity.getRelatedEntityType()).isNull();
+  }
+
+  @Test
+  void shouldTransformAssignedUserTaskRecord() {
+    // given
+    final UserTaskRecordValue recordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .withUserTaskKey(123L)
+            .withProcessInstanceKey(456L)
+            .withProcessDefinitionKey(789L)
+            .withBpmnProcessId("test-process")
+            .withElementInstanceKey(111L)
+            .withTenantId("tenant-1")
+            .withAssignee("assignee-1")
+            .build();
+
+    final Record<UserTaskRecordValue> record =
+        factory.generateRecord(
+            ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.ASSIGNED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getUserTaskKey()).isEqualTo(123L);
+    assertThat(entity.getEntityKey()).isEqualTo("123");
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(456L);
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(789L);
+    assertThat(entity.getProcessDefinitionId()).isEqualTo("test-process");
+    assertThat(entity.getElementInstanceKey()).isEqualTo(111L);
+    assertThat(entity.getTenant().get().tenantId()).isEqualTo("tenant-1");
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
+    assertThat(entity.getRelatedEntityKey()).isEqualTo("assignee-1");
+    assertThat(entity.getRelatedEntityType()).isEqualTo(AuditLogEntityType.USER);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/VariableAddUpdateAuditLogTransformerTest.java
@@ -31,6 +31,7 @@ class VariableAddUpdateAuditLogTransformerTest {
     final VariableRecordValue recordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
+            .withName("variable-name")
             .withProcessDefinitionKey(456L)
             .withBpmnProcessId("bpmn-process-id")
             .withTenantId("tenant-1")
@@ -56,5 +57,6 @@ class VariableAddUpdateAuditLogTransformerTest {
     assertThat(entity.getRootProcessInstanceKey())
         .isPositive()
         .isEqualTo(record.getValue().getRootProcessInstanceKey());
+    assertThat(entity.getEntityDescription()).isEqualTo("variable-name");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
@@ -114,7 +114,7 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
     // generic fields
     entity
         .setEntityKey(log.getEntityKey())
-        .setEntityType(mapEntityType(log))
+        .setEntityType(mapEntityType(log.getEntityType()))
         .setCategory(mapCategory(log))
         .setOperationType(mapOperationType(log))
         .setActorType(mapActorType(log))
@@ -146,7 +146,10 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
         .setDeploymentKey(log.getDeploymentKey())
         .setFormKey(log.getFormKey())
         .setResourceKey(log.getResourceKey())
-        .setRootProcessInstanceKey(log.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(log.getRootProcessInstanceKey())
+        .setRelatedEntityKey(log.getRelatedEntityKey())
+        .setRelatedEntityType(mapEntityType(log.getRelatedEntityType()))
+        .setEntityDescription(log.getEntityDescription());
   }
 
   @VisibleForTesting
@@ -154,10 +157,9 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
     return transformer;
   }
 
-  private AuditLogEntityType mapEntityType(final AuditLogEntry info) {
-    return Objects.nonNull(info.getEntityType())
-        ? AuditLogEntityType.valueOf(info.getEntityType().name())
-        : null;
+  private AuditLogEntityType mapEntityType(
+      final io.camunda.search.entities.AuditLogEntity.AuditLogEntityType entityType) {
+    return Objects.nonNull(entityType) ? AuditLogEntityType.valueOf(entityType.name()) : null;
   }
 
   private AuditLogOperationResult mapResult(final AuditLogEntry log) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandler.java
@@ -73,6 +73,7 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
             // Generic fields
             .entityKey(log.getEntityKey())
             .entityType(log.getEntityType())
+            .entityDescription(log.getEntityDescription())
             .category(log.getCategory())
             .operationType(log.getOperationType())
             .actorId(log.getActor().actorId())
@@ -104,6 +105,8 @@ public class AuditLogExportHandler<R extends RecordValue> implements RdbmsExport
             .deploymentKey(log.getDeploymentKey())
             .formKey(log.getFormKey())
             .resourceKey(log.getResourceKey())
+            .relatedEntityKey(log.getRelatedEntityKey())
+            .relatedEntityType(log.getRelatedEntityType())
             .partitionId(record.getPartitionId());
 
     return auditLog.build();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AuditLogExportHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.service.AuditLogWriter;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
@@ -144,7 +145,10 @@ class AuditLogExportHandlerTest {
             .setDeploymentKey(606L)
             .setFormKey(707L)
             .setResourceKey(808L)
-            .setRootProcessInstanceKey(909L);
+            .setRootProcessInstanceKey(909L)
+            .setRelatedEntityKey("related-entity-key")
+            .setRelatedEntityType(AuditLogEntityType.USER)
+            .setEntityDescription("entity-description");
 
     when(transformer.create(record)).thenReturn(entry);
     handler.export(record);
@@ -202,5 +206,8 @@ class AuditLogExportHandlerTest {
     assertThat(entity.resourceKey()).isEqualTo(808L);
     assertThat(entity.rootProcessInstanceKey()).isEqualTo(909L);
     assertThat(entity.partitionId()).isEqualTo(record.getPartitionId());
+    assertThat(entity.relatedEntityKey()).isEqualTo("related-entity-key");
+    assertThat(entity.relatedEntityType()).isEqualTo(AuditLogEntityType.USER);
+    assertThat(entity.entityDescription()).isEqualTo("entity-description");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -394,6 +394,7 @@ components:
         - USER
         - USER_TASK
         - VARIABLE
+        - CLIENT
 
     AuditLogOperationTypeEnum:
       type: string


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Populates the primary audit log details according to the [User Operation Audit Log design document](https://docs.google.com/document/d/1COzShIcqFqZlq6ZRfuL9VeHD7oNvVd8vhnezxGlYTU0/edit?tab=t.c482jdb4ehw2). Adds acceptance tests for the new details for `relatedEntityKey`, `relatedEntityType` and `entityDescription`. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45170 
