### PR TITLE
feat: add rootProcessInstanceKey to job activation response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -149,4 +149,17 @@ public interface ActivatedJob {
    * @return the tags associated with the job inherited from the process instance on job creation.
    */
   Set<String> getTags();
+
+  /**
+   * The key of the root process instance. This is the key of the top-level process instance that
+   * started the process instance hierarchy containing this job. For jobs in top-level process
+   * instances, this is the same as {@link #getProcessInstanceKey()}.
+   *
+   * <p><b>Note:</b> This field is only available when using the REST API. When using the gRPC API,
+   * this method returns {@code null}.
+   *
+   * @return the key of the root process instance, or {@code null} if not available (gRPC API or
+   *     pre-8.9 data)
+   */
+  Long getRootProcessInstanceKey();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -57,6 +57,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final JobKind kind;
   private final ListenerEventType listenerEventType;
   private final Set<String> tags;
+  private final Long rootProcessInstanceKey;
 
   private Map<String, Object> variablesAsMap;
 
@@ -86,6 +87,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     kind = EnumUtil.convert(job.getKind(), JobKind.class);
     listenerEventType = EnumUtil.convert(job.getListenerEventType(), ListenerEventType.class);
     tags = Collections.unmodifiableSet(new HashSet<>(job.getTagsList()));
+    // gRPC doesn't have rootProcessInstanceKey - return null
+    rootProcessInstanceKey = null;
   }
 
   public ActivatedJobImpl(
@@ -122,6 +125,10 @@ public final class ActivatedJobImpl implements ActivatedJob {
     listenerEventType = EnumUtil.convert(job.getListenerEventType(), ListenerEventType.class);
     tags =
         job.getTags() == null ? Collections.emptySet() : Collections.unmodifiableSet(job.getTags());
+    rootProcessInstanceKey =
+        job.getRootProcessInstanceKey() != null
+            ? Long.parseLong(job.getRootProcessInstanceKey())
+            : null;
   }
 
   @Override
@@ -247,6 +254,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public Set<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/StreamJobsTest.java
@@ -106,6 +106,8 @@ public final class StreamJobsTest extends ClientTest {
         .isEqualTo(activatedJob1.getProcessDefinitionVersion());
     assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob1.getProcessDefinitionKey());
     assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob1.getProcessInstanceKey());
+    // rootProcessInstanceKey is only returned for REST API
+    assertThat(job.getRootProcessInstanceKey()).isNull();
     assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob1.getCustomHeaders()));
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
@@ -123,6 +125,8 @@ public final class StreamJobsTest extends ClientTest {
         .isEqualTo(activatedJob2.getProcessDefinitionVersion());
     assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob2.getProcessDefinitionKey());
     assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob2.getProcessInstanceKey());
+    // rootProcessInstanceKey is only returned for REST API
+    assertThat(job.getRootProcessInstanceKey()).isNull();
     assertThat(job.getCustomHeaders()).isEqualTo(fromJsonAsMap(activatedJob2.getCustomHeaders()));
     assertThat(job.getWorker()).isEqualTo(activatedJob2.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -71,7 +71,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .variables(singletonMap("key", "val"))
             .tenantId("test-tenant-1")
             .kind(JobKindEnum.BPMN_ELEMENT)
-            .listenerEventType(JobListenerEventTypeEnum.START);
+            .listenerEventType(JobListenerEventTypeEnum.START)
+            .rootProcessInstanceKey("321");
 
     final ActivatedJobResult activatedJob2 =
         new ActivatedJobResult()
@@ -90,7 +91,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .variables(singletonMap("bar", 3))
             .tenantId("test-tenant-2")
             .kind(JobKindEnum.BPMN_ELEMENT)
-            .listenerEventType(JobListenerEventTypeEnum.END);
+            .listenerEventType(JobListenerEventTypeEnum.END)
+            .rootProcessInstanceKey("444");
 
     gatewayService.onActivateJobsRequest(
         new JobActivationResult().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
@@ -123,6 +125,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
         .isEqualTo(activatedJob1.getProcessDefinitionKey());
     assertThat(String.valueOf(job.getProcessInstanceKey()))
         .isEqualTo(activatedJob1.getProcessInstanceKey());
+    assertThat(String.valueOf(job.getRootProcessInstanceKey()))
+        .isEqualTo(activatedJob1.getRootProcessInstanceKey());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob1.getCustomHeaders());
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
@@ -145,6 +149,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
         .isEqualTo(activatedJob2.getProcessDefinitionVersion());
     assertThat(String.valueOf(job.getProcessDefinitionKey()))
         .isEqualTo(activatedJob2.getProcessDefinitionKey());
+    assertThat(String.valueOf(job.getRootProcessInstanceKey()))
+        .isEqualTo(activatedJob2.getRootProcessInstanceKey());
     assertThat(String.valueOf(job.getProcessInstanceKey()))
         .isEqualTo(activatedJob2.getProcessInstanceKey());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob2.getCustomHeaders());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -198,26 +198,35 @@ public final class ResponseMapper {
   }
 
   private static ActivatedJobResult toActivatedJob(final long jobKey, final JobRecord job) {
-    return new ActivatedJobResult()
-        .jobKey(KeyUtil.keyToString(jobKey))
-        .type(job.getType())
-        .processDefinitionId(job.getBpmnProcessId())
-        .elementId(job.getElementId())
-        .processInstanceKey(KeyUtil.keyToString(job.getProcessInstanceKey()))
-        .processDefinitionVersion(job.getProcessDefinitionVersion())
-        .processDefinitionKey(KeyUtil.keyToString(job.getProcessDefinitionKey()))
-        .elementInstanceKey(KeyUtil.keyToString(job.getElementInstanceKey()))
-        .worker(bufferAsString(job.getWorkerBuffer()))
-        .retries(job.getRetries())
-        .deadline(job.getDeadline())
-        .variables(job.getVariables())
-        .customHeaders(job.getCustomHeadersObjectMap())
-        .userTask(toUserTaskProperties(job))
-        .tenantId(job.getTenantId())
-        .kind(EnumUtil.convert(job.getJobKind(), JobKindEnum.class))
-        .listenerEventType(
-            EnumUtil.convert(job.getJobListenerEventType(), JobListenerEventTypeEnum.class))
-        .tags(job.getTags());
+    final var result =
+        new ActivatedJobResult()
+            .jobKey(KeyUtil.keyToString(jobKey))
+            .type(job.getType())
+            .processDefinitionId(job.getBpmnProcessId())
+            .elementId(job.getElementId())
+            .processInstanceKey(KeyUtil.keyToString(job.getProcessInstanceKey()))
+            .processDefinitionVersion(job.getProcessDefinitionVersion())
+            .processDefinitionKey(KeyUtil.keyToString(job.getProcessDefinitionKey()))
+            .elementInstanceKey(KeyUtil.keyToString(job.getElementInstanceKey()))
+            .worker(bufferAsString(job.getWorkerBuffer()))
+            .retries(job.getRetries())
+            .deadline(job.getDeadline())
+            .variables(job.getVariables())
+            .customHeaders(job.getCustomHeadersObjectMap())
+            .userTask(toUserTaskProperties(job))
+            .tenantId(job.getTenantId())
+            .kind(EnumUtil.convert(job.getJobKind(), JobKindEnum.class))
+            .listenerEventType(
+                EnumUtil.convert(job.getJobListenerEventType(), JobListenerEventTypeEnum.class))
+            .tags(job.getTags());
+
+    // rootProcessInstanceKey is only set for process instances created after version 8.9
+    final long rootProcessInstanceKey = job.getRootProcessInstanceKey();
+    if (rootProcessInstanceKey > 0) {
+      result.rootProcessInstanceKey(KeyUtil.keyToString(rootProcessInstanceKey));
+    }
+
+    return result;
   }
 
   private static UserTaskProperties toUserTaskProperties(final JobRecord job) {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -415,6 +415,8 @@ components:
           $ref: '#/components/schemas/UserTaskProperties'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        rootProcessInstanceKey:
+          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
 
     UserTaskProperties:
       type: object


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Exposes `rootProcessInstanceKey` field in ActivatedJob REST response (response of `POST /jobs/activation`), and in the Java client `ActivatedJob` class 
`rootProcessInstanceKey` is only set for REST and for activated jobs belonging to PI hierarchies created in 8.9+. It will be returned as null for older data and for gRPC.

`rootProcessInstanceKey` was added to search and getById query APIs responses in https://github.com/camunda/camunda/pull/45314 , full list of updated endpoints can be found in https://github.com/camunda/camunda/issues/43395

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/43395
