### PR TITLE
[Backport stable/8.8] ci: use digest-based inspection for multi-arch Docker images

### DIFF
--- a/.github/actions/verify-platform-docker/action.yml
+++ b/.github/actions/verify-platform-docker/action.yml
@@ -47,6 +47,5 @@ runs:
         declare -a platforms=(${PLATFORMS_RAW//,/ })
 
         for platform in "${platforms[@]}"; do
-          docker pull --platform "$platform" "${{ inputs.imageName }}:${VERSION}"
           ${PWD}/.ci/docker/test/verify.sh "${{ inputs.imageName }}:${VERSION}" "$(echo $platform | cut -d '/' -f 2)"
         done


### PR DESCRIPTION
# Description
Backport of #45721 to `stable/8.8`.

relates to 