### PR TITLE
fix: fallback to prefer gRPC for CPT

### DIFF
--- a/testing/camunda-process-test-example/src/test/resources/application.yml
+++ b/testing/camunda-process-test-example/src/test/resources/application.yml
@@ -1,8 +1,3 @@
-camunda:
-  client:
-    # Workaround for integration tests
-    prefer-rest-over-grpc: false
-
 logging:
   level:
     root: info

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -148,6 +148,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public CamundaClient createClient(final Consumer<CamundaClientBuilder> modifier) {
     final CamundaClientBuilder builder = camundaClientBuilderFactory.get();
+    builder.preferRestOverGrpc(false);
 
     modifier.accept(builder);
 


### PR DESCRIPTION
## Description

We encountered instabilities we first need to root-cause and address.

This reverts commit 887893b2179a5e85de1f77e10aa9780216ccfbdc to stabilize tests. It also removes a temporary workaround to the CPT example, as this became redundant with the revert.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #45667
