### PR TITLE
fix: fail spring startup on continuous backups with document based databases

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -808,9 +808,12 @@ public class BrokerBasedPropertiesOverride {
     final var dbType = unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType();
 
     return (dbType.isElasticSearch() || dbType.isOpenSearch())
-        && primaryStorageBackup.isContinuous()
-        && !(primaryStorageBackup.getSchedule() == null
-            || primaryStorageBackup.getSchedule().isBlank())
+        && (primaryStorageBackup.isContinuous() || hasScheduleConfig(primaryStorageBackup));
+  }
+
+  private boolean hasScheduleConfig(final PrimaryStorageBackup primaryStorageBackup) {
+    return primaryStorageBackup.getSchedule() != null
+        && !primaryStorageBackup.getSchedule().isBlank()
         && !primaryStorageBackup.getSchedule().equalsIgnoreCase("none");
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
@@ -17,9 +18,11 @@ import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
 import io.camunda.zeebe.backup.schedule.Schedule.NoneSchedule;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -83,6 +86,7 @@ public class PrimaryStorageBackupPropertiesTest {
   @Nested
   @TestPropertySource(
       properties = {
+        "camunda.data.secondary-storage.type=none",
         "camunda.data.primary-storage.backup.schedule=PT5H",
         "camunda.data.primary-storage.backup.checkpoint-interval=PT2M",
         "camunda.data.primary-storage.backup.retention.clean-up-schedule=PT12H",
@@ -168,6 +172,162 @@ public class PrimaryStorageBackupPropertiesTest {
     @Test
     void shouldParseConfig() {
       assertThat(backupSchedulerCfg.isContinuous()).isTrue();
+    }
+  }
+
+  @Nested
+  class ContinuousBackupsStartupCompatibility {
+
+    @Test
+    void shouldFailToStartWithElasticsearchAndContinuousBackups() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.primary-storage.backup.schedule",
+              "PT1H",
+              "camunda.data.secondary-storage.type",
+              "elasticsearch");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should fail
+      assertThatThrownBy(app::run)
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+    }
+
+    @Test
+    void shouldFailToStartWithOpensearchAndContinuousBackups() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.primary-storage.backup.schedule",
+              "PT1H",
+              "camunda.data.secondary-storage.type",
+              "opensearch");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should fail
+      assertThatThrownBy(app::run)
+          .hasRootCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+    }
+
+    @Test
+    void shouldStartIfContinuousBackupsNotEnabled() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.schedule",
+              "PT1H",
+              "camunda.data.secondary-storage.type",
+              "opensearch");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldStartIfNoScheduleProvided() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.secondary-storage.type",
+              "opensearch");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldStartOnRdbms() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.primary-storage.backup.schedule",
+              "PT1H",
+              "camunda.data.secondary-storage.type",
+              "rdbms");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldStartOnNoDb() {
+
+      // given
+      final Map<String, Object> properties =
+          Map.of(
+              "camunda.data.primary-storage.backup.continuous",
+              "true",
+              "camunda.data.primary-storage.backup.schedule",
+              "PT1H",
+              "camunda.data.secondary-storage.type",
+              "none");
+
+      final var app =
+          new SpringApplication(
+              UnifiedConfiguration.class,
+              BrokerBasedPropertiesOverride.class,
+              UnifiedConfigurationHelper.class);
+      app.setAdditionalProfiles("broker");
+      app.setDefaultProperties(properties);
+
+      // when/then - application startup should succeed
+      assertThatCode(app::run).doesNotThrowAnyException();
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/PrimaryStorageBackupPropertiesTest.java
@@ -208,7 +208,7 @@ public class PrimaryStorageBackupPropertiesTest {
       assertThatThrownBy(app::run)
           .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
-              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+              "Continuous backups are not compatible with secondary storage: `elasticsearch`. Please disable continuous backups");
     }
 
     @Test
@@ -236,7 +236,7 @@ public class PrimaryStorageBackupPropertiesTest {
       assertThatThrownBy(app::run)
           .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
-              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+              "Continuous backups are not compatible with secondary storage: `opensearch`. Please disable continuous backups");
     }
 
     @Test
@@ -262,7 +262,7 @@ public class PrimaryStorageBackupPropertiesTest {
       assertThatThrownBy(app::run)
           .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
-              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+              "Continuous backups are not compatible with secondary storage: `opensearch`. Please disable continuous backups");
     }
 
     @Test
@@ -311,7 +311,7 @@ public class PrimaryStorageBackupPropertiesTest {
       assertThatThrownBy(app::run)
           .hasRootCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
-              "Continuous backups are not compatible with document-based secondary storage. Please disable continuous backups");
+              "Continuous backups are not compatible with secondary storage: `opensearch`. Please disable continuous backups");
     }
 
     @Test

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStep.java
@@ -22,31 +22,26 @@ public class CheckpointSchedulerServiceStep extends AbstractBrokerStartupStep {
     final var backupCfg = brokerStartupContext.getBrokerConfiguration().getData().getBackup();
     final var scheduler = brokerStartupContext.getActorSchedulingService();
     final var meterRegistry = brokerStartupContext.getMeterRegistry();
-    final var partitionManager = brokerStartupContext.getPartitionManager();
 
-    if (backupCfg.isContinuous()) {
-      concurrencyControl.run(
-          () -> {
-            final CheckpointSchedulingService schedulingService =
-                new CheckpointSchedulingService(
-                    brokerStartupContext.getClusterServices().getMembershipService(),
-                    scheduler,
-                    backupCfg,
-                    brokerStartupContext.getBrokerClient(),
-                    meterRegistry);
+    concurrencyControl.run(
+        () -> {
+          final CheckpointSchedulingService schedulingService =
+              new CheckpointSchedulingService(
+                  brokerStartupContext.getClusterServices().getMembershipService(),
+                  scheduler,
+                  backupCfg,
+                  brokerStartupContext.getBrokerClient(),
+                  meterRegistry);
 
-            concurrencyControl.runOnCompletion(
-                scheduler.submitActor(schedulingService),
-                proceed(
-                    () -> {
-                      brokerStartupContext.setCheckpointSchedulingService(schedulingService);
-                      startupFuture.complete(brokerStartupContext);
-                    },
-                    startupFuture));
-          });
-    } else {
-      startupFuture.complete(brokerStartupContext);
-    }
+          concurrencyControl.runOnCompletion(
+              scheduler.submitActor(schedulingService),
+              proceed(
+                  () -> {
+                    brokerStartupContext.setCheckpointSchedulingService(schedulingService);
+                    startupFuture.complete(brokerStartupContext);
+                  },
+                  startupFuture));
+        });
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -84,8 +84,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
     }
 
     final var retentionCfg = backupCfg.getRetention();
-    if (retentionCfg.getCleanupSchedule() != null
-        && !(retentionCfg.getCleanupSchedule() instanceof NoneSchedule)) {
+    if (shouldRegisterRetentionJob()) {
       final var backupStore = buildBackupStore(backupCfg);
       backupRetentionJob =
           new BackupRetention(
@@ -192,6 +191,14 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
         .min(Comparator.comparing(Member::id, MemberId::compareTo))
         .map(lowestMember -> !lowestMember.id().equals(localMemberId))
         .orElse(false);
+  }
+
+  private boolean shouldRegisterRetentionJob() {
+    final var retentionCfg = backupCfg.getRetention();
+    return retentionCfg.getWindow() != null
+        && !retentionCfg.getWindow().isZero()
+        && retentionCfg.getCleanupSchedule() != null
+        && !(retentionCfg.getCleanupSchedule() instanceof NoneSchedule);
   }
 
   private BackupStore buildBackupStore(final BackupCfg backupCfg) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CheckpointSchedulerServiceStepTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +35,6 @@ public class CheckpointSchedulerServiceStepTest {
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
 
   private BrokerStartupContext mockBrokerStartupContext;
-  private ActorSchedulingService mockActorSchedulingService;
-  private ClusterMembershipService mockMembershipService;
   private CheckpointSchedulingService mockCheckpointSchedulingService;
 
   private ActorFuture<BrokerStartupContext> future;
@@ -47,8 +44,8 @@ public class CheckpointSchedulerServiceStepTest {
   @BeforeEach
   void setUp() {
     mockBrokerStartupContext = mock(BrokerStartupContext.class);
-    mockActorSchedulingService = mock(ActorSchedulingService.class);
-    mockMembershipService = mock(ClusterMembershipService.class);
+    final ActorSchedulingService mockActorSchedulingService = mock(ActorSchedulingService.class);
+    final ClusterMembershipService mockMembershipService = mock(ClusterMembershipService.class);
     mockCheckpointSchedulingService = mock(CheckpointSchedulingService.class);
     when(mockCheckpointSchedulingService.closeAsync())
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
@@ -82,33 +79,8 @@ public class CheckpointSchedulerServiceStepTest {
     // then
     assertThat(future).succeedsWithin(TIME_OUT);
     assertThat(future.join()).isNotNull();
-  }
-
-  @Test
-  void shouldRegisterSchedulingService() {
-    // when
-    TEST_BROKER_CONFIG.getData().getBackup().setContinuous(true);
-    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
-
-    // then
-    assertThat(future).succeedsWithin(TIME_OUT);
-    assertThat(future.join()).isNotNull();
     final var argumentCaptor = ArgumentCaptor.forClass(CheckpointSchedulingService.class);
     verify(mockBrokerStartupContext).setCheckpointSchedulingService(argumentCaptor.capture());
-  }
-
-  @Test
-  void shouldNotRegisterSchedulingService() {
-    // when
-    TEST_BROKER_CONFIG.getData().getBackup().setContinuous(false);
-    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
-
-    // then
-    assertThat(future).succeedsWithin(TIME_OUT);
-    assertThat(future.join()).isNotNull();
-    final var argumentCaptor = ArgumentCaptor.forClass(CheckpointSchedulingService.class);
-    verify(mockBrokerStartupContext, times(0))
-        .setCheckpointSchedulingService(argumentCaptor.capture());
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
@@ -57,7 +57,7 @@ final class ContinuousBackupIT {
   @TestZeebe
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
-          .withSecondaryStorageType(SecondaryStorageType.elasticsearch)
+          .withSecondaryStorageType(SecondaryStorageType.none)
           .withUnifiedConfig(this::configureBroker);
 
   private BackupActuator backupActuator;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To ensure continuous backups are not used with Elasticsearch/Opensearch, forcefully cancel Spring's startup context during property overriding. This is to not create false expectations that continuous backups are compatible with document based storages.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45647 
