### PR TITLE
fix: hide multiple-instances hint for instance selection

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -85,6 +85,7 @@ const TopPanel: React.FC = observer(() => {
   const {
     clearSelection,
     selectedElementId,
+    selectedElementInstanceKey,
     selectElement,
     selectedAnchorElementId,
   } = useProcessInstanceElementSelection();
@@ -125,8 +126,8 @@ const TopPanel: React.FC = observer(() => {
   const {data: selectedElementRunningInstancesCount} =
     useTotalRunningInstancesForFlowNode(selectedElementId ?? undefined);
   const hasSelectedElementMultipleRunningInstances =
-    selectedElementRunningInstancesCount !== undefined &&
-    selectedElementRunningInstancesCount > 1;
+    selectedElementInstanceKey === null &&
+    (selectedElementRunningInstancesCount ?? 0) > 1;
 
   const {
     data: processDefinitionData,


### PR DESCRIPTION
## Description

This PR adjust the logic for `hasSelectedElementMultipleRunningInstances` so the "multiple instances" info banner is shown for the same selections as in v8.9.0-alpha4 (old selection logic).

**Important:** I am not quit sure if it is correct to not consider `isSelectedInstanceMultiInstanceBody`. Currently (and in Alpha 4), selecting the multi-instance subprocess in the "Multi-Instance Process" process shows the info banner when selected in the diagram, but hides it when selected in the history. I am wondering if it would actually be correct to show the banner when the multi-instance element is selected in the history. 🤔

## Related issues

closes #45557
