### PR TITLE
feat: make `--to` parameter optional when restoring a backup from time range

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -656,6 +656,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,7 @@
     <version.jackson3>3.0.4</version.jackson3>
     <version.json-base>3.0.0</version.json-base>
     <version.json-flattener>0.18.0</version.json-flattener>
+    <version.jspecify>1.0.0</version.jspecify>
     <version.junit>6.0.3</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.3</version.log4j>
@@ -2036,6 +2037,12 @@
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
         <version>${version.jakarta-activation}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${version.jspecify}</version>
       </dependency>
 
       <!-- required between me.dinowernli:java-grpc-prometheus and com.google.guava:guava -->

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -121,6 +121,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
@@ -13,11 +13,14 @@ import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Similar to {@link BackupIdentifier} but fields that are omitted should be interpreted as a
  * wildcard.
  */
+@NullMarked
 public interface BackupIdentifierWildcard {
   /**
    * @return id of the broker which took this backup.
@@ -109,7 +112,7 @@ public interface BackupIdentifierWildcard {
       return new Exact(checkpointId);
     }
 
-    static CheckpointPattern of(final String pattern) {
+    static CheckpointPattern of(@Nullable final String pattern) {
       if (pattern == null || pattern.isEmpty() || "*".equals(pattern)) {
         return new Any();
       } else if (pattern.endsWith("*")) {

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -123,6 +123,11 @@
       <artifactId>camunda-db-rdbms</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -132,10 +132,10 @@ public final class BackupRangeResolver {
 
     // if to was not set, then the interval can be computed with `from` and the last backup
     final var interval =
-        to != null
-            ? Interval.closed(from, to)
-            : Interval.closed(
-                from, statusInterval.getRight().end().descriptor().get().checkpointTimestamp());
+        Interval.closed(
+            from,
+            Optional.ofNullable(to)
+                .orElse(statusInterval.getRight().end().descriptor().get().checkpointTimestamp()));
 
     // Retrieve all BackupStatus in the BackupRange
     // note that all backups must be retrieved as we only know the extremes, not every backup inside

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -196,8 +196,10 @@ public final class BackupRangeResolver {
           // ignore this backup
           continue;
         }
-        if (interval != null && timeInterval.contains(interval)) {
-          return Optional.of(new Tuple<>(completeRange, statusInterval));
+        if (interval != null) {
+          if (timeInterval.contains(interval)) {
+            return Optional.of(new Tuple<>(completeRange, statusInterval));
+          }
         } else if (timeInterval.contains(from)) {
           return Optional.of(new Tuple<>(completeRange, statusInterval));
         }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -34,6 +34,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * {@link BackupStore} to fetch and manage backup data required for restoring partitions or
  * determining safe starting checkpoints.
  */
+@NullMarked
 public final class BackupRangeResolver {
 
   private static final Logger LOG = LoggerFactory.getLogger(BackupRangeResolver.class);
@@ -57,7 +60,8 @@ public final class BackupRangeResolver {
    *     per task
    */
   public CompletableFuture<GlobalRestoreInfo> getRestoreInfoForAllPartitions(
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final int partitionCount,
       final Map<Integer, Long> exportedPositions,
       final CheckpointIdGenerator checkpointIdGenerator,
@@ -85,7 +89,8 @@ public final class BackupRangeResolver {
                     () ->
                         getInformationPerPartition(
                             partition,
-                            interval,
+                            from,
+                            to,
                             exportedPositions.get(partition),
                             checkpointIdGenerator),
                     executor))
@@ -102,7 +107,8 @@ public final class BackupRangeResolver {
 
   public PartitionRestoreInfo getInformationPerPartition(
       final int partition,
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final long exporterPosition,
       final CheckpointIdGenerator checkpointIdGenerator) {
     final var rangeMarkers = store.rangeMarkers(partition).join();
@@ -110,18 +116,26 @@ public final class BackupRangeResolver {
 
     // finds the BackupRange that entirely covers the interval `[from, to]`
     final var statusInterval =
-        findBackupRangeCoveringInterval(interval, ranges, partition)
+        findBackupRangeCoveringInterval(from, to, ranges, partition)
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "No complete backup range found for partition %d in interval %s, ranges=%s, timeInterval=%s"
+                        "No complete backup range found for partition %d in interval [%s, %s], ranges=%s, timeInterval=%s"
                             .formatted(
                                 partition,
-                                interval,
+                                from,
+                                to,
                                 ranges,
                                 ranges.stream()
                                     .map(r -> r.timeInterval(checkpointIdGenerator))
                                     .toList())));
+
+    // if to was not set, then the interval can be computed with `from` and the last backup
+    final var interval =
+        to != null
+            ? Interval.closed(from, to)
+            : Interval.closed(
+                from, statusInterval.getRight().end().descriptor().get().checkpointTimestamp());
 
     // Retrieve all BackupStatus in the BackupRange
     // note that all backups must be retrieved as we only know the extremes, not every backup inside
@@ -155,17 +169,21 @@ public final class BackupRangeResolver {
    * interval. If such a range is found, it is returned along with its corresponding backup status
    * interval. If no range meets the criteria, an empty {@code Optional} is returned.
    *
-   * @param interval the target time interval that needs to be covered
+   * @param from the target start of time interval that needs to be covered
+   * @param to the target end of time interval that needs to be covered (optional, the end of the
+   *     backup range will be used instead)
    * @param ranges a chronologically ordered collection of backup ranges to search
    * @param partitionId the partition ID used for mapping backup checkpoints to their statuses
    * @return an {@code Optional} containing a tuple of the matching complete backup range and its
    *     corresponding status interval if found; otherwise, an empty {@code Optional}
    */
   public Optional<Tuple<Complete, Interval<BackupStatus>>> findBackupRangeCoveringInterval(
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final SequencedCollection<BackupRange> ranges,
       final int partitionId) {
     // ranges are ordered chronologically, so we start from the latest one, going backwards in time
+    final var interval = to != null ? Interval.closed(from, to) : null;
     for (final var range : ranges.reversed()) {
       if (range instanceof final BackupRange.Complete completeRange) {
         // get the BackupStatuses from the store
@@ -178,7 +196,9 @@ public final class BackupRangeResolver {
           // ignore this backup
           continue;
         }
-        if (timeInterval.contains(interval)) {
+        if (interval != null && timeInterval.contains(interval)) {
+          return Optional.of(new Tuple<>(completeRange, statusInterval));
+        } else if (timeInterval.contains(from)) {
           return Optional.of(new Tuple<>(completeRange, statusInterval));
         }
       }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -64,9 +64,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.agrona.collections.MutableBoolean;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NullMarked
 public class RestoreManager implements CloseableSilently {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
   private final BrokerCfg configuration;
@@ -74,7 +77,7 @@ public class RestoreManager implements CloseableSilently {
   private final BackupRangeResolver rangeResolver;
   private final MeterRegistry meterRegistry;
   private final CheckpointIdGenerator checkpointIdGenerator;
-  private final ExporterPositionMapper exporterPositionMapper;
+  @Nullable private final ExporterPositionMapper exporterPositionMapper;
   private final ExecutorService executor;
 
   @VisibleForTesting
@@ -88,7 +91,7 @@ public class RestoreManager implements CloseableSilently {
   public RestoreManager(
       final BrokerCfg configuration,
       final BackupStore backupStore,
-      final ExporterPositionMapper exporterPositionMapper,
+      @Nullable final ExporterPositionMapper exporterPositionMapper,
       final MeterRegistry meterRegistry) {
     checkpointIdGenerator =
         new CheckpointIdGenerator(configuration.getData().getBackup().getOffset());
@@ -109,12 +112,12 @@ public class RestoreManager implements CloseableSilently {
 
   public void restore(
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
     if (exporterPositionMapper == null) {
-      restoreTimeRange(from, to, validateConfig, ignoreFilesInTarget);
+      restoreTimeRange(from, to != null ? to : Instant.now(), validateConfig, ignoreFilesInTarget);
     } else {
       restoreRdbms(from, to, validateConfig, ignoreFilesInTarget);
     }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -125,7 +125,7 @@ public class RestoreManager implements CloseableSilently {
 
   private void restoreRdbms(
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
@@ -137,7 +137,7 @@ public class RestoreManager implements CloseableSilently {
     final var restoreInfos =
         rangeResolver
             .getRestoreInfoForAllPartitions(
-                interval, partitionCount, exportedPositions, checkpointIdGenerator, executor)
+                from, to, partitionCount, exportedPositions, checkpointIdGenerator, executor)
             .join();
 
     LOG.info(

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.backup.api.BackupRangeMarker;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.api.Interval;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
@@ -40,12 +39,15 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@NullMarked
 final class BackupRangeResolverTest {
 
   private static final int NODE_ID = 0;
@@ -163,6 +165,25 @@ final class BackupRangeResolverTest {
   }
 
   @Test
+  void shouldRestoreToEndOfRangeWhenToIsMissing() {
+    // given
+    store
+        .forPartition(1)
+        .withRange(100, 400)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40))
+        .addBackup(400, 4000, 3001, minutesAfterBase(60));
+
+    // when - time interval [20, 40] covers only checkpoints 200 and 300
+    final var result = resolve(1, minutesAfterBase(20), null, Map.of(1, 2500L));
+
+    // then - only backups within time interval are returned
+    assertThat(result.globalCheckpointId()).isEqualTo(400L);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(200L, 300L, 400L);
+  }
+
+  @Test
   void shouldHandleDifferentSafeStartsPerPartition() {
     // given - partitions have different exported positions, so different safe starts
     store
@@ -200,8 +221,8 @@ final class BackupRangeResolverTest {
             () -> resolve(1, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L)))
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[]");
+        .hasRootCauseMessage(
+            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[], timeInterval=[]");
   }
 
   @Test
@@ -289,11 +310,11 @@ final class BackupRangeResolverTest {
 
     // when/then
     assertThatThrownBy(
-            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L, 2, 2500L)))
+            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(30), Map.of(1, 2500L, 2, 2500L)))
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[Complete[checkpointInterval=[100, 200]]");
+        .hasRootCauseMessage(
+            "No complete backup range found for partition 2 in interval [2026-01-20T10:00:00Z, 2026-01-20T10:30:00Z], ranges=[Complete[checkpointInterval=[100, 200]]], timeInterval=[[1970-01-01T00:00:00.100Z, 1970-01-01T00:00:00.200Z]]");
   }
 
   @Test
@@ -461,18 +482,12 @@ final class BackupRangeResolverTest {
   private GlobalRestoreInfo resolve(
       final int partitionCount,
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final Map<Integer, Long> exportedPositions) {
-    final var value =
-        resolver
-            .getRestoreInfoForAllPartitions(
-                Interval.closed(from, to),
-                partitionCount,
-                exportedPositions,
-                checkIdGenerator,
-                DIRECT_EXECUTOR)
-            .join();
-    return value;
+    return resolver
+        .getRestoreInfoForAllPartitions(
+            from, to, partitionCount, exportedPositions, checkIdGenerator, DIRECT_EXECUTOR)
+        .join();
   }
 
   private static Instant minutesAfterBase(final int minutes) {
@@ -605,7 +620,7 @@ final class BackupRangeResolverTest {
           backups.values().stream()
               .filter(backup -> wildcard.matches(backup.id()))
               .map(this::toStatus)
-              .map(s -> (BackupStatus) s)
+              .map(BackupStatus.class::cast)
               .toList();
       return CompletableFuture.completedFuture(matchingBackups);
     }
@@ -619,6 +634,12 @@ final class BackupRangeResolverTest {
     @Override
     public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
       return CompletableFuture.completedFuture(backups.get(id));
+    }
+
+    @Override
+    public CompletableFuture<BackupStatusCode> markFailed(
+        final BackupIdentifier id, final String failureReason) {
+      return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
     }
 
     @Override
@@ -647,12 +668,6 @@ final class BackupRangeResolverTest {
     @Override
     public CompletableFuture<Void> closeAsync() {
       return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
-    public CompletableFuture<BackupStatusCode> markFailed(
-        final BackupIdentifier id, final String failureReason) {
-      return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
     }
 
     private BackupStatusImpl toStatus(final Backup backup) {

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -167,18 +167,20 @@ final class BackupRangeResolverTest {
   @Test
   void shouldRestoreToEndOfRangeWhenToIsMissing() {
     // given
-    store
-        .forPartition(1)
-        .withRange(100, 400)
-        .addBackup(100, 1000, 1, minutesAfterBase(0))
-        .addBackup(200, 2000, 1001, minutesAfterBase(20))
-        .addBackup(300, 3000, 2001, minutesAfterBase(40))
-        .addBackup(400, 4000, 3001, minutesAfterBase(60));
+    for (int i = 1; i < 3; i++) {
+      store
+          .forPartition(i)
+          .withRange(100, 400)
+          .addBackup(100, 1000, 1, minutesAfterBase(0))
+          .addBackup(200, 2000, 1001, minutesAfterBase(20))
+          .addBackup(300, 3000, 2001, minutesAfterBase(40))
+          .addBackup(400, 4000, 3001, minutesAfterBase(60));
+    }
 
     // when - time interval [20, 40] covers only checkpoints 200 and 300
     final var result = resolve(1, minutesAfterBase(20), null, Map.of(1, 2500L));
 
-    // then - only backups within time interval are returned
+    // then - all backups after `from` are returned
     assertThat(result.globalCheckpointId()).isEqualTo(400L);
     assertThat(result.backupsByPartitionId().get(1)).containsExactly(200L, 300L, 400L);
   }


### PR DESCRIPTION
## Description
Makes `--to` parameter from `RestoreApp` optional.
When it's missing the default it's either `Instant.now()` if restoring for a time range or the `checkpointTimestamp` of the `BackupRange` which contains `from`. 


I added `jspecify` to `zeebe-backup` and `zeebe-restore` without adding any annotation processor, as of now it just generates warning in IntelliJ.

/cc @npepinpe 

## Related issues

closes #40232
