### PR TITLE
feat: add proxy authentication support for Optimize ES and OpenSearch connectors

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -102,6 +102,7 @@ public final class ConfigurationServiceConstants {
   public static final String ELASTICSEARCH_SECURITY_SSL_CERTIFICATE_AUTHORITIES =
       ELASTICSEARCH + ".security.ssl.certificate_authorities";
 
+  public static final String OPENSEARCH_PROXY = OPENSEARCH + ".connection.proxy";
   public static final String OPENSEARCH_CONNECTION_NODES = OPENSEARCH + ".connection.nodes";
 
   public static final String OPENSEARCH_SECURITY_USERNAME = OPENSEARCH + ".security.username";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ElasticSearchConfiguration.java
@@ -53,7 +53,7 @@ public class ElasticSearchConfiguration {
   public ProxyConfiguration getProxyConfig() {
     final ProxyConfiguration proxyConfiguration = connection.getProxy();
     if (proxyConfiguration != null) {
-      proxyConfiguration.validate();
+      proxyConfiguration.validate(ConfigurationServiceConstants.ELASTICSEARCH_PROXY);
     }
     return proxyConfiguration;
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/OpenSearchConfiguration.java
@@ -51,6 +51,15 @@ public class OpenSearchConfiguration {
   }
 
   @JsonIgnore
+  public ProxyConfiguration getProxyConfig() {
+    final ProxyConfiguration proxyConfiguration = connection.getProxy();
+    if (proxyConfiguration != null) {
+      proxyConfiguration.validate(ConfigurationServiceConstants.OPENSEARCH_PROXY);
+    }
+    return proxyConfiguration;
+  }
+
+  @JsonIgnore
   public Boolean getSkipHostnameVerification() {
     return connection.getSkipHostnameVerification();
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ProxyConfiguration.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
-import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.ELASTICSEARCH_PROXY;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
@@ -29,25 +27,47 @@ public class ProxyConfiguration {
   @JsonProperty("sslEnabled")
   private boolean sslEnabled;
 
+  @JsonProperty("username")
+  private String username;
+
+  @JsonProperty("password")
+  private String password;
+
   public ProxyConfiguration(
-      final boolean enabled, final String host, final Integer port, final boolean sslEnabled) {
+      final boolean enabled,
+      final String host,
+      final Integer port,
+      final boolean sslEnabled,
+      final String username,
+      final String password) {
     this.enabled = enabled;
     this.host = host;
     this.port = port;
     this.sslEnabled = sslEnabled;
+    this.username = username;
+    this.password = password;
+  }
+
+  public ProxyConfiguration(
+      final boolean enabled, final String host, final Integer port, final boolean sslEnabled) {
+    this(enabled, host, port, sslEnabled, null, null);
   }
 
   public ProxyConfiguration() {}
 
   public void validate() {
+    validate("proxy");
+  }
+
+  public void validate(final String configPath) {
     if (enabled) {
       if (host == null || host.isEmpty()) {
         throw new OptimizeConfigurationException(
-            ELASTICSEARCH_PROXY + ".host must be set and not empty if proxy is enabled");
+            configPath + ".host must be set and not empty if proxy is enabled");
       }
       if (port == null) {
         throw new OptimizeConfigurationException(
-            ELASTICSEARCH_PROXY + ".port must be set and not empty if proxy is enabled");
+            configPath + ".port must be set and not empty if proxy is enabled");
       }
     }
   }
@@ -88,6 +108,24 @@ public class ProxyConfiguration {
     this.sslEnabled = sslEnabled;
   }
 
+  public String getUsername() {
+    return username;
+  }
+
+  @JsonProperty("username")
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  @JsonProperty("password")
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof ProxyConfiguration;
   }
@@ -101,12 +139,14 @@ public class ProxyConfiguration {
     return enabled == that.enabled
         && sslEnabled == that.sslEnabled
         && Objects.equals(host, that.host)
-        && Objects.equals(port, that.port);
+        && Objects.equals(port, that.port)
+        && Objects.equals(username, that.username)
+        && Objects.equals(password, that.password);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(enabled, host, port, sslEnabled);
+    return Objects.hash(enabled, host, port, sslEnabled, username, password);
   }
 
   @Override
@@ -119,6 +159,8 @@ public class ProxyConfiguration {
         + getPort()
         + ", sslEnabled="
         + isSslEnabled()
+        + ", username="
+        + getUsername()
         + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
@@ -42,6 +42,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -291,8 +292,10 @@ public class ElasticsearchClientBuilder {
   }
 
   private static void addPreemptiveProxyAuthInterceptor(
-      final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder,
-      final ProxyConfiguration proxyConfig) {
+      final HttpAsyncClientBuilder builder, final ProxyConfiguration proxyConfig) {
+    if (proxyConfig == null) {
+      return;
+    }
     if (proxyConfig.getUsername() != null
         && !proxyConfig.getUsername().isEmpty()
         && proxyConfig.getPassword() != null

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -297,6 +297,20 @@ opensearch:
         httpPort: ${CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT:9200}
     # Determines whether the hostname verification should be skipped
     skipHostnameVerification: ${CAMUNDA_OPTIMIZE_OPENSEARCH_CONNECTION_SKIP_HOSTNAME_VERIFICATION:false}
+    # HTTP forward proxy configuration
+    proxy:
+      # whether an HTTP proxy should be used for requests to OpenSearch
+      enabled: false
+      # the host of the proxy to use
+      host: null
+      # the port of the proxy to use
+      port: null
+      # whether this proxy is using a secured connection
+      sslEnabled: false
+      # optional username for proxy authentication
+      username: null
+      # optional password for proxy authentication
+      password: null
     # Configuration relating to OS backup
   backup:
     # The repository name in which the backups should be stored
@@ -408,6 +422,10 @@ es:
       port: null
       # whether this proxy is using a secured connection
       sslEnabled: false
+      # optional username for proxy authentication
+      username: null
+      # optional password for proxy authentication
+      password: null
     # Determines whether the hostname verification should be skipped
     skipHostnameVerification: ${CAMUNDA_OPTIMIZE_ELASTICSEARCH_CONNECTION_SKIP_HOSTNAME_VERIFICATION:false}
   # Configuration relating to ES backup

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
@@ -173,6 +173,16 @@ public class ConfigurationServiceTest {
   }
 
   @Test
+  public void invalidOpenSearchProxyConfigThrowsError() {
+    final String[] locations = {
+      defaultConfigFile(), "config-samples/config-invalid-opensearch-proxy-config.yaml"
+    };
+    final ConfigurationService underTest = createConfiguration(locations);
+    assertThatThrownBy(() -> underTest.getOpenSearchConfiguration().getProxyConfig())
+        .isInstanceOf(OptimizeConfigurationException.class);
+  }
+
+  @Test
   public void resolvePropertiesFromEnvironmentVariables() {
     // when
     final String[] locations = {defaultConfigFile(), "environment-variable-test-config.yaml"};

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ProxyConfigurationTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ProxyConfigurationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.util.configuration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
@@ -44,5 +45,78 @@ public class ProxyConfigurationTest {
 
     assertThatExceptionOfType(OptimizeConfigurationException.class)
         .isThrownBy(() -> proxyConfiguration.validate());
+  }
+
+  @Test
+  public void testUsernameAndPasswordFieldsAreStoredAndRetrieved() {
+    final ProxyConfiguration proxyConfiguration =
+        new ProxyConfiguration(true, "proxy.example.com", 8080, false, "user", "pass");
+
+    assertThat(proxyConfiguration.getUsername()).isEqualTo("user");
+    assertThat(proxyConfiguration.getPassword()).isEqualTo("pass");
+    assertThat(proxyConfiguration.getHost()).isEqualTo("proxy.example.com");
+    assertThat(proxyConfiguration.getPort()).isEqualTo(8080);
+    assertThat(proxyConfiguration.isEnabled()).isTrue();
+    assertThat(proxyConfiguration.isSslEnabled()).isFalse();
+  }
+
+  @Test
+  public void testValidatePassesWithUsernameAndPassword() {
+    final ProxyConfiguration proxyConfiguration =
+        new ProxyConfiguration(true, "proxy.example.com", 8080, true, "user", "pass");
+
+    proxyConfiguration.validate();
+  }
+
+  @Test
+  public void testValidatePassesWithoutUsernameAndPassword() {
+    final ProxyConfiguration proxyConfiguration =
+        new ProxyConfiguration(true, "proxy.example.com", 8080, false);
+
+    proxyConfiguration.validate();
+  }
+
+  @Test
+  public void testValidateWithConfigPath() {
+    final ProxyConfiguration proxyConfiguration = new ProxyConfiguration(true, null, 80, false);
+
+    assertThatExceptionOfType(OptimizeConfigurationException.class)
+        .isThrownBy(() -> proxyConfiguration.validate("$.opensearch.connection.proxy"))
+        .withMessageContaining("$.opensearch.connection.proxy.host");
+  }
+
+  @Test
+  public void testEqualsAndHashCodeIncludeUsernameAndPassword() {
+    final ProxyConfiguration config1 =
+        new ProxyConfiguration(true, "host", 80, false, "user1", "pass1");
+    final ProxyConfiguration config2 =
+        new ProxyConfiguration(true, "host", 80, false, "user1", "pass1");
+    final ProxyConfiguration config3 =
+        new ProxyConfiguration(true, "host", 80, false, "user2", "pass2");
+
+    assertThat(config1).isEqualTo(config2);
+    assertThat(config1.hashCode()).isEqualTo(config2.hashCode());
+    assertThat(config1).isNotEqualTo(config3);
+  }
+
+  @Test
+  public void testToStringDoesNotContainPassword() {
+    final ProxyConfiguration proxyConfiguration =
+        new ProxyConfiguration(true, "host", 80, false, "user", "secret");
+
+    final String toString = proxyConfiguration.toString();
+    assertThat(toString).contains("username=user");
+    assertThat(toString).doesNotContain("secret");
+    assertThat(toString).doesNotContain("password");
+  }
+
+  @Test
+  public void testSettersWork() {
+    final ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+    proxyConfiguration.setUsername("user");
+    proxyConfiguration.setPassword("pass");
+
+    assertThat(proxyConfiguration.getUsername()).isEqualTo("user");
+    assertThat(proxyConfiguration.getPassword()).isEqualTo("pass");
   }
 }

--- a/optimize/util/optimize-commons/src/test/resources/config-samples/config-invalid-opensearch-proxy-config.yaml
+++ b/optimize/util/optimize-commons/src/test/resources/config-samples/config-invalid-opensearch-proxy-config.yaml
@@ -1,0 +1,4 @@
+opensearch:
+  connection:
+    proxy:
+      enabled: true


### PR DESCRIPTION
## Summary

- Add username/password proxy authentication with preemptive `Proxy-Authorization: Basic` header to both the Elasticsearch and OpenSearch client builders in Optimize, matching the proxy capabilities already present in Operate and Tasklist connectors
- Extend `ProxyConfiguration` with `username` and `password` fields,

## Changes

### Core Implementation

**`ProxyConfiguration.java`**
- Added `username` and `password` fields 
- New 6-arg constructor (`enabled, host, port, sslEnabled, username, password`); backward-compatible 4-arg constructor delegates to it
- Made `validate()` database-agnostic with `validate(String configPath)` overload

**`ElasticsearchClientBuilder.java`**
- Added `addPreemptiveProxyAuthInterceptor()` using **HC4** API (2-arg interceptor `(request, context)`, `HttpHost(host, port, scheme)`)
- Called after existing `setProxy()` when proxy credentials are configured

**`OpenSearchClientBuilder.java`**
- Added `addPreemptiveProxyAuthInterceptor()` using **HC5** API (3-arg interceptor `(request, entity, context)`, `HttpHost(scheme, host, port)`)
- Added proxy routing and auth in `configureHttpClient()` after SSL setup

**`OpenSearchConfiguration.java`**
- Added `getProxyConfig()` method mirroring the ES version, with validation using `OPENSEARCH_PROXY` constant

**`ConfigurationServiceConstants.java`**
- Added `OPENSEARCH_PROXY` constant

**`service-config.yaml`**
- Added full proxy config block under `opensearch.connection` (`enabled`, `host`, `port`, `sslEnabled`, `username`, `password`)
- Added `username: null` and `password: null` to existing ES proxy config

### Tests

**`ElasticsearchClientBuilderTest.java`** — 3 new tests:
- Proxy enabled without credentials: no `Proxy-Authorization` header
- Proxy enabled with credentials: `Proxy-Authorization: Basic <base64>` header present
- Proxy disabled with credentials: no `Proxy-Authorization` header

**`OpenSearchClientBuilderTest.java`** — 3 new tests:
- Same 3 patterns as ES, using HC5 API and MockServer

**`ConfigurationServiceTest.java`** — 1 new test:
- `invalidOpenSearchProxyConfigThrowsError`: validates that enabling proxy without host/port throws `OptimizeConfigurationException`

**`ProxyConfigurationTest.java`** — 7 new tests:
- Field storage/retrieval, validation with/without credentials, configPath validation, equals/hashCode with new fields, toString password omission, setters

**`config-invalid-opensearch-proxy-config.yaml`** — New test resource

## Verification

- All **42 tests** pass (7 OS + 7 ES + 11 ProxyConfig + 17 ConfigService)
- `spotless:check` and `license:check` pass