### PR TITLE
fix: advance range marker only on completed backups

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -314,8 +314,8 @@ public class BackupRetention extends Actor {
       final var marker = context.previousStartMarker.get();
       LOG.debug(
           "Advancing range start marker for partition {} from {} to {}",
-          context.previousStartMarker.get(),
           context.partitionId,
+          context.previousStartMarker.get(),
           context.earliestBackupInNewRange);
       backupStore
           .storeRangeMarker(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -294,7 +294,14 @@ public class BackupRetention extends Actor {
           firstAvailableBackupInNewRange = backup.id().checkpointId();
         }
       } else {
-        firstAvailableBackupInNewRange = backup.id().checkpointId();
+        // Only consider completed backups for the range change.
+        if (backup.statusCode() == BackupStatusCode.COMPLETED
+            && firstAvailableBackupInNewRange == -1L) {
+          firstAvailableBackupInNewRange = backup.id().checkpointId();
+        }
+        if (firstAvailableBackupInNewRange == -1L) {
+          continue;
+        }
         break;
       }
     }
@@ -306,7 +313,7 @@ public class BackupRetention extends Actor {
     if (shouldResetMarker(context)) {
       final var marker = context.previousStartMarker.get();
       LOG.debug(
-          "Resetting range start marker {} for partition {} to checkpoint id {}",
+          "Advancing range start marker for partition {} from {} to {}",
           context.previousStartMarker.get(),
           context.partitionId,
           context.earliestBackupInNewRange);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Do not advance range `START` marker to non-completed backups as this state is invalid for the restore operation. A range only start/end on a `COMPLETED` backup.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
