### PR TITLE
fix: avoid concurrent access to RocksDB in global listener test

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenersInitializationTest.java
@@ -49,6 +49,9 @@ public class GlobalListenersInitializationTest {
     RecordingExporter.globalListenerBatchRecords(GlobalListenerBatchIntent.CONFIGURED).await();
 
     // then the engine's processing state contains the expected configuration
+    // Note: we access the engine's processing state directly,
+    // this requires us to pause processing to avoid concurrency problems
+    engine.pauseProcessing(1);
     final GlobalListenerBatchRecord currentConfig =
         engine.getProcessingState().getGlobalListenersState().getCurrentConfig();
     assertThat(currentConfig).isNotNull();


### PR DESCRIPTION
## Description

In the `GlobalListenerInitializationTest`, the processing state of the engine is accessed directly while the engine is still running. This can cause concurrency problems related to RocksDb, causing the test to crash sometimes (see links below).

This PR solves this by pausing the engine processing before accessing the state.

- [Failed run](https://github.com/camunda/camunda/actions/runs/21956567520/job/63422238470)
- [Discussion on Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1770968766053149)
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

