### PR TITLE
Expose configuration property for business id uniqueness validation

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -28,6 +28,9 @@ public class Camunda {
   @NestedConfigurationProperty private Security security = new Security();
   @NestedConfigurationProperty private Expression expression = new Expression();
 
+  @NestedConfigurationProperty
+  private ProcessInstanceCreation processInstanceCreation = new ProcessInstanceCreation();
+
   public Cluster getCluster() {
     return cluster;
   }
@@ -90,5 +93,13 @@ public class Camunda {
 
   public void setExpression(final Expression expression) {
     this.expression = expression;
+  }
+
+  public ProcessInstanceCreation getProcessInstanceCreation() {
+    return processInstanceCreation;
+  }
+
+  public void setProcessInstanceCreation(final ProcessInstanceCreation processInstanceCreation) {
+    this.processInstanceCreation = processInstanceCreation;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -18,10 +18,6 @@ public class Engine {
   @NestedConfigurationProperty
   private EngineBatchOperation batchOperations = new EngineBatchOperation();
 
-  /** Configuration properties for the engine's process instance creation settings. */
-  @NestedConfigurationProperty
-  private ProcessInstanceCreation processInstanceCreation = new ProcessInstanceCreation();
-
   public Distribution getDistribution() {
     return distribution;
   }
@@ -36,13 +32,5 @@ public class Engine {
 
   public void setBatchOperations(final EngineBatchOperation batchOperations) {
     this.batchOperations = batchOperations;
-  }
-
-  public ProcessInstanceCreation getProcessInstanceCreation() {
-    return processInstanceCreation;
-  }
-
-  public void setProcessInstanceCreation(final ProcessInstanceCreation processInstanceCreation) {
-    this.processInstanceCreation = processInstanceCreation;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -18,6 +18,10 @@ public class Engine {
   @NestedConfigurationProperty
   private EngineBatchOperation batchOperations = new EngineBatchOperation();
 
+  /** Configuration properties for the engine's process instance creation settings. */
+  @NestedConfigurationProperty
+  private ProcessInstanceCreation processInstanceCreation = new ProcessInstanceCreation();
+
   public Distribution getDistribution() {
     return distribution;
   }
@@ -32,5 +36,13 @@ public class Engine {
 
   public void setBatchOperations(final EngineBatchOperation batchOperations) {
     this.batchOperations = batchOperations;
+  }
+
+  public ProcessInstanceCreation getProcessInstanceCreation() {
+    return processInstanceCreation;
+  }
+
+  public void setProcessInstanceCreation(final ProcessInstanceCreation processInstanceCreation) {
+    this.processInstanceCreation = processInstanceCreation;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -17,17 +17,15 @@ public class ProcessInstanceCreation {
           "zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled");
 
   /**
-   * Whether to enable business id uniqueness check when creating process instances using a
-   * BusinessId.
+   * Controls uniqueness enforcement of business IDs across active process instances.
    *
-   * <p>If enabled, the broker will check if there is already an existing active root process
-   * instance with the same business id and reject the creation if there is.
-   *
-   * <p>This is disabled by default, but can be enabled to prevent duplicate process instances with
-   * the same business id from being created.
-   *
-   * <p>Note: When enabled, BusinessId Uniqueness validation will only be applied to process
-   * instances created using a BusinessId after enabling the feature.
+   * <ul>
+   *   <li><b>Disabled (default):</b> Multiple active process instances can share the same business
+   *       ID. No tracking or validation is performed.
+   *   <li><b>Enabled:</b> Creating a process instance with a business ID that is already in use by
+   *       an active process instance will be rejected. Business IDs of process instances created
+   *       before enabling this setting are not tracked, so duplicates with those are not detected.
+   * </ul>
    */
   private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
 

--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.Set;
+
+public class ProcessInstanceCreation {
+  private static final String PREFIX = "camunda.processing.engine.process-instance-creation";
+  private static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
+  private static final Set<String> LEGACY_BUSINESS_ID_UNIQUENESS_ENABLED_PROPERTIES =
+      Set.of(
+          "zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled");
+
+  /**
+   * Whether to enable business id uniqueness check when creating process instances using a
+   * BusinessId.
+   *
+   * <p>If enabled, the broker will check if there is already an existing active root process
+   * instance with the same business id and reject the creation if there is.
+   *
+   * <p>This is disabled by default, but can be enabled to prevent duplicate process instances with
+   * the same business id from being created.
+   */
+  private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
+
+  public boolean isBusinessIdUniquenessEnabled() {
+    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+        PREFIX + ".business-id-uniqueness-enabled",
+        businessIdUniquenessEnabled,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_BUSINESS_ID_UNIQUENESS_ENABLED_PROPERTIES);
+  }
+
+  public void setBusinessIdUniquenessEnabled(final boolean businessIdUniquenessEnabled) {
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -10,7 +10,7 @@ package io.camunda.configuration;
 import java.util.Set;
 
 public class ProcessInstanceCreation {
-  private static final String PREFIX = "camunda.processing.engine.process-instance-creation";
+  private static final String PREFIX = "camunda.process-instance-creation";
   private static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
   private static final Set<String> LEGACY_BUSINESS_ID_UNIQUENESS_ENABLED_PROPERTIES =
       Set.of(
@@ -25,6 +25,9 @@ public class ProcessInstanceCreation {
    *
    * <p>This is disabled by default, but can be enabled to prevent duplicate process instances with
    * the same business id from being created.
+   *
+   * <p>Note: When enabled, BusinessId Uniqueness validation will only be applied to process
+   * instances created using a BusinessId after enabling the feature.
    */
   private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -217,6 +217,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromDistribution(override);
     populateFromBatchOperations(override);
     populateFromExpression(override);
+    populateFromProcessInstanceCreation(override);
   }
 
   private void populateFromDistribution(final BrokerBasedProperties override) {
@@ -1024,5 +1025,19 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getEngine()
         .setGlobalListeners(unifiedConfiguration.getCamunda().getCluster().getGlobalListeners());
+  }
+
+  private void populateFromProcessInstanceCreation(final BrokerBasedProperties override) {
+    override
+        .getExperimental()
+        .getEngine()
+        .getProcessInstanceCreation()
+        .setBusinessIdUniquenessEnabled(
+            unifiedConfiguration
+                .getCamunda()
+                .getProcessing()
+                .getEngine()
+                .getProcessInstanceCreation()
+                .isBusinessIdUniquenessEnabled());
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1035,8 +1035,6 @@ public class BrokerBasedPropertiesOverride {
         .setBusinessIdUniquenessEnabled(
             unifiedConfiguration
                 .getCamunda()
-                .getProcessing()
-                .getEngine()
                 .getProcessInstanceCreation()
                 .isBusinessIdUniquenessEnabled());
   }

--- a/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.ProcessInstanceCreationCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class ProcessInstanceCreationTest {
+  @Nested
+  class WithNoneSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNoneSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetDefaultBusinessIdUniquenessEnabled() {
+      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
+          .returns(false, ProcessInstanceCreationCfg::isBusinessIdUniquenessEnabled);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.process-instance-creation.business-id-uniqueness-enabled=true",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetProcessInstanceCreation() {
+      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
+          .returns(true, ProcessInstanceCreationCfg::isBusinessIdUniquenessEnabled);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled=true",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetProcessInstanceCreationFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
+          .returns(true, ProcessInstanceCreationCfg::isBusinessIdUniquenessEnabled);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.process-instance-creation.business-id-uniqueness-enabled=true",
+        // legacy
+        "zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled=false",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetProcessInstanceCreationFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getProcessInstanceCreation())
+          .returns(true, ProcessInstanceCreationCfg::isBusinessIdUniquenessEnabled);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessInstanceCreationTest.java
@@ -44,7 +44,7 @@ public class ProcessInstanceCreationTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.processing.engine.process-instance-creation.business-id-uniqueness-enabled=true",
+        "camunda.process-instance-creation.business-id-uniqueness-enabled=true",
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -83,7 +83,7 @@ public class ProcessInstanceCreationTest {
   @TestPropertySource(
       properties = {
         // new
-        "camunda.processing.engine.process-instance-creation.business-id-uniqueness-enabled=true",
+        "camunda.process-instance-creation.business-id-uniqueness-enabled=true",
         // legacy
         "zeebe.broker.experimental.engine.processInstanceCreation.businessIdUniquenessEnabled=false",
       })

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -967,6 +967,16 @@ camunda: # Type: io.camunda.configuration.Camunda
       gateway-address: null # Type: String, Env: CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS
       secure: null # Type: Boolean, Env: CAMUNDA_OPERATE_ZEEBE_SECURE
   
+  process-instance-creation: # Type: io.camunda.configuration.ProcessInstanceCreation  
+    # Whether to enable business id uniqueness check when creating process instances using a BusinessId.
+    # If enabled, the broker will check if there is already an existing active root process instance with
+    # the same business id and reject the creation if there is.
+    # This is disabled by default, but can be enabled to prevent duplicate process instances with the same
+    # business id from being created.
+    # Note: When enabled, BusinessId Uniqueness validation will only be applied to process instances
+    # created using a BusinessId after enabling the feature.
+    business-id-uniqueness-enabled: false # Type: Boolean, Env: CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED
+  
   processing: # Type: io.camunda.configuration.Processing  
     # While disabled, checking the Time-To-Live of buffered messages blocks all other executions that
     # occur on the stream processor, including process execution and job activation/completion. When

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -279,9 +279,11 @@ camunda: # Type: io.camunda.configuration.Camunda
       # latency between brokers is high, it would help to set a higher timeout here.
       snapshot-request-timeout: null # Type: Duration, Env: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
     
+    receive-on-legacy-subject: true # Type: Boolean, Env: CAMUNDA_CLUSTER_RECEIVEONLEGACYSUBJECT
     # The number of replicas for each partition in the cluster. The replication factor cannot be greater
     # than the number of nodes in the cluster.
     replication-factor: 1 # Type: Integer, Env: CAMUNDA_CLUSTER_REPLICATIONFACTOR
+    send-on-legacy-subject: true # Type: Boolean, Env: CAMUNDA_CLUSTER_SENDONLEGACYSUBJECT
     # The number of nodes in the cluster.
     size: 1 # Type: Integer, Env: CAMUNDA_CLUSTER_SIZE
   
@@ -606,6 +608,14 @@ camunda: # Type: io.camunda.configuration.Camunda
           cache-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROCESSCACHE_CACHENAME
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROCESSCACHE_DATABASENAME
         
+        proxy: # Type: io.camunda.search.connect.configuration.ProxyConfiguration  
+          enabled: null # Type: Boolean, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_ENABLED
+          host: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_HOST
+          password: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_PASSWORD
+          port: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_PORT
+          ssl-enabled: null # Type: Boolean, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_SSLENABLED
+          username: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_PROXY_USERNAME
+        
         # What default refresh interval we will use for all indices
         refresh-interval: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_REFRESHINTERVAL
         # Per-index refresh interval overrides.
@@ -684,6 +694,14 @@ camunda: # Type: io.camunda.configuration.Camunda
         process-cache: # Type: io.camunda.configuration.Cache  
           cache-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROCESSCACHE_CACHENAME
           database-name: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROCESSCACHE_DATABASENAME
+        
+        proxy: # Type: io.camunda.search.connect.configuration.ProxyConfiguration  
+          enabled: null # Type: Boolean, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_ENABLED
+          host: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_HOST
+          password: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_PASSWORD
+          port: null # Type: Integer, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_PORT
+          ssl-enabled: null # Type: Boolean, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_SSLENABLED
+          username: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_PROXY_USERNAME
         
         # What default refresh interval we will use for all indices
         refresh-interval: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_REFRESHINTERVAL
@@ -815,6 +833,7 @@ camunda: # Type: io.camunda.configuration.Camunda
     index-prefix: null # Type: String, Env: CAMUNDA_DATABASE_INDEXPREFIX
     interceptor-plugins: null # Type: List<io.camunda.search.connect.plugin.PluginConfiguration>, Env: CAMUNDA_DATABASE_INTERCEPTORPLUGINS
     password: null # Type: String, Env: CAMUNDA_DATABASE_PASSWORD
+    proxy: null # Type: io.camunda.search.connect.configuration.ProxyConfiguration, Env: CAMUNDA_DATABASE_PROXY
     retention: # Type: io.camunda.configuration.beans.LegacySearchEngineRetentionProperties  
       apply-policy-job-interval: null # Type: Duration, Env: CAMUNDA_DATABASE_RETENTION_APPLYPOLICYJOBINTERVAL
       enabled: null # Type: Boolean, Env: CAMUNDA_DATABASE_RETENTION_ENABLED
@@ -873,6 +892,14 @@ camunda: # Type: io.camunda.configuration.Camunda
       index-prefix: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX
       interceptor-plugins: null # Type: List<io.camunda.search.connect.plugin.PluginConfiguration>, Env: CAMUNDA_OPERATE_ELASTICSEARCH_INTERCEPTORPLUGINS
       password: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PASSWORD
+      proxy: # Type: io.camunda.operate.property.ProxyProperties  
+        enabled: null # Type: Boolean, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_ENABLED
+        host: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_HOST
+        password: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_PASSWORD
+        port: null # Type: Integer, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_PORT
+        ssl-enabled: null # Type: Boolean, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_SSLENABLED
+        username: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_PROXY_USERNAME
+      
       socket-timeout: null # Type: Integer, Env: CAMUNDA_OPERATE_ELASTICSEARCH_SOCKETTIMEOUT
       ssl: # Type: io.camunda.operate.property.SslProperties  
         certificate-path: null # Type: String, Env: CAMUNDA_OPERATE_ELASTICSEARCH_SSL_CERTIFICATEPATH
@@ -911,6 +938,14 @@ camunda: # Type: io.camunda.configuration.Camunda
       interceptor-plugins: null # Type: List<io.camunda.search.connect.plugin.PluginConfiguration>, Env: CAMUNDA_OPERATE_OPENSEARCH_INTERCEPTORPLUGINS
       os-date-format: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_OSDATEFORMAT
       password: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_PASSWORD
+      proxy: # Type: io.camunda.operate.property.ProxyProperties  
+        enabled: null # Type: Boolean, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_ENABLED
+        host: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_HOST
+        password: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_PASSWORD
+        port: null # Type: Integer, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_PORT
+        ssl-enabled: null # Type: Boolean, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_SSLENABLED
+        username: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_PROXY_USERNAME
+      
       socket-timeout: null # Type: Integer, Env: CAMUNDA_OPERATE_OPENSEARCH_SOCKETTIMEOUT
       ssl: # Type: io.camunda.operate.property.SslProperties  
         certificate-path: null # Type: String, Env: CAMUNDA_OPERATE_OPENSEARCH_SSL_CERTIFICATEPATH
@@ -1246,6 +1281,14 @@ camunda: # Type: io.camunda.configuration.Camunda
       interceptor-plugins: null # Type: List<io.camunda.search.connect.plugin.PluginConfiguration>, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_INTERCEPTORPLUGINS
       max-terms-count: null # Type: Integer, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_MAXTERMSCOUNT
       password: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PASSWORD
+      proxy: # Type: io.camunda.tasklist.property.ProxyProperties  
+        enabled: null # Type: Boolean, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_ENABLED
+        host: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_HOST
+        password: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_PASSWORD
+        port: null # Type: Integer, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_PORT
+        ssl-enabled: null # Type: Boolean, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_SSLENABLED
+        username: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_PROXY_USERNAME
+      
       socket-timeout: null # Type: Integer, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_SOCKETTIMEOUT
       ssl: # Type: io.camunda.tasklist.property.SslProperties  
         certificate-path: null # Type: String, Env: CAMUNDA_TASKLIST_ELASTICSEARCH_SSL_CERTIFICATEPATH
@@ -1280,6 +1323,14 @@ camunda: # Type: io.camunda.configuration.Camunda
       interceptor-plugins: null # Type: List<io.camunda.search.connect.plugin.PluginConfiguration>, Env: CAMUNDA_TASKLIST_OPENSEARCH_INTERCEPTORPLUGINS
       max-terms-count: null # Type: Integer, Env: CAMUNDA_TASKLIST_OPENSEARCH_MAXTERMSCOUNT
       password: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_PASSWORD
+      proxy: # Type: io.camunda.tasklist.property.ProxyProperties  
+        enabled: null # Type: Boolean, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_ENABLED
+        host: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_HOST
+        password: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_PASSWORD
+        port: null # Type: Integer, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_PORT
+        ssl-enabled: null # Type: Boolean, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_SSLENABLED
+        username: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_PROXY_USERNAME
+      
       socket-timeout: null # Type: Integer, Env: CAMUNDA_TASKLIST_OPENSEARCH_SOCKETTIMEOUT
       ssl: # Type: io.camunda.tasklist.property.SslProperties  
         certificate-path: null # Type: String, Env: CAMUNDA_TASKLIST_OPENSEARCH_SSL_CERTIFICATEPATH

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -967,16 +967,6 @@ camunda: # Type: io.camunda.configuration.Camunda
       gateway-address: null # Type: String, Env: CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS
       secure: null # Type: Boolean, Env: CAMUNDA_OPERATE_ZEEBE_SECURE
   
-  process-instance-creation: # Type: io.camunda.configuration.ProcessInstanceCreation  
-    # Whether to enable business id uniqueness check when creating process instances using a BusinessId.
-    # If enabled, the broker will check if there is already an existing active root process instance with
-    # the same business id and reject the creation if there is.
-    # This is disabled by default, but can be enabled to prevent duplicate process instances with the same
-    # business id from being created.
-    # Note: When enabled, BusinessId Uniqueness validation will only be applied to process instances
-    # created using a BusinessId after enabling the feature.
-    business-id-uniqueness-enabled: false # Type: Boolean, Env: CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED
-  
   processing: # Type: io.camunda.configuration.Processing  
     # While disabled, checking the Time-To-Live of buffered messages blocks all other executions that
     # occur on the stream processor, including process execution and job activation/completion. When
@@ -1099,6 +1089,14 @@ camunda: # Type: io.camunda.configuration.Camunda
         # Allows configuring command redistribution retry interval. This is the initial interval used when
         # retrying command distributions that have not been acknowledged.
         redistribution-interval: null # Type: Duration, Env: CAMUNDA_PROCESSING_ENGINE_DISTRIBUTION_REDISTRIBUTIONINTERVAL
+      
+      process-instance-creation: # Type: io.camunda.configuration.ProcessInstanceCreation  
+        # Whether to enable business id uniqueness check when creating process instances using a BusinessId.
+        # If enabled, the broker will check if there is already an existing active root process instance with
+        # the same business id and reject the creation if there is.
+        # This is disabled by default, but can be enabled to prevent duplicate process instances with the same
+        # business id from being created.
+        business-id-uniqueness-enabled: false # Type: Boolean, Env: CAMUNDA_PROCESSING_ENGINE_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED
     
     flow-control: # Type: io.camunda.configuration.FlowControl  
       request: # Type: io.camunda.configuration.Limit  

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -24,6 +24,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
+  private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -37,6 +38,7 @@ public final class EngineCfg implements ConfigurationEntry {
     usageMetrics.init(globalConfig, brokerBase);
     globalListeners.init(globalConfig, brokerBase);
     expression.init(globalConfig, brokerBase);
+    processInstanceCreation.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -127,6 +129,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.expression = expression;
   }
 
+  public ProcessInstanceCreationCfg getProcessInstanceCreation() {
+    return processInstanceCreation;
+  }
+
+  public void setProcessInstanceCreation(final ProcessInstanceCreationCfg processInstanceCreation) {
+    this.processInstanceCreation = processInstanceCreation;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -152,6 +162,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + maxProcessDepth
         + ", expression="
         + expression
+        + ", processInstanceCreation="
+        + processInstanceCreation
         + '}';
   }
 
@@ -188,6 +200,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setCommandRedistributionMaxBackoff(distribution.getMaxBackoffDuration())
         .setMaxProcessDepth(getMaxProcessDepth())
         .setGlobalListeners(globalListeners.createGlobalListenersConfiguration())
-        .setExpressionEvaluationTimeout(expression.getTimeout());
+        .setExpressionEvaluationTimeout(expression.getTimeout())
+        .setBusinessIdUniquenessEnabled(processInstanceCreation.isBusinessIdUniquenessEnabled());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ProcessInstanceCreationCfg.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+
+public class ProcessInstanceCreationCfg implements ConfigurationEntry {
+
+  private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
+
+  public boolean isBusinessIdUniquenessEnabled() {
+    return businessIdUniquenessEnabled;
+  }
+
+  public void setBusinessIdUniquenessEnabled(final boolean businessIdUniquenessEnabled) {
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessInstanceCreationCfg{"
+        + "businessIdUniquenessEnabled="
+        + businessIdUniquenessEnabled
+        + '}';
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -61,6 +61,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_MAX_UNIQUE_JOB_METRICS_KEYS);
     assertThat(configuration.getGlobalListeners().userTask()).isEmpty();
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(configuration.isBusinessIdUniquenessEnabled())
+        .isEqualTo(EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED);
   }
 
   @Test
@@ -96,6 +98,7 @@ final class EngineCfgTest {
     assertListenerCfg(
         taskListeners.get(1), "test2", new String[] {"assigning", "canceling"}, "2", true);
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(2));
+    assertThat(configuration.isBusinessIdUniquenessEnabled()).isTrue();
   }
 
   void assertListenerCfg(

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -40,3 +40,5 @@ zeebe:
               afterNonGlobal: true
         expression:
           timeout: 2s
+        processInstanceCreation:
+          businessIdUniquenessEnabled: true

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -94,11 +94,22 @@ public final class EngineConfiguration {
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
   private Duration commandRedistributionMaxBackoff =
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
-
-  private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
   private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
   private GlobalListenersConfiguration globalListeners = GlobalListenersConfiguration.empty();
   private Duration expressionEvaluationTimeout = DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
+
+  /**
+   * Controls uniqueness enforcement of business IDs across active process instances.
+   *
+   * <ul>
+   *   <li><b>Disabled (default):</b> Multiple active process instances can share the same business
+   *       ID. No tracking or validation is performed.
+   *   <li><b>Enabled:</b> Creating a process instance with a business ID that is already in use by
+   *       an active process instance will be rejected. Business IDs of process instances created
+   *       before enabling this setting are not tracked, so duplicates with those are not detected.
+   * </ul>
+   */
+  private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -58,6 +58,7 @@ public final class EngineConfiguration {
       Duration.ofMinutes(5);
   public static final boolean DEFAULT_ENABLE_IDENTITY_SETUP = true;
   public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(5);
+  public static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
 
   private int maxJobTypeLength = DEFAULT_MAX_JOB_TYPE_LENGTH;
   private int maxTenantIdLength = DEFAULT_MAX_TENANT_ID_LENGTH;
@@ -94,6 +95,7 @@ public final class EngineConfiguration {
   private Duration commandRedistributionMaxBackoff =
       DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
 
+  private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
   private boolean enableIdentitySetup = DEFAULT_ENABLE_IDENTITY_SETUP;
   private GlobalListenersConfiguration globalListeners = GlobalListenersConfiguration.empty();
   private Duration expressionEvaluationTimeout = DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
@@ -415,6 +417,16 @@ public final class EngineConfiguration {
   public EngineConfiguration setExpressionEvaluationTimeout(
       final Duration expressionEvaluationTimeout) {
     this.expressionEvaluationTimeout = expressionEvaluationTimeout;
+    return this;
+  }
+
+  public boolean isBusinessIdUniquenessEnabled() {
+    return businessIdUniquenessEnabled;
+  }
+
+  public EngineConfiguration setBusinessIdUniquenessEnabled(
+      final boolean businessIdUniquenessEnabled) {
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     return this;
   }
 }


### PR DESCRIPTION
## Description

This PR exposes a new configuration property for business id uniqueness validation across all configuration layers (engine, broker, and unified configurations). The implementation provides proper configuration plumbing to pass the `businessIdUniquenessEnabled` flag from the unified configuration down to the engine layer, enabling future logic to leverage this feature toggle.

The configuration is available through:
- Application yaml: `camunda.process-instance-creation.business-id-uniqueness-enabled`
- Env Var: `CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED`
 
> [!NOTE]
>This config value is not used yet. Usage will come in a separate PR. This is important now to allow collaboration with downstream teams (console, controller) on providing the config as a toggle in the SaaS console app.

**Changes:**
- Added `businessIdUniquenessEnabled` configuration property with a default value of `false` across engine, broker, and unified configuration layers
- Added comprehensive test coverage for the new configuration property


## Related issues

closes #45714