### PR TITLE
ci: fix docker image verification by removing verified image

### DIFF
--- a/.github/actions/verify-platform-docker/action.yml
+++ b/.github/actions/verify-platform-docker/action.yml
@@ -49,4 +49,5 @@ runs:
         for platform in "${platforms[@]}"; do
           docker pull --platform "$platform" "${{ inputs.imageName }}:${VERSION}"
           ${PWD}/.ci/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$(echo $platform | cut -d '/' -f 2)"
+          docker image rm --platform "$platform" "${{ inputs.imageName }}:${VERSION}"
         done


### PR DESCRIPTION
Workaround for https://github.com/moby/moby/issues/51779.
The `docker pull` actually pulls for all platforms now, even though we are only requesting one, breaking our verification script which only expects one platform. Rather than adjusting the script to support multiple platforms being available at once, we now just remove the image of the wrong platform.