### PR TITLE
ci: use digest-based inspection for multi-arch Docker images

### DIFF
--- a/.github/actions/verify-platform-docker/action.yml
+++ b/.github/actions/verify-platform-docker/action.yml
@@ -47,6 +47,5 @@ runs:
         declare -a platforms=(${PLATFORMS_RAW//,/ })
 
         for platform in "${platforms[@]}"; do
-          docker pull --platform "$platform" "${{ inputs.imageName }}:${VERSION}"
           ${PWD}/.ci/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$(echo $platform | cut -d '/' -f 2)"
         done


### PR DESCRIPTION
## Description

Update verify.sh to extract platform-specific digests from the manifest
using `docker buildx imagetools inspect --raw`, then pull and inspect
by digest. This approach works reliably with Docker CLI v29+ where the
containerd image store handles multi-arch images differently.

The verify-platform-docker action no longer needs to pull images
upfront since the script handles platform-specific pulls internally.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
