### PR TITLE
45635 make history deletion use process instance key

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import java.util.List;
 
-public interface AuditLogMapper extends RootProcessInstanceDependantMapper {
+public interface AuditLogMapper extends ProcessInstanceDependantMapper {
 
   void insert(BatchInsertDto<AuditLogDbModel> dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/CorrelatedMessageSubscriptionMapper.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.read.domain.CorrelatedMessageSubscriptionDbQuery;
 import io.camunda.db.rdbms.write.domain.CorrelatedMessageSubscriptionDbModel;
 import java.util.List;
 
-public interface CorrelatedMessageSubscriptionMapper extends RootProcessInstanceDependantMapper {
+public interface CorrelatedMessageSubscriptionMapper extends ProcessInstanceDependantMapper {
 
   Long count(CorrelatedMessageSubscriptionDbQuery query);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import java.util.List;
 
-public interface DecisionInstanceMapper extends RootProcessInstanceDependantMapper {
+public interface DecisionInstanceMapper extends ProcessInstanceDependantMapper {
 
   void insert(DecisionInstanceDbModel decisionInstance);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/FlowNodeInstanceMapper.java
@@ -14,7 +14,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public interface FlowNodeInstanceMapper extends RootProcessInstanceDependantMapper {
+public interface FlowNodeInstanceMapper extends ProcessInstanceDependantMapper {
 
   void insert(BatchInsertDto<FlowNodeInstanceDbModel> dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/IncidentMapper.java
@@ -16,7 +16,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionE
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import java.util.List;
 
-public interface IncidentMapper extends RootProcessInstanceDependantMapper {
+public interface IncidentMapper extends ProcessInstanceDependantMapper {
 
   void insert(IncidentDbModel incident);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import java.util.List;
 
-public interface JobMapper extends RootProcessInstanceDependantMapper {
+public interface JobMapper extends ProcessInstanceDependantMapper {
 
   void insert(BatchInsertDto<JobDbModel> dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
@@ -14,7 +14,7 @@ import io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatistics
 import java.util.List;
 
 public interface MessageSubscriptionMapper
-    extends HistoryCleanupMapper, RootProcessInstanceDependantMapper {
+    extends HistoryCleanupMapper, ProcessInstanceDependantMapper {
 
   void insert(MessageSubscriptionDbModel messageSubscription);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
@@ -16,7 +16,13 @@ import java.util.List;
  */
 public interface ProcessInstanceDependantMapper {
 
+  // for history deletion API
+  int deleteProcessInstanceRelatedData(DeleteProcessInstanceRelatedDataDto dto);
+
+  // for history cleanup
   int deleteRootProcessInstanceRelatedData(DeleteRootProcessInstanceRelatedDataDto dto);
+
+  record DeleteProcessInstanceRelatedDataDto(List<Long> processInstanceKeys, int limit) {}
 
   record DeleteRootProcessInstanceRelatedDataDto(List<Long> rootProcessInstanceKeys, int limit) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceDependantMapper.java
@@ -14,7 +14,7 @@ import java.util.List;
  * interface should be extended by mappers that should delete process instance related data upon a
  * process instance deletion.
  */
-public interface RootProcessInstanceDependantMapper {
+public interface ProcessInstanceDependantMapper {
 
   int deleteRootProcessInstanceRelatedData(DeleteRootProcessInstanceRelatedDataDto dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SequenceFlowMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SequenceFlowMapper.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.read.domain.SequenceFlowDbQuery;
 import io.camunda.db.rdbms.write.domain.SequenceFlowDbModel;
 import java.util.List;
 
-public interface SequenceFlowMapper extends RootProcessInstanceDependantMapper {
+public interface SequenceFlowMapper extends ProcessInstanceDependantMapper {
 
   List<SequenceFlowDbModel> search(SequenceFlowDbQuery processInstanceKey);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UserTaskMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/UserTaskMapper.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskMigrationDbModel;
 import java.util.List;
 
-public interface UserTaskMapper extends RootProcessInstanceDependantMapper {
+public interface UserTaskMapper extends ProcessInstanceDependantMapper {
 
   void insert(UserTaskDbModel taskDbModel);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -14,7 +14,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
-public interface VariableMapper extends RootProcessInstanceDependantMapper {
+public interface VariableMapper extends ProcessInstanceDependantMapper {
 
   void insert(BatchInsertDto<VariableDbModel> dto);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -47,11 +47,11 @@ import io.camunda.db.rdbms.write.service.JobWriter;
 import io.camunda.db.rdbms.write.service.MappingRuleWriter;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
+import io.camunda.db.rdbms.write.service.ProcessInstanceDependant;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.db.rdbms.write.service.RdbmsWriter;
 import io.camunda.db.rdbms.write.service.RoleWriter;
-import io.camunda.db.rdbms.write.service.RootProcessInstanceDependant;
 import io.camunda.db.rdbms.write.service.SequenceFlowWriter;
 import io.camunda.db.rdbms.write.service.TenantWriter;
 import io.camunda.db.rdbms.write.service.UsageMetricTUWriter;
@@ -277,10 +277,10 @@ public class RdbmsWriters {
     return getWriter(HistoryDeletionWriter.class);
   }
 
-  public List<RootProcessInstanceDependant> getProcessInstanceDependantWriters() {
+  public List<ProcessInstanceDependant> getProcessInstanceDependantWriters() {
     return writers.values().stream()
-        .filter(RootProcessInstanceDependant.class::isInstance)
-        .map(RootProcessInstanceDependant.class::cast)
+        .filter(ProcessInstanceDependant.class::isInstance)
+        .map(ProcessInstanceDependant.class::cast)
         .toList();
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -22,7 +22,7 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public class AuditLogWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final AuditLogMapper mapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/CorrelatedMessageSubscriptionWriter.java
@@ -14,7 +14,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class CorrelatedMessageSubscriptionWriter extends RootProcessInstanceDependant
+public class CorrelatedMessageSubscriptionWriter extends ProcessInstanceDependant
     implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -19,7 +19,7 @@ import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.time.OffsetDateTime;
 import java.util.List;
 
-public class DecisionInstanceWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class DecisionInstanceWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final DecisionInstanceMapper mapper;
   private final ExecutionQueue executionQueue;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -24,7 +24,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
 
-public class FlowNodeInstanceWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class FlowNodeInstanceWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final RdbmsWriterConfig config;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -46,7 +46,7 @@ public class HistoryCleanupService {
   private final UsageMetricWriter usageMetricWriter;
   private final UsageMetricTUWriter usageMetricTUWriter;
   private final AuditLogWriter auditLogWriter;
-  private final Map<String, RootProcessInstanceDependant> rootProcessInstanceDependentChildWriters;
+  private final Map<String, ProcessInstanceDependant> rootProcessInstanceDependentChildWriters;
 
   private final Map<Integer, Duration> lastCleanupInterval = new HashMap<>();
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -81,16 +81,19 @@ public class HistoryDeletionService {
       return List.of();
     }
 
-    final var allProcessInstanceDependantDataDeleted =
-        rdbmsWriters.getProcessInstanceDependantWriters().stream()
-            .filter(dependant -> !(dependant instanceof AuditLogWriter))
-            .allMatch(
-                dependant -> {
-                  final var limit = config.dependentRowLimit();
-                  final var deletedRows =
-                      dependant.deleteRootProcessInstanceRelatedData(processInstanceKeys, limit);
-                  return deletedRows < limit;
-                });
+    boolean allProcessInstanceDependantDataDeleted = true;
+    final var limit = config.dependentRowLimit();
+    for (final var dependant : rdbmsWriters.getProcessInstanceDependantWriters()) {
+      // TODO check if we should still have this or not
+      // if (dependant instanceof AuditLogWriter) {
+      //  continue;
+      // }
+      final var deletedRows =
+          dependant.deleteProcessInstanceRelatedData(processInstanceKeys, limit);
+      if (deletedRows >= limit) {
+        allProcessInstanceDependantDataDeleted = false;
+      }
+    }
 
     if (allProcessInstanceDependantDataDeleted) {
       rdbmsWriters.getProcessInstanceWriter().deleteByKeys(processInstanceKeys);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -84,10 +84,9 @@ public class HistoryDeletionService {
     boolean allProcessInstanceDependantDataDeleted = true;
     final var limit = config.dependentRowLimit();
     for (final var dependant : rdbmsWriters.getProcessInstanceDependantWriters()) {
-      // TODO check if we should still have this or not
-      // if (dependant instanceof AuditLogWriter) {
-      //  continue;
-      // }
+      if (dependant instanceof AuditLogWriter) {
+        continue;
+      }
       final var deletedRows =
           dependant.deleteProcessInstanceRelatedData(processInstanceKeys, limit);
       if (deletedRows >= limit) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IncidentWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class IncidentWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private static final Logger LOG = LoggerFactory.getLogger(IncidentWriter.class);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -21,7 +21,7 @@ import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.util.function.Function;
 
-public class JobWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final VendorDatabaseProperties vendorDatabaseProperties;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -14,7 +14,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class MessageSubscriptionWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class MessageSubscriptionWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
@@ -7,22 +7,22 @@
  */
 package io.camunda.db.rdbms.write.service;
 
-import io.camunda.db.rdbms.sql.RootProcessInstanceDependantMapper;
-import io.camunda.db.rdbms.sql.RootProcessInstanceDependantMapper.DeleteRootProcessInstanceRelatedDataDto;
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper.DeleteRootProcessInstanceRelatedDataDto;
 import java.util.List;
 
-public abstract class RootProcessInstanceDependant {
+public abstract class ProcessInstanceDependant {
 
-  private final RootProcessInstanceDependantMapper rootProcessInstanceDependantMapper;
+  private final ProcessInstanceDependantMapper processInstanceDependantMapper;
 
-  public RootProcessInstanceDependant(
-      final RootProcessInstanceDependantMapper rootProcessInstanceDependantMapper) {
-    this.rootProcessInstanceDependantMapper = rootProcessInstanceDependantMapper;
+  public ProcessInstanceDependant(
+      final ProcessInstanceDependantMapper processInstanceDependantMapper) {
+    this.processInstanceDependantMapper = processInstanceDependantMapper;
   }
 
   public int deleteRootProcessInstanceRelatedData(
       final List<Long> rootProcessInstanceKeys, final int limit) {
-    return rootProcessInstanceDependantMapper.deleteRootProcessInstanceRelatedData(
+    return processInstanceDependantMapper.deleteRootProcessInstanceRelatedData(
         new DeleteRootProcessInstanceRelatedDataDto(rootProcessInstanceKeys, limit));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceDependant.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.service;
 
 import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper.DeleteProcessInstanceRelatedDataDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper.DeleteRootProcessInstanceRelatedDataDto;
 import java.util.List;
 
@@ -18,6 +19,12 @@ public abstract class ProcessInstanceDependant {
   public ProcessInstanceDependant(
       final ProcessInstanceDependantMapper processInstanceDependantMapper) {
     this.processInstanceDependantMapper = processInstanceDependantMapper;
+  }
+
+  public int deleteProcessInstanceRelatedData(
+      final List<Long> processInstanceKeys, final int limit) {
+    return processInstanceDependantMapper.deleteProcessInstanceRelatedData(
+        new DeleteProcessInstanceRelatedDataDto(processInstanceKeys, limit));
   }
 
   public int deleteRootProcessInstanceRelatedData(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/SequenceFlowWriter.java
@@ -14,7 +14,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class SequenceFlowWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class SequenceFlowWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
@@ -16,7 +16,7 @@ import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class UserTaskWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class UserTaskWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -18,7 +18,7 @@ import io.camunda.db.rdbms.write.queue.InsertVariableMerger;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
-public class VariableWriter extends RootProcessInstanceDependant implements RdbmsWriter {
+public class VariableWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final VendorDatabaseProperties vendorDatabaseProperties;

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -389,6 +389,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'AUDIT_LOG'"/>
+    <bind name="primaryKeyColumn" value="'AUDIT_LOG_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <delete id="deleteProcessDefinitionRelatedData">
     DELETE
     FROM ${prefix}AUDIT_LOG

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -279,6 +279,14 @@
     </include>
   </sql>
 
+  <!-- history deletion API deletes by process instance -->
+  <sql id="processInstanceHistoryDeletion">
+    <bind name="deletionKeys" value="processInstanceKeys"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletionByKeys">
+      <property name="deletionKeyColumn" value="PROCESS_INSTANCE_KEY"/>
+    </include>
+  </sql>
+
   <resultMap id="flowNodeStatisticsResultMap"
     type="io.camunda.search.entities.ProcessFlowNodeStatisticsEntity">
     <constructor>

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -218,20 +218,21 @@
     WHERE t1.${keyColumn} = t2.${keyColumn}
   </sql>
 
-  <sql id="rootProcessInstanceHistoryDeletion">
+  <!-- shared SQL for history deletion and cleanup -->
+  <sql id="historyDeletionByKeys">
     DELETE
     FROM ${prefix}${tableName}
-    WHERE ROOT_PROCESS_INSTANCE_KEY IN
-    <foreach collection="rootProcessInstanceKeys" item="key" open="(" separator=", " close=")">
+    WHERE ${deletionKeyColumn} IN
+    <foreach collection="deletionKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
     LIMIT #{limit}
   </sql>
-  <sql id="rootProcessInstanceHistoryDeletion" databaseId="mssql">
+  <sql id="historyDeletionByKeys" databaseId="mssql">
     DELETE TOP (#{limit})
     FROM ${prefix}${tableName}
-    WHERE ROOT_PROCESS_INSTANCE_KEY IN
-    <foreach collection="rootProcessInstanceKeys" item="key" open="(" separator=", " close=")">
+    WHERE ${deletionKeyColumn} IN
+    <foreach collection="deletionKeys" item="key" open="(" separator=", " close=")">
       #{key}
     </foreach>
   </sql>
@@ -240,34 +241,42 @@
     We also do not use an IN clause to select the process instance keys,
     but use XMLTABLE to handle large lists of keys. Oracle has a natural limit of 1000 elements per IN clause.
   -->
-  <sql id="rootProcessInstanceHistoryDeletion" databaseId="oracle">
+  <sql id="historyDeletionByKeys" databaseId="oracle">
     <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'rowid'"/>
     DELETE
     FROM ${prefix}${tableName} t1
     WHERE ${keyColumn} IN (SELECT t2.${keyColumn}
-                           FROM ${prefix}${tableName} t2
-                           WHERE t2.ROOT_PROCESS_INSTANCE_KEY IN (
-                               SELECT COLUMN_VALUE
-                               FROM XMLTABLE('/d/r'
-                                    PASSING XMLTYPE(#{rootProcessInstanceKeys, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
-                                    COLUMNS COLUMN_VALUE NUMBER PATH 'text()')
-                             )
-                           AND ROWNUM &lt;= #{limit})
+    FROM ${prefix}${tableName} t2
+    WHERE t2.${deletionKeyColumn} IN (
+    SELECT COLUMN_VALUE
+    FROM XMLTABLE('/d/r'
+    PASSING XMLTYPE(#{deletionKeys, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
+    COLUMNS COLUMN_VALUE NUMBER PATH 'text()')
+    )
+    AND ROWNUM &lt;= #{limit})
   </sql>
 
   <!--
     Special handling for PostgreSQL to delete using ctid or a specified primary key column.
     This avoids issues with large IN clauses by using ANY with an array parameter.
     -->
-  <sql id="rootProcessInstanceHistoryDeletion" databaseId="postgresql">
+  <sql id="historyDeletionByKeys" databaseId="postgresql">
     <bind name="keyColumn" value="primaryKeyColumn != null &amp;&amp; primaryKeyColumn != '' ? primaryKeyColumn : 'ctid'"/>
     DELETE
     FROM ${prefix}${tableName} t1
     USING (SELECT ${keyColumn}
-           FROM ${prefix}${tableName}
-           WHERE ROOT_PROCESS_INSTANCE_KEY = ANY(#{rootProcessInstanceKeys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
-           LIMIT #{limit}) t2
+    FROM ${prefix}${tableName}
+    WHERE ${deletionKeyColumn} = ANY(#{deletionKeys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
+    LIMIT #{limit}) t2
     WHERE t1.${keyColumn} = t2.${keyColumn}
+  </sql>
+
+  <!-- history cleanup deletes by root process instance -->
+  <sql id="rootProcessInstanceHistoryDeletion">
+    <bind name="deletionKeys" value="rootProcessInstanceKeys"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyDeletionByKeys">
+        <property name="deletionKeyColumn" value="ROOT_PROCESS_INSTANCE_KEY"/>
+    </include>
   </sql>
 
   <resultMap id="flowNodeStatisticsResultMap"

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -198,4 +198,10 @@
     <bind name="primaryKeyColumn" value="''"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
+
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'CORRELATED_MESSAGE_SUBSCRIPTION'"/>
+    <bind name="primaryKeyColumn" value="''"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -336,6 +336,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'DECISION_INSTANCE'"/>
+    <bind name="primaryKeyColumn" value="'DECISION_INSTANCE_ID'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <delete id="deleteByKeys">
     DELETE FROM ${prefix}DECISION_INSTANCE
     WHERE DECISION_INSTANCE_KEY IN

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -250,4 +250,10 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'FLOW_NODE_INSTANCE'"/>
+    <bind name="primaryKeyColumn" value="'FLOW_NODE_INSTANCE_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -226,6 +226,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'INCIDENT'"/>
+    <bind name="primaryKeyColumn" value="'INCIDENT_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <select id="processInstanceStatisticsByErrorCount" parameterType="io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery"
           resultType="long">
     SELECT COUNT(*)

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -291,4 +291,10 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'JOB'"/>
+    <bind name="primaryKeyColumn" value="'JOB_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -209,6 +209,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'MESSAGE_SUBSCRIPTION'"/>
+    <bind name="primaryKeyColumn" value="'MESSAGE_SUBSCRIPTION_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <!-- Message Subscription Process Definition Statistics Aggregation -->
   <select id="getProcessDefinitionStatistics"
     parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionMessageSubscriptionStatisticsDbQuery"

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -195,6 +195,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'SEQUENCE_FLOW'"/>
+    <bind name="primaryKeyColumn" value="''"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel">
     DELETE FROM ${prefix}SEQUENCE_FLOW
     WHERE FLOW_NODE_ID = #{flowNodeId}

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -422,4 +422,10 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'USER_TASK'"/>
+    <bind name="primaryKeyColumn" value="'USER_TASK_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -166,6 +166,12 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'VARIABLE'"/>
+    <bind name="primaryKeyColumn" value="'VAR_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
   <update id="migrateToProcess" parameterType="java.util.Map">
       UPDATE ${prefix}VARIABLE
       SET PROCESS_DEFINITION_ID = #{processDefinitionId}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
-import io.camunda.db.rdbms.sql.RootProcessInstanceDependantMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionBatch;
@@ -67,7 +67,7 @@ public class HistoryDeletionServiceTest {
                     createModel(processInstanceKey1, HistoryDeletionTypeDbModel.PROCESS_INSTANCE),
                     createModel(
                         processInstanceKey2, HistoryDeletionTypeDbModel.PROCESS_INSTANCE))));
-    final var mapperMock = mock(RootProcessInstanceDependantMapper.class);
+    final var mapperMock = mock(ProcessInstanceDependantMapper.class);
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
         .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));
 
@@ -92,7 +92,7 @@ public class HistoryDeletionServiceTest {
     // given
     when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
         .thenReturn(new HistoryDeletionBatch(List.of()));
-    final var mapperMock = mock(RootProcessInstanceDependantMapper.class);
+    final var mapperMock = mock(ProcessInstanceDependantMapper.class);
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
         .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));
 
@@ -115,7 +115,7 @@ public class HistoryDeletionServiceTest {
             new HistoryDeletionBatch(
                 List.of(
                     createModel(processInstanceKey, HistoryDeletionTypeDbModel.PROCESS_INSTANCE))));
-    final var mapperMock = mock(RootProcessInstanceDependantMapper.class);
+    final var mapperMock = mock(ProcessInstanceDependantMapper.class);
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
         .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));
     when(mapperMock.deleteRootProcessInstanceRelatedData(any()))
@@ -285,7 +285,7 @@ public class HistoryDeletionServiceTest {
                     createModel(
                         decisionInstanceKey1, HistoryDeletionTypeDbModel.DECISION_INSTANCE))));
     // Mock process instance dependant writers to return limit, meaning not all data deleted
-    final var mapperMock = mock(RootProcessInstanceDependantMapper.class);
+    final var mapperMock = mock(ProcessInstanceDependantMapper.class);
     when(mapperMock.deleteRootProcessInstanceRelatedData(any()))
         .thenReturn(10000); // return the limit, meaning not all dependant data deleted
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
@@ -340,10 +340,10 @@ public class HistoryDeletionServiceTest {
     return new HistoryDeletionDbModel(processInstanceKey, type, 2L, 1);
   }
 
-  private static class TestProcessInstanceDependantWriter extends RootProcessInstanceDependant {
+  private static class TestProcessInstanceDependantWriter extends ProcessInstanceDependant {
     public TestProcessInstanceDependantWriter(
-        final RootProcessInstanceDependantMapper rootProcessInstanceDependantMapper) {
-      super(rootProcessInstanceDependantMapper);
+        final ProcessInstanceDependantMapper processInstanceDependantMapper) {
+      super(processInstanceDependantMapper);
     }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -76,10 +76,10 @@ public class HistoryDeletionServiceTest {
 
     // then
     verify(mapperMock)
-        .deleteRootProcessInstanceRelatedData(
+        .deleteProcessInstanceRelatedData(
             argThat(
                 dto ->
-                    dto.rootProcessInstanceKeys()
+                    dto.processInstanceKeys()
                         .equals(List.of(processInstanceKey1, processInstanceKey2))));
     verify(rdbmsWritersMock.getProcessInstanceWriter())
         .deleteByKeys(List.of(processInstanceKey1, processInstanceKey2));
@@ -100,7 +100,7 @@ public class HistoryDeletionServiceTest {
     historyDeletionService.deleteHistory(1);
 
     // then
-    verify(mapperMock, never()).deleteRootProcessInstanceRelatedData(any());
+    verify(mapperMock, never()).deleteProcessInstanceRelatedData(any());
     verify(rdbmsWritersMock.getProcessInstanceWriter(), never()).deleteByKeys(anyList());
     verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
   }
@@ -118,7 +118,7 @@ public class HistoryDeletionServiceTest {
     final var mapperMock = mock(ProcessInstanceDependantMapper.class);
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
         .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));
-    when(mapperMock.deleteRootProcessInstanceRelatedData(any()))
+    when(mapperMock.deleteProcessInstanceRelatedData(any()))
         .thenReturn(10000); // not all dependant data deleted
 
     // when
@@ -286,7 +286,7 @@ public class HistoryDeletionServiceTest {
                         decisionInstanceKey1, HistoryDeletionTypeDbModel.DECISION_INSTANCE))));
     // Mock process instance dependant writers to return limit, meaning not all data deleted
     final var mapperMock = mock(ProcessInstanceDependantMapper.class);
-    when(mapperMock.deleteRootProcessInstanceRelatedData(any()))
+    when(mapperMock.deleteProcessInstanceRelatedData(any()))
         .thenReturn(10000); // return the limit, meaning not all dependant data deleted
     when(rdbmsWritersMock.getProcessInstanceDependantWriters())
         .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
@@ -49,13 +49,18 @@ public abstract class ProcessInstanceHistory {
 
   protected void processInstanceAndRelatedRecordsHaveBeenDeleted(
       final RdbmsService rdbmsService, final long processInstanceKey) {
+    processInstanceAndNonAuditLogRelatedRecordsHaveBeenDeleted(rdbmsService, processInstanceKey);
+    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+  }
+
+  protected void processInstanceAndNonAuditLogRelatedRecordsHaveBeenDeleted(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
     assertThat(processInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
     assertThat(flowNodeInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
     assertThat(userTaskCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
     assertThat(variableCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
     assertThat(incidentCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
     assertThat(decisionInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
-    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
   }
 
   protected long processInstanceCount(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/history/ProcessInstanceHistory.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
+import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
+import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
+import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
+import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
+import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
+import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
+import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
+import io.camunda.search.clients.reader.SearchEntityReader;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.TypedSearchQuery;
+import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.FilterUtil;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class ProcessInstanceHistory {
+
+  protected void processInstanceAndRelatedRecordsExist(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
+    assertThat(processInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(1L);
+    assertThat(flowNodeInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+    assertThat(userTaskCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+    assertThat(variableCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+    assertThat(incidentCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+    assertThat(decisionInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
+  }
+
+  protected void processInstanceAndRelatedRecordsHaveBeenDeleted(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
+    assertThat(processInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(flowNodeInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(userTaskCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(variableCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(incidentCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(decisionInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(0L);
+  }
+
+  protected long processInstanceCount(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
+    return processInstanceCount(rdbmsService, List.of(processInstanceKey));
+  }
+
+  protected long processInstanceCount(
+      final RdbmsService rdbmsService, final List<Long> processInstanceKeys) {
+    return entityCount(
+        rdbmsService.getProcessInstanceReader(),
+        ProcessInstanceQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.processInstanceKeyOperations(
+                            FilterUtil.mapDefaultToOperation(processInstanceKeys)))));
+  }
+
+  protected long flowNodeInstanceCount(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getFlowNodeInstanceReader(),
+        FlowNodeInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  protected long userTaskCount(final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getUserTaskReader(),
+        UserTaskQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  protected long variableCount(final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getVariableReader(),
+        VariableQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  protected long incidentCount(final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getIncidentReader(),
+        IncidentQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  protected long decisionInstanceCount(
+      final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getDecisionInstanceReader(),
+        DecisionInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  protected long auditLogCount(final RdbmsService rdbmsService, final long processInstanceKey) {
+    return entityCount(
+        rdbmsService.getAuditLogReader(),
+        AuditLogQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
+  }
+
+  private <T, Q extends TypedSearchQuery<?, ?>> long entityCount(
+      final SearchEntityReader<T, Q> entityReader, final Q query) {
+    return entityReader.search(query, ResourceAccessChecks.disabled()).total();
+  }
+
+  protected long createRandomProcessWithRelevantRelatedData(
+      final RdbmsService rdbmsService,
+      final RdbmsWriters rdbmsWriters,
+      final Function<ProcessInstanceDbModelBuilder, ProcessInstanceDbModelBuilder>
+          builderFunction) {
+
+    final ProcessInstanceDbModel processInstance =
+        ProcessInstanceFixtures.createAndSaveRandomProcessInstance(rdbmsWriters, builderFunction);
+    final long processInstanceKey = processInstance.processInstanceKey();
+    final long rootProcessInstanceKey = processInstance.rootProcessInstanceKey();
+
+    FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances(
+        rdbmsWriters,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    UserTaskFixtures.createAndSaveRandomUserTasks(
+        rdbmsService,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    VariableFixtures.createAndSaveRandomVariables(
+        rdbmsService,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    IncidentFixtures.createAndSaveRandomIncidents(
+        rdbmsWriters,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    DecisionInstanceFixtures.createAndSaveRandomDecisionInstances(
+        rdbmsWriters,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    AuditLogFixtures.createAndSaveRandomAuditLogs(
+        rdbmsWriters,
+        b ->
+            b.processInstanceKey(processInstanceKey)
+                .rootProcessInstanceKey(rootProcessInstanceKey));
+
+    return processInstanceKey;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db.historydeletion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
@@ -63,7 +64,8 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     historyDeletionService.deleteHistory(0);
 
     // then
-    processInstanceAndRelatedRecordsHaveBeenDeleted(rdbmsService, processInstanceKey);
+    processInstanceAndNonAuditLogRelatedRecordsHaveBeenDeleted(rdbmsService, processInstanceKey);
+    auditLogsNotDeleted(rdbmsService, processInstanceKey);
     processInstanceAndRelatedRecordsExist(rdbmsService, otherProcessInstanceKey);
   }
 
@@ -107,6 +109,10 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
     assertThat(variableCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
     assertThat(incidentCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
     assertThat(decisionInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
-    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    auditLogsNotDeleted(rdbmsService, processInstanceKey);
+  }
+
+  private void auditLogsNotDeleted(final RdbmsService rdbmsService, final long processInstanceKey) {
+    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(20L);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.historydeletion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel;
+import io.camunda.db.rdbms.write.service.HistoryDeletionService;
+import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
+import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import java.time.Duration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
+  @TestTemplate
+  public void shouldExecuteHistoryDeletionForProcessInstanceSuccessfully(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var writers = testApplication.getRdbmsService().createWriter(0);
+    final var historyDeletionService =
+        new HistoryDeletionService(
+            writers,
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000));
+
+    final long processInstanceKey = ProcessInstanceFixtures.nextKey();
+    createRandomProcessWithRelevantRelatedData(
+        rdbmsService, writers, b -> b.partitionId(0).processInstanceKey(processInstanceKey));
+
+    final long otherProcessInstanceKey = ProcessInstanceFixtures.nextKey();
+    createRandomProcessWithRelevantRelatedData(
+        rdbmsService, writers, b -> b.partitionId(0).processInstanceKey(otherProcessInstanceKey));
+
+    processInstanceAndRelatedRecordsExist(rdbmsService, processInstanceKey);
+    processInstanceAndRelatedRecordsExist(rdbmsService, otherProcessInstanceKey);
+
+    final HistoryDeletionDbModel deletionDbModel =
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(processInstanceKey)
+            .resourceType(HistoryDeletionDbModel.HistoryDeletionTypeDbModel.PROCESS_INSTANCE)
+            .batchOperationKey(ProcessInstanceFixtures.nextKey())
+            .partitionId(0)
+            .build();
+
+    writers.getHistoryDeletionWriter().create(deletionDbModel);
+    writers.flush();
+
+    // when
+    historyDeletionService.deleteHistory(0);
+
+    // then
+    processInstanceAndRelatedRecordsHaveBeenDeleted(rdbmsService, processInstanceKey);
+    processInstanceAndRelatedRecordsExist(rdbmsService, otherProcessInstanceKey);
+  }
+
+  @TestTemplate
+  public void shouldExitEarlyIfProcessInstanceDependentChildrenNotFullyDeleted(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var rdbmsService = testApplication.getRdbmsService();
+    final var writers = testApplication.getRdbmsService().createWriter(0);
+    final var historyDeletionService =
+        new HistoryDeletionService(
+            writers,
+            rdbmsService.getHistoryDeletionDbReader(),
+            rdbmsService.getProcessInstanceReader(),
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10));
+
+    final long processInstanceKey = ProcessInstanceFixtures.nextKey();
+    createRandomProcessWithRelevantRelatedData(
+        rdbmsService, writers, b -> b.partitionId(0).processInstanceKey(processInstanceKey));
+
+    processInstanceAndRelatedRecordsExist(rdbmsService, processInstanceKey);
+
+    final HistoryDeletionDbModel deletionDbModel =
+        new HistoryDeletionDbModel.Builder()
+            .resourceKey(processInstanceKey)
+            .resourceType(HistoryDeletionDbModel.HistoryDeletionTypeDbModel.PROCESS_INSTANCE)
+            .batchOperationKey(ProcessInstanceFixtures.nextKey())
+            .partitionId(0)
+            .build();
+
+    writers.getHistoryDeletionWriter().create(deletionDbModel);
+    writers.flush();
+
+    // when
+    historyDeletionService.deleteHistory(0);
+
+    // then
+    assertThat(processInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(1L);
+    assertThat(flowNodeInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    assertThat(userTaskCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    assertThat(variableCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    assertThat(incidentCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    assertThat(decisionInstanceCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+    assertThat(auditLogCount(rdbmsService, processInstanceKey)).isEqualTo(10L);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -284,6 +284,48 @@ public class IncidentIT {
   }
 
   @TestTemplate
+  public void shouldDeleteProcessInstanceRelatedData(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final IncidentDbReader reader = rdbmsService.getIncidentReader();
+
+    final var definition =
+        ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
+    final var item1 =
+        createAndSaveIncident(
+            rdbmsWriters, b -> b.processDefinitionKey(definition.processDefinitionKey()));
+    final var item2 =
+        createAndSaveIncident(
+            rdbmsWriters, b -> b.processDefinitionKey(definition.processDefinitionKey()));
+    final var item3 =
+        createAndSaveIncident(
+            rdbmsWriters, b -> b.processDefinitionKey(definition.processDefinitionKey()));
+
+    // when
+    final int deleted =
+        rdbmsWriters
+            .getIncidentWriter()
+            .deleteProcessInstanceRelatedData(List.of(item2.processInstanceKey()), 10);
+
+    // then
+    assertThat(deleted).isEqualTo(1);
+    final var searchResult =
+        reader.search(
+            IncidentQuery.of(
+                b ->
+                    b.filter(f -> f.processDefinitionKeys(definition.processDefinitionKey()))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(20))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items()).hasSize(2);
+    assertThat(searchResult.items().stream().map(IncidentEntity::incidentKey))
+        .containsExactlyInAnyOrder(item1.incidentKey(), item3.incidentKey());
+  }
+
+  @TestTemplate
   public void shouldDeleteRootProcessInstanceRelatedData(
       final CamundaRdbmsTestApplication testApplication) {
     // given


### PR DESCRIPTION
This make the history deletion (not history _cleanup_) use process instance key (not _root_ process instance key) for it's deletes.  It was changed by accident when changing the code for history cleanup.

Most of the line count here is the addition of extra tests, to ensure both the root process + non-root process deletion stuff works for all relevant entities.  Also added some extra ITs to specifically check how things behave for non-root processes (which are processes started via call activity).

closes #45635
