### PR TITLE
refactor: remove Carbon warnings

### DIFF
--- a/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
+++ b/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
@@ -40,11 +40,8 @@ const PartiallyExpandableDataTable: React.FC<Props> = ({
   dataTestId,
 }) => {
   return (
-    <DataTable
-      size="sm"
-      headers={headers}
-      rows={rows}
-      render={({
+    <DataTable size="sm" headers={headers} rows={rows}>
+      {({
         rows,
         headers,
         getTableContainerProps,
@@ -112,7 +109,7 @@ const PartiallyExpandableDataTable: React.FC<Props> = ({
           </Table>
         </TableContainer>
       )}
-    />
+    </DataTable>
   );
 };
 

--- a/operate/client/src/App/Decisions/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Decisions/Filters/OptionalFiltersFormGroup.tsx
@@ -207,7 +207,7 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
                 <IconButton
                   kind="ghost"
                   label={`Remove ${OPTIONAL_FILTER_FIELDS[filter].label} Filter`}
-                  align="top-right"
+                  align="top-end"
                   size="sm"
                   onClick={() => {
                     onVisibleFilterChange(

--- a/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
@@ -287,7 +287,7 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
                 <IconButton
                   kind="ghost"
                   label={`Remove ${OPTIONAL_FILTER_FIELDS[filter].label} Filter`}
-                  align="top-right"
+                  align="top-end"
                   size="sm"
                   onClick={() => {
                     onVisibleFilterChange(

--- a/operate/client/src/modules/components/DataTable/index.tsx
+++ b/operate/client/src/modules/components/DataTable/index.tsx
@@ -71,11 +71,8 @@ const DataTable = React.forwardRef<HTMLDivElement, Props>(
   ) => {
     return (
       <Container className={className} ref={ref}>
-        <CarbonDataTable
-          size={size}
-          headers={rawHeaders}
-          rows={rows}
-          render={({
+        <CarbonDataTable size={size} headers={rawHeaders} rows={rows}>
+          {({
             rows,
             headers,
             getTableContainerProps,
@@ -159,7 +156,7 @@ const DataTable = React.forwardRef<HTMLDivElement, Props>(
               </Table>
             </TableContainer>
           )}
-        />
+        </CarbonDataTable>
       </Container>
     );
   },

--- a/operate/client/src/modules/components/IconInput/IconTextArea.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextArea.tsx
@@ -26,7 +26,7 @@ const IconTextArea: React.FC<Props> = ({
   invalid,
   onIconClick,
   buttonLabel,
-  tooltipPosition = 'top-right',
+  tooltipPosition = 'top-end',
   ...props
 }) => {
   return (

--- a/operate/client/src/modules/components/IconInput/IconTextInput.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextInput.tsx
@@ -26,7 +26,7 @@ const IconTextInput: React.FC<Props> = ({
   invalid,
   onIconClick,
   buttonLabel,
-  tooltipPosition = 'top-right',
+  tooltipPosition = 'top-end',
   ...props
 }) => {
   return (

--- a/operate/client/src/modules/components/SortableTable/index.tsx
+++ b/operate/client/src/modules/components/SortableTable/index.tsx
@@ -130,7 +130,8 @@ const SortableTable = <
         rows={rows}
         headers={headerColumns}
         size={size}
-        render={({
+      >
+        {({
           rows,
           headers,
           getHeaderProps,
@@ -249,7 +250,7 @@ const SortableTable = <
             </Table>
           </TableContainer>
         )}
-      />
+      </DataTable>
     </Container>
   );
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This mutes the following warnings:

- `Warning: The prop `render` has been deprecated for the DataTable component. It will be removed in the next major release`
- `Warning: "top-right" is a deprecated value for the "align" prop on the "ForwardRef" component. Use "top-end" instead. "top-right" will be removed in the next major release.
Warning: "top-right" is a deprecated value for the "align" prop on the "Popover" component. Use "top-end" instead. "top-right" will be removed in the next major release.`
