### PR TITLE
feat: Rename Identity UI to Admin UI

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -18,7 +18,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Deprecated
 public class IdentityClientConfigController {
 
-  /** Redirects legacy /identity/config.js to /admin/config.js. */
+  /**
+   * Redirects legacy /identity/config.js to /admin/config.js.
+   *
+   * <p>TODO(#44427): This can be removed after sufficient migration period (Epic #44427).
+   */
   @GetMapping(path = "/identity/config.js")
   @Hidden
   public String redirectToAdminConfig() {

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityClientConfigController.java
@@ -21,7 +21,7 @@ public class IdentityClientConfigController {
   /**
    * Redirects legacy /identity/config.js to /admin/config.js.
    *
-   * <p>TODO(#44427): This can be removed after sufficient migration period (Epic #44427).
+   * <p>TODO(#46027): This can be removed after sufficient migration period.
    */
   @GetMapping(path = "/identity/config.js")
   @Hidden

--- a/identity/client/README.md
+++ b/identity/client/README.md
@@ -1,4 +1,4 @@
-# Identity frontend
+# Admin frontend
 
 To start in development mode run
 

--- a/identity/client/index.html
+++ b/identity/client/index.html
@@ -15,7 +15,7 @@
     <script type="text/javascript" src="./config.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Camunda Identity</title>
+    <title>Camunda Admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -42,8 +42,8 @@ const AppHeader = ({ hideNavLinks = false }) => {
     <C3Navigation
       toggleAppbar={(isAppBarOpen) => setIsAppBarOpen(isAppBarOpen)}
       app={{
-        name: "Identity",
-        ariaLabel: "Identity",
+        name: "Admin",
+        ariaLabel: "Admin",
         routeProps: {
           to: "/",
         },

--- a/identity/client/src/pages/login/LoginPage.tsx
+++ b/identity/client/src/pages/login/LoginPage.tsx
@@ -180,7 +180,7 @@ export const LoginPage: React.FC = () => {
       <Content>
         <Header>
           <CamundaLogo />
-          <h1>{t("identity")}</h1>
+          <h1>{t("admin")}</h1>
         </Header>
         <LoginForm onSuccess={onSuccess} />
         {!hasProductionLicense && (

--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -31,6 +31,7 @@
   "hidePassword": "Hide password",
   "showPassword": "Show password",
   "login": "Login",
+  "admin": "Admin",
   "identity": "Identity",
   "licenseInfo": "Non-Production License. If you would like information on production usage, please refer to our <2>terms & conditions page</2> or <2>contact sales</2>.",
   "loading": "Loading",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -8,14 +8,14 @@
 
 export const Paths = {
   login(application: string): string {
-    // Identity uses /admin path after migration
+    // TODO(#46027): This can be removed after sufficient migration period.
     if (application === 'identity') {
       return '/admin/login';
     }
     return `/${application}/login`;
   },
   forbidden(application: string): string {
-    // Identity uses /admin path after migration
+    // TODO(#46027): This can be removed after sufficient migration period.
     if (application === 'identity') {
       return '/admin/forbidden';
     }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -8,12 +8,14 @@
 
 export const Paths = {
   login(application: string): string {
+    // Identity uses /admin path after migration
     if (application === 'identity') {
       return '/admin/login';
     }
     return `/${application}/login`;
   },
   forbidden(application: string): string {
+    // Identity uses /admin path after migration
     if (application === 'identity') {
       return '/admin/forbidden';
     }


### PR DESCRIPTION
## Description

We are slowly renaming the OC Identity app into OC Admin. This PR should take care of all the UI labelling. 

<img width="1201" height="260" alt="Screenshot 2026-02-18 at 12 19 53" src="https://github.com/user-attachments/assets/bde62dd1-1fbc-4a17-9175-911857295792" />

<img width="874" height="130" alt="Screenshot 2026-02-18 at 12 20 01" src="https://github.com/user-attachments/assets/2828c5e5-a0c6-46e9-9fec-5d33b06d86a7" />

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/44428
