### PR TITLE
Deprecate memory allocation strategy for 8.10.

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -70,12 +70,7 @@ public class RocksDb {
    * value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
-   *
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
    */
-  @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
 
   /**
@@ -185,22 +180,10 @@ public class RocksDb {
     this.memoryLimit = memoryLimit;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -71,9 +71,9 @@ public class RocksDb {
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    *
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
@@ -186,9 +186,9 @@ public class RocksDb {
   }
 
   /**
-   * @deprecated This configuration will be removed in a future release (deprecated in 8.10). The
-   *     default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the
-   *     recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
@@ -196,9 +196,9 @@ public class RocksDb {
   }
 
   /**
-   * @deprecated This configuration will be removed in a future release (deprecated in 8.10). The
-   *     default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the
-   *     recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -70,7 +70,12 @@ public class RocksDb {
    * value is set to 'BROKER', the total memory allocated to RocksDB will be equal to the configured
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
+   *
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
    */
+  @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
 
   /**
@@ -180,10 +185,22 @@ public class RocksDb {
     this.memoryLimit = memoryLimit;
   }
 
+  /**
+   * @deprecated This configuration will be removed in a future release (deprecated in 8.10). The
+   *     default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the
+   *     recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
+  /**
+   * @deprecated This configuration will be removed in a future release (deprecated in 8.10). The
+   *     default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the
+   *     recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
   }

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -71,7 +71,7 @@ public class RocksDb {
    * memory limit. If set to 'FRACTION', Zeebe will allocate a configurable percentage of total RAM
    * to RocksDB that can be configured via the memoryFraction configuration [0,1].
    */
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
 
   /**
    * Configures the fraction of total system memory to allocate to RocksDB when using the 'FRACTION'

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -67,8 +67,10 @@ public class RocksDbSharedCache {
       // check that memoryFraction is between 0 and 1 and warn if it is too high
       warnIfTooHighFraction(rocksdbCfg);
     } else {
-      LOGGER.warn(
-          "Note: This configuration will be deprecated in 8.10, and the default behaviour will be per FRACTION strategy. Please use the recommended alternative configuration for memory allocation.");
+      if (rocksdbCfg.getMemoryAllocationStrategy() == MemoryAllocationStrategy.PARTITION) {
+        LOGGER.warn(
+            "Note: CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYFRACTION is set to PARTITION, this configuration will be set to FRACTION by default in 8.10. If the intended goal is to use PARTITION strategy, please set it explicitly.");
+      }
       // for strategies other than FRACTION which are static sizes, we check if maxMemoryFraction is
       // correctly set, and if so, we validate the allocated memory does not go above the threshold.
       validateMaxMemoryFraction(rocksdbCfg, totalMemorySize, blockCacheBytes);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -67,6 +67,8 @@ public class RocksDbSharedCache {
       // check that memoryFraction is between 0 and 1 and warn if it is too high
       warnIfTooHighFraction(rocksdbCfg);
     } else {
+      LOGGER.warn(
+          "Note: This configuration will be deprecated in 8.10, and the default behaviour will be per FRACTION strategy. Please use the recommended alternative configuration for memory allocation.");
       // for strategies other than FRACTION which are static sizes, we check if maxMemoryFraction is
       // correctly set, and if so, we validate the allocated memory does not go above the threshold.
       validateMaxMemoryFraction(rocksdbCfg, totalMemorySize, blockCacheBytes);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -31,9 +31,9 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
@@ -94,9 +94,9 @@ public final class RocksdbCfg implements ConfigurationEntry {
   }
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
@@ -104,9 +104,9 @@ public final class RocksdbCfg implements ConfigurationEntry {
   }
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -29,7 +29,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.FRACTION;
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
   private double memoryFraction = 0.1;
   private double maxMemoryFraction = -1;
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -29,15 +29,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
-
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
-
   private double memoryFraction = 0.1;
   private double maxMemoryFraction = -1;
 
@@ -93,22 +85,10 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.memoryFraction = memoryFraction;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -29,7 +29,15 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
   private boolean enableSstPartitioning = RocksDbConfiguration.DEFAULT_SST_PARTITIONING_ENABLED;
+
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+
   private double memoryFraction = 0.1;
   private double maxMemoryFraction = -1;
 
@@ -85,10 +93,22 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.memoryFraction = memoryFraction;
   }
 
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public void setMemoryAllocationStrategy(final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;
   }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -72,12 +72,6 @@ public final class RocksDbConfiguration {
    */
   private int ioRateBytesPerSecond = DEFAULT_IO_RATE_BYTES_PER_SECOND;
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   private MemoryAllocationStrategy memoryAllocationStrategy =
       DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
 
@@ -165,22 +159,10 @@ public final class RocksDbConfiguration {
     return this;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
-  /**
-   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
-   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
-   *     alternative configuration for memory allocation.
-   */
-  @Deprecated
   public RocksDbConfiguration setMemoryAllocationStrategy(
       final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -72,8 +72,12 @@ public final class RocksDbConfiguration {
    */
   private int ioRateBytesPerSecond = DEFAULT_IO_RATE_BYTES_PER_SECOND;
 
-  private MemoryAllocationStrategy memoryAllocationStrategy =
-      DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). Please use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
+  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
 
   public RocksDbConfiguration() {}
 
@@ -159,10 +163,22 @@ public final class RocksDbConfiguration {
     return this;
   }
 
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
     return memoryAllocationStrategy;
   }
 
+  /**
+   * @deprecated This configuration property will be removed in a future release (deprecated in
+   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
+   *     use the recommended alternative configuration for memory allocation.
+   */
+  @Deprecated
   public RocksDbConfiguration setMemoryAllocationStrategy(
       final MemoryAllocationStrategy memoryAllocationStrategy) {
     this.memoryAllocationStrategy = memoryAllocationStrategy;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -43,7 +43,7 @@ public final class RocksDbConfiguration {
 
   public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
   public static final MemoryAllocationStrategy DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY =
-      MemoryAllocationStrategy.FRACTION;
+      MemoryAllocationStrategy.PARTITION;
   private Properties columnFamilyOptions = new Properties();
   private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
   private long memoryLimit = DEFAULT_MEMORY_LIMIT;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -73,11 +73,13 @@ public final class RocksDbConfiguration {
   private int ioRateBytesPerSecond = DEFAULT_IO_RATE_BYTES_PER_SECOND;
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). Please use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
-  private MemoryAllocationStrategy memoryAllocationStrategy = MemoryAllocationStrategy.PARTITION;
+  private MemoryAllocationStrategy memoryAllocationStrategy =
+      DEFAULT_ROCKSDB_MEMORY_ALLOCATION_STRATEGY;
 
   public RocksDbConfiguration() {}
 
@@ -164,9 +166,9 @@ public final class RocksDbConfiguration {
   }
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public MemoryAllocationStrategy getMemoryAllocationStrategy() {
@@ -174,9 +176,9 @@ public final class RocksDbConfiguration {
   }
 
   /**
-   * @deprecated This configuration property will be removed in a future release (deprecated in
-   *     8.10). The default behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please
-   *     use the recommended alternative configuration for memory allocation.
+   * @deprecated This configuration property is deprecated and will be removed in 8.10. The default
+   *     behavior will be per {@link MemoryAllocationStrategy#FRACTION}. Please use the recommended
+   *     alternative configuration for memory allocation.
    */
   @Deprecated
   public RocksDbConfiguration setMemoryAllocationStrategy(


### PR DESCRIPTION
## Description

This PR makes the default memory allocation strategy PARTITION in preparation for the 8.9 release. 
Additionally, it also deprecates this configuration and warns that the default behaviour will be `FRACTION` in 8.10.
See [thread](https://camunda.slack.com/archives/C09RELB6D5G/p1770816635981659) for explanation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
