### PR TITLE
build: add maven-build-cache-extension to .mvn/extensions

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -15,4 +15,10 @@
     <artifactId>maven-profiler</artifactId>
     <version>3.3</version>
   </extension>
+
+  <extension>
+    <groupId>org.apache.maven.extensions</groupId>
+    <artifactId>maven-build-cache-extension</artifactId>
+    <version>1.2.2</version>
+  </extension>
 </extensions>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.2.0">
+  <configuration>
+    <enabled>false</enabled>
+    <hashAlgorithm>XX</hashAlgorithm>
+    <validateXml>true</validateXml>
+    <local>
+      <maxBuildsCached>5</maxBuildsCached>
+    </local>
+  </configuration>
+  <input>
+    <global>
+      <glob>{*.java,*.xml,*.properties, *.proto, resources/api/*.xml, rest-api*.yml }</glob>
+    </global>
+  </input>
+</cache>


### PR DESCRIPTION
## Description
The extension is disabled by default, so there are no changes for users/CI unless they opt in explicitly by setting
`-Dmaven.build.cache.enabled=true`.
Because it's not enabled by default, there's no remote che configured. This is meant as a way to experiment with this extension as it may provide incorrect results until its configured properly

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
