### PR TITLE
feat: add tenantfilter to rest api

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -79,6 +79,7 @@ import io.camunda.gateway.protocol.model.SetVariableRequest;
 import io.camunda.gateway.protocol.model.SignalBroadcastRequest;
 import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
 import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
+import io.camunda.gateway.protocol.model.TenantFilterEnum;
 import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
 import io.camunda.gateway.protocol.model.UserTaskAssignmentRequest;
 import io.camunda.gateway.protocol.model.UserTaskCompletionRequest;
@@ -118,6 +119,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.Part;
 import java.io.IOException;
@@ -125,6 +127,7 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -203,27 +206,23 @@ public class RequestMapper {
   public static Either<ProblemDetail, ActivateJobsRequest> toJobsActivationRequest(
       final JobActivationRequest activationRequest, final boolean multiTenancyEnabled) {
 
-    final Either<ProblemDetail, List<String>> validationResponse =
-        validateTenantIds(
-                getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds),
-                multiTenancyEnabled,
-                "Activate Jobs")
-            .flatMap(
-                tenantIds ->
-                    validateJobActivationRequest(activationRequest)
-                        .map(Either::<ProblemDetail, List<String>>left)
-                        .orElseGet(() -> Either.right(tenantIds)));
+    final var tenantFilter = convertTenantFilter(activationRequest.getTenantFilter());
 
-    return validationResponse.map(
-        tenantIds ->
-            new ActivateJobsRequest(
-                activationRequest.getType(),
-                activationRequest.getMaxJobsToActivate(),
-                tenantIds,
-                activationRequest.getTimeout(),
-                getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
-                getStringListOrEmpty(activationRequest, JobActivationRequest::getFetchVariable),
-                getLongOrZero(activationRequest, JobActivationRequest::getRequestTimeout)));
+    // Validate job activation request
+    final var jobValidationError = validateJobActivationRequest(activationRequest);
+    if (jobValidationError.isPresent()) {
+      return Either.left(jobValidationError.get());
+    }
+
+    // Resolve and validate tenant IDs based on filter
+    final Either<ProblemDetail, List<String>> tenantIdsResult =
+        resolveTenantIds(activationRequest, tenantFilter, multiTenancyEnabled);
+    if (tenantIdsResult.isLeft()) {
+      return Either.left(tenantIdsResult.getLeft());
+    }
+
+    return Either.right(
+        buildActivateJobsRequest(activationRequest, tenantIdsResult.get(), tenantFilter));
   }
 
   public static FailJobRequest toJobFailRequest(
@@ -913,6 +912,56 @@ public class RequestMapper {
                 getKeyOrDefault(
                     request, ConditionalEvaluationInstruction::getProcessDefinitionKey, -1L),
                 request.getVariables()));
+  }
+
+  private static TenantFilter convertTenantFilter(final TenantFilterEnum gatewayFilter) {
+    if (gatewayFilter == null) {
+      return TenantFilter.PROVIDED;
+    }
+
+    return switch (gatewayFilter) {
+      case TenantFilterEnum.ASSIGNED -> TenantFilter.ASSIGNED;
+      case TenantFilterEnum.PROVIDED -> TenantFilter.PROVIDED;
+    };
+  }
+
+  private static Either<ProblemDetail, List<String>> resolveTenantIds(
+      final JobActivationRequest activationRequest,
+      final TenantFilter tenantFilter,
+      final boolean multiTenancyEnabled) {
+
+    // ASSIGNED filter requires multi-tenancy to be enabled
+    if (tenantFilter == TenantFilter.ASSIGNED) {
+      if (!multiTenancyEnabled) {
+        return Either.left(
+            GatewayErrorMapper.createProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                "Expected to handle request Activate Jobs with ASSIGNED tenant filter, but multi-tenancy is disabled",
+                INVALID_ARGUMENT.name()));
+      }
+      return Either.right(Collections.emptyList());
+    }
+
+    // PROVIDED filter - validate the provided tenant IDs
+    final List<String> providedTenantIds =
+        getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds);
+    return validateTenantIds(providedTenantIds, multiTenancyEnabled, "Activate Jobs");
+  }
+
+  private static ActivateJobsRequest buildActivateJobsRequest(
+      final JobActivationRequest activationRequest,
+      final List<String> tenantIds,
+      final TenantFilter tenantFilter) {
+
+    return new ActivateJobsRequest(
+        activationRequest.getType(),
+        activationRequest.getMaxJobsToActivate(),
+        tenantIds,
+        tenantFilter,
+        activationRequest.getTimeout(),
+        getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
+        getStringListOrEmpty(activationRequest, JobActivationRequest::getFetchVariable),
+        getLongOrZero(activationRequest, JobActivationRequest::getRequestTimeout));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -930,7 +930,6 @@ public class RequestMapper {
       final TenantFilter tenantFilter,
       final boolean multiTenancyEnabled) {
 
-    // ASSIGNED filter requires multi-tenancy to be enabled
     if (tenantFilter == TenantFilter.ASSIGNED) {
       if (!multiTenancyEnabled) {
         return Either.left(
@@ -942,7 +941,6 @@ public class RequestMapper {
       return Either.right(Collections.emptyList());
     }
 
-    // PROVIDED filter - validate the provided tenant IDs
     final List<String> providedTenantIds =
         getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds);
     return validateTenantIds(providedTenantIds, multiTenancyEnabled, "Activate Jobs");

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -12,14 +12,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.DeleteResourceRequest;
+import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationPlan;
 import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
+import io.camunda.gateway.protocol.model.TenantFilterEnum;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -251,6 +254,296 @@ class RequestMapperTest {
       assertThat(problemDetail.getStatus()).isEqualTo(400);
       assertThat(problemDetail.getDetail()).contains("operationReference");
       assertThat(problemDetail.getDetail()).contains("> 0");
+    }
+  }
+
+  @Nested
+  class JobActivationRequestMappingTest {
+
+    @Test
+    void shouldMapJobActivationWithProvidedTenantFilterAndTenantIds() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a")
+              .addTenantIdsItem("tenant-b");
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.type()).isEqualTo("test-job");
+      assertThat(activateJobsRequest.maxJobsToActivate()).isEqualTo(10);
+      assertThat(activateJobsRequest.timeout()).isEqualTo(5000L);
+      assertThat(activateJobsRequest.tenantIds()).containsExactly("tenant-a", "tenant-b");
+      assertThat(activateJobsRequest.tenantFilter()).isEqualTo(TenantFilter.PROVIDED);
+    }
+
+    @Test
+    void shouldMapJobActivationWithAssignedTenantFilterAndNoTenantIds() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(5)
+              .timeout(3000L)
+              .tenantFilter(TenantFilterEnum.ASSIGNED);
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.type()).isEqualTo("test-job");
+      assertThat(activateJobsRequest.tenantIds())
+          .describedAs("With ASSIGNED filter, tenant IDs should be empty")
+          .isEmpty();
+      assertThat(activateJobsRequest.tenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+    }
+
+    @Test
+    void shouldIgnoreTenantIdsWhenAssignedTenantFilterIsUsed() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(5)
+              .timeout(3000L)
+              .addTenantIdsItem("tenant-a")
+              .addTenantIdsItem("tenant-b")
+              .tenantFilter(TenantFilterEnum.ASSIGNED);
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.tenantIds())
+          .describedAs(
+              "Provided tenant IDs should be ignored when ASSIGNED filter is used. "
+                  + "Tenant IDs will be determined from authorized tenants instead.")
+          .isEmpty();
+      assertThat(activateJobsRequest.tenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
+    }
+
+    @Test
+    void shouldRejectProvidedFilterWithoutTenantIdsWhenMultiTenancyEnabled() {
+      // given
+      final var request =
+          new JobActivationRequest().type("test-job").maxJobsToActivate(10).timeout(5000L);
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("Activate Jobs");
+      assertThat(problemDetail.getDetail()).contains("no tenant identifier");
+    }
+
+    @Test
+    void shouldDefaultToProvidedTenantFilterWhenNotSpecified() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.tenantFilter())
+          .describedAs("When no tenant filter is specified, it should default to PROVIDED")
+          .isEqualTo(TenantFilter.PROVIDED);
+      assertThat(activateJobsRequest.tenantIds()).containsExactly("tenant-a");
+    }
+
+    @Test
+    void shouldMapJobActivationWithDefaultTenantWhenMultiTenancyDisabled() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(5)
+              .timeout(3000L)
+              .worker("test-worker");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, false);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.tenantIds())
+          .describedAs(
+              "When multi-tenancy is disabled, default tenant ID should be automatically added")
+          .containsExactly("<default>");
+      assertThat(activateJobsRequest.tenantFilter()).isEqualTo(TenantFilter.PROVIDED);
+    }
+
+    @Test
+    void shouldRejectNonDefaultTenantIdWhenMultiTenancyDisabled() {
+      // given - tenant ID provided when multi-tenancy is disabled
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, false);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("multi-tenancy is disabled");
+    }
+
+    @Test
+    void shouldMapJobActivationWithAllFields() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("complex-job")
+              .maxJobsToActivate(15)
+              .timeout(10000L)
+              .worker("worker-123")
+              .requestTimeout(30000L)
+              .addFetchVariableItem("var1")
+              .addFetchVariableItem("var2")
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.type()).isEqualTo("complex-job");
+      assertThat(activateJobsRequest.maxJobsToActivate()).isEqualTo(15);
+      assertThat(activateJobsRequest.timeout()).isEqualTo(10000L);
+      assertThat(activateJobsRequest.worker()).isEqualTo("worker-123");
+      assertThat(activateJobsRequest.requestTimeout()).isEqualTo(30000L);
+      assertThat(activateJobsRequest.fetchVariable()).containsExactly("var1", "var2");
+      assertThat(activateJobsRequest.tenantIds()).containsExactly("tenant-a");
+    }
+
+    @Test
+    void shouldRejectJobActivationWithInvalidType() {
+      // given - request with empty type
+      final var request =
+          new JobActivationRequest()
+              .type("")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("type");
+    }
+
+    @Test
+    void shouldRejectJobActivationWithInvalidMaxJobsToActivate() {
+      // given - request with invalid maxJobsToActivate
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(0)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("maxJobsToActivate");
+    }
+
+    @Test
+    void shouldRejectJobActivationWithInvalidTimeout() {
+      // given - request with invalid timeout
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(0L)
+              .addTenantIdsItem("tenant-a");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("timeout");
+    }
+
+    @Test
+    void shouldMapJobActivationWithMultipleTenantIds() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .addTenantIdsItem("tenant-a")
+              .addTenantIdsItem("tenant-b")
+              .addTenantIdsItem("tenant-c");
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var activateJobsRequest = result.get();
+      assertThat(activateJobsRequest.tenantIds())
+          .containsExactly("tenant-a", "tenant-b", "tenant-c");
+    }
+
+    @Test
+    void shouldRejectAssignedTenantFilterWhenMultiTenancyDisabled() {
+      // given
+      final var request =
+          new JobActivationRequest()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .tenantFilter(TenantFilterEnum.ASSIGNED);
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, false);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail())
+          .contains("ASSIGNED tenant filter")
+          .contains("multi-tenancy is disabled");
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -78,6 +79,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
         new BrokerActivateJobsRequest(request.type())
             .setMaxJobsToActivate(request.maxJobsToActivate())
             .setTenantIds(request.tenantIds())
+            .setTenantFilter(request.tenantFilter())
             .setTimeout(request.timeout())
             .setWorker(request.worker())
             .setVariables(request.fetchVariable());
@@ -153,6 +155,7 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       String type,
       int maxJobsToActivate,
       List<String> tenantIds,
+      TenantFilter tenantFilter,
       long timeout,
       String worker,
       List<String> fetchVariable,

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -300,6 +300,13 @@ components:
           type: array
           items:
             $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        tenantFilter:
+          allOf:
+            - $ref: '#/components/schemas/TenantFilterEnum'
+          description: >
+            The tenant filtering strategy - determines whether to use provided tenant IDs or
+            assigned tenant IDs from the authenticated principal's authorized tenants.
+          default: PROVIDED
       required:
         - type
         - timeout
@@ -935,6 +942,17 @@ components:
           nullable: true
 
     ## Enums
+
+    TenantFilterEnum:
+      description: >
+        The tenant filtering strategy for job activation.
+        Determines whether to use tenant IDs provided in the request or tenant IDs
+        assigned to the authenticated principal.
+      type: string
+      enum:
+        - PROVIDED
+        - ASSIGNED
+      default: PROVIDED
 
     JobStateEnum:
       description: The state of the job.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements the new TenantFilter support in the REST gateway (the gRPC implementation can be seen [here](https://github.com/camunda/camunda/pull/45617)). Things to note:

 * We default to `TenantFilter.PROVIDED` when no value is specific to maintain backwards compatibility
 * The existing tenantId check remains in-place considering the multitenancy flag
 * We mirror the handling of mutitenancy being enabled and tenantIds being provided when the filter is ASSIGNED
 * When `TenantFilter.ASSIGNED` is provided we mirror the gRPC side and provide an empty tenantId list.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45343, closes https://github.com/camunda/camunda/issues/45344, closes https://github.com/camunda/camunda/issues/45346
