### PR TITLE
feat: last alpha should be created from stable/new-minor + backport rules

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -341,6 +341,12 @@ For C8 monorepo minor releases, we enforce two distinct stages to ensure quality
 - ✅ All cross-component features targeted for the minor must be fully implemented, documented, and working end-to-end
 - ❌ No new features, scope extensions, or risky changes after this point
 - ✅ Bug fixes, stabilization work, and E2E testing continue
+- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/<minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
+  - This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
+  - Critical fixes can still be backported to the active alpha release branch if a new RC is needed
+- **Bug Fix Handling During Alpha Release**:
+  - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
+  - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
 - **Notification Process**: Send calendar invite to engineering teams (Core Features, Orchestration, QA, DevOps/Release, and other relevant teams) with:
 - **Subject**: `Camunda repo (Zeebe/Operate/Tasklist/Identity/Optimize) Release Minor <version> - Feature Freeze`
 - **Body**:

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -291,14 +291,13 @@ Minor releases happen less often than other release types, so not all steps are 
    * Ensure all expected SNAPSHOT artifacts are produced correctly.
 
 :::note
-For 8.9.0 we would like to try this other approach
-- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/> <minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
-- This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
-- Critical fixes can still be backported to the active alpha release branch if a new RC is needed
-- **Bug Fix Handling During Alpha Release**:
-- ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
-- Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
-:::
+For 8.9.0 we evaluate the following approach (to be decided if kept for future minor versions)
+
+- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/<minor>` branch from `main` early (at the latest alpha code freeze day), then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
+  - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
+    - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
+  - **Bug Fix Handling After Last Alpha Release (Minor Version Feature Freeze)**:
+    :::
 
 3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -289,10 +289,20 @@ Minor releases happen less often than other release types, so not all steps are 
    * This can be done with the following command `./mvnw release:update-versions -DdevelopmentVersion=8.(x+1).0-SNAPSHOT`
 2. Create the `stable/8.x` release branch from latest `release-8.x.0-alphaN`, to enforce code freeze
    * Ensure all expected SNAPSHOT artifacts are produced correctly.
-3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
-   * This may need temporary admin permissions for the initial manual push of the new branch.
-4. Bump configured versions in upgrade tests of the previous minor version to `8.x`
-   * TODO: add references to known upgrade tests if possible
+
+> ![NOTE]
+>
+>> For 8.9.0 we would like to try this other approach
+>> - **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/> <minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
+>> - This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
+>> - Critical fixes can still be backported to the active alpha release branch if a new RC is needed
+>> - **Bug Fix Handling During Alpha Release**:
+>> - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
+>> - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
+>> 3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
+>> * This may need temporary admin permissions for the initial manual push of the new branch.
+>> 4. Bump configured versions in upgrade tests of the previous minor version to `8.x`
+>> * TODO: add references to known upgrade tests if possible
 
 Also, we have to do similar steps for the [ZPT repository](https://github.com/camunda/zeebe-process-test) in coordination with stakeholders from Camunda Ex team:
 
@@ -341,12 +351,6 @@ For C8 monorepo minor releases, we enforce two distinct stages to ensure quality
 - ✅ All cross-component features targeted for the minor must be fully implemented, documented, and working end-to-end
 - ❌ No new features, scope extensions, or risky changes after this point
 - ✅ Bug fixes, stabilization work, and E2E testing continue
-- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/<minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
-  - This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
-  - Critical fixes can still be backported to the active alpha release branch if a new RC is needed
-- **Bug Fix Handling During Alpha Release**:
-  - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
-  - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
 - **Notification Process**: Send calendar invite to engineering teams (Core Features, Orchestration, QA, DevOps/Release, and other relevant teams) with:
 - **Subject**: `Camunda repo (Zeebe/Operate/Tasklist/Identity/Optimize) Release Minor <version> - Feature Freeze`
 - **Body**:

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -290,19 +290,23 @@ Minor releases happen less often than other release types, so not all steps are 
 2. Create the `stable/8.x` release branch from latest `release-8.x.0-alphaN`, to enforce code freeze
    * Ensure all expected SNAPSHOT artifacts are produced correctly.
 
-> ![NOTE]
->
->> For 8.9.0 we would like to try this other approach
->> - **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/> <minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
->> - This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
->> - Critical fixes can still be backported to the active alpha release branch if a new RC is needed
->> - **Bug Fix Handling During Alpha Release**:
->> - ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
->> - Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
->> 3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
->> * This may need temporary admin permissions for the initial manual push of the new branch.
->> 4. Bump configured versions in upgrade tests of the previous minor version to `8.x`
->> * TODO: add references to known upgrade tests if possible
+:::note
+For 8.9.0 we would like to try this other approach
+- **Branch Strategy**: To allow continuous bug fix integration during the alpha release process, consider creating `stable/> <minor>` branch from `main` early, then creating the alpha release branch from `stable/<minor>` instead of directly from `main`
+- This allows non-critical bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed
+- Critical fixes can still be backported to the active alpha release branch if a new RC is needed
+- **Bug Fix Handling During Alpha Release**:
+- ⚠️ **Important**: Any bug fixes merged to `main` after the last alpha release branch (`release-<version>-alpha<N>`) has been created must be backported to `stable/<minor>` to be included in the minor release
+- Critical bug fixes merged after that point should be backported to both `stable/<minor>` and the active alpha release branch and may trigger a new Release Candidate
+:::
+
+3. [Configure `unified-ci-merges-stable-branches` branch protection ruleset](https://github.com/camunda/infra-core/blob/stage/terraform/github/prod/rulesets-camunda-camunda.tf) to include new `stable/8.x` branch
+
+* This may need temporary admin permissions for the initial manual push of the new branch.
+
+4. Bump configured versions in upgrade tests of the previous minor version to `8.x`
+
+* TODO: add references to known upgrade tests if possible
 
 Also, we have to do similar steps for the [ZPT repository](https://github.com/camunda/zeebe-process-test) in coordination with stakeholders from Camunda Ex team:
 
@@ -333,12 +337,13 @@ In addition to the standard steps above, recent minor releases have surfaced sev
 - **Optimize Previous Version Management (8.9+)**
   - Starting with 8.9, Optimize is included in the monorepo release process (`includeOptimize=true`).
 
-> [!WARNING]
-> - **Manual Step Required:** Two manual updates are needed:
-> 1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
-> 2. After cutting the stable branch, bump `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
-> - The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
-> - **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
+:::warning
+- **Manual Step Required:** Two manual updates are needed:
+1. Before cutting a new stable branch (performing the first minor release X.Y.0), set `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) to the previous minor version (e.g., for 8.9.0 release, set to `8.8.0`).
+2. After cutting the stable branch, bump `project.previousVersion` in the [Optimize root `pom.xml`](https://github.com/camunda/camunda/blob/main/optimize/pom.xml#L47) on main to prepare for the next minor version line (e.g., after 8.9.0 release, update main to `8.9.0` for future 8.10.x alphas).
+- The release workflow validates `project.previousVersion` for minor releases (X.Y.0) when cutting stable branches, and should also validate that main has been properly updated when releasing new alpha versions for the next minor line.
+- **Action:** Monitor completion of [issue #40258](https://github.com/camunda/camunda/issues/40258) to automate this step and eliminate the manual requirement.
+:::
 
 ### Feature Freeze vs Code Freeze (Minor Releases)
 


### PR DESCRIPTION
## Description

This pull request updates the monorepo minor release documentation to clarify the branch strategy and bug fix handling during the alpha release process. The changes aim to ensure a smoother release flow and set clear expectations for how and when bug fixes should be integrated.

Release process improvements:

* Added a recommended branch strategy: create a `stable/<minor>` branch from `main` early, then create the alpha release branch from `stable/<minor>`, allowing ongoing bug fixes to be merged into `stable/<minor>` while the alpha release candidate is being processed.
* Clarified bug fix handling during the alpha release: bug fixes merged to `main` after the last alpha release branch is created will not automatically be included in the minor release; non-critical fixes should be backported to `stable/<minor>` after alpha release completion, while only critical fixes should be backported to both `stable/<minor>` and the alpha release branch. [[1]](diffhunk://#diff-ce682c3bacecd59af2992a372526097689a7e0ebb9c8c53ebae7267142c53cc6R344-R349) [[2]](diffhunk://#diff-ce682c3bacecd59af2992a372526097689a7e0ebb9c8c53ebae7267142c53cc6R362-R363)

Communication updates:

* Updated the notification template to highlight the importance of proper bug fix backporting and branch usage during the release process.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
