### PR TITLE
feat: bump zod schema version to 0.0.38

### DIFF
--- a/client-components/package-lock.json
+++ b/client-components/package-lock.json
@@ -3944,7 +3944,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.37",
+			"version": "0.0.38",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.2.3",

--- a/client-components/packages/camunda-api-zod-schemas/package.json
+++ b/client-components/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.37",
+	"version": "0.0.38",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Bump zod schema version to 0.0.38

## Related issues

related to https://github.com/camunda/camunda/issues/44946
