### PR TITLE
feat: add id length validator to engine

### DIFF
--- a/zeebe/bpmn-model/pom.xml
+++ b/zeebe/bpmn-model/pom.xml
@@ -65,6 +65,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/CompositeValidationVisitor.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/CompositeValidationVisitor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.traversal.TypeHierarchyVisitor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.type.ModelElementType;
+import org.camunda.bpm.model.xml.validation.ValidationResults;
+
+/**
+ * A composite implementation of {@link ValidationVisitor} that delegates visiting to multiple other
+ * validation visitors and merges their validation results.
+ */
+public class CompositeValidationVisitor extends TypeHierarchyVisitor {
+
+  private final List<ValidationVisitor> visitors;
+
+  public CompositeValidationVisitor(final ValidationVisitor... visitors) {
+    this.visitors = Arrays.asList(visitors);
+  }
+
+  @Override
+  protected void visit(
+      final ModelElementType implementedType, final BpmnModelElementInstance instance) {
+    for (final ValidationVisitor visitor : visitors) {
+      visitor.visit(implementedType, instance);
+    }
+  }
+
+  public void reset() {
+    for (final ValidationVisitor visitor : visitors) {
+      visitor.reset();
+    }
+  }
+
+  public List<ValidationResults> getValidationResults() {
+    return visitors.stream()
+        .map(ValidationVisitor::getValidationResult)
+        .collect(Collectors.toList());
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompositeValidationVisitorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompositeValidationVisitorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import java.util.List;
+import org.camunda.bpm.model.xml.type.ModelElementType;
+import org.camunda.bpm.model.xml.validation.ValidationResults;
+import org.junit.Test;
+
+public class CompositeValidationVisitorTest {
+
+  @Test
+  public void shouldDelegateVisitToAllVisitors() {
+    // given - mock visitors
+    final ValidationVisitor visitor1 = mock(ValidationVisitor.class);
+    final ValidationVisitor visitor2 = mock(ValidationVisitor.class);
+    final ValidationVisitor visitor3 = mock(ValidationVisitor.class);
+
+    final CompositeValidationVisitor compositeVisitor =
+        new CompositeValidationVisitor(visitor1, visitor2, visitor3);
+
+    compositeVisitor.visit(mock(ModelElementType.class), mock(BpmnModelElementInstance.class));
+
+    // then - all visitors should have been called with visit()
+    verify(visitor1).visit(any(ModelElementType.class), any(BpmnModelElementInstance.class));
+    verify(visitor2).visit(any(ModelElementType.class), any(BpmnModelElementInstance.class));
+    verify(visitor3).visit(any(ModelElementType.class), any(BpmnModelElementInstance.class));
+  }
+
+  @Test
+  public void shouldCollectValidationResultsFromAllVisitors() {
+    // given - mock visitors with different results
+    final ValidationVisitor visitor1 = mock(ValidationVisitor.class);
+    final ValidationVisitor visitor2 = mock(ValidationVisitor.class);
+
+    final ValidationResults results1 = createValidationResults(true);
+    final ValidationResults results2 = createValidationResults(false);
+
+    when(visitor1.getValidationResult()).thenReturn(results1);
+    when(visitor2.getValidationResult()).thenReturn(results2);
+
+    final CompositeValidationVisitor compositeVisitor =
+        new CompositeValidationVisitor(visitor1, visitor2);
+
+    // when
+    final List<ValidationResults> results = compositeVisitor.getValidationResults();
+
+    // then
+    assertThat(results).hasSize(2);
+    assertThat(results.get(0).hasErrors()).isTrue();
+    assertThat(results.get(1).hasErrors()).isFalse();
+  }
+
+  @Test
+  public void shouldResetAllVisitors() {
+    // given - mock visitors
+    final ValidationVisitor visitor1 = mock(ValidationVisitor.class);
+    final ValidationVisitor visitor2 = mock(ValidationVisitor.class);
+    final ValidationVisitor visitor3 = mock(ValidationVisitor.class);
+
+    final CompositeValidationVisitor compositeVisitor =
+        new CompositeValidationVisitor(visitor1, visitor2, visitor3);
+
+    // when
+    compositeVisitor.reset();
+
+    // then - reset should have been called on all visitors
+    verify(visitor1, times(1)).reset();
+    verify(visitor2, times(1)).reset();
+    verify(visitor3, times(1)).reset();
+  }
+
+  private ValidationResults createValidationResults(final boolean hasErrors) {
+    final ValidationResults results = mock(ValidationResults.class);
+    when(results.hasErrors()).thenReturn(hasErrors);
+    if (hasErrors) {
+      when(results.getErrorCount()).thenReturn(1);
+    } else {
+      when(results.getErrorCount()).thenReturn(0);
+    }
+
+    return results;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -180,6 +180,8 @@ public final class EngineCfg implements ConfigurationEntry {
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())
+        .setMaxIdFieldLength(validators.getMaxIdFieldLength())
+        .setMaxNameFieldLength(validators.getMaxNameFieldLength())
         .setBatchOperationSchedulerInterval(batchOperations.getSchedulerInterval())
         .setBatchOperationChunkSize(batchOperations.getChunkSize())
         .setBatchOperationQueryPageSize(batchOperations.getQueryPageSize())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 public class ValidatorsCfg implements ConfigurationEntry {
 
   private int resultsOutputMaxSize = EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+  private int maxIdFieldLength = EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH;
+  private int maxNameFieldLength = EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH;
 
   public int getResultsOutputMaxSize() {
     return resultsOutputMaxSize;
@@ -22,8 +24,31 @@ public class ValidatorsCfg implements ConfigurationEntry {
     this.resultsOutputMaxSize = resultsOutputMaxSize;
   }
 
+  public int getMaxIdFieldLength() {
+    return maxIdFieldLength;
+  }
+
+  public void setMaxIdFieldLength(final int maxIdFieldLength) {
+    this.maxIdFieldLength = maxIdFieldLength;
+  }
+
+  public int getMaxNameFieldLength() {
+    return maxNameFieldLength;
+  }
+
+  public void setMaxNameFieldLength(final int maxNameFieldLength) {
+    this.maxNameFieldLength = maxNameFieldLength;
+  }
+
   @Override
   public String toString() {
-    return "BpmnValidatorsCfg{" + "resultsOutputMaxSize=" + resultsOutputMaxSize + '}';
+    return "BpmnValidatorsCfg{"
+        + "resultsOutputMaxSize="
+        + resultsOutputMaxSize
+        + ", maxIdFieldLength="
+        + maxIdFieldLength
+        + ", maxNameFieldLength="
+        + maxNameFieldLength
+        + '}';
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -55,6 +55,10 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_MAX_WORKER_NAME_LENGTH);
     assertThat(configuration.getMaxJobTypeLength())
         .isEqualTo(EngineConfiguration.DEFAULT_MAX_JOB_TYPE_LENGTH);
+    assertThat(configuration.getMaxIdFieldLength())
+        .isEqualTo(EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH);
+    assertThat(configuration.getMaxNameFieldLength())
+        .isEqualTo(EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH);
     assertThat(configuration.getMaxTenantIdLength())
         .isEqualTo(EngineConfiguration.DEFAULT_MAX_TENANT_ID_LENGTH);
     assertThat(configuration.getMaxUniqueJobMetricsKeys())
@@ -87,6 +91,8 @@ final class EngineCfgTest {
         .isEqualTo(Duration.ofMinutes(20));
     assertThat(configuration.getJobMetricsExportInterval()).isEqualTo(Duration.ofMinutes(10));
     assertThat(configuration.isJobMetricsExportEnabled()).isFalse();
+    assertThat(configuration.getMaxIdFieldLength()).isEqualTo(255);
+    assertThat(configuration.getMaxNameFieldLength()).isEqualTo(256);
     assertThat(configuration.getMaxWorkerNameLength()).isEqualTo(50);
     assertThat(configuration.getMaxJobTypeLength()).isEqualTo(75);
     assertThat(configuration.getMaxTenantIdLength()).isEqualTo(20);

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -20,6 +20,8 @@ zeebe:
           maxTenantIdLength: 20
           maxUniqueKeys: 5000
         validators:
+          maxIdFieldLength: 255
+          maxNameFieldLength: 256
           resultsOutputMaxSize: 2000
         distribution:
           redistributionInterval: 60s

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -34,6 +34,8 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_USAGE_METRICS_EXPORT_INTERVAL = Duration.ofMinutes(5);
   public static final Duration DEFAULT_JOB_METRICS_EXPORT_INTERVAL = Duration.ofMinutes(5);
   public static final int DEFAULT_MAX_WORKER_NAME_LENGTH = 100;
+  public static final int DEFAULT_MAX_ID_FIELD_LENGTH = 32 * 1024;
+  public static final int DEFAULT_MAX_NAME_FIELD_LENGTH = 32 * 1024;
   public static final int DEFAULT_MAX_JOB_TYPE_LENGTH = 100;
   public static final int DEFAULT_MAX_TENANT_ID_LENGTH = 30;
   public static final int DEFAULT_MAX_UNIQUE_JOB_METRICS_KEYS = 9500;
@@ -60,6 +62,8 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(5);
   public static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
 
+  private int maxIdFieldLength = DEFAULT_MAX_ID_FIELD_LENGTH;
+  private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxJobTypeLength = DEFAULT_MAX_JOB_TYPE_LENGTH;
   private int maxTenantIdLength = DEFAULT_MAX_TENANT_ID_LENGTH;
   private int maxUniqueJobMetricsKeys = DEFAULT_MAX_UNIQUE_JOB_METRICS_KEYS;
@@ -400,6 +404,24 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setMaxWorkerNameLength(final int maxWorkerNameLength) {
     this.maxWorkerNameLength = maxWorkerNameLength;
+    return this;
+  }
+
+  public int getMaxIdFieldLength() {
+    return maxIdFieldLength;
+  }
+
+  public EngineConfiguration setMaxIdFieldLength(final int maxIdFieldLength) {
+    this.maxIdFieldLength = maxIdFieldLength;
+    return this;
+  }
+
+  public int getMaxNameFieldLength() {
+    return maxNameFieldLength;
+  }
+
+  public EngineConfiguration setMaxNameFieldLength(final int maxNameFieldLength) {
+    this.maxNameFieldLength = maxNameFieldLength;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
 import java.time.InstantSource;
 
 public final class BpmnFactory {
@@ -31,12 +32,12 @@ public final class BpmnFactory {
   public static BpmnValidator createValidator(
       final InstantSource clock,
       final ExpressionProcessor expressionProcessor,
-      final int validatorResultsOutputMaxSize,
+      final BpmnValidatorConfig config,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
     return new BpmnValidator(
         createExpressionLanguage(new ZeebeFeelEngineClock(clock), expressionLanguageMetrics),
         expressionProcessor,
-        validatorResultsOutputMaxSize);
+        config);
   }
 
   private static ExpressionLanguage createExpressionLanguage(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/IdLengthValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/IdLengthValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class IdLengthValidator implements ModelElementValidator<BaseElement> {
+
+  private final int maxFieldLength;
+
+  public IdLengthValidator(final int maxFieldLength) {
+    this.maxFieldLength = maxFieldLength;
+  }
+
+  @Override
+  public Class<BaseElement> getElementType() {
+    return BaseElement.class;
+  }
+
+  @Override
+  public void validate(
+      final BaseElement element, final ValidationResultCollector validationResultCollector) {
+
+    if (element.getId() != null && element.getId().length() > maxFieldLength) {
+      validationResultCollector.addError(
+          0,
+          "IDs must not be longer than the configured max-id-length of "
+              + maxFieldLength
+              + " characters.");
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import java.util.Collection;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+
+public final class ZeebeConfigurationValidators {
+
+  public static Collection<ModelElementValidator<?>> getValidators(
+      final BpmnValidatorConfig config) {
+    return List.of(new IdLengthValidator(config.maxIdFieldLength()));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -71,7 +71,11 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
         BpmnFactory.createValidator(
             clock,
             expressionProcessor,
-            config.getValidatorsResultsOutputMaxSize(),
+            BpmnValidatorConfig.builder()
+                .withMaxIdFieldLength(config.getMaxIdFieldLength())
+                .withMaxNameFieldLength(config.getMaxNameFieldLength())
+                .withValidatorResultsOutputMaxSize(config.getValidatorsResultsOutputMaxSize())
+                .build(),
             expressionLanguageMetrics);
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidatorConfig.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidatorConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public record BpmnValidatorConfig(
+    int maxIdFieldLength, int maxNameFieldLength, int validatorResultsOutputMaxSize) {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder implements ObjectBuilder<BpmnValidatorConfig> {
+    private int maxIdFieldLength = EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH;
+    private int maxNameFieldLength = EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH;
+    private int validatorResultsOutputMaxSize =
+        EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+
+    public Builder withMaxIdFieldLength(final int maxIdFieldLength) {
+      this.maxIdFieldLength = maxIdFieldLength;
+      return this;
+    }
+
+    public Builder withMaxNameFieldLength(final int maxNameFieldLength) {
+      this.maxNameFieldLength = maxNameFieldLength;
+      return this;
+    }
+
+    public Builder withValidatorResultsOutputMaxSize(final int validatorResultsOutputMaxSize) {
+      this.validatorResultsOutputMaxSize = validatorResultsOutputMaxSize;
+      return this;
+    }
+
+    @Override
+    public BpmnValidatorConfig build() {
+      return new BpmnValidatorConfig(
+          maxIdFieldLength, maxNameFieldLength, validatorResultsOutputMaxSize);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/IdLengthTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/IdLengthTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class IdLengthTest {
+
+  @ParameterizedTest
+  @MethodSource("idLengthTestCases")
+  void idLengthExceeded(
+      final Class<? extends BpmnModelElementInstance> expectedElementClass,
+      final ProcessBuilder processBuilder) {
+
+    final var id = "a".repeat(ProcessValidationUtil.MAX_ID_FIELD_LENGTH + 1);
+
+    // when
+    final var process = processBuilder.build(id);
+
+    // then
+    ProcessValidationUtil.validateProcess(
+        process,
+        ExpectedValidationResult.expect(
+            expectedElementClass,
+            "IDs must not be longer than the configured max-id-length of %s characters"
+                .formatted(ProcessValidationUtil.MAX_ID_FIELD_LENGTH)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("idLengthTestCases")
+  void idLengthNotExceeded(
+      final Class<? extends BpmnModelElementInstance> expectedElementClass,
+      final ProcessBuilder processBuilder) {
+
+    final var id = "a".repeat(ProcessValidationUtil.MAX_ID_FIELD_LENGTH);
+
+    // when
+    final var process = processBuilder.build(id);
+
+    // then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  private static Stream<Arguments> idLengthTestCases() {
+    return Stream.of(
+        Arguments.of(
+            Process.class,
+            (ProcessBuilder)
+                id ->
+                    Bpmn.createExecutableProcess(id)
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeJobType("test"))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            ServiceTask.class,
+            (ProcessBuilder)
+                id ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent()
+                        .serviceTask(id, t -> t.zeebeJobType("test"))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            StartEvent.class,
+            (ProcessBuilder)
+                id ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent(id)
+                        .serviceTask("task", t -> t.zeebeJobType("test"))
+                        .endEvent()
+                        .done()));
+  }
+
+  @FunctionalInterface
+  private interface ProcessBuilder {
+    BpmnModelInstance build(String id);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
 import io.camunda.zeebe.engine.processing.expression.ScopedEvaluationContext;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -27,6 +28,9 @@ import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 
 public class ProcessValidationUtil {
+
+  public static final int MAX_ID_FIELD_LENGTH = 1024;
+  public static final int MAX_NAME_FIELD_LENGTH = 1024;
 
   /**
    * Validate the provided {@link BpmnModelInstance}, asserting that is NOT a valid process
@@ -84,7 +88,12 @@ public class ProcessValidationUtil {
         new ValidationVisitor(
             Stream.of(
                     ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor),
-                    ZeebeDesignTimeValidators.VALIDATORS)
+                    ZeebeDesignTimeValidators.VALIDATORS,
+                    ZeebeConfigurationValidators.getValidators(
+                        BpmnValidatorConfig.builder()
+                            .withMaxIdFieldLength(MAX_ID_FIELD_LENGTH)
+                            .withMaxNameFieldLength(MAX_NAME_FIELD_LENGTH)
+                            .build()))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList()));
     walker.walk(visitor);


### PR DESCRIPTION
## Description

Checks the length of ID fields in all BPMN elements to not exceed a given size limit. This is needed so a given secondary storage can size their String fields accordingly.
- For ES/OS, this value will be set to 32KB, the natural size of a string field in ES. This way, this change is also backwards compatible with existing clusters.

Introduced:
- a new set of Bpmn validators: The ZeebeConfigurationValidators. These validate, based on configurable settings, the BPMN diagram
- two new engine properties: max-id-size and max-name-size (the latter will be used in future PR)

## Related issues

closes #45674
