### PR TITLE
fix: Handle BatchOperation.INITIALIZED event in RDBMS exporter to align state lifecycle with ES/OS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -28,6 +28,8 @@ public interface BatchOperationMapper extends HistoryCleanupMapper {
 
   void insertErrors(BatchOperationErrorsDto error);
 
+  void activate(BatchOperationActivateDto dto);
+
   void updateCompleted(BatchOperationUpdateDto dto);
 
   void updateItemsWithState(BatchOperationItemStatusUpdateDto dto);
@@ -53,6 +55,8 @@ public interface BatchOperationMapper extends HistoryCleanupMapper {
   record CleanupBatchOperationHistoryDto(OffsetDateTime cleanupDate, int limit) {}
 
   record UpdateHistoryCleanupDateDto(String batchOperationKey, OffsetDateTime historyCleanupDate) {}
+
+  record BatchOperationActivateDto(String batchOperationKey, OffsetDateTime startDate) {}
 
   record BatchOperationUpdateDto(
       String batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationActivateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationErrorsDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemStatusUpdateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
@@ -75,6 +76,16 @@ public class BatchOperationWriter implements RdbmsWriter {
             batchOperation));
     LOGGER.trace("Force flush to directly create batch operation: {}", batchOperation);
     executionQueue.flush();
+  }
+
+  public void activate(final String batchOperationKey, final OffsetDateTime startDate) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.UPDATE,
+            batchOperationKey,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.activate",
+            new BatchOperationActivateDto(batchOperationKey, startDate)));
   }
 
   public void updateBatchAndInsertItems(

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -86,6 +86,14 @@
     </foreach>
   </insert>
 
+  <update id="activate"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationActivateDto">
+    UPDATE ${prefix}BATCH_OPERATION
+    SET STATE      = 'ACTIVE',
+        START_DATE = #{startDate, jdbcType=TIMESTAMP}
+    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+  </update>
+
   <update id="updateCompleted"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateDto">
     UPDATE ${prefix}BATCH_OPERATION

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -83,22 +83,49 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   @Test
-  public void shouldExportActiveBatchOperation() {
+  public void shouldExportCreatedBatchOperation() {
     // given
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
+    assertThat(batchOperation)
+        .hasValueSatisfying(
+            entity -> {
+              assertThat(entity.state()).isEqualTo(BatchOperationState.CREATED);
+              assertThat(entity.startDate()).isNull();
+            });
+  }
+
+  @Test
+  public void shouldExportInitializedBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
-    assertThat(batchOperation).isNotNull();
-    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
-    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey));
+    assertThat(batchOperation)
+        .hasValueSatisfying(
+            entity -> {
+              assertThat(entity.operationsTotalCount()).isEqualTo(3);
+              assertThat(entity.state()).isEqualTo(BatchOperationState.ACTIVE);
+              assertThat(entity.startDate()).isNotNull();
+            });
   }
 
   @Test
@@ -215,6 +242,8 @@ class RdbmsExporterBatchOperationsIT {
     // given
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var canceledProcessRecord =
@@ -222,6 +251,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(canceledProcessRecord);
 
@@ -241,6 +271,8 @@ class RdbmsExporterBatchOperationsIT {
     // given
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var canceledProcessRecord =
@@ -248,6 +280,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(canceledProcessRecord);
 
@@ -271,6 +304,8 @@ class RdbmsExporterBatchOperationsIT {
     // given
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var rejectedCancelProcessRecord =
@@ -278,6 +313,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(rejectedCancelProcessRecord);
 
@@ -297,6 +333,8 @@ class RdbmsExporterBatchOperationsIT {
     // given
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var rejectedCancelProcessRecord =
@@ -304,6 +342,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(rejectedCancelProcessRecord);
 
@@ -328,6 +367,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.RESOLVE_INCIDENT);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var incidentKey = 1L;
     final var incidentResolvedRecord =
@@ -335,6 +376,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(incidentResolvedRecord);
 
@@ -354,6 +396,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.RESOLVE_INCIDENT);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var incidentKey = 1L;
     final var resolveIncidentFailedRecord =
@@ -361,6 +405,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(resolveIncidentFailedRecord);
 
@@ -380,6 +425,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var processMigratedRecord =
@@ -387,6 +434,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(processMigratedRecord);
 
@@ -406,6 +454,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var processFailedMigrateRecord =
@@ -414,6 +464,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(processFailedMigrateRecord);
 
@@ -433,6 +484,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var processInstanceModifiedRecord =
@@ -441,6 +494,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(processInstanceModifiedRecord);
 
@@ -460,6 +514,8 @@ class RdbmsExporterBatchOperationsIT {
     final var batchOperationCreatedRecord =
         FIXTURES.getBatchOperationCreatedRecord(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
     final var processInstanceKey = 1L;
     final var modifyProcessIncidentFailedRecord =
@@ -468,6 +524,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // when
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(modifyProcessIncidentFailedRecord);
 
@@ -484,9 +541,12 @@ class RdbmsExporterBatchOperationsIT {
   private long givenBatchOperationIsCreatedAndIsActive() {
     final var batchOperationCreatedRecord = FIXTURES.getBatchOperationCreatedRecord();
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationInitializedRecord =
+        FIXTURES.getBatchOperationInitializedRecord(batchOperationKey);
     final var batchOperationChunkRecord = FIXTURES.getBatchOperationChunkRecord(batchOperationKey);
 
     exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationInitializedRecord);
     exporter.export(batchOperationChunkRecord);
     final var batchOperation =
         rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationInitializationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
@@ -633,6 +634,26 @@ public class RecordFixtures {
             ImmutableBatchOperationCreationRecordValue.builder()
                 .from((ImmutableBatchOperationCreationRecordValue) recordValueRecord.getValue())
                 .withBatchOperationType(type)
+                .build())
+        .build();
+  }
+
+  public ImmutableRecord<RecordValue> getBatchOperationInitializedRecord(
+      final Long batchOperationKey) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.BATCH_OPERATION_INITIALIZATION);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(BatchOperationIntent.INITIALIZED)
+        .withPosition(nextPosition())
+        .withPartitionId(1)
+        .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableBatchOperationInitializationRecordValue.builder()
+                .from(
+                    (ImmutableBatchOperationInitializationRecordValue) recordValueRecord.getValue())
+                .withBatchOperationKey(batchOperationKey)
                 .build())
         .build();
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -47,6 +47,7 @@ import io.camunda.exporter.rdbms.handlers.UserTaskExportHandler;
 import io.camunda.exporter.rdbms.handlers.VariableExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationChunkExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationCreatedExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationInitializedExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationLifecycleManagementExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.DecisionInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.IncidentBatchOperationExportHandler;
@@ -289,6 +290,9 @@ public class RdbmsExporterWrapper implements Exporter {
         ValueType.BATCH_OPERATION_CREATION,
         new BatchOperationCreatedExportHandler(
             rdbmsWriters.getBatchOperationWriter(), batchOperationCache));
+    builder.withHandler(
+        ValueType.BATCH_OPERATION_INITIALIZATION,
+        new BatchOperationInitializedExportHandler(rdbmsWriters.getBatchOperationWriter()));
     builder.withHandler(
         ValueType.BATCH_OPERATION_CHUNK,
         new BatchOperationChunkExportHandler(rdbmsWriters.getBatchOperationWriter()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
-import io.camunda.zeebe.util.DateUtil;
 import io.camunda.zeebe.util.SemanticVersion;
 
 /**
@@ -63,9 +62,8 @@ public class BatchOperationCreatedExportHandler
     final String batchOperationKey = String.valueOf(record.getKey());
     return new BatchOperationDbModel.Builder()
         .batchOperationKey(batchOperationKey)
-        .state(BatchOperationState.ACTIVE)
+        .state(BatchOperationState.CREATED)
         .operationType(BatchOperationType.valueOf(value.getBatchOperationType().name()))
-        .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
         .actorType(actorInfo.type())
         .actorId(actorInfo.id())
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationInitializedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationInitializedExportHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationInitializationRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+
+/**
+ * Exports a batch operation initialization record to the database. This handler transitions the
+ * batch operation to {@code ACTIVE} state and sets the {@code startDate}.
+ */
+public class BatchOperationInitializedExportHandler
+    implements RdbmsExportHandler<BatchOperationInitializationRecordValue> {
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public BatchOperationInitializedExportHandler(final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<BatchOperationInitializationRecordValue> record) {
+    return record.getValueType() == ValueType.BATCH_OPERATION_INITIALIZATION
+        && record.getIntent().equals(BatchOperationIntent.INITIALIZED);
+  }
+
+  @Override
+  public void export(final Record<BatchOperationInitializationRecordValue> record) {
+    final var value = record.getValue();
+    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
+    final var startDate = DateUtil.toOffsetDateTime(record.getTimestamp());
+    batchOperationWriter.activate(batchOperationKey, startDate);
+  }
+}


### PR DESCRIPTION
## Description

This PR aligns the RDBMS exporter's `BatchOperation` lifecycle handling with the ES/OS exporter by introducing support for the `INITIALIZED` event.

### Why

The RDBMS exporter was missing handling for the `BatchOperation.INITIALIZED` event. This caused batch operations to be created directly in `ACTIVE` state with `startDate` set on the `CREATED` event — diverging from ES/OS, which follows a `CREATED` -> `ACTIVE` transition and only sets `startDate` upon `INITIALIZED`. This inconsistency may lead to different API responses depending on the storage backend.

### How

### RDBMS exporter changes
- **`BatchOperationCreatedExportHandler`**: Now creates records in `CREATED` state without setting `startDate`, matching the ES/OS `CREATED` event semantics.
- **`BatchOperationInitializedExportHandler`** *(new)*: Handles `BATCH_OPERATION_INITIALIZATION[INITIALIZED]` events - transitions the batch operation to `ACTIVE` state and sets `startDate` from the record timestamp, mirroring the ES/OS `BatchOperationInitializedHandler`.
- **`RdbmsExporterWrapper`**: Registers the new `BatchOperationInitializedExportHandler` for `ValueType.BATCH_OPERATION_INITIALIZATION`.

### Data layer changes
- **`BatchOperationMapper`**: Added `activate(BatchOperationActivateDto)` method and `BatchOperationActivateDto` record.
- **`BatchOperationMapper.xml`**: Added `activate` SQL update statement that sets `STATE = 'ACTIVE'` and `START_DATE` by `BATCH_OPERATION_KEY`.
- **`BatchOperationWriter`**: Added `activate(batchOperationKey, startDate)` method that enqueues the activation update.

### Tests
- Added `shouldActivateBatchOperation` test to `BatchOperationIT` that verifies a batch operation in `CREATED` state transitions to `ACTIVE` with the correct `startDate` after calling `activate`.
- Fix test failures in `RdbmsExporterBatchOperationsIT` and `RdbmsExporterIT` caused by moving `ACTIVE` state transition logic from the `CREATED` event handler to the new `INITIALIZED` event handler, by adding `batchOperationInitializedRecord` export to all test methods that create batch operations and expect `ACTIVE` state.

## State lifecycle (before & after this change)

| Event         | RDBMS (before) | RDBMS (after) | ES/OS       |
|---------------|----------------|---------------|-------------|
| `CREATED`     | `ACTIVE` + `startDate` | `CREATED` (no `startDate`) | `CREATED` (no `startDate`) |
| `INITIALIZED` | *(not handled)* | `ACTIVE` + `startDate` | `ACTIVE` + `startDate` |

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44899
