### PR TITLE
feat: upload GCS snapshot files in parallel via TransferManager

### DIFF
--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -138,6 +138,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
       <scope>test</scope>
@@ -164,6 +170,7 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.api:*</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
@@ -170,8 +175,10 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
-            <ignoredUsedUndeclaredDependency>com.google.api:*</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>com.google.api:*</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -28,6 +28,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
+
+  public static final String SNAPSHOT_FILESET_NAME = "snapshot";
+  public static final String SEGMENTS_FILESET_NAME = "segments";
+
   /**
    * The path format consists of the following elements:
    *
@@ -63,9 +67,8 @@ final class FileSetManager {
    * immutable, so the Path-based upload (which reads the file twice for CRC32C verification) is
    * safe.
    */
-  void saveSnapshot(
-      final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
-    final var prefix = fileSetPath(id, fileSetName);
+  void saveSnapshot(final BackupIdentifier id, final NamedFileSet fileSet) {
+    final var prefix = fileSetPath(id, SNAPSHOT_FILESET_NAME);
     final var namedFiles = fileSet.namedFiles();
     final var pathToName =
         namedFiles.entrySet().stream()
@@ -108,14 +111,15 @@ final class FileSetManager {
    *
    * @see <a href="https://github.com/camunda/camunda/issues/45636">#45636</a>
    */
-  void saveSegments(
-      final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
+  void saveSegments(final BackupIdentifier id, final NamedFileSet fileSet) {
     for (final var namedFile : fileSet.namedFiles().entrySet()) {
       final var fileName = namedFile.getKey();
       final var filePath = namedFile.getValue();
       try (final var inputStream = Files.newInputStream(filePath)) {
         client.createFrom(
-            blobInfo(id, fileSetName, fileName), inputStream, BlobWriteOption.doesNotExist());
+            blobInfo(id, SEGMENTS_FILESET_NAME, fileName),
+            inputStream,
+            BlobWriteOption.doesNotExist());
       } catch (final IOException e) {
         throw new UncheckedIOException(e);
       }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -69,7 +69,7 @@ final class FileSetManagerTest {
         .thenReturn(uploadJob);
 
     // when
-    manager.saveSnapshot(backupIdentifier, "filesetName", namedFileSet);
+    manager.saveSnapshot(backupIdentifier, namedFileSet);
 
     // then
     verify(transferManager).uploadFiles(anyList(), any(ParallelUploadConfig.class));
@@ -100,8 +100,7 @@ final class FileSetManagerTest {
         .thenReturn(uploadJob);
 
     // when throw
-    Assertions.assertThatThrownBy(
-            () -> manager.saveSnapshot(backupIdentifier, "filesetName", namedFileSet))
+    Assertions.assertThatThrownBy(() -> manager.saveSnapshot(backupIdentifier, namedFileSet))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }
@@ -116,7 +115,7 @@ final class FileSetManagerTest {
         new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
 
     // when
-    manager.saveSegments(backupIdentifier, "filesetName", namedFileSet);
+    manager.saveSegments(backupIdentifier, namedFileSet);
 
     // then
     verify(storage, times(2)).createFrom(any(), any(InputStream.class), any());
@@ -135,8 +134,7 @@ final class FileSetManagerTest {
         .thenThrow(new StorageException(412, "expected"));
 
     // when throw
-    Assertions.assertThatThrownBy(
-            () -> manager.saveSegments(backupIdentifier, "filesetName", namedFileSet))
+    Assertions.assertThatThrownBy(() -> manager.saveSegments(backupIdentifier, namedFileSet))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -10,11 +10,18 @@ package io.camunda.zeebe.backup.gcs;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.transfermanager.ParallelUploadConfig;
+import com.google.cloud.storage.transfermanager.TransferManager;
+import com.google.cloud.storage.transfermanager.TransferStatus;
+import com.google.cloud.storage.transfermanager.UploadJob;
+import com.google.cloud.storage.transfermanager.UploadResult;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
@@ -27,42 +34,109 @@ import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 final class FileSetManagerTest {
-  @Test
-  void shouldSaveFileSet(@TempDir final Path tempDir) throws IOException {
-    // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
-    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
-    final var file1 = Files.createFile(tempDir.resolve("file1"));
-    final var file2 = Files.createFile(tempDir.resolve("file2"));
-    final var namedFileSet =
-        new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
+  private final Storage storage;
+  private final TransferManager transferManager;
+  private final FileSetManager manager;
 
-    // when
-    manager.save(backupIdentifier, "filesetName", namedFileSet);
-
-    // then
-    verify(mockClient, times(2)).createFrom(any(), any(InputStream.class), any());
+  FileSetManagerTest(@Mock final Storage storage, @Mock final TransferManager transferManager) {
+    this.storage = storage;
+    this.transferManager = transferManager;
+    manager = new FileSetManager(storage, transferManager, BucketInfo.of("bucket"), "basePath");
   }
 
   @Test
-  void shouldThrowExceptionOnSaveFileSet(@TempDir final Path tempDir) throws IOException {
+  void shouldSaveSnapshotFilesInParallel(@TempDir final Path tempDir) throws IOException {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var file1 = Files.createFile(tempDir.resolve("file1"));
     final var file2 = Files.createFile(tempDir.resolve("file2"));
     final var namedFileSet =
         new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
-    when(mockClient.createFrom(any(), any(InputStream.class), any()))
+
+    final var uploadJob =
+        UploadJob.newBuilder()
+            .setParallelUploadConfig(
+                ParallelUploadConfig.newBuilder().setBucketName("bucket").build())
+            .build();
+    when(transferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(uploadJob);
+
+    // when
+    manager.saveSnapshot(backupIdentifier, "filesetName", namedFileSet);
+
+    // then
+    verify(transferManager).uploadFiles(anyList(), any(ParallelUploadConfig.class));
+  }
+
+  @Test
+  void shouldThrowExceptionOnSaveSnapshotWhenUploadFails(@TempDir final Path tempDir)
+      throws IOException {
+    // given
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
+
+    final var failedResult =
+        UploadResult.newBuilder(
+                BlobInfo.newBuilder("bucket", "test").build(), TransferStatus.FAILED_TO_FINISH)
+            .setException(new StorageException(412, "expected"))
+            .build();
+    final var uploadJob =
+        UploadJob.newBuilder()
+            .setUploadResults(List.of(ApiFutures.immediateFuture(failedResult)))
+            .setParallelUploadConfig(
+                ParallelUploadConfig.newBuilder().setBucketName("bucket").build())
+            .build();
+    when(transferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(uploadJob);
+
+    // when throw
+    Assertions.assertThatThrownBy(
+            () -> manager.saveSnapshot(backupIdentifier, "filesetName", namedFileSet))
+        .isInstanceOf(StorageException.class)
+        .hasMessageContaining("expected");
+  }
+
+  @Test
+  void shouldSaveSegmentFilesSequentially(@TempDir final Path tempDir) throws IOException {
+    // given
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
+
+    // when
+    manager.saveSegments(backupIdentifier, "filesetName", namedFileSet);
+
+    // then
+    verify(storage, times(2)).createFrom(any(), any(InputStream.class), any());
+    verifyNoInteractions(transferManager);
+  }
+
+  @Test
+  void shouldThrowExceptionOnSaveSegments(@TempDir final Path tempDir) throws IOException {
+    // given
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
+    when(storage.createFrom(any(), any(InputStream.class), any()))
         .thenThrow(new StorageException(412, "expected"));
 
     // when throw
-    Assertions.assertThatThrownBy(() -> manager.save(backupIdentifier, "filesetName", namedFileSet))
+    Assertions.assertThatThrownBy(
+            () -> manager.saveSegments(backupIdentifier, "filesetName", namedFileSet))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }
@@ -71,14 +145,12 @@ final class FileSetManagerTest {
   @Test
   void shouldDeleteFileSet() {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
 
     final var mockBlob = mock(Blob.class);
     final var mockPage = mock(Page.class);
     when(mockPage.iterateAll()).thenReturn(List.of(mockBlob));
-    when(mockClient.list(eq("bucket"), any())).thenReturn(mockPage);
+    when(storage.list(eq("bucket"), any())).thenReturn(mockPage);
 
     // when
     manager.delete(backupIdentifier, "filesetName");
@@ -90,10 +162,8 @@ final class FileSetManagerTest {
   @Test
   void shouldThrowExceptionOnDeleteFileSetWhenListThrows() {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
-    when(mockClient.list(eq("bucket"), any())).thenThrow(new StorageException(412, "expected"));
+    when(storage.list(eq("bucket"), any())).thenThrow(new StorageException(412, "expected"));
 
     // when throw
     Assertions.assertThatThrownBy(() -> manager.delete(backupIdentifier, "filesetName"))
@@ -105,15 +175,13 @@ final class FileSetManagerTest {
   @Test
   void shouldThrowExceptionOnDeleteFileSetWhenBlobDeleteThrows() {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
 
     final Blob mockBlob = mock(Blob.class);
     when(mockBlob.delete()).thenThrow(new StorageException(412, "expected"));
     final var mockPage = mock(Page.class);
     when(mockPage.iterateAll()).thenReturn(List.of(mockBlob));
-    when(mockClient.list(eq("bucket"), any())).thenReturn(mockPage);
+    when(storage.list(eq("bucket"), any())).thenReturn(mockPage);
 
     // when throw
     Assertions.assertThatThrownBy(() -> manager.delete(backupIdentifier, "filesetName"))
@@ -124,8 +192,6 @@ final class FileSetManagerTest {
   @Test
   void shouldRestoreFileSet() {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var fileSet =
         new FileSet(List.of(new NamedFile("snapshotFile"), new NamedFile("snapshotFile2")));
@@ -141,22 +207,18 @@ final class FileSetManagerTest {
     Assertions.assertThat(namedFileSet.namedFiles())
         .isEqualTo(Map.of("snapshotFile", expectedPath1, "snapshotFile2", expectedPath2));
 
-    verify(mockClient).downloadTo(any(), eq(expectedPath1));
-    verify(mockClient).downloadTo(any(), eq(expectedPath2));
+    verify(storage).downloadTo(any(), eq(expectedPath1));
+    verify(storage).downloadTo(any(), eq(expectedPath2));
   }
 
   @Test
   void shouldThrowRestoreFileSetWhenDownloadToFails() {
     // given
-    final var mockClient = mock(Storage.class);
-    final var manager = new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath");
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var fileSet =
         new FileSet(List.of(new NamedFile("snapshotFile"), new NamedFile("snapshotFile2")));
     final Path restorePath = Path.of("restorePath");
-    doThrow(new StorageException(412, "expected"))
-        .when(mockClient)
-        .downloadTo(any(), any(Path.class));
+    doThrow(new StorageException(412, "expected")).when(storage).downloadTo(any(), any(Path.class));
 
     // when - then throw
     assertThatThrownBy(() -> manager.restore(backupIdentifier, "filesetName", fileSet, restorePath))


### PR DESCRIPTION
## Summary

- Use the GCS `TransferManager` API to upload **snapshot files in parallel**, improving backup throughput
- Keep **segment files sequential** via `InputStream` to avoid CRC32C checksum mismatches on mutable files (#45636)
- This is the corrected approach from the reverted #45294, which used `TransferManager` for all files

## Changes

- **`FileSetManager`**: Split `save()` into `saveSnapshot()` (parallel via `TransferManager`) and `saveSegments()` (sequential via `InputStream`)
- **`GcsBackupStore`**: Create and wire `TransferManager`, close it on shutdown
- **`FileSetManagerTest`**: Add dedicated tests for parallel snapshot and sequential segment upload paths

relates to #45636