### PR TITLE
fix: when exporting with default last_updated value (-1) this fallbac to null

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
@@ -127,9 +127,11 @@ public class JobBatchMetricsExportedHandler
 
   private OffsetDateTime getLastUpdatedAtForStatus(
       final JobMetricsValue jobMetrics, final JobMetricsExportState jobState) {
-    return OffsetDateTime.ofInstant(
-        Instant.ofEpochMilli(
-            jobMetrics.getStatusMetrics().get(jobState.getIndex()).getLastUpdatedAt()),
-        ZoneOffset.UTC);
+    final long lastUpdatedAt =
+        jobMetrics.getStatusMetrics().get(jobState.getIndex()).getLastUpdatedAt();
+    if (lastUpdatedAt == -1L) {
+      return null;
+    }
+    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(lastUpdatedAt), ZoneOffset.UTC);
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobMetricsBatchExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobMetricsBatchExportHandler.java
@@ -94,9 +94,11 @@ public class JobMetricsBatchExportHandler
 
   private OffsetDateTime getLastUpdatedAtForStatus(
       final JobMetricsValue jobMetrics, final JobMetricsExportState jobState) {
-    return OffsetDateTime.ofInstant(
-        Instant.ofEpochMilli(
-            jobMetrics.getStatusMetrics().get(jobState.getIndex()).getLastUpdatedAt()),
-        ZoneOffset.UTC);
+    final long lastUpdatedAt =
+        jobMetrics.getStatusMetrics().get(jobState.getIndex()).getLastUpdatedAt();
+    if (lastUpdatedAt == -1L) {
+      return null;
+    }
+    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(lastUpdatedAt), ZoneOffset.UTC);
   }
 }


### PR DESCRIPTION
This pull request makes a small but important improvement to the way job metrics timestamps are handled in two exporter handler classes. The change ensures that if the `lastUpdatedAt` timestamp is unset (represented by `-1L`), the method returns `null` instead of an invalid date.

Handling of unset timestamps:

* Updated the `getLastUpdatedAtForStatus` method in both `JobBatchMetricsExportedHandler.java` and `JobMetricsBatchExportHandler.java` to return `null` when `lastUpdatedAt` is `-1L`, preventing the creation of invalid `OffsetDateTime` instances. [[1]](diffhunk://#diff-096833dfb85efa406d01b0e7c907750f89f5b59bd97891af703e8e9c494552ceL130-R135) [[2]](diffhunk://#diff-07cba0f0837556f66d6c347a0562d5b7111447d5d8a5e809287a9c340fc1a106L97-R102)