### PR TITLE
feat: include infosec registry upload for Optimize

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -736,7 +736,7 @@ jobs:
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
       DOCKER_IMAGE: camunda/optimize
-      DOCKER_INTERNAL_IMAGE_DOCKER_HUB: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
+      DOCKER_INFOSEC_REGISTRY_IMAGE: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
     steps:
       - uses: actions/checkout@v6
         with:
@@ -842,7 +842,7 @@ jobs:
           timeout_minutes: 10
           command: |
             docker -D buildx imagetools create \
-              --tag ${{ env.DOCKER_INTERNAL_IMAGE_DOCKER_HUB }}:${{ env.RELEASE_VERSION }} \
+              --tag ${{ env.DOCKER_INFOSEC_REGISTRY_IMAGE }}:${{ env.RELEASE_VERSION }} \
               ${{ steps.build-optimize-docker.outputs.image }}
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -736,6 +736,7 @@ jobs:
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
       DOCKER_IMAGE: camunda/optimize
+      DOCKER_INTERNAL_IMAGE_DOCKER_HUB: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
     steps:
       - uses: actions/checkout@v6
         with:
@@ -763,6 +764,19 @@ jobs:
           registry: reg.mini.dev
           username: minimus
           password: ${{ steps.secrets.outputs.minimus-token }}
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v3"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "projects/271764561088/locations/global/workloadIdentityPools/github/providers/camunda"
+          service_account: "github-actions-camunda@team-infosec.iam.gserviceaccount.com"
+      - name: Login to infosec registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v7
         with:
@@ -816,6 +830,19 @@ jobs:
           command: |
             docker -D buildx imagetools create \
               --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-optimize-docker.outputs.image }}
+      - name: Sync Optimize Docker Image to Internal Registry
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_INTERNAL_IMAGE_DOCKER_HUB }}:${{ env.RELEASE_VERSION }} \
               ${{ steps.build-optimize-docker.outputs.image }}
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -724,7 +724,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ inputs.includeOptimize }}
-    permissions: {}  # GITHUB_TOKEN unused in this job
+    permissions:
+      contents: "write"
+      id-token: "write"
     services:
       # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
       # registry. As we want to verify the images first before pushing them to dockerhub though,


### PR DESCRIPTION
## Description

This pull request updates the `camunda-platform-release.yml` GitHub Actions workflow to support publishing Docker images to an internal Google Cloud registry, in addition to the existing Docker Hub workflows. The changes include new environment variables, authentication steps for Google Cloud, and a new job step to sync the Docker image to the internal registry.

Follow up to https://github.com/camunda/camunda/pull/41961 and https://github.com/camunda/camunda/issues/40184?reload=1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
