### PR TITLE
Implement individual global listener commands

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -58,11 +60,17 @@ public final class GlobalListenerDeleteProcessor
       return;
     }
 
-    final long key = keyGenerator.nextKey();
-    writers.state().appendFollowUpEvent(key, GlobalListenerIntent.DELETED, validRecord.get());
+    final var record = validRecord.get();
+    // Generate a key for the new configuration after the listener update
+    final long configKey = keyGenerator.nextKey();
+    record.setConfigKey(configKey);
 
+    emitChangeEvents(record);
+
+    // Note: the configuration key is used as the command key for distribution, ensuring
+    // configuration changes are applied in order
     distributionBehavior
-        .withKey(key)
+        .withKey(configKey)
         .inQueue(DistributionQueue.GLOBAL_LISTENERS.getQueueId())
         .distribute(command);
   }
@@ -74,7 +82,7 @@ public final class GlobalListenerDeleteProcessor
     final var listener =
         globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
     if (listener != null) {
-      writers.state().appendFollowUpEvent(command.getKey(), GlobalListenerIntent.DELETED, record);
+      emitChangeEvents(record);
     } else {
       final var message =
           LISTENER_NOT_EXISTS_ERROR_MESSAGE.formatted(record.getListenerType(), record.getId());
@@ -85,6 +93,24 @@ public final class GlobalListenerDeleteProcessor
 
   private Either<Rejection, GlobalListenerRecord> validateCommand(
       final TypedRecord<GlobalListenerRecord> command) {
-    return Either.right(command.getValue());
+    // TODO: actual validation
+    final var record = command.getValue();
+    final var resolvedRecord =
+        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+    record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
+    return Either.right(record);
+  }
+
+  private void emitChangeEvents(final GlobalListenerRecord record) {
+    writers
+        .state()
+        .appendFollowUpEvent(record.getGlobalListenerKey(), GlobalListenerIntent.DELETED, record);
+    writers
+        .state()
+        .appendFollowUpEvent(
+            record.getConfigKey(),
+            GlobalListenerBatchIntent.CONFIGURED,
+            new GlobalListenerBatchRecord()
+                .setGlobalListenerBatchKey(record.getGlobalListenerKey()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -16,7 +16,9 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.globallistener.GlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -55,25 +57,47 @@ public final class GlobalListenerUpdateProcessor
       return;
     }
 
-    final long key = keyGenerator.nextKey();
-    writers.state().appendFollowUpEvent(key, GlobalListenerIntent.UPDATED, validRecord.get());
+    final var record = validRecord.get();
+    // Generate a key for the new configuration after the listener update
+    final long configKey = keyGenerator.nextKey();
+    record.setConfigKey(configKey);
 
+    emitChangeEvents(record);
+
+    // Note: the configuration key is used as the command key for distribution, ensuring
+    // configuration changes are applied in order
     distributionBehavior
-        .withKey(key)
+        .withKey(configKey)
         .inQueue(DistributionQueue.GLOBAL_LISTENERS.getQueueId())
         .distribute(command);
   }
 
   @Override
   public void processDistributedCommand(final TypedRecord<GlobalListenerRecord> command) {
-    writers
-        .state()
-        .appendFollowUpEvent(command.getKey(), GlobalListenerIntent.UPDATED, command.getValue());
+    emitChangeEvents(command.getValue());
     distributionBehavior.acknowledgeCommand(command);
   }
 
   private Either<Rejection, GlobalListenerRecord> validateCommand(
       final TypedRecord<GlobalListenerRecord> command) {
-    return Either.right(command.getValue());
+    // TODO: actual validation
+    final var record = command.getValue();
+    final var resolvedRecord =
+        globalListenersState.getGlobalListener(record.getListenerType(), record.getId());
+    record.setGlobalListenerKey(resolvedRecord.getGlobalListenerKey());
+    return Either.right(record);
+  }
+
+  private void emitChangeEvents(final GlobalListenerRecord record) {
+    writers
+        .state()
+        .appendFollowUpEvent(record.getGlobalListenerKey(), GlobalListenerIntent.UPDATED, record);
+    writers
+        .state()
+        .appendFollowUpEvent(
+            record.getConfigKey(),
+            GlobalListenerBatchIntent.CONFIGURED,
+            new GlobalListenerBatchRecord()
+                .setGlobalListenerBatchKey(record.getGlobalListenerKey()));
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -52,6 +52,9 @@
                 },
                 "listenerType": {
                   "type": "keyword"
+                },
+                "configKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -45,6 +45,9 @@
             },
             "listenerType": {
               "type": "keyword"
+            },
+            "configKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-batch-template.json
@@ -52,6 +52,9 @@
                 },
                 "listenerType": {
                   "type": "keyword"
+                },
+                "configKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-global-listener-template.json
@@ -45,6 +45,9 @@
             },
             "listenerType": {
               "type": "keyword"
+            },
+            "configKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/globallistener/GlobalListenerRecord.java
@@ -55,8 +55,10 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
   private final EnumProperty<GlobalListenerType> listenerTypeProp =
       new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
 
+  private final LongProperty configKeyProp = new LongProperty("configKey", -1L);
+
   public GlobalListenerRecord() {
-    super(9);
+    super(10);
     declareProperty(globalListenerKeyProp)
         .declareProperty(idProp)
         .declareProperty(typeProp)
@@ -65,7 +67,8 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
         .declareProperty(afterNonGlobalProp)
         .declareProperty(priorityProp)
         .declareProperty(sourceProp)
-        .declareProperty(listenerTypeProp);
+        .declareProperty(listenerTypeProp)
+        .declareProperty(configKeyProp);
   }
 
   @Override
@@ -159,6 +162,16 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setListenerType(final GlobalListenerType listenerType) {
     listenerTypeProp.setValue(listenerType);
+    return this;
+  }
+
+  @Override
+  public Long getConfigKey() {
+    return configKeyProp.getValue();
+  }
+
+  public GlobalListenerRecord setConfigKey(final Long configKey) {
+    configKeyProp.setValue(configKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4450,7 +4450,8 @@ final class JsonSerializableToJsonTest {
             "afterNonGlobal": false,
             "priority": 50,
             "source": "CONFIGURATION",
-            "listenerType": "USER_TASK"
+            "listenerType": "USER_TASK",
+            "configKey": -1
           },
           {
             "globalListenerKey": -1,
@@ -4461,7 +4462,8 @@ final class JsonSerializableToJsonTest {
             "afterNonGlobal": true,
             "priority": 10,
             "source": "CONFIGURATION",
-            "listenerType": "USER_TASK"
+            "listenerType": "USER_TASK",
+            "configKey": -1
           }
          ],
         "createdListenerKeys": [
@@ -4522,7 +4524,8 @@ final class JsonSerializableToJsonTest {
             "afterNonGlobal": false,
             "priority": 50,
             "source": "CONFIGURATION",
-            "listenerType": "USER_TASK"
+            "listenerType": "USER_TASK",
+            "configKey": -1
           },
           {
             "globalListenerKey": 125,
@@ -4533,7 +4536,8 @@ final class JsonSerializableToJsonTest {
             "afterNonGlobal": true,
             "priority": 10,
             "source": "CONFIGURATION",
-            "listenerType": "USER_TASK"
+            "listenerType": "USER_TASK",
+            "configKey": -1
           },
           {
             "globalListenerKey": 124,
@@ -4544,7 +4548,8 @@ final class JsonSerializableToJsonTest {
             "afterNonGlobal": false,
             "priority": 50,
             "source": "CONFIGURATION",
-            "listenerType": "USER_TASK"
+            "listenerType": "USER_TASK",
+            "configKey": -1
           }
         ],
         "createdListenerKeys": [
@@ -4586,7 +4591,8 @@ final class JsonSerializableToJsonTest {
                     .setRetries(5)
                     .setAfterNonGlobal(true)
                     .setPriority(10)
-                    .setSource(GlobalListenerSource.API),
+                    .setSource(GlobalListenerSource.API)
+                    .setConfigKey(124L),
         """
     {
       "globalListenerKey": 123,
@@ -4597,7 +4603,8 @@ final class JsonSerializableToJsonTest {
       "afterNonGlobal": true,
       "priority": 10,
       "source": "API",
-      "listenerType": "USER_TASK"
+      "listenerType": "USER_TASK",
+      "configKey": 124
     }
     """
       },
@@ -4614,7 +4621,8 @@ final class JsonSerializableToJsonTest {
       "afterNonGlobal": false,
       "priority": 50,
       "source": "CONFIGURATION",
-      "listenerType": "USER_TASK"
+      "listenerType": "USER_TASK",
+      "configKey": -1
     }
     """
       }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/GlobalListenerRecord.golden
@@ -55,8 +55,10 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
   private final EnumProperty<GlobalListenerType> listenerTypeProp =
       new EnumProperty<>("listenerType", GlobalListenerType.class, GlobalListenerType.USER_TASK);
 
+  private final LongProperty configKeyProp = new LongProperty("configKey", -1L);
+
   public GlobalListenerRecord() {
-    super(9);
+    super(10);
     declareProperty(globalListenerKeyProp)
         .declareProperty(idProp)
         .declareProperty(typeProp)
@@ -65,7 +67,8 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
         .declareProperty(afterNonGlobalProp)
         .declareProperty(priorityProp)
         .declareProperty(sourceProp)
-        .declareProperty(listenerTypeProp);
+        .declareProperty(listenerTypeProp)
+        .declareProperty(configKeyProp);
   }
 
   @Override
@@ -159,6 +162,16 @@ public final class GlobalListenerRecord extends UnifiedRecordValue
 
   public GlobalListenerRecord setListenerType(final GlobalListenerType listenerType) {
     listenerTypeProp.setValue(listenerType);
+    return this;
+  }
+
+  @Override
+  public Long getConfigKey() {
+    return configKeyProp.getValue();
+  }
+
+  public GlobalListenerRecord setConfigKey(final Long configKey) {
+    configKeyProp.setValue(configKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GlobalListenerRecordValue.java
@@ -128,4 +128,10 @@ public interface GlobalListenerRecordValue extends RecordValue {
    * @return the listener type
    */
   GlobalListenerType getListenerType();
+
+  /**
+   * When this value is set, it indicates that the record is part of the changes necessary to define
+   * a global listeners configuration with this key.
+   */
+  Long getConfigKey();
 }


### PR DESCRIPTION
## Description

This PR implements the following `GLOBAL_LISTENER` commands by mutating the state in order to update the global listeners configuration:
- `CREATE`
- `UPDATE`
- `DELETE`

Global listener commands are implemented by:
- applying the required change to the individual listener
(create/update/delete)
- update the global listeners configuration key in order to mark the
configuration as changed

Since commands are distributed, the keys of both the listener and the new configuraiton need to be distributed to the other partitions as well.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

closes #43187
