### PR TITLE
fix: block major+minor Docker updates for docker.elastic.co ES images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -154,6 +154,7 @@
       ],
       "matchPackageNames": [
         "elasticsearch",
+        "docker.elastic.co/elasticsearch/elasticsearch",
         "opensearchproject/opensearch",
         "eclipse-temurin",
         "reg.mini.dev/1212/openjre-base"


### PR DESCRIPTION
## Summary

- The Renovate rule blocking major+minor Docker updates for Elasticsearch only matched the Docker Hub short name `elasticsearch`, not the `docker.elastic.co/elasticsearch/elasticsearch` registry prefix actually used in the codebase.
- This allowed PR #45605 to upgrade ES from 8.19.11 to 9.3.0 across a major version boundary and automerge.
- Adds `docker.elastic.co/elasticsearch/elasticsearch` to the `matchPackageNames` list in the blocking rule so both registries are covered.

## Related

- Caused by: #45605