### PR TITLE
[Backport stable/8.8] fix: fallback to prefer gRPC for CPT

### DIFF
--- a/testing/camunda-process-test-example/src/test/resources/application.yml
+++ b/testing/camunda-process-test-example/src/test/resources/application.yml
@@ -1,8 +1,3 @@
-camunda:
-  client:
-    # Workaround for integration tests
-    prefer-rest-over-grpc: false
-
 logging:
   level:
     root: info

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -105,6 +105,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public CamundaClient createClient(final Consumer<CamundaClientBuilder> modifier) {
     final CamundaClientBuilder builder = camundaClientBuilderFactory.get();
+    builder.preferRestOverGrpc(false);
 
     modifier.accept(builder);
 


### PR DESCRIPTION
# Description
Backport of #45776 to `stable/8.8`.

relates to #45667