### PR TITLE
test: fix multi instance selection E2E test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -98,14 +98,10 @@ test.describe('Multi Instance Flow Node Selection', () => {
     operateProcessInstancePage,
     operateDiagramPage,
   }) => {
-    await test.step('Expand and click on Task B flow node', async () => {
+    await test.step('Expand Task B (Multi instance) flow node', async () => {
       await operateProcessInstancePage.expandTreeItemInHistory(
         /^task b \(multi instance\)$/i,
       );
-      await operateProcessInstancePage
-        .findTreeItemInHistory(/^task b \(multi instance\)$/i)
-        .first()
-        .click();
     });
 
     await test.step('Verify 5 child Task B instances are visible', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -94,7 +94,7 @@ test.describe('Multi Instance Flow Node Selection', () => {
     });
   });
 
-  test('select flow node in diagram', async ({
+  test('verify execution counts and incidents display for multi-instance flow node', async ({
     operateProcessInstancePage,
     operateDiagramPage,
   }) => {


### PR DESCRIPTION
## Description

This PR fixes a failing Operate E2E test.

In the test a specific element is selected from the instance history. The metadata popover overlapped the incident banner, which caused the test to be stuck, because the banner cannot be expanded:

<img width="1280" height="720" alt="32c85924de6f8d3a3c580b0ecc27bab9aa3c7540" src="https://github.com/user-attachments/assets/fb5dcb46-7404-43e3-9a17-81e350a22f83" />

As a fix the element selection is removed. I could not find any reason why the element needs to be selected. There is no assertion on the metadata popover, so I think it's safe to not select it.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
