### PR TITLE
[Backport stable/8.8] perf: use original message size to estimate memory usage

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -286,10 +286,6 @@
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-stream-platform</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -286,6 +286,10 @@
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -11,12 +11,12 @@ import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.utils.EntitySizeEstimator;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
-import io.camunda.exporter.utils.EntitySizeEstimator;
+import io.camunda.zeebe.protocol.record.WrittenRecord;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -141,8 +141,8 @@ public final class ExporterBatchWriter {
   }
 
   private long recordSize(final Record<?> record) {
-    if (record instanceof final TypedRecordImpl typedRecord) {
-      return typedRecord.getRawLength();
+    if (record instanceof final WrittenRecord writtenRecord) {
+      return writtenRecord.getRawLength();
     } else if (record instanceof final BufferWriter writer) {
       return writer.getLength();
     } else {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -11,12 +11,14 @@ import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import io.camunda.exporter.utils.EntitySizeEstimator;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import io.camunda.exporter.utils.EntitySizeEstimator;
 import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,19 +27,22 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Caches exporter entities of different types and provide the method to flush them in a batch. */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class ExporterBatchWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterBatchWriter.class);
+  private boolean warnAboutMessageSizeEstimation = false;
   private final Map<EntityIdAndEntityType, ExporterEntity> cachedEntities = new HashMap<>();
   private final Map<EntityIdTypeAndHandler, ExporterEntity> cachedEntitiesToFlush =
       new LinkedHashMap<>();
-  private final Map<EntityIdAndEntityType, Long> cachedEntitySizes = new HashMap<>();
   private final Map<Long, Long> cachedRecordTimestamps = new HashMap<>();
-
   private final Map<ValueType, List<ExportHandler>> handlers;
   private final BiConsumer<String, Error> customErrorHandler;
   private final CamundaExporterMetrics metrics;
+  private long memoryEstimation = 0L;
 
   private ExporterBatchWriter(
       final Map<ValueType, List<ExportHandler>> handlers,
@@ -51,28 +56,36 @@ public final class ExporterBatchWriter {
   public void addRecord(final Record<?> record) {
     final ValueType valueType = record.getValueType();
 
+    final var serializedSize = recordSize(record);
+
     handlers
         .getOrDefault(valueType, Collections.emptyList())
         .forEach(
             handler -> {
               if (handler.handlesRecord(record)) {
                 final List<String> entityIds = handler.generateIds(record);
-                entityIds.forEach(id -> updateAndCacheEntity(record, handler, id));
+                entityIds.forEach(
+                    id -> {
+                      updateAndCacheEntity(record, handler, id, serializedSize);
+                    });
               }
             });
   }
 
   private void updateAndCacheEntity(
-      final Record<?> record, final ExportHandler handler, final String id) {
+      final Record<?> record, final ExportHandler handler, final String id, final long length) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
     final ExporterEntity entity =
-        cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
+        cachedEntities.computeIfAbsent(
+            cacheKey,
+            (k) -> {
+              memoryEstimation += length;
+              return handler.createNewEntity(id);
+            });
 
     handler.updateEntity(record, entity);
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
-
-    cachedEntitySizes.put(cacheKey, EntitySizeEstimator.estimateEntitySize(entity));
 
     // we store all handlers for an entity to make sure not to miss any flushes.
     // we flush them in the same order as they were originally run.
@@ -103,8 +116,7 @@ public final class ExporterBatchWriter {
   }
 
   public int getBatchMemoryEstimateInMb() {
-    return (int) cachedEntitySizes.values().stream().mapToLong(Long::longValue).sum()
-        / (1024 * 1024);
+    return (int) (memoryEstimation / (1024 * 1024));
   }
 
   private void observeRecordTimestamps() {
@@ -125,7 +137,23 @@ public final class ExporterBatchWriter {
   private void reset() {
     cachedEntities.clear();
     cachedEntitiesToFlush.clear();
-    cachedEntitySizes.clear();
+    memoryEstimation = 0;
+  }
+
+  private long recordSize(final Record<?> record) {
+    if (record instanceof final TypedRecordImpl typedRecord) {
+      return typedRecord.getRawLength();
+    } else if (record instanceof final BufferWriter writer) {
+      return writer.getLength();
+    } else {
+      if (!warnAboutMessageSizeEstimation) {
+        LOG.debug(
+            "Message size estimation is not supported for record type: {}, using ObjectSizeEstimator",
+            record.getClass().getSimpleName());
+        warnAboutMessageSizeEstimation = true;
+      }
+      return EntitySizeEstimator.estimateEntitySize(record);
+    }
   }
 
   public static final class Builder {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/EntitySizeEstimator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/EntitySizeEstimator.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.utils;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
-import io.camunda.webapps.schema.entities.ExporterEntity;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.io.output.NullOutputStream;
 
@@ -24,7 +23,7 @@ public class EntitySizeEstimator {
             return kryo;
           });
 
-  public static long estimateEntitySize(final ExporterEntity<?> entity) {
+  public static long estimateEntitySize(final Object entity) {
     final Kryo kryo = THREAD_LOCAL_KRYO.get();
 
     try (final CountingOutputStream countingStream =

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/WrittenRecord.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/WrittenRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record;
+
+/** A record that has been written to the log, hence it is immutable. */
+public interface WrittenRecord {
+
+  /**
+   * @return the length of the event i.e. the number of bytes it occupies in the log
+   */
+  int getRawLength();
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -152,6 +152,11 @@ public final class TypedRecordImpl implements TypedRecord {
     return metadata.getLength() + value.getLength();
   }
 
+  @JsonIgnore
+  public int getRawLength() {
+    return rawEvent.getLength();
+  }
+
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -17,12 +17,13 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.WrittenRecord;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.StringUtil;
 import java.util.Map;
 
-public final class TypedRecordImpl implements TypedRecord {
+public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   private final int partitionId;
   private LoggedEvent rawEvent;
   private RecordMetadata metadata;
@@ -152,6 +153,7 @@ public final class TypedRecordImpl implements TypedRecord {
     return metadata.getLength() + value.getLength();
   }
 
+  @Override
   @JsonIgnore
   public int getRawLength() {
     return rawEvent.getLength();


### PR DESCRIPTION
# Description
Backport of #45522 to `stable/8.8`.

relates to #44131