### PR TITLE
Backup response contains backup id

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -383,6 +383,7 @@ public final class BackupEndpoint {
       final long backupId) {
     return new WebEndpointResponse<>(
         new TakeBackupRuntimeResponse()
+            .backupId(backupId)
             .message(
                 "A backup with id %d has been scheduled. Use GET actuator/backups/%d to monitor the status."
                     .formatted(backupId, backupId)),

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -500,6 +500,10 @@ components:
       description: Response body for take backup
       type: object
       properties:
+        backupId:
+          description: The ID of the backup that has been scheduled
+          allOf:
+            - $ref: '#/components/schemas/BackupId'
         message:
           description: A message indicating backup has been triggered
           type: string

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -216,12 +216,12 @@ final class BackupEndpointTest {
       // then
       verify(requestHandler, times(2)).takeBackup();
       assertThat(firstBackup.getStatus()).isEqualTo(202);
-      var msg = ((TakeBackupRuntimeResponse) firstBackup.getBody()).getMessage();
-      final var backupId1 = Long.parseLong(msg.replaceAll(".*id (\\d+).*", "$1"));
+      final var firstBody = (TakeBackupRuntimeResponse) firstBackup.getBody();
+      final var backupId1 = firstBody.getBackupId();
 
       assertThat(secondBackup.getStatus()).isEqualTo(202);
-      msg = ((TakeBackupRuntimeResponse) secondBackup.getBody()).getMessage();
-      final var backupId2 = Long.parseLong(msg.replaceAll(".*id (\\d+).*", "$1"));
+      final var secondBody = (TakeBackupRuntimeResponse) secondBackup.getBody();
+      final var backupId2 = secondBody.getBackupId();
 
       assertThat(backupId2).isGreaterThan(backupId1);
       assertThat(Instant.ofEpochMilli(backupId2))
@@ -262,8 +262,8 @@ final class BackupEndpointTest {
       // then
       verify(requestHandler, times(1)).takeBackup(anyLong());
       assertThat(response.getStatus()).isEqualTo(202);
-      final var msg = ((TakeBackupRuntimeResponse) response.getBody()).getMessage();
-      final var backupId = Long.parseLong(msg.replaceAll(".*id (\\d+).*", "$1"));
+      final var body = (TakeBackupRuntimeResponse) response.getBody();
+      final var backupId = body.getBackupId();
 
       final var actualTimestamp = backupId - offset;
 


### PR DESCRIPTION
`POST /backupRuntime` returns a 202 response when a backup is successfully scheduled. Previously the only way to obtain the backup ID was to parse the human-readable message field with something like a regex. This is fragile and inconvenient, especially when the ID is auto-generated (continuous backup mode).

This change adds backupId (int64) to the response schema alongside the existing message field, so the response now looks like:

```json
{
  "backupId": 1234567890,
  "message": "A backup with id 1234567890 has been scheduled ..."
}
```

The field is populated for both manual and continuous backup modes. The message field is kept for backward compatibility.