### PR TITLE
[CPT] Stabilize integration tests in example module 

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessJavaUnitTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessJavaUnitTest.java
@@ -22,7 +22,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.process.test.api.CamundaProcessTest;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,9 +46,9 @@ public class ProcessJavaUnitTest {
     // given
     final String shippingId = "shipping-1";
 
-    completeJobs("collect-money", Collections.emptyMap());
-    completeJobs("fetch-items", Collections.emptyMap());
-    completeJobs("ship-parcel", Map.of("shipping_id", shippingId));
+    processTestContext.mockJobWorker("collect-money").thenComplete();
+    processTestContext.mockJobWorker("fetch-items").thenComplete();
+    processTestContext.mockJobWorker("ship-parcel").thenComplete(Map.of("shipping_id", shippingId));
 
     final var processInstance =
         client
@@ -85,10 +84,10 @@ public class ProcessJavaUnitTest {
     // given
     final String shippingId = "shipping-2";
 
-    completeJobs("collect-money", Collections.emptyMap());
-    completeJobs("fetch-items", Collections.emptyMap());
-    completeJobs("ship-parcel", Map.of("shipping_id", shippingId));
-    completeJobs("request-tracking-code", Collections.emptyMap());
+    processTestContext.mockJobWorker("collect-money").thenComplete();
+    processTestContext.mockJobWorker("fetch-items").thenComplete();
+    processTestContext.mockJobWorker("ship-parcel").thenComplete(Map.of("shipping_id", shippingId));
+    processTestContext.mockJobWorker("request-tracking-code").thenComplete();
 
     final var processInstance =
         client
@@ -109,13 +108,5 @@ public class ProcessJavaUnitTest {
         .hasCompletedElements(byName("Request tracking code"))
         .hasActiveElements(byName("Received tracking code"))
         .isActive();
-  }
-
-  private void completeJobs(final String jobType, final Map<String, Object> variables) {
-    client
-        .newWorker()
-        .jobType(jobType)
-        .handler((jobClient, job) -> jobClient.newCompleteCommand(job).variables(variables).send())
-        .open();
   }
 }

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessUnitTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessUnitTest.java
@@ -22,7 +22,6 @@ import io.camunda.client.CamundaClient;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +42,9 @@ public class ProcessUnitTest {
     // given
     final String shippingId = "shipping-1";
 
-    completeJobs("collect-money", Collections.emptyMap());
-    completeJobs("fetch-items", Collections.emptyMap());
-    completeJobs("ship-parcel", Map.of("shipping_id", shippingId));
+    processTestContext.mockJobWorker("collect-money").thenComplete();
+    processTestContext.mockJobWorker("fetch-items").thenComplete();
+    processTestContext.mockJobWorker("ship-parcel").thenComplete(Map.of("shipping_id", shippingId));
 
     final var processInstance =
         client
@@ -81,10 +80,10 @@ public class ProcessUnitTest {
     // given
     final String shippingId = "shipping-2";
 
-    completeJobs("collect-money", Collections.emptyMap());
-    completeJobs("fetch-items", Collections.emptyMap());
-    completeJobs("ship-parcel", Map.of("shipping_id", shippingId));
-    completeJobs("request-tracking-code", Collections.emptyMap());
+    processTestContext.mockJobWorker("collect-money").thenComplete();
+    processTestContext.mockJobWorker("fetch-items").thenComplete();
+    processTestContext.mockJobWorker("ship-parcel").thenComplete(Map.of("shipping_id", shippingId));
+    processTestContext.mockJobWorker("request-tracking-code").thenComplete();
 
     final var processInstance =
         client
@@ -105,13 +104,5 @@ public class ProcessUnitTest {
         .hasCompletedElements(byName("Request tracking code"))
         .hasActiveElements(byName("Received tracking code"))
         .isActive();
-  }
-
-  private void completeJobs(final String jobType, final Map<String, Object> variables) {
-    client
-        .newWorker()
-        .jobType(jobType)
-        .handler((jobClient, job) -> jobClient.newCompleteCommand(job).variables(variables).send())
-        .open();
   }
 }

--- a/testing/camunda-process-test-example/src/test/resources/application.yml
+++ b/testing/camunda-process-test-example/src/test/resources/application.yml
@@ -1,3 +1,8 @@
+camunda:
+  client:
+    # Workaround for integration tests
+    prefer-rest-over-grpc: false
+
 logging:
   level:
     root: info


### PR DESCRIPTION
## Description

The following integration tests are failing a lot in CI:
• 351x `ProcessJavaUnitTest.requestTrackingCode`
• 347x `ProcessIntegrationTest.requestTrackingCode`
• 339x `ProcessUnitTest.requestTrackingCode`

Solve the issue by:
- Using the CPT mock job worker
- Disabling the client property to prefer REST over gRPC. Only a quick-fix. 

As a follow-up, we need to invest in why the CPT tests are much slower, and the job worker doesn't work when using REST instead of gRPC.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

caused by https://github.com/camunda/camunda/pull/45272
