### PR TITLE
ci: disable lockfile maintenance for npm package managers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,11 +29,7 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "addLabels": [
-      "automerge"
-    ]
+    "enabled": false
   },
   "hostRules": [
     {
@@ -109,15 +105,6 @@
       "addLabels": [
         "area/frontend"
       ]
-    },
-    {
-      "description": "Disable lockfile maintenance for npm package managers.",
-      "matchManagers": [
-        "npm"
-      ],
-      "lockFileMaintenance": {
-        "enabled": false
-      }
     },
     {
       "description": "Identify updates related to backend dependencies.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -111,6 +111,15 @@
       ]
     },
     {
+      "description": "Disable lockfile maintenance for npm package managers.",
+      "matchManagers": [
+        "npm"
+      ],
+      "lockFileMaintenance": {
+        "enabled": false
+      }
+    },
+    {
       "description": "Identify updates related to backend dependencies.",
       "matchManagers": [
         "maven"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,6 +71,22 @@
       "enabled": false
     },
     {
+      "description": "Disable npm patch updates for frontend apps on stable branches.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/"
+      ],
+      "matchFileNames": [
+        "operate/**",
+        "tasklist/**",
+        "identity/**",
+        "optimize/**"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
       "matchManagers": [
         "dockerfile",

--- a/c8run/e2e_tests/.npmrc
+++ b/c8run/e2e_tests/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/identity/client/.npmrc
+++ b/identity/client/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/operate/client/.npmrc
+++ b/operate/client/.npmrc
@@ -1,2 +1,3 @@
 install-links=true
 min-release-age=3
+ignore-scripts=true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/qa/orchestration-cluster-smoke-tests/.npmrc
+++ b/qa/orchestration-cluster-smoke-tests/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/scripts/codeowners-utils/.npmrc
+++ b/scripts/codeowners-utils/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true

--- a/tasklist/client/.npmrc
+++ b/tasklist/client/.npmrc
@@ -1,2 +1,3 @@
 install-links=true
 min-release-age=3
+ignore-scripts=true

--- a/testing/camunda-process-test-coverage-frontend-new/.npmrc
+++ b/testing/camunda-process-test-coverage-frontend-new/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+ignore-scripts=true

--- a/testing/camunda-process-test-coverage-frontend/.npmrc
+++ b/testing/camunda-process-test-coverage-frontend/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=3
+ignore-scripts=true


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

@cmur2 I would like to disable lockfile maintenance for `npm` packages

It's totally not viable to handle this. This option nukes the entire lockfile which means thousands of transitive deps will get updated which causes a lot of changes in the project. [Here](https://github.com/user-attachments/files/25261913/log.txt) you can check the TS errors from this [PR](https://github.com/camunda/camunda/pull/29033). And this is only the TS errors from Operate. There's still linting and fixing tests. And this is for 4 different components.

There's also the increased risk of supply chain attacks. If we start to use some fresher version of some deep transitive dep there might be a chance that we start installing a compromised package.

I also disabled the NPM scripts for all NPM components and completely disabled Renovate on Operate, Tasklist, Identity and Optimize since we have [SBOM scanning on those components](https://github.com/camunda/camunda/pull/51723)
