### PR TITLE
Write businessId in compact record log

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -548,12 +548,23 @@ public class CompactRecordLogger {
 
   private String summarizeProcessInformation(
       final String bpmnProcessId, final long processInstanceKey) {
+    final var businessId = "";
+    return summarizeProcessInformation(bpmnProcessId, processInstanceKey, businessId);
+  }
 
+  private String summarizeProcessInformation(
+      final String bpmnProcessId, final long processInstanceKey, final String businessId) {
     final var formattedProcessId =
         StringUtils.isEmpty(bpmnProcessId) ? "?" : formatId(bpmnProcessId);
     final var formattedInstanceKey = processInstanceKey < 0 ? "?" : shortenKey(processInstanceKey);
 
-    return String.format(" in <process %s[%s]>", formattedProcessId, formattedInstanceKey);
+    if (businessId.isEmpty()) {
+      return String.format(" in <process %s[%s]>", formattedProcessId, formattedInstanceKey);
+    } else {
+      final var formattedBusinessId = formatId(businessId);
+      return " in <process %s[%s]%s>"
+          .formatted(formattedProcessId, formattedInstanceKey, formattedBusinessId);
+    }
   }
 
   private String summarizeProcessInformation(
@@ -790,7 +801,8 @@ public class CompactRecordLogger {
         .append(" ")
         .append(formatId(value.getElementId()))
         .append(
-            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+            summarizeProcessInformation(
+                value.getBpmnProcessId(), value.getProcessInstanceKey(), value.getBusinessId()))
         .append(summarizeTreePath(value))
         .toString();
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -783,7 +783,7 @@ public class CompactRecordLogger {
     return result.toString();
   }
 
-  private String summarizeProcessInstance(final Record<?> record) {
+  protected String summarizeProcessInstance(final Record<?> record) {
     final var value = (ProcessInstanceRecordValue) record.getValue();
     return new StringBuilder()
         .append(value.getBpmnElementType())

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
@@ -111,6 +112,31 @@ class CompactRecordLoggerTest {
                   assertThat(r)
                       .containsAnyOf("tenant1=[7654321, 1234567]", "tenant1=[1234567, 7654321]")
                       .contains("tenant2=[9876543]"));
+    }
+
+    @Test
+    void shouldSummarizeProcessInfoInProcessInstanceRecords() {
+      // given
+      final var logger = new CompactRecordLogger(java.util.List.of());
+      final var record =
+          ImmutableRecord.builder()
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .withValue(
+                  ImmutableProcessInstanceRecordValue.builder()
+                      .withBpmnProcessId("procID")
+                      .withBusinessId("bizzID")
+                      .withProcessInstanceKey(123L)
+                      .build())
+              .build();
+
+      // when
+      final String result = logger.summarizeProcessInstance(record);
+
+      // then
+      assertThat(result)
+          .contains(
+              """
+              in <process "procID"[K123]"bizzID">""");
     }
   }
 }

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -56,7 +56,7 @@ class CompactRecordLoggerTest {
     @Test
     void shouldSummarizeUsageMetricsWithCounterCorrectly() {
       // given
-      final var logger = new CompactRecordLogger(java.util.List.of());
+      final var logger = new CompactRecordLogger(List.of());
       final var usageMetricsRecord =
           ImmutableRecord.builder()
               .withValueType(ValueType.USAGE_METRIC)
@@ -83,7 +83,7 @@ class CompactRecordLoggerTest {
     @Test
     void shouldSummarizeUsageMetricsWithSetCorrectly() {
       // given
-      final var logger = new CompactRecordLogger(java.util.List.of());
+      final var logger = new CompactRecordLogger(List.of());
       final var usageMetricsRecord =
           ImmutableRecord.builder()
               .withValueType(ValueType.USAGE_METRIC)
@@ -117,7 +117,7 @@ class CompactRecordLoggerTest {
     @Test
     void shouldSummarizeProcessInfoInProcessInstanceRecords() {
       // given
-      final var logger = new CompactRecordLogger(java.util.List.of());
+      final var logger = new CompactRecordLogger(List.of());
       final var record =
           ImmutableRecord.builder()
               .withValueType(ValueType.PROCESS_INSTANCE)


### PR DESCRIPTION
## Description

Enhances the `CompactRecordLogger` to include the `businessId` (business key) in its output for process instance records. This improves observability and troubleshooting, especially for business key uniqueness enforcement.

### Changes

- **`CompactRecordLogger.java`**: Added a new overload of `summarizeProcessInformation` that accepts a `businessId` parameter. When a non-empty `businessId` is present, it is formatted and appended to the process summary (e.g. `<process "myProcess"[K1]"myBusinessId">`). The existing overload without `businessId` delegates to the new one with an empty string, preserving backward compatibility. The `summarizeProcessInstance` method now passes the `businessId` from the record value to the new overload. Visibility of `summarizeProcessInstance` was changed from `private` to `protected` to allow direct testing.

- **`CompactRecordLoggerTest.java`**: Added a new test `shouldSummarizeProcessInfoInProcessInstanceRecords` that verifies the `businessId` is correctly included in the compact log output for process instance records. Also cleaned up existing tests to use `List.of()` instead of `java.util.List.of()`.

### Example output

Before: `<process "myProcess"[K1]>`  
After (with businessId): `<process "myProcess"[K1]"myBusinessId">`  
After (without businessId): `<process "myProcess"[K1]>` _(unchanged)_

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45529