### PR TITLE
feat: Update Identity URLs to Admin

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -170,6 +170,7 @@ public class WebSecurityConfig {
           "/login/**",
           "/logout",
           "/identity/**",
+          "/admin/**",
           "/operate/**",
           "/tasklist/**",
           "/",

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -27,8 +27,8 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
 
   public static final String ADMIN_ROLE_ID = DefaultRole.ADMIN.getId();
   public static final String USER_MEMBERS = "users";
-  public static final String REDIRECT_PATH = "/identity/setup";
-  public static final String ASSETS_PATH = "/identity/assets";
+  public static final String REDIRECT_PATH = "/admin/setup";
+  public static final String ASSETS_PATH = "/admin/assets";
   private static final Logger LOG = LoggerFactory.getLogger(AdminUserCheckFilter.class);
   private final SecurityConfiguration securityConfig;
   private final RoleServices roleServices;

--- a/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
@@ -28,7 +28,7 @@ public class WebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(WebComponentAuthorizationCheckFilter.class);
-  private static final List<String> WEB_COMPONENTS = List.of("identity", "operate", "tasklist");
+  private static final List<String> WEB_COMPONENTS = List.of("admin", "operate", "tasklist");
   private static final List<String> STATIC_RESOURCES =
       List.of(".css", ".js", ".js.map", ".jpg", ".png", "woff2", ".ico", ".svg");
   final UrlPathHelper urlPathHelper = new UrlPathHelper();

--- a/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
@@ -28,7 +28,8 @@ public class WebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(WebComponentAuthorizationCheckFilter.class);
-  private static final List<String> WEB_COMPONENTS = List.of("admin", "operate", "tasklist");
+  private static final List<String> WEB_COMPONENTS =
+      List.of("identity", "admin", "operate", "tasklist");
   private static final List<String> STATIC_RESOURCES =
       List.of(".css", ".js", ".js.map", ".jpg", ".png", "woff2", ".ico", ".svg");
   final UrlPathHelper urlPathHelper = new UrlPathHelper();
@@ -85,6 +86,16 @@ public class WebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
 
   private boolean hasAccessToComponent(final String component) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
+    if ("admin".equals(component) || "identity".equals(component)) {
+      return resourceAccessProvider
+              .hasResourceAccessByResourceId(
+                  authentication, COMPONENT_ACCESS_AUTHORIZATION, "identity")
+              .allowed()
+          || resourceAccessProvider
+              .hasResourceAccessByResourceId(
+                  authentication, COMPONENT_ACCESS_AUTHORIZATION, "admin")
+              .allowed();
+    }
     return resourceAccessProvider
         .hasResourceAccessByResourceId(authentication, COMPONENT_ACCESS_AUTHORIZATION, component)
         .allowed();

--- a/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilter.java
@@ -86,6 +86,9 @@ public class WebComponentAuthorizationCheckFilter extends OncePerRequestFilter {
 
   private boolean hasAccessToComponent(final String component) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
+    // We want to temporarily support both "admin" and "identity" as components for the
+    // authorization check, for backwards compatibility.
+    // TODO(#46027): Drop support for "identity" component for 8.10
     if ("admin".equals(component) || "identity".equals(component)) {
       return resourceAccessProvider
               .hasResourceAccessByResourceId(

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -54,7 +54,7 @@ class AdminUserCheckFilterTest {
     adminUserCheckFilter.doFilterInternal(request, response, filterChain);
 
     // then
-    verify(response).sendRedirect("localhost:8080/identity/setup");
+    verify(response).sendRedirect("localhost:8080/admin/setup");
   }
 
   @Test
@@ -99,7 +99,7 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     when(request.getContextPath()).thenReturn("");
-    when(request.getRequestURI()).thenReturn("/identity/setup");
+    when(request.getRequestURI()).thenReturn("/admin/setup");
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
 
@@ -115,7 +115,7 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     when(request.getContextPath()).thenReturn("");
-    when(request.getRequestURI()).thenReturn("/identity/assets/some-asset.js");
+    when(request.getRequestURI()).thenReturn("/admin/assets/some-asset.js");
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
 

--- a/authentication/src/test/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/WebComponentAuthorizationCheckFilterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static io.camunda.service.authorization.Authorizations.COMPONENT_ACCESS_AUTHORIZATION;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.reader.ResourceAccess;
+import io.camunda.security.reader.ResourceAccessProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class WebComponentAuthorizationCheckFilterTest {
+
+  @Mock private CamundaAuthenticationProvider authenticationProvider;
+  @Mock private ResourceAccessProvider resourceAccessProvider;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain filterChain;
+  @Mock private CamundaAuthentication authentication;
+
+  private WebComponentAuthorizationCheckFilter filter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    final var securityConfig = new SecurityConfiguration();
+    securityConfig.getAuthorizations().setEnabled(true);
+
+    when(authenticationProvider.getCamundaAuthentication()).thenReturn(authentication);
+
+    filter =
+        new WebComponentAuthorizationCheckFilter(
+            securityConfig, authenticationProvider, resourceAccessProvider);
+
+    when(request.getContextPath()).thenReturn("");
+
+    final var mockAuth = mock(Authentication.class);
+    when(mockAuth.isAuthenticated()).thenReturn(true);
+    SecurityContextHolder.getContext().setAuthentication(mockAuth);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldAllowAccessToAdminWithIdentityPermission() throws ServletException, IOException {
+    // given
+    when(request.getRequestURI()).thenReturn("/admin/user");
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/admin/user"));
+
+    final var identityAccess = mock(ResourceAccess.class);
+    when(identityAccess.allowed()).thenReturn(true);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("identity")))
+        .thenReturn(identityAccess);
+
+    final var adminAccess = mock(ResourceAccess.class);
+    when(adminAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("admin")))
+        .thenReturn(adminAccess);
+
+    // when
+    filter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldAllowAccessToIdentityWithAdminPermission() throws ServletException, IOException {
+    // given
+    when(request.getRequestURI()).thenReturn("/identity/user");
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/identity/user"));
+
+    final var adminAccess = mock(ResourceAccess.class);
+    when(adminAccess.allowed()).thenReturn(true);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("admin")))
+        .thenReturn(adminAccess);
+
+    final var identityAccess = mock(ResourceAccess.class);
+    when(identityAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("identity")))
+        .thenReturn(identityAccess);
+
+    // when
+    filter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldDenyAccessToAdminWithoutEitherPermission() throws ServletException, IOException {
+    // given
+    when(request.getRequestURI()).thenReturn("/admin/user");
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/admin/user"));
+
+    final var identityAccess = mock(ResourceAccess.class);
+    when(identityAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("identity")))
+        .thenReturn(identityAccess);
+
+    final var adminAccess = mock(ResourceAccess.class);
+    when(adminAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("admin")))
+        .thenReturn(adminAccess);
+
+    // when
+    filter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(response).sendRedirect("/admin/forbidden");
+  }
+
+  @Test
+  void shouldDenyAccessToIdentityWithoutEitherPermission() throws ServletException, IOException {
+    // given
+    when(request.getRequestURI()).thenReturn("/identity/user");
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/identity/user"));
+
+    final var identityAccess = mock(ResourceAccess.class);
+    when(identityAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("identity")))
+        .thenReturn(identityAccess);
+
+    final var adminAccess = mock(ResourceAccess.class);
+    when(adminAccess.allowed()).thenReturn(false);
+    when(resourceAccessProvider.hasResourceAccessByResourceId(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION), eq("admin")))
+        .thenReturn(adminAccess);
+
+    // when
+    filter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(response).sendRedirect("/identity/forbidden");
+  }
+}

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -103,6 +103,7 @@ public class WebappsConfigurationInitializer
 
     if (activeProfiles.contains(IDENTITY.getId())) {
       locations.add(DEFAULT_RESOURCES_LOCATION + "identity/");
+      locations.add(DEFAULT_RESOURCES_LOCATION + "admin/");
     }
 
     // Store locations and merge everything

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.identity.webapp.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.swagger.v3.oas.annotations.Hidden;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class AdminClientConfigController {
+  private static final Logger LOG = LoggerFactory.getLogger(AdminClientConfigController.class);
+
+  private static final String IS_OIDC = "isOidc";
+  private static final String IS_CAMUNDA_GROUPS_ENABLED = "isCamundaGroupsEnabled";
+  private static final String IS_TENANTS_API_ENABLED = "isTenantsApiEnabled";
+  private static final String ORGANIZATION_ID = "organizationId";
+  private static final String CLUSTER_ID = "clusterId";
+  private static final String ID_PATTERN = "idPattern";
+  private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
+  private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
+
+  private final String clientConfigAsJS;
+  private final ObjectMapper objectMapper;
+
+  public AdminClientConfigController(final SecurityConfiguration securityConfiguration) {
+    objectMapper = new ObjectMapper();
+    clientConfigAsJS = generateClientConfig(securityConfiguration);
+  }
+
+  private String generateClientConfig(final SecurityConfiguration securityConfiguration) {
+    try {
+      final Map<String, String> config = createConfigMap(securityConfiguration);
+      final String configJson = objectMapper.writeValueAsString(config);
+      return String.format(CONFIG_JS_TEMPLATE, configJson);
+    } catch (final JsonProcessingException e) {
+      LOG.warn("Error serializing client config to JSON", e);
+      return FALLBACK_CONFIG_JS;
+    }
+  }
+
+  private Map<String, String> createConfigMap(final SecurityConfiguration securityConfiguration) {
+    final var config = new java.util.HashMap<String, String>();
+    final var saasConfiguration = securityConfiguration.getSaas();
+
+    config.put(IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)));
+    config.put(
+        IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)));
+    config.put(
+        IS_TENANTS_API_ENABLED,
+        String.valueOf(securityConfiguration.getMultiTenancy().isApiEnabled()));
+    config.put(ORGANIZATION_ID, saasConfiguration.getOrganizationId());
+    config.put(CLUSTER_ID, saasConfiguration.getClusterId());
+    config.put(ID_PATTERN, securityConfiguration.getIdValidationPattern());
+
+    return config;
+  }
+
+  private boolean isOidcAuthentication(final SecurityConfiguration securityConfiguration) {
+    return AuthenticationMethod.OIDC.equals(securityConfiguration.getAuthentication().getMethod());
+  }
+
+  private boolean isCamundaGroupsEnabled(final SecurityConfiguration securityConfiguration) {
+    final var authentication = securityConfiguration.getAuthentication();
+    final var oidcConfig = authentication.getOidc();
+    return oidcConfig == null
+        || oidcConfig.getGroupsClaim() == null
+        || oidcConfig.getGroupsClaim().isEmpty();
+  }
+
+  @GetMapping(path = "/admin/config.js", produces = "text/javascript;charset=UTF-8")
+  @ResponseBody
+  @Hidden
+  public String getClientConfig() {
+    return clientConfigAsJS;
+  }
+}

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.identity.webapp.controllers;
+
+import io.camunda.webapps.controllers.WebappsRequestForwardManager;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class AdminIndexController {
+  private final ServletContext context;
+
+  private final WebappsRequestForwardManager webappsRequestForwardManager;
+
+  public AdminIndexController(
+      final ServletContext context,
+      final WebappsRequestForwardManager webappsRequestForwardManager) {
+    this.context = context;
+    this.webappsRequestForwardManager = webappsRequestForwardManager;
+  }
+
+  @GetMapping({"/admin", "/admin/", "/admin/index.html"})
+  public String admin(final Model model) throws IOException {
+    model.addAttribute("contextPath", context.getContextPath() + "/admin/");
+    return "admin/index";
+  }
+
+  /**
+   * Forwards SPA routes to index.html, excluding static assets.
+   *
+   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
+   *
+   * <ul>
+   *   <li>{@code (?!assets)} - excludes "assets"
+   *   <li>{@code .*} - matches any other path segment
+   * </ul>
+   *
+   * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
+   * mappings higher precedence than static resource handlers. Without this pattern, requests like
+   * {@code /admin/assets/index.css} would be forwarded to index.html instead of being served as
+   * static files.
+   */
+  @RequestMapping(value = {"/admin/{path:^(?!assets).*}", "/admin/{path:^(?!assets).*}/**"})
+  public String forwardToAdmin(final HttpServletRequest request) {
+    return webappsRequestForwardManager.forward(request, "admin");
+  }
+}

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -7,84 +7,21 @@
  */
 package io.camunda.identity.webapp.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.entity.AuthenticationMethod;
 import io.swagger.v3.oas.annotations.Hidden;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 
+/**
+ * @deprecated please use {@link AdminClientConfigController} instead.
+ */
 @Controller
+@Deprecated
 public class IdentityClientConfigController {
 
-  private static final Logger LOG = LoggerFactory.getLogger(IdentityClientConfigController.class);
-
-  private static final String IS_OIDC = "isOidc";
-  private static final String IS_CAMUNDA_GROUPS_ENABLED = "isCamundaGroupsEnabled";
-  private static final String IS_TENANTS_API_ENABLED = "isTenantsApiEnabled";
-  private static final String ORGANIZATION_ID = "organizationId";
-  private static final String CLUSTER_ID = "clusterId";
-  private static final String ID_PATTERN = "idPattern";
-  private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
-  private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
-
-  private final String clientConfigAsJS;
-  private final ObjectMapper objectMapper;
-
-  public IdentityClientConfigController(final SecurityConfiguration securityConfiguration) {
-    objectMapper = new ObjectMapper();
-    clientConfigAsJS = generateClientConfig(securityConfiguration);
-  }
-
-  private String generateClientConfig(final SecurityConfiguration securityConfiguration) {
-    try {
-      final Map<String, String> config = createConfigMap(securityConfiguration);
-      final String configJson = objectMapper.writeValueAsString(config);
-      return String.format(CONFIG_JS_TEMPLATE, configJson);
-    } catch (final JsonProcessingException e) {
-      LOG.warn("Error serializing client config to JSON", e);
-      return FALLBACK_CONFIG_JS;
-    }
-  }
-
-  private Map<String, String> createConfigMap(final SecurityConfiguration securityConfiguration) {
-    final var config = new java.util.HashMap<String, String>();
-    final var saasConfiguration = securityConfiguration.getSaas();
-
-    config.put(IS_OIDC, String.valueOf(isOidcAuthentication(securityConfiguration)));
-    config.put(
-        IS_CAMUNDA_GROUPS_ENABLED, String.valueOf(isCamundaGroupsEnabled(securityConfiguration)));
-    config.put(
-        IS_TENANTS_API_ENABLED,
-        String.valueOf(securityConfiguration.getMultiTenancy().isApiEnabled()));
-    config.put(ORGANIZATION_ID, saasConfiguration.getOrganizationId());
-    config.put(CLUSTER_ID, saasConfiguration.getClusterId());
-    config.put(ID_PATTERN, securityConfiguration.getIdValidationPattern());
-
-    return config;
-  }
-
-  private boolean isOidcAuthentication(final SecurityConfiguration securityConfiguration) {
-    return AuthenticationMethod.OIDC.equals(securityConfiguration.getAuthentication().getMethod());
-  }
-
-  private boolean isCamundaGroupsEnabled(final SecurityConfiguration securityConfiguration) {
-    final var authentication = securityConfiguration.getAuthentication();
-    final var oidcConfig = authentication.getOidc();
-    return oidcConfig == null
-        || oidcConfig.getGroupsClaim() == null
-        || oidcConfig.getGroupsClaim().isEmpty();
-  }
-
-  @GetMapping(path = "/identity/config.js", produces = "text/javascript;charset=UTF-8")
-  @ResponseBody
+  /** Redirects legacy /identity/config.js to /admin/config.js. */
+  @GetMapping(path = "/identity/config.js")
   @Hidden
-  public String getClientConfig() {
-    return clientConfigAsJS;
+  public String redirectToAdminConfig() {
+    return "redirect:/admin/config.js";
   }
 }

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
@@ -7,52 +7,32 @@
  */
 package io.camunda.identity.webapp.controllers;
 
-import io.camunda.webapps.controllers.WebappsRequestForwardManager;
-import jakarta.servlet.ServletContext;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
+
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+/**
+ * @deprecated please use {@link AdminIndexController} instead.
+ */
 @Controller
+@Deprecated
 public class IdentityIndexController {
 
-  private final ServletContext context;
-
-  private final WebappsRequestForwardManager webappsRequestForwardManager;
-
-  public IdentityIndexController(
-      final ServletContext context,
-      final WebappsRequestForwardManager webappsRequestForwardManager) {
-    this.context = context;
-    this.webappsRequestForwardManager = webappsRequestForwardManager;
-  }
-
   @GetMapping({"/identity", "/identity/", "/identity/index.html"})
-  public String identity(final Model model) throws IOException {
-    model.addAttribute("contextPath", context.getContextPath() + "/identity/");
-    return "identity/index";
+  public String redirectIdentityRoot(final HttpServletRequest request) {
+    return "redirect:/admin" + getRequestedUrl(request).replaceFirst("^/identity", "");
   }
 
   /**
-   * Forwards SPA routes to index.html, excluding static assets.
+   * Redirects all legacy /identity/* routes to /admin/*.
    *
-   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
-   *
-   * <ul>
-   *   <li>{@code (?!assets)} - excludes "assets"
-   *   <li>{@code .*} - matches any other path segment
-   * </ul>
-   *
-   * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
-   * mappings higher precedence than static resource handlers. Without this pattern, requests like
-   * {@code /operate/assets/index.css} would be forwarded to index.html instead of being served as
-   * static files.
+   * <p>Excludes assets as they are handled by static resource handlers.
    */
   @RequestMapping(value = {"/identity/{path:^(?!assets).*}", "/identity/{path:^(?!assets).*}/**"})
-  public String forwardToIdentity(final HttpServletRequest request) {
-    return webappsRequestForwardManager.forward(request, "identity");
+  public String redirectIdentityRoutes(final HttpServletRequest request) {
+    return "redirect:/admin" + getRequestedUrl(request).replaceFirst("^/identity", "");
   }
 }

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.identity.webapp.controllers.AdminClientConfigController;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SaasConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+public class AdminClientConfigControllerTest {
+  private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    // MockMvc will be setup for each test with a specific controller configuration
+  }
+
+  static Stream<Arguments> configurationProvider() {
+    return Stream.of(
+        // AuthMethod, GroupsClaim, MultiTenancyEnabled, ExpectedIsOidc, ExpectedCamundaGroups,
+        // ExpectedTenantsApi, ExpectedOrganizationId, ExpectedClusterId
+        Arguments.of(
+            AuthenticationMethod.OIDC,
+            null,
+            true,
+            "true",
+            "true",
+            "true",
+            "test-org",
+            "test-cluster"),
+        Arguments.of(
+            AuthenticationMethod.OIDC,
+            null,
+            false,
+            "true",
+            "true",
+            "false",
+            "test-org",
+            "test-cluster"),
+        Arguments.of(
+            AuthenticationMethod.OIDC,
+            "",
+            false,
+            "true",
+            "true",
+            "false",
+            "test-org",
+            "test-cluster"),
+        Arguments.of(
+            AuthenticationMethod.OIDC,
+            "groups",
+            true,
+            "true",
+            "false",
+            "true",
+            "test-org",
+            "test-cluster"),
+        Arguments.of(
+            AuthenticationMethod.OIDC,
+            "groups",
+            false,
+            "true",
+            "false",
+            "false",
+            "test-org",
+            "test-cluster"),
+        Arguments.of(AuthenticationMethod.BASIC, null, true, "false", "true", "true", null, null),
+        Arguments.of(AuthenticationMethod.BASIC, null, false, "false", "true", "false", null, null),
+        Arguments.of(
+            AuthenticationMethod.BASIC, "groups", true, "false", "true", "true", null, null),
+        Arguments.of(
+            AuthenticationMethod.BASIC, "groups", false, "false", "true", "false", null, null));
+  }
+
+  @ParameterizedTest(
+      name =
+          "AuthMethod={0}, GroupsClaim={1}, MultiTenancy={2} -> OIDC={3}, CamundaGroups={4}, TenantsApi={5}")
+  @MethodSource("configurationProvider")
+  void shouldReturnCorrectClientConfigForAllPermutations(
+      final AuthenticationMethod authMethod,
+      final String groupsClaim,
+      final boolean multiTenancyEnabled,
+      final String expectedIsOidc,
+      final String expectedCamundaGroups,
+      final String expectedTenantsApi,
+      final String expectedOrganizationId,
+      final String expectedClusterId)
+      throws Exception {
+
+    final var securityConfiguration =
+        createSecurityConfiguration(
+            authMethod,
+            groupsClaim,
+            multiTenancyEnabled,
+            expectedOrganizationId,
+            expectedClusterId);
+    final var controller = new AdminClientConfigController(securityConfiguration);
+
+    // Setup MockMvc with the controller for this specific test
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    final String response =
+        mockMvc
+            .perform(get("/admin/config.js"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("text/javascript;charset=UTF-8"))
+            .andExpect(header().doesNotExist("Content-Security-Policy"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // Extract JSON configuration from JavaScript response
+    final Map<String, String> configResponse = extractConfigFromResponse(response);
+
+    // Assert all configuration values
+    assertThat(configResponse)
+        .containsEntry("isOidc", expectedIsOidc)
+        .containsEntry("isCamundaGroupsEnabled", expectedCamundaGroups)
+        .containsEntry("isTenantsApiEnabled", expectedTenantsApi)
+        .containsEntry("organizationId", expectedOrganizationId)
+        .containsEntry("clusterId", expectedClusterId);
+  }
+
+  private SecurityConfiguration createSecurityConfiguration(
+      final AuthenticationMethod authMethod,
+      final String groupsClaim,
+      final boolean multiTenancyEnabled,
+      final String organizationId,
+      final String clusterId) {
+
+    final var securityConfiguration = new SecurityConfiguration();
+
+    // Configure authentication
+    final var authentication = new AuthenticationConfiguration();
+    authentication.setMethod(authMethod);
+
+    if (authMethod == AuthenticationMethod.OIDC) {
+      final var oidcConfig = new OidcAuthenticationConfiguration();
+      oidcConfig.setGroupsClaim(groupsClaim);
+      authentication.setOidc(oidcConfig);
+    }
+
+    securityConfiguration.setAuthentication(authentication);
+
+    // Configure multi-tenancy
+    final var multiTenancy = new MultiTenancyConfiguration();
+    multiTenancy.setApiEnabled(multiTenancyEnabled);
+    securityConfiguration.setMultiTenancy(multiTenancy);
+
+    // Configure SaaS
+    final var saasConfiguration = new SaasConfiguration();
+    saasConfiguration.setOrganizationId(organizationId);
+    saasConfiguration.setClusterId(clusterId);
+    securityConfiguration.setSaas(saasConfiguration);
+
+    return securityConfiguration;
+  }
+
+  private Map<String, String> extractConfigFromResponse(final String response) throws Exception {
+    final var jsonConfigBodyStartIdx = response.indexOf('{');
+    assertThat(jsonConfigBodyStartIdx).isNotEqualTo(-1);
+    final var jsonConfigBodyEndIdx = response.lastIndexOf('}');
+    assertThat(jsonConfigBodyEndIdx).isNotEqualTo(-1);
+
+    return objectMapper.readValue(
+        response.substring(jsonConfigBodyStartIdx, jsonConfigBodyEndIdx + 1), Map.class);
+  }
+}

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminIndexControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminIndexControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.camunda.identity.webapp.controllers.AdminIndexController;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.ExtendedModelMap;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminIndexControllerTest {
+  @Mock private ServletContext servletContext;
+  @Mock private WebappsRequestForwardManager webappsRequestForwardManager;
+  @Mock private HttpServletRequest request;
+
+  private AdminIndexController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new AdminIndexController(servletContext, webappsRequestForwardManager);
+  }
+
+  @Test
+  void shouldReturnAdminIndexView() throws IOException {
+    // Given
+    when(servletContext.getContextPath()).thenReturn("/camunda");
+    final var model = new ExtendedModelMap();
+
+    // When
+    final var viewName = controller.admin(model);
+
+    // Then
+    assertThat(viewName).isEqualTo("admin/index");
+    assertThat(model.getAttribute("contextPath")).isEqualTo("/camunda/admin/");
+  }
+
+  @Test
+  void shouldForwardToAdminForRootPath() {
+    // Given
+    when(webappsRequestForwardManager.forward(any(HttpServletRequest.class), eq("admin")))
+        .thenReturn("forward:/admin/app");
+
+    // When
+    final String result = controller.forwardToAdmin(request);
+
+    // Then
+    assertThat(result).isEqualTo("forward:/admin/app");
+  }
+}

--- a/dist/src/test/java/io/camunda/webapps/controllers/IdentityClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/IdentityClientConfigControllerTest.java
@@ -7,188 +7,31 @@
  */
 package io.camunda.webapps.controllers;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.identity.webapp.controllers.IdentityClientConfigController;
-import io.camunda.security.configuration.AuthenticationConfiguration;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
-import io.camunda.security.configuration.OidcAuthenticationConfiguration;
-import io.camunda.security.configuration.SaasConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.security.entity.AuthenticationMethod;
-import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class IdentityClientConfigControllerTest {
 
   private MockMvc mockMvc;
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeEach
   void setUp() {
-    // MockMvc will be setup for each test with a specific controller configuration
-  }
-
-  static Stream<Arguments> configurationProvider() {
-    return Stream.of(
-        // AuthMethod, GroupsClaim, MultiTenancyEnabled, ExpectedIsOidc, ExpectedCamundaGroups,
-        // ExpectedTenantsApi, ExpectedOrganizationId, ExpectedClusterId
-        Arguments.of(
-            AuthenticationMethod.OIDC,
-            null,
-            true,
-            "true",
-            "true",
-            "true",
-            "test-org",
-            "test-cluster"),
-        Arguments.of(
-            AuthenticationMethod.OIDC,
-            null,
-            false,
-            "true",
-            "true",
-            "false",
-            "test-org",
-            "test-cluster"),
-        Arguments.of(
-            AuthenticationMethod.OIDC,
-            "",
-            false,
-            "true",
-            "true",
-            "false",
-            "test-org",
-            "test-cluster"),
-        Arguments.of(
-            AuthenticationMethod.OIDC,
-            "groups",
-            true,
-            "true",
-            "false",
-            "true",
-            "test-org",
-            "test-cluster"),
-        Arguments.of(
-            AuthenticationMethod.OIDC,
-            "groups",
-            false,
-            "true",
-            "false",
-            "false",
-            "test-org",
-            "test-cluster"),
-        Arguments.of(AuthenticationMethod.BASIC, null, true, "false", "true", "true", null, null),
-        Arguments.of(AuthenticationMethod.BASIC, null, false, "false", "true", "false", null, null),
-        Arguments.of(
-            AuthenticationMethod.BASIC, "groups", true, "false", "true", "true", null, null),
-        Arguments.of(
-            AuthenticationMethod.BASIC, "groups", false, "false", "true", "false", null, null));
-  }
-
-  @ParameterizedTest(
-      name =
-          "AuthMethod={0}, GroupsClaim={1}, MultiTenancy={2} -> OIDC={3}, CamundaGroups={4}, TenantsApi={5}")
-  @MethodSource("configurationProvider")
-  void shouldReturnCorrectClientConfigForAllPermutations(
-      final AuthenticationMethod authMethod,
-      final String groupsClaim,
-      final boolean multiTenancyEnabled,
-      final String expectedIsOidc,
-      final String expectedCamundaGroups,
-      final String expectedTenantsApi,
-      final String expectedOrganizationId,
-      final String expectedClusterId)
-      throws Exception {
-
-    // Create controller with specific configuration
-    final var securityConfiguration =
-        createSecurityConfiguration(
-            authMethod,
-            groupsClaim,
-            multiTenancyEnabled,
-            expectedOrganizationId,
-            expectedClusterId);
-    final var controller = new IdentityClientConfigController(securityConfiguration);
-
-    // Setup MockMvc with the controller for this specific test
+    final var controller = new IdentityClientConfigController();
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
-
-    final String response =
-        mockMvc
-            .perform(get("/identity/config.js"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType("text/javascript;charset=UTF-8"))
-            .andExpect(header().doesNotExist("Content-Security-Policy"))
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-    // Extract JSON configuration from JavaScript response
-    final Map<String, String> configResponse = extractConfigFromResponse(response);
-
-    // Assert all configuration values
-    assertThat(configResponse)
-        .containsEntry("isOidc", expectedIsOidc)
-        .containsEntry("isCamundaGroupsEnabled", expectedCamundaGroups)
-        .containsEntry("isTenantsApiEnabled", expectedTenantsApi)
-        .containsEntry("organizationId", expectedOrganizationId)
-        .containsEntry("clusterId", expectedClusterId);
   }
 
-  private SecurityConfiguration createSecurityConfiguration(
-      final AuthenticationMethod authMethod,
-      final String groupsClaim,
-      final boolean multiTenancyEnabled,
-      final String organizationId,
-      final String clusterId) {
-
-    final var securityConfiguration = new SecurityConfiguration();
-
-    // Configure authentication
-    final var authentication = new AuthenticationConfiguration();
-    authentication.setMethod(authMethod);
-
-    if (authMethod == AuthenticationMethod.OIDC) {
-      final var oidcConfig = new OidcAuthenticationConfiguration();
-      oidcConfig.setGroupsClaim(groupsClaim);
-      authentication.setOidc(oidcConfig);
-    }
-
-    securityConfiguration.setAuthentication(authentication);
-
-    // Configure multi-tenancy
-    final var multiTenancy = new MultiTenancyConfiguration();
-    multiTenancy.setApiEnabled(multiTenancyEnabled);
-    securityConfiguration.setMultiTenancy(multiTenancy);
-
-    // Configure SaaS
-    final var saasConfiguration = new SaasConfiguration();
-    saasConfiguration.setOrganizationId(organizationId);
-    saasConfiguration.setClusterId(clusterId);
-    securityConfiguration.setSaas(saasConfiguration);
-
-    return securityConfiguration;
-  }
-
-  private Map<String, String> extractConfigFromResponse(final String response) throws Exception {
-    final var jsonConfigBodyStartIdx = response.indexOf('{');
-    assertThat(jsonConfigBodyStartIdx).isNotEqualTo(-1);
-    final var jsonConfigBodyEndIdx = response.lastIndexOf('}');
-    assertThat(jsonConfigBodyEndIdx).isNotEqualTo(-1);
-
-    return objectMapper.readValue(
-        response.substring(jsonConfigBodyStartIdx, jsonConfigBodyEndIdx + 1), Map.class);
+  @Test
+  void shouldRedirectIdentityConfigToAdminConfig() throws Exception {
+    mockMvc
+        .perform(get("/identity/config.js"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().string("Location", "/admin/config.js"));
   }
 }

--- a/dist/src/test/java/io/camunda/webapps/controllers/IdentityIndexControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/IdentityIndexControllerTest.java
@@ -8,20 +8,16 @@
 package io.camunda.webapps.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.camunda.identity.webapp.controllers.IdentityIndexController;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.ui.ExtendedModelMap;
 
 @ExtendWith(MockitoExtension.class)
 class IdentityIndexControllerTest {
@@ -34,33 +30,90 @@ class IdentityIndexControllerTest {
 
   @BeforeEach
   void setUp() {
-    controller = new IdentityIndexController(servletContext, webappsRequestForwardManager);
+    controller = new IdentityIndexController();
   }
 
   @Test
-  void shouldReturnIdentityIndexView() throws IOException {
+  void shouldRedirectIdentityRootToAdmin() {
     // Given
-    when(servletContext.getContextPath()).thenReturn("/camunda");
-    final var model = new ExtendedModelMap();
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity");
+    when(request.getQueryString()).thenReturn(null);
 
     // When
-    final var viewName = controller.identity(model);
+    final var result = controller.redirectIdentityRoot(request);
 
     // Then
-    assertThat(viewName).isEqualTo("identity/index");
-    assertThat(model.getAttribute("contextPath")).isEqualTo("/camunda/identity/");
+    assertThat(result).isEqualTo("redirect:/admin");
   }
 
   @Test
-  void shouldForwardToIdentityForRootPath() {
+  void shouldRedirectIdentityRootWithTrailingSlashToAdmin() {
     // Given
-    when(webappsRequestForwardManager.forward(any(HttpServletRequest.class), eq("identity")))
-        .thenReturn("forward:/identity/app");
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/");
+    when(request.getQueryString()).thenReturn(null);
 
     // When
-    final String result = controller.forwardToIdentity(request);
+    final var result = controller.redirectIdentityRoot(request);
 
     // Then
-    assertThat(result).isEqualTo("forward:/identity/app");
+    assertThat(result).isEqualTo("redirect:/admin/");
+  }
+
+  @Test
+  void shouldRedirectIdentityRoutesToAdmin() {
+    // Given
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/users");
+    when(request.getQueryString()).thenReturn(null);
+
+    // When
+    final var result = controller.redirectIdentityRoutes(request);
+
+    // Then
+    assertThat(result).isEqualTo("redirect:/admin/users");
+  }
+
+  @Test
+  void shouldRedirectIdentityRoutesWithQueryParams() {
+    // Given
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/users");
+    when(request.getQueryString()).thenReturn("filter=active");
+
+    // When
+    final var result = controller.redirectIdentityRoutes(request);
+
+    // Then
+    assertThat(result).isEqualTo("redirect:/admin/users?filter=active");
+  }
+
+  @Test
+  void shouldRedirectIdentityNestedRoutesToAdmin() {
+    // Given
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/users/123");
+    when(request.getQueryString()).thenReturn(null);
+
+    // When
+    final var result = controller.redirectIdentityRoutes(request);
+
+    // Then
+    assertThat(result).isEqualTo("redirect:/admin/users/123");
+  }
+
+  @Test
+  void shouldRedirectWithContextPath() {
+    // Given
+    when(request.getContextPath()).thenReturn("/camunda");
+    when(request.getRequestURI()).thenReturn("/camunda/identity/users");
+    when(request.getQueryString()).thenReturn(null);
+
+    // When
+    final var result = controller.redirectIdentityRoutes(request);
+
+    // Then
+    assertThat(result).isEqualTo("redirect:/admin/users");
   }
 }

--- a/identity/client/pom.xml
+++ b/identity/client/pom.xml
@@ -23,6 +23,11 @@
   <build>
     <resources>
       <resource>
+        <targetPath>${project.build.outputDirectory}/META-INF/resources/admin</targetPath>
+        <directory>dist</directory>
+      </resource>
+      <!-- Legacy Identity path for backwards compatibility -->
+      <resource>
         <targetPath>${project.build.outputDirectory}/META-INF/resources/identity</targetPath>
         <directory>dist</directory>
       </resource>

--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -97,7 +97,7 @@ const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
   }
 
   if (
-    !camundaUser?.authorizedComponents.includes("identity") &&
+    !camundaUser?.authorizedComponents.includes("admin") &&
     !camundaUser?.authorizedComponents.includes("*")
   ) {
     return (

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -11,7 +11,7 @@ import {
   getClientConfigString,
 } from "src/configuration/clientConfig";
 
-const identityPath = "/identity";
+const adminPath = "/admin";
 
 const apiBaseUrl = "/v2";
 
@@ -34,23 +34,23 @@ export const docsUrl = "https://docs.camunda.io";
 export const isSaaS = Boolean(getClientConfigString("organizationId"));
 
 export function getApiBaseUrl() {
-  return getBasePathBeforeIdentity() + apiBaseUrl;
+  return getBasePathBeforeAdmin() + apiBaseUrl;
 }
 
 export function getLoginApiUrl() {
-  return getBasePathBeforeIdentity() + loginApiUrl;
+  return getBasePathBeforeAdmin() + loginApiUrl;
 }
 
 export function getLogoutApiUrl() {
-  return getBasePathBeforeIdentity() + logoutApiUrl;
+  return getBasePathBeforeAdmin() + logoutApiUrl;
 }
 
 export function getBaseUrl() {
-  return getBasePathBeforeIdentity() + identityPath;
+  return getBasePathBeforeAdmin() + adminPath;
 }
 
-export function getBasePathBeforeIdentity(): string {
+export function getBasePathBeforeAdmin(): string {
   const uiPath = window.location.pathname;
-  const endIndex = uiPath.indexOf(identityPath);
+  const endIndex = uiPath.indexOf(adminPath);
   return uiPath.substring(0, endIndex);
 }

--- a/identity/client/vite.config.ts
+++ b/identity/client/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig(
           changeOrigin: true,
         },
         [configPath]: {
-          target: "http://localhost:8080/identity",
+          target: "http://localhost:8080/admin",
           changeOrigin: true,
         },
       },

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -78,7 +78,7 @@ class ApplicationAuthorizationIT {
       HttpClient.newBuilder().followRedirects(Redirect.NEVER).build();
 
   @ParameterizedTest
-  @ValueSource(strings = {"operate", "identity"})
+  @ValueSource(strings = {"operate", "admin"})
   void accessComponentUserWithoutComponentAccessNotAllowed(
       final String appName, @Authenticated(RESTRICTED) final CamundaClient restrictedClient)
       throws IOException, URISyntaxException, InterruptedException {
@@ -99,7 +99,7 @@ class ApplicationAuthorizationIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"operate", "identity", "tasklist"})
+  @ValueSource(strings = {"operate", "admin", "tasklist"})
   void accessComponentNoUserAllowed(
       final String componentName, @Authenticated(ADMIN) final CamundaClient client)
       throws IOException, URISyntaxException, InterruptedException {
@@ -172,7 +172,7 @@ class ApplicationAuthorizationIT {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"operate", "identity", "tasklist"})
+  @ValueSource(strings = {"operate", "admin", "tasklist"})
   void accessComponentUserWithComponentWildcardAccessAllowed(
       final String componentName, @Authenticated(ADMIN) final CamundaClient adminClient)
       throws IOException, URISyntaxException, InterruptedException {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
@@ -46,7 +46,7 @@ test.describe.parallel('login page', () => {
     await expect(page).toHaveURL(`${relativizePath(Paths.users())}`);
     await identityHeader.logout();
     await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=/identity/`,
+      `${relativizePath(Paths.login('identity'))}?next=/admin/`,
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -8,28 +8,34 @@
 
 export const Paths = {
   login(application: string): string {
+    if (application === 'identity') {
+      return '/admin/login';
+    }
     return `/${application}/login`;
   },
   forbidden(application: string): string {
+    if (application === 'identity') {
+      return '/admin/forbidden';
+    }
     return `/${application}/forbidden`;
   },
   mappingRules() {
-    return '/identity/mapping-rules';
+    return '/admin/mapping-rules';
   },
   users() {
-    return '/identity/users';
+    return '/admin/users';
   },
   groups() {
-    return '/identity/groups';
+    return '/admin/groups';
   },
   roles() {
-    return '/identity/roles';
+    return '/admin/roles';
   },
   tenants() {
-    return '/identity/tenants';
+    return '/admin/tenants';
   },
   authorizations() {
-    return '/identity/authorizations';
+    return '/admin/authorizations';
   },
   operateDashboard() {
     return '/operate';


### PR DESCRIPTION
## Description

This PR achieves 2 mains things

1. New `/admin` endpoints are exposed to replace the (now legacy) `/identity` endpoints. These new endpoints should behave in exactly the same way as the `/identity....` endpoints.

2. The (now legacy) `/identity...` endpoints should redirect to the corresponding `/admin...` endpoints. So:
* `/identity` redirects to `/admin`
* `/identity/config.js` redirects to `/admin/config.js`
* `/identity/...` redirects to `/admin/...`

The following screenshots show the 302 Redirects for the aforementioned cases.

<img width="372" height="719" alt="Screenshot 2026-02-16 at 15 11 35" src="https://github.com/user-attachments/assets/932fa8c1-4278-4c04-8203-8fde87611d34" />

<img width="430" height="686" alt="Screenshot 2026-02-16 at 15 41 12" src="https://github.com/user-attachments/assets/f7bfac2e-8a16-4354-9f22-7448b5ca87cb" />

<img width="403" height="687" alt="Screenshot 2026-02-16 at 15 11 53" src="https://github.com/user-attachments/assets/514751ad-e024-4c5b-900a-bae74fc4aa8a" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/44432
