### PR TITLE
feat: bump @camunda/camunda-api-zod-schemas to v0.0.38 in all clients

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.9.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.37",
+        "@camunda/camunda-api-zod-schemas": "0.0.38",
         "@camunda/camunda-composite-components": "0.21.4",
         "@carbon/elements": "^11.57.0",
         "@carbon/react": "1.100.0",
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.37.tgz",
-      "integrity": "sha512-7c4BZKZRFQ/hF0cIup8vS8RfKL57n8GI7av2K72qcD7bz+GKamozA1vwV9BTHnIu7draL36l4hhCcuYSZ2hSjA==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.38.tgz",
+      "integrity": "sha512-b19YHPXpN6eBt19b7QSSLx1TZ1VQZM3yyl0BavFm30zRe/9T09of4Qr6DdpFtvR5HJIlFHiXGHdfEO2De7XzfA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.37",
+    "@camunda/camunda-api-zod-schemas": "0.0.38",
     "@camunda/camunda-composite-components": "0.21.4",
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.100.0",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.37",
+        "@camunda/camunda-api-zod-schemas": "0.0.38",
         "@camunda/camunda-composite-components": "0.21.4",
         "@carbon/elements": "11.84.0",
         "@carbon/react": "1.100.0",
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.37.tgz",
-      "integrity": "sha512-7c4BZKZRFQ/hF0cIup8vS8RfKL57n8GI7av2K72qcD7bz+GKamozA1vwV9BTHnIu7draL36l4hhCcuYSZ2hSjA==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.38.tgz",
+      "integrity": "sha512-b19YHPXpN6eBt19b7QSSLx1TZ1VQZM3yyl0BavFm30zRe/9T09of4Qr6DdpFtvR5HJIlFHiXGHdfEO2De7XzfA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.37",
+    "@camunda/camunda-api-zod-schemas": "0.0.38",
     "@camunda/camunda-composite-components": "0.21.4",
     "@carbon/elements": "11.84.0",
     "@carbon/react": "1.100.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.19.0",
         "@bpmn-io/form-js-viewer": "1.19.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.37",
+        "@camunda/camunda-api-zod-schemas": "0.0.38",
         "@camunda/camunda-composite-components": "0.20.2",
         "@carbon/elements": "11.84.0",
         "@carbon/react": "1.100.0",
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.37.tgz",
-      "integrity": "sha512-7c4BZKZRFQ/hF0cIup8vS8RfKL57n8GI7av2K72qcD7bz+GKamozA1vwV9BTHnIu7draL36l4hhCcuYSZ2hSjA==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.38.tgz",
+      "integrity": "sha512-b19YHPXpN6eBt19b7QSSLx1TZ1VQZM3yyl0BavFm30zRe/9T09of4Qr6DdpFtvR5HJIlFHiXGHdfEO2De7XzfA==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.19.0",
     "@bpmn-io/form-js-viewer": "1.19.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.37",
+    "@camunda/camunda-api-zod-schemas": "0.0.38",
     "@camunda/camunda-composite-components": "0.20.2",
     "@carbon/elements": "11.84.0",
     "@carbon/react": "1.100.0",


### PR DESCRIPTION
## Description

Bump @camunda/camunda-api-zod-schemas to v0.0.38 in all clients

## Related issues

related to https://github.com/camunda/camunda/issues/44946
