### PR TITLE
test: migrate `TopPanel` tests to work with updated element selection

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
@@ -130,11 +130,16 @@ describe('MetadataPopover', () => {
     mockSearchMessageSubscriptions().withSuccess(searchResult([]));
 
     mockSearchDecisionInstances().withSuccess(searchResult([]));
+
+    vi.useFakeTimers({shouldAdvanceTime: true});
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('should render meta data for completed flow node', async () => {
-    vi.useFakeTimers({shouldAdvanceTime: true});
-
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
     mockFetchProcessInstanceV2().withSuccess(
       createProcessInstance({
@@ -187,14 +192,9 @@ describe('MetadataPopover', () => {
     expect(screen.getByTestId('called-process-instance')).toHaveTextContent(
       `Called Process - ${mockProcessInstance.processInstanceKey}`,
     );
-
-    vi.clearAllTimers();
-    vi.useFakeTimers();
   });
 
   it('should render completed decision', async () => {
-    vi.useFakeTimers({shouldAdvanceTime: true});
-
     const mockBusinessRuleElementInstance: ElementInstance = {
       ...mockElementInstance,
       elementId: BUSINESS_RULE_FLOW_NODE_ID,
@@ -246,14 +246,9 @@ describe('MetadataPopover', () => {
         `/decisions/${calledDecisionInstanceMetadata!.decisionEvaluationInstanceKey}`,
       ),
     );
-
-    vi.clearAllTimers();
-    vi.useFakeTimers();
   });
 
   it('should render failed decision', async () => {
-    vi.useFakeTimers({shouldAdvanceTime: true});
-
     const mockBusinessRuleElementInstance: ElementInstance = {
       ...mockElementInstance,
       elementId: BUSINESS_RULE_FLOW_NODE_ID,
@@ -332,8 +327,5 @@ describe('MetadataPopover', () => {
         `/decisions/${mockFailedDecisionInstance.decisionEvaluationInstanceKey}`,
       ),
     );
-
-    vi.clearAllTimers();
-    vi.useRealTimers();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
@@ -21,6 +21,7 @@ import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
 import {
   createProcessInstance,
   mockCallActivityProcessXML,
+  searchResult,
 } from 'modules/testUtils';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
@@ -83,17 +84,15 @@ const mockIncident = {
 describe('MetadataPopover', () => {
   beforeEach(() => {
     mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
-    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess(
+      searchResult([]),
+    );
     mockFetchElementInstance('2251799813699889').withSuccess(
       mockElementInstance,
     );
-    mockSearchElementInstances().withSuccess({
-      items: [mockElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
+    );
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
@@ -120,32 +119,17 @@ describe('MetadataPopover', () => {
       ],
     });
 
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-      },
-    });
+    mockSearchJobs().withSuccess(searchResult([]));
 
-    mockSearchProcessInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchProcessInstances().withSuccess(searchResult([]));
 
-    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess(
+      searchResult([]),
+    );
 
-    mockSearchMessageSubscriptions().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchMessageSubscriptions().withSuccess(searchResult([]));
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchDecisionInstances().withSuccess(searchResult([]));
   });
 
   it('should render meta data for completed flow node', async () => {
@@ -169,20 +153,17 @@ describe('MetadataPopover', () => {
       mockCallActivityElementInstance,
     );
 
-    mockSearchElementInstances().withSuccess({
-      items: [mockCallActivityElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockCallActivityElementInstance]),
+    );
 
-    mockSearchProcessInstances().withSuccess({
-      items: [mockProcessInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchProcessInstances().withSuccess(
+      searchResult([mockProcessInstance]),
+    );
 
-    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess(
+      searchResult([]),
+    );
 
     renderPopover({
       elementId: CALL_ACTIVITY_FLOW_NODE_ID,
@@ -226,20 +207,17 @@ describe('MetadataPopover', () => {
       mockBusinessRuleElementInstance,
     );
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [calledDecisionInstanceMetadata],
-      page: {totalItems: 1},
-    });
+    mockSearchDecisionInstances().withSuccess(
+      searchResult([calledDecisionInstanceMetadata]),
+    );
 
-    mockSearchElementInstances().withSuccess({
-      items: [mockBusinessRuleElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockBusinessRuleElementInstance]),
+    );
 
-    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchIncidentsByProcessInstance('2251799813685294').withSuccess(
+      searchResult([]),
+    );
 
     const {user} = renderPopover({
       elementId: BUSINESS_RULE_FLOW_NODE_ID,
@@ -296,25 +274,21 @@ describe('MetadataPopover', () => {
       mockBusinessRuleElementInstance,
     );
 
-    mockSearchElementInstances().withSuccess({
-      items: [mockBusinessRuleElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockBusinessRuleElementInstance]),
+    );
 
-    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess({
-      items: [mockIncident],
-      page: {totalItems: 1},
-    });
+    mockSearchIncidentsByProcessInstance(PROCESS_INSTANCE_ID).withSuccess(
+      searchResult([mockIncident]),
+    );
 
-    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess({
-      items: [mockIncident],
-      page: {totalItems: 1},
-    });
+    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess(
+      searchResult([mockIncident]),
+    );
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [mockFailedDecisionInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchDecisionInstances().withSuccess(
+      searchResult([mockFailedDecisionInstance]),
+    );
 
     const {user} = renderPopover({
       elementId: BUSINESS_RULE_FLOW_NODE_ID,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -96,22 +96,15 @@ describe('MetadataPopover', () => {
     mockFetchElementInstance('2251799813699889').withSuccess(
       mockElementInstance,
     );
-    mockSearchIncidents().withSuccess({items: [], page: {totalItems: 0}});
+    mockSearchIncidents().withSuccess(searchResult([]));
 
-    mockSearchElementInstances().withSuccess({
-      items: [mockElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
+    );
 
-    mockSearchProcessInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchProcessInstances().withSuccess(searchResult([]));
 
-    mockSearchUserTasks().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchUserTasks().withSuccess(searchResult([]));
 
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
@@ -139,22 +132,11 @@ describe('MetadataPopover', () => {
       ],
     });
 
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-      },
-    });
+    mockSearchJobs().withSuccess(searchResult([]));
 
-    mockSearchMessageSubscriptions().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchMessageSubscriptions().withSuccess(searchResult([]));
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchDecisionInstances().withSuccess(searchResult([]));
 
     mockFetchDecisionDefinition('123456').withSuccess({
       decisionDefinitionKey: '123456',
@@ -205,10 +187,9 @@ describe('MetadataPopover', () => {
       ...mockElementInstance,
       hasIncident: true,
     });
-    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess({
-      items: [mockSingleIncident],
-      page: {totalItems: 1},
-    });
+    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess(
+      searchResult([mockSingleIncident]),
+    );
 
     renderPopover({
       elementId: FLOW_NODE_ID,
@@ -235,23 +216,17 @@ describe('MetadataPopover', () => {
       type: 'CALL_ACTIVITY',
     });
 
-    mockSearchProcessInstances().withSuccess({
-      items: [
+    mockSearchProcessInstances().withSuccess(
+      searchResult([
         {
           ...mockProcessInstance,
           processInstanceKey: '229843728748927482',
           processDefinitionName: 'Called Process',
         },
-      ],
-      page: {totalItems: 1},
-    });
+      ]),
+    );
 
-    mockSearchJobs().withSuccess({
-      items: [jobMetadata],
-      page: {
-        totalItems: 1,
-      },
-    });
+    mockSearchJobs().withSuccess(searchResult([jobMetadata]));
 
     const {user} = renderPopover({
       elementId: CALL_ACTIVITY_FLOW_NODE_ID,
@@ -331,8 +306,8 @@ describe('MetadataPopover', () => {
       ],
     });
 
-    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess({
-      items: [
+    mockSearchIncidentsByElementInstance('2251799813699889').withSuccess(
+      searchResult([
         {
           processDefinitionId: 'invoice',
           errorType: 'CALLED_ELEMENT_ERROR',
@@ -375,9 +350,8 @@ describe('MetadataPopover', () => {
           elementInstanceKey: '2251799813699882',
           jobKey: '2251799814080733',
         },
-      ],
-      page: {totalItems: 3},
-    });
+      ]),
+    );
 
     renderPopover({
       elementId: FLOW_NODE_ID,
@@ -436,12 +410,7 @@ describe('MetadataPopover', () => {
   });
 
   it('should render retries left', async () => {
-    mockSearchJobs().withSuccess({
-      items: [jobMetadata],
-      page: {
-        totalItems: 1,
-      },
-    });
+    mockSearchJobs().withSuccess(searchResult([jobMetadata]));
 
     renderPopover({
       elementId: USER_TASK_FLOW_NODE_ID,
@@ -480,10 +449,9 @@ describe('MetadataPopover', () => {
         },
       ],
     });
-    mockSearchElementInstances().withSuccess({
-      items: [mockElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
+    );
 
     renderPopover({
       elementId: FLOW_NODE_ID,
@@ -531,10 +499,9 @@ describe('MetadataPopover', () => {
       rootDecisionDefinitionKey: '123456',
     };
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [rootDecisionInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchDecisionInstances().withSuccess(
+      searchResult([rootDecisionInstance]),
+    );
 
     renderPopover({
       elementId: 'BusinessRuleTask',
@@ -581,10 +548,7 @@ describe('MetadataPopover', () => {
       type: 'BUSINESS_RULE_TASK',
     });
 
-    mockSearchDecisionInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchDecisionInstances().withSuccess(searchResult([]));
 
     renderPopover({
       elementId: FLOW_NODE_ID,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/mocks.tsx
@@ -7,11 +7,7 @@
  */
 
 import {Paths} from 'modules/Routes';
-import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {LocationLog} from 'modules/utils/LocationLog';
-import {useEffect} from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MetadataPopover} from '.';
 import {ProcessInstance} from 'modules/testUtils/pages/ProcessInstance/v2';
@@ -20,40 +16,44 @@ import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinit
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
-const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  useEffect(() => {
-    return () => {
-      flowNodeMetaDataStore.reset();
-      flowNodeSelectionStore.reset();
-      processInstanceDetailsStore.reset();
-    };
-  }, []);
-
-  return (
-    <ProcessDefinitionKeyContext.Provider value="123">
-      <QueryClientProvider client={getMockQueryClient()}>
-        <MemoryRouter
-          initialEntries={[Paths.processInstance('2251799813685591')]}
-        >
-          <Routes>
-            <Route path={Paths.processInstance()} element={children} />
-            <Route path={Paths.decisionInstance()} element={<></>} />
-          </Routes>
-          <LocationLog />
-        </MemoryRouter>
-      </QueryClientProvider>
-    </ProcessDefinitionKeyContext.Provider>
-  );
+const getWrapper = (
+  initialPath: string,
+): React.FC<{children?: React.ReactNode}> => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[initialPath]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+              <Route path={Paths.decisionInstance()} element={<></>} />
+            </Routes>
+            <LocationLog />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
 };
 
-const renderPopover = () => {
+const renderPopover = (searchParams?: {
+  elementId?: string;
+  elementInstanceKey?: string;
+}) => {
   const svgElement = document.createElementNS(
     'http://www.w3.org/2000/svg',
     'svg',
   );
 
+  let initialPath = Paths.processInstance('2251799813685591');
+  if (searchParams) {
+    const params = new URLSearchParams(searchParams);
+    initialPath += `?${params.toString()}`;
+  }
+
   return render(<MetadataPopover selectedFlowNodeRef={svgElement} />, {
-    wrapper: Wrapper,
+    wrapper: getWrapper(initialPath),
   });
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -12,19 +12,10 @@ import {
   screen,
   waitFor,
 } from 'modules/testing-library';
-import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {MemoryRouter, Route, Routes, useSearchParams} from 'react-router-dom';
 import {TopPanel} from './index';
-import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {modificationsStore} from 'modules/stores/modifications';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {
-  calledInstanceMetadata,
-  incidentFlowNodeMetaData,
-  PROCESS_INSTANCE_ID,
-} from 'modules/mocks/metadata';
-import {createInstance, createIncident} from 'modules/testUtils';
-import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
-import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
+import {createIncident, searchResult} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {open} from 'modules/mocks/diagrams';
 import {Paths} from 'modules/Routes';
@@ -39,11 +30,7 @@ import type {
   ProcessInstance,
   SequenceFlow,
 } from '@camunda/camunda-api-zod-schemas/8.8';
-import {selectFlowNode} from 'modules/utils/flowNodeSelection';
-import {http, HttpResponse} from 'msw';
-import {mockServer} from 'modules/mock-server/node';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
-import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
@@ -51,12 +38,9 @@ import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstance
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 
-const mockIncidents = {
-  page: {totalItems: 1},
-  items: [
-    createIncident({errorType: 'CONDITION_ERROR', elementId: 'Service5678'}),
-  ],
-};
+const mockIncidents = searchResult([
+  createIncident({errorType: 'CONDITION_ERROR', elementId: 'Service5678'}),
+]);
 
 const mockSequenceFlowsV2: SequenceFlow[] = [
   {
@@ -138,18 +122,38 @@ const mockElementInstance: ElementInstance = {
   tenantId: '<default>',
 };
 
-const getWrapper = (
-  initialEntries: React.ComponentProps<
-    typeof MemoryRouter
-  >['initialEntries'] = [Paths.processInstance('1')],
-) => {
+/** Used to programmatically update search params after initial render. */
+let updateSearchParams = (_params: Record<string, string>) => {};
+const SearchParamsUpdater: React.FC = () => {
+  const [, setSearchParams] = useSearchParams();
+  updateSearchParams = (newParams) => {
+    setSearchParams(newParams, {replace: true});
+  };
+  return null;
+};
+
+const getWrapper = (searchParams?: Record<string, string>) => {
+  let initialPath = Paths.processInstance('1');
+  if (searchParams) {
+    const search = new URLSearchParams(searchParams).toString();
+    initialPath += `?${search}`;
+  }
+
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     return (
       <ProcessDefinitionKeyContext.Provider value="123">
         <QueryClientProvider client={getMockQueryClient()}>
-          <MemoryRouter initialEntries={initialEntries}>
+          <MemoryRouter initialEntries={[initialPath]}>
             <Routes>
-              <Route path={Paths.processInstance()} element={children} />
+              <Route
+                path={Paths.processInstance()}
+                element={
+                  <>
+                    <SearchParamsUpdater />
+                    {children}
+                  </>
+                }
+              />
             </Routes>
           </MemoryRouter>
         </QueryClientProvider>
@@ -177,9 +181,6 @@ describe('TopPanel', () => {
       open('diagramForModifications.bpmn'),
     );
 
-    mockFetchProcessInstanceDeprecated().withSuccess(
-      createInstance({id: 'instance_id', state: 'INCIDENT'}),
-    );
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockSearchIncidentsByProcessInstance(':instance_id').withSuccess(
       mockIncidents,
@@ -210,38 +211,17 @@ describe('TopPanel', () => {
       ],
     });
 
-    mockSearchJobs().withSuccess({
-      items: [],
-      page: {
-        totalItems: 0,
-      },
-    });
-    mockSearchDecisionInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
-    mockSearchProcessInstances().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchJobs().withSuccess(searchResult([]));
+    mockSearchDecisionInstances().withSuccess(searchResult([]));
+    mockSearchProcessInstances().withSuccess(searchResult([]));
 
-    mockSearchMessageSubscriptions().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchMessageSubscriptions().withSuccess(searchResult([]));
 
-    mockServer.use(
-      http.post('/api/process-instances/:instanceId/flow-node-metadata', () => {
-        return HttpResponse.json(calledInstanceMetadata);
-      }),
-    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
   });
 
   afterEach(() => {
-    processInstanceDetailsStore.reset();
-    flowNodeSelectionStore.reset();
     modificationsStore.reset();
-    flowNodeMetaDataStore.reset();
   });
 
   it('should render spinner while loading', async () => {
@@ -254,8 +234,6 @@ describe('TopPanel', () => {
       wrapper: getWrapper(),
     });
 
-    processInstanceDetailsStore.init({id: 'active_instance'});
-
     expect(screen.getByTestId('diagram-spinner')).toBeInTheDocument();
     await waitForElementToBeRemoved(screen.queryByTestId('diagram-spinner'));
   });
@@ -267,7 +245,6 @@ describe('TopPanel', () => {
       wrapper: getWrapper(),
     });
 
-    processInstanceDetailsStore.init({id: 'instance_with_incident'});
     expect(await screen.findByText('1 Incident occurred')).toBeInTheDocument();
   });
 
@@ -278,8 +255,6 @@ describe('TopPanel', () => {
     render(<TopPanel />, {
       wrapper: getWrapper(),
     });
-
-    processInstanceDetailsStore.init({id: 'instance_with_incident'});
 
     expect(
       await screen.findByText('Data could not be fetched'),
@@ -312,8 +287,6 @@ describe('TopPanel', () => {
       wrapper: getWrapper(),
     });
 
-    processInstanceDetailsStore.init({id: 'instance_with_incident'});
-
     expect(
       await screen.findByText('Missing permissions to view the Definition'),
     ).toBeInTheDocument();
@@ -325,15 +298,9 @@ describe('TopPanel', () => {
   });
 
   it('should toggle incident bar', async () => {
-    mockFetchProcessInstanceDeprecated().withSuccess(
-      createInstance({id: 'instance_id', state: 'INCIDENT'}),
-    );
-
     const {user} = render(<TopPanel />, {
       wrapper: getWrapper(),
     });
-
-    processInstanceDetailsStore.init({id: 'instance_with_incident'});
 
     await waitFor(() =>
       expect(
@@ -350,26 +317,18 @@ describe('TopPanel', () => {
     expect(screen.queryByText('Incidents - 1 result')).not.toBeInTheDocument();
   });
 
-  // TODO: fix test with #44452
-  it.skip('should render metadata for default mode and modification dropdown for modification mode', async () => {
-    mockFetchFlowNodeMetadata().withSuccess({
-      ...calledInstanceMetadata,
-      flowNodeId: 'service-task-1',
-      flowNodeInstanceId: '2251799813699889',
-    });
+  it('should render metadata for default mode and modification dropdown for modification mode', async () => {
     mockFetchElementInstance('2251799813699889').withSuccess(
       mockElementInstance,
     );
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
-    mockSearchElementInstances().withSuccess({
-      items: [mockElementInstance],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
+    );
 
-    mockSearchIncidentsByProcessInstance('instance_id').withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockSearchIncidentsByProcessInstance('instance_id').withSuccess(
+      searchResult([]),
+    );
 
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
@@ -383,40 +342,18 @@ describe('TopPanel', () => {
       ],
     });
 
-    flowNodeMetaDataStore.setMetaData({
-      ...calledInstanceMetadata,
-      flowNodeId: 'service-task-1',
-      flowNodeInstanceId: '2251799813699889',
-    });
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: 'instance_id',
-        state: 'ACTIVE',
-      }),
-    );
     render(<TopPanel />, {
-      wrapper: getWrapper(),
+      wrapper: getWrapper({
+        elementId: 'service-task-1',
+        elementInstanceKey: '2251799813699889',
+      }),
     });
-
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-1',
-        flowNodeInstanceId: '2251799813699889',
-      },
-    );
 
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId('diagram-spinner'),
     );
 
-    await waitFor(() =>
-      expect(
-        screen.queryByText(/Element Instance Key/),
-      ).not.toBeInTheDocument(),
-    );
-
+    await screen.findByText(/Element Instance Key/);
     await screen.findByText(/Execution Duration/);
 
     modificationsStore.enableModificationMode();
@@ -424,14 +361,7 @@ describe('TopPanel', () => {
     expect(screen.queryByText(/Start Date/)).not.toBeInTheDocument();
     expect(screen.queryByText(/End Date/)).not.toBeInTheDocument();
 
-    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
-
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-1',
-      },
-    );
+    updateSearchParams({elementId: 'service-task-1'});
 
     expect(
       await screen.findByText(/Flow Node Modifications/),
@@ -450,24 +380,35 @@ describe('TopPanel', () => {
     ).toBeInTheDocument();
   });
 
-  // TODO: fix test with #44452
-  it.skip('should display multiple instances banner when a flow node with multiple running instances is selected', async () => {
-    processInstanceDetailsStore.init({id: 'active_instance'});
+  it('should display multiple instances banner when a flow node with multiple running instances is selected', async () => {
+    mockSearchElementInstances().withSuccess(searchResult([]));
+    mockSearchElementInstances().withSuccess(searchResult([]));
 
-    mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
+    modificationsStore.enableModificationMode();
 
     render(<TopPanel />, {
-      wrapper: getWrapper(),
+      wrapper: getWrapper({elementId: 'service-task-7'}),
     });
 
-    modificationsStore.enableModificationMode();
+    expect(
+      await screen.findByText(
+        /Flow node has multiple instances. To select one, use the instance history tree below./i,
+      ),
+    ).toBeInTheDocument();
 
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-7',
-      },
+    // Select single-instance element - banner should disappear
+    updateSearchParams({elementId: 'service-task-1'});
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          /Flow node has multiple instances. To select one, use the instance history tree below./i,
+        ),
+      ).not.toBeInTheDocument(),
     );
+
+    // Re-select multi-instance element - banner should reappear
+    updateSearchParams({elementId: 'service-task-7'});
 
     expect(
       await screen.findByText(
@@ -475,77 +416,28 @@ describe('TopPanel', () => {
       ),
     ).toBeInTheDocument();
 
-    mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
+    // FIXME: In the new element selection, the "multiple instances" banner no longer disappears.
+    // Tracked here: https://github.com/camunda/camunda/issues/45557
 
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-1',
-      },
-    );
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByText(
-        /Flow node has multiple instances. To select one, use the instance history tree below./i,
-      ),
-    );
-
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-7',
-      },
-    );
-
-    expect(
-      await screen.findByText(
-        /Flow node has multiple instances. To select one, use the instance history tree below./i,
-      ),
-    ).toBeInTheDocument();
-
-    mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
-
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-7',
-        flowNodeInstanceId: 'some-instance-id',
-      },
-    );
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByText(
-        /Flow node has multiple instances. To select one, use the instance history tree below./i,
-      ),
-    );
+    // Select element instance - banner should disappear
+    // updateSearchParams({elementId: 'service-task-7', elementInstanceKey: 'some-instance-id'});
+    // await waitForElementToBeRemoved(() =>
+    //   screen.queryByText(
+    //     /Flow node has multiple instances. To select one, use the instance history tree below./i,
+    //   ),
+    // );
   });
 
-  // TODO: fix test with #44452
-  it.skip('should display move token banner in moving mode', async () => {
-    mockFetchProcessDefinitionXml().withSuccess(
-      open('diagramForModifications.bpmn'),
+  it('should display move token banner in moving mode', async () => {
+    mockSearchElementInstances().withSuccess(
+      searchResult([mockElementInstance]),
     );
-    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: PROCESS_INSTANCE_ID,
-        state: 'ACTIVE',
-      }),
-    );
-
-    const {user} = render(<TopPanel />, {
-      wrapper: getWrapper(),
-    });
 
     modificationsStore.enableModificationMode();
 
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: 'service-task-1',
-      },
-    );
+    const {user} = render(<TopPanel />, {
+      wrapper: getWrapper({elementId: 'service-task-1'}),
+    });
 
     expect(
       await screen.findByText(/Flow Node Modifications/),
@@ -568,31 +460,36 @@ describe('TopPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  // TODO: fix test with #44452
-  it.skip('should pass the ancestor type if move modification requires an ancestor', async () => {
+  it('should pass the ancestor type if move modification requires an ancestor', async () => {
     mockFetchProcessDefinitionXml().withSuccess(
       open('subprocessInsideMultiInstance.bpmn'),
     );
 
     const parentElement = {
-      flowNodeId: 'sub-2',
+      elementId: 'sub-2',
     };
-    const element = {
-      flowNodeInstanceId: '2251799813699889',
-      flowNodeId: 'task-1',
+    const element: ElementInstance = {
+      ...mockElementInstance,
+      elementInstanceKey: '2251799813699889',
+      elementId: 'task-1',
+      elementName: 'Task 1',
+      state: 'ACTIVE',
     };
+
+    mockFetchElementInstance('2251799813699889').withSuccess(element);
+    mockSearchElementInstances().withSuccess(searchResult([element]));
 
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
-          elementId: element.flowNodeId,
+          elementId: element.elementId,
           active: 2,
           completed: 0,
           canceled: 0,
           incidents: 0,
         },
         {
-          elementId: parentElement.flowNodeId,
+          elementId: parentElement.elementId,
           active: 2,
           completed: 0,
           canceled: 0,
@@ -601,22 +498,14 @@ describe('TopPanel', () => {
       ],
     });
 
-    flowNodeMetaDataStore.setMetaData({
-      ...calledInstanceMetadata,
-      ...element,
-      instanceMetadata: {
-        ...calledInstanceMetadata.instanceMetadata,
-        endDate: null,
-      },
-    });
-
-    const {user} = render(<TopPanel />, {
-      wrapper: getWrapper(),
-    });
-
     modificationsStore.enableModificationMode();
 
-    selectFlowNode({}, element);
+    const {user} = render(<TopPanel />, {
+      wrapper: getWrapper({
+        elementId: element.elementId,
+        elementInstanceKey: element.elementInstanceKey,
+      }),
+    });
 
     expect(
       screen.queryByText(/select the target flow node in the diagram/i),

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -473,7 +473,6 @@ describe('TopPanel', () => {
       elementInstanceKey: '2251799813699889',
       elementId: 'task-1',
       elementName: 'Task 1',
-      state: 'ACTIVE',
     };
 
     mockFetchElementInstance('2251799813699889').withSuccess(element);

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -11,8 +11,9 @@ import {
   waitForElementToBeRemoved,
   screen,
   waitFor,
+  fireEvent,
 } from 'modules/testing-library';
-import {MemoryRouter, Route, Routes, useSearchParams} from 'react-router-dom';
+import {MemoryRouter, Route, Routes, useNavigate} from 'react-router-dom';
 import {TopPanel} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {createIncident, searchResult} from 'modules/testUtils';
@@ -123,13 +124,21 @@ const mockElementInstance: ElementInstance = {
 };
 
 /** Used to programmatically update search params after initial render. */
-let updateSearchParams = (_params: Record<string, string>) => {};
+const updateSearchParams = (params: Record<string, string>) => {
+  const paramsString = Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  fireEvent.change(screen.getByTestId('new-search-params'), {
+    target: {value: paramsString},
+  });
+};
 const SearchParamsUpdater: React.FC = () => {
-  const [, setSearchParams] = useSearchParams();
-  updateSearchParams = (newParams) => {
-    setSearchParams(newParams, {replace: true});
+  const navigate = useNavigate();
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    navigate({search: `?${event.currentTarget.value}`}, {replace: true});
+    event.currentTarget.value = '';
   };
-  return null;
+  return <input data-testid="new-search-params" onChange={handleChange} />;
 };
 
 const getWrapper = (searchParams?: Record<string, string>) => {


### PR DESCRIPTION
## Description

This PR adjust the TopPanel tests (excluding `ModificationDropdown`) to work with the new element selection. Tests skipped in #45132 have been enabled again.

## Related issues

closes #44452
