### PR TITLE
feat: extend audit log schema with related entity and description fields

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.38
+
+### 🚀 Enhancements
+
+- update zod schema for audit log endpoint with related entity fields and description ([#45669](https://github.com/camunda/camunda/pull/45669))
+
+### ❤️ Contributors
+
+- Daniel Kelemen ([@danielkelemen](https://github.com/danielkelemen))
+
 ## v0.0.37
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -89,6 +89,9 @@ const auditLogSchema = z.object({
 	deploymentKey: z.string().optional(),
 	formKey: z.string().optional(),
 	resourceKey: z.string().optional(),
+	relatedEntityKey: z.string().optional(),
+	relatedEntityType: auditLogEntityTypeSchema.optional(),
+	entityDescription: z.string().optional(),
 });
 type AuditLog = z.infer<typeof auditLogSchema>;
 
@@ -109,6 +112,8 @@ const auditLogFilterSchema = z
 		deploymentKey: advancedStringFilterSchema.optional(),
 		formKey: advancedStringFilterSchema.optional(),
 		resourceKey: advancedStringFilterSchema.optional(),
+		relatedEntityType: getEnumFilterSchema(auditLogEntityTypeSchema).optional(),
+		entityDescription: advancedStringFilterSchema.optional(),
 	})
 	.partial();
 


### PR DESCRIPTION
## Description

Extend audit log schema with related entity and description fields

## Related issues

related to https://github.com/camunda/camunda/issues/44946
