### PR TITLE
Extend processInstanceModification test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -417,10 +417,13 @@ class OperateProcessInstancePage {
     return this.modalDialog.getByRole('button', {name: 'Cancel'});
   }
 
-  getMoveInstanceModificationText(sourceFlowNode: string, targetFlowNode: string) {
+  getMoveInstanceModificationText(
+    sourceFlowNode: string,
+    targetFlowNode: string,
+  ) {
     return this.page.getByText(
       new RegExp(`move "${sourceFlowNode}" to "${targetFlowNode}"`, 'i'),
-    ); 
+    );
   }
 
   async clickDialogDeleteVariableModification(index?: number) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -417,6 +417,12 @@ class OperateProcessInstancePage {
     return this.modalDialog.getByRole('button', {name: 'Cancel'});
   }
 
+  getMoveInstanceModificationText(sourceFlowNode: string, targetFlowNode: string) {
+    return this.page.getByText(
+      new RegExp(`move "${sourceFlowNode}" to "${targetFlowNode}"`, 'i'),
+    ); 
+  }
+
   async clickDialogDeleteVariableModification(index?: number) {
     await this.getDialogDeleteVariableModificationButton(index).click();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -186,7 +186,7 @@ export class OperateProcessInstanceViewModificationModePage {
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')
-          .getByRole('textbox', { name: 'Editor content' }),
+          .getByRole('textbox', {name: 'Editor content'}),
       },
       valueErrorMessage: this.page
         .getByTestId(`variable-newVariables[${index}]`)
@@ -239,7 +239,7 @@ export class OperateProcessInstanceViewModificationModePage {
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')
-          .getByRole('textbox', { name: 'Editor content' }),
+          .getByRole('textbox', {name: 'Editor content'}),
       },
       valueErrorMessage: this.page
         .getByTestId(`variable-${name}`)
@@ -419,7 +419,7 @@ export class OperateProcessInstanceViewModificationModePage {
 
   async moveInstanceFromSelectedFlowNodeToTarget(
     sourceFlowNodeName: string,
-    targetFlowNodeName: string, 
+    targetFlowNodeName: string,
   ): Promise<void> {
     await this.clickFlowNode(sourceFlowNodeName);
     await this.clickMoveInstanceButtononPopup();
@@ -616,8 +616,7 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async editNewVariableJSONInModal(variableIndex: number, json: string) {
-    await this.newVariableByIndex(variableIndex)
-      .value.clear();
+    await this.newVariableByIndex(variableIndex).value.clear();
     await this.newVariableByIndex(variableIndex).jsonEditorButton.click();
     const jsonEditorModal =
       this.newVariableByIndex(variableIndex).jsonEditorModal;
@@ -641,9 +640,7 @@ export class OperateProcessInstanceViewModificationModePage {
     await expect(jsonEditorModal.inputField).toBeEnabled();
     await this.fillMonacoEditor(jsonEditorModal.inputField, json);
     await jsonEditorModal.applyButton.click();
-    await this.editableExistingVariableByName(
-      variableName,
-    ).value.click();
+    await this.editableExistingVariableByName(variableName).value.click();
     await this.page.keyboard.press('Tab');
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -348,6 +348,10 @@ export class OperateProcessInstanceViewModificationModePage {
     await this.moveAllButtononPopup.click();
   }
 
+  async clickMoveInstanceButtononPopup(): Promise<void> {
+    await this.moveSelectedInstanceButton.click();
+  }
+
   async clickCancelButtononPopup(): Promise<void> {
     await this.cancelButtonPopup.click();
   }
@@ -409,6 +413,16 @@ export class OperateProcessInstanceViewModificationModePage {
   ): Promise<void> {
     await this.clickFlowNode(sourceFlowNodeName);
     await this.clickMoveAllButtononPopup();
+    await expect(this.moveTokensMessage).toBeVisible();
+    await this.clickFlowNode(targetFlowNodeName);
+  }
+
+  async moveInstanceFromSelectedFlowNodeToTarget(
+    sourceFlowNodeName: string,
+    targetFlowNodeName: string, 
+  ): Promise<void> {
+    await this.clickFlowNode(sourceFlowNodeName);
+    await this.clickMoveInstanceButtononPopup();
     await expect(this.moveTokensMessage).toBeVisible();
     await this.clickFlowNode(targetFlowNodeName);
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -716,6 +716,4 @@ export class OperateProcessInstanceViewModificationModePage {
       expect(variableName).not.toContain(forbiddenText);
     });
   }
-
-  async findVariableModificationInDialog(variableName: string) {}
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -802,17 +802,17 @@ test.describe('Process Instance Modifications', () => {
       ).toHaveValue('1');
     });
 
-    // await test.step('Undo again and verify new variable field removed', async () => {
-    //   await operateProcessInstancePage.undoModification();
+    await test.step('Undo again and verify new variable field removed', async () => {
+      await operateProcessInstancePage.undoModification();
 
-    //   // here might be needed change from hidden to add token operation
-    //   await expect(
-    //     operateProcessInstancePage.lastAddedModificationText,
-    //   ).toBeHidden();
-    //   await expect(
-    //     operateProcessInstancePage.getVariableTestId('newVariables[0]'),
-    //   ).toBeHidden();
-    // });
+      // here might be needed change from hidden to add token operation
+      await expect(
+        operateProcessInstancePage.lastAddedModificationText,
+      ).toBeHidden();
+      await expect(
+        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+      ).toBeHidden();
+    });
 
     await test.step('Add variables to different scopes with same name', async () => {
       await operateProcessInstancePage.addNewVariableModificationMode(
@@ -821,8 +821,8 @@ test.describe('Process Instance Modifications', () => {
         '1',
       );
 
-      const addedTokenInHisotry = `${neverFailsHistoryItem}, this flow node instance is planned to be added`;
-      await operateProcessInstancePage.clickTreeItem(addedTokenInHisotry);
+      const addedTokenInHistory = `${neverFailsHistoryItem}, this flow node instance is planned to be added`;
+      await operateProcessInstancePage.clickTreeItem(addedTokenInHistory);
       await expect(
         page.getByText(/The Flow Node has no Variables/i),
       ).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -527,17 +527,9 @@ test.describe('Process Instance Modifications', () => {
         .deleteButton.click();
 
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
-      for (let i = 0; ; i++) {
-        const row =
-          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-            i,
-          );
-        if (!(await row.nameValue.isVisible())) {
-          break;
-        }
-        const variableName = await row.nameValue.innerText();
-        expect(variableName).not.toContain('testVariableToRemove');
-      }
+      await operateProcessInstanceViewModificationModePage.expectVariableNotPresentInDialog(
+        'testVariableToRemove',
+      );
       await operateProcessInstanceViewModificationModePage.clickCancelButtonDialog();
     });
 
@@ -559,38 +551,13 @@ test.describe('Process Instance Modifications', () => {
 
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
 
-      let variableModificationFound = false;
+      await operateProcessInstanceViewModificationModePage.deleteVariableModificationFromDialog(
+        {nameText: 'testVariableToMeow: "meow"'},
+      );
 
-      for (let i = 0; ; i++) {
-        const row =
-          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-            i,
-          );
-        if (!(await row.nameValue.isVisible())) {
-          break;
-        }
-        const variableNameValue = await row.nameValue.innerText();
-        if (variableNameValue === 'testVariableToMeow: "meow"') {
-          await expect(row.nameValue).toHaveText('testVariableToMeow: "meow"');
-          await row.deleteVariableModificationButton.click();
-          variableModificationFound = true;
-          break;
-        }
-      }
-      expect(variableModificationFound).toBeTruthy();
-
-      for (let i = 0; ; i++) {
-        const row =
-          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-            i,
-          );
-        if (!(await row.nameValue.isVisible())) {
-          break;
-        }
-        const variableName = await row.nameValue.innerText();
-
-        expect(variableName).not.toContain('testVariableToMeow');
-      }
+      await operateProcessInstanceViewModificationModePage.expectVariableNotPresentInDialog(
+        'testVariableToMeow',
+      );
 
       await operateProcessInstanceViewModificationModePage.clickCancelButtonDialog();
     });
@@ -835,17 +802,17 @@ test.describe('Process Instance Modifications', () => {
       ).toHaveValue('1');
     });
 
-    await test.step('Undo again and verify new variable field removed', async () => {
-      await operateProcessInstancePage.undoModification();
+    // await test.step('Undo again and verify new variable field removed', async () => {
+    //   await operateProcessInstancePage.undoModification();
 
-      // here might be needed change from hidden to add token operation
-      await expect(
-        operateProcessInstancePage.lastAddedModificationText,
-      ).toBeHidden();
-      await expect(
-        operateProcessInstancePage.getVariableTestId('newVariables[0]'),
-      ).toBeHidden();
-    });
+    //   // here might be needed change from hidden to add token operation
+    //   await expect(
+    //     operateProcessInstancePage.lastAddedModificationText,
+    //   ).toBeHidden();
+    //   await expect(
+    //     operateProcessInstancePage.getVariableTestId('newVariables[0]'),
+    //   ).toBeHidden();
+    // });
 
     await test.step('Add variables to different scopes with same name', async () => {
       await operateProcessInstancePage.addNewVariableModificationMode(
@@ -877,27 +844,9 @@ test.describe('Process Instance Modifications', () => {
         ),
       ).toHaveCount(2);
 
-      let variableModificationFound = false;
-
-      for (let i = 0; ; i++) {
-        const row =
-          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-            i,
-          );
-        if (!(await row.nameValue.isVisible())) {
-          break;
-        }
-        const variableNameValue = await row.nameValue.innerText();
-        const scope = await row.scope.innerText();
-        if (scope === 'Never fails' && variableNameValue === 'test3: 1') {
-          await expect(row.nameValue).toHaveText('test3: 1');
-          await expect(row.scope).toHaveText('Never fails');
-          await row.deleteVariableModificationButton.click();
-          variableModificationFound = true;
-          break;
-        }
-      }
-      expect(variableModificationFound).toBeTruthy();
+      await operateProcessInstanceViewModificationModePage.deleteVariableModificationFromDialog(
+        {nameText: 'test3: 1', scopeText: 'Never fails'},
+      );
 
       await operateProcessInstancePage.clickDialogCancel();
 
@@ -908,21 +857,13 @@ test.describe('Process Instance Modifications', () => {
 
     await test.step('Verify first scope still has the variable creation scheduled', async () => {
       await operateProcessInstancePage.clickApplyModifications();
+      const row =
+        operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
+          0,
+        );
 
-      for (let i = 0; ; i++) {
-        const row =
-          operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
-            i,
-          );
-        if (!(await row.nameValue.isVisible())) {
-          break;
-        }
-        const variableNameValue = await row.nameValue.innerText();
-        const scope = await row.scope.innerText();
-
-        await expect(row.nameValue).toHaveText('test3: 1');
-        await expect(row.scope).toHaveText('Without Incidents Process');
-      }
+      await expect(row.nameValue).toHaveText('test3: 1');
+      await expect(row.scope).toHaveText('Without Incidents Process');
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -58,7 +58,7 @@ const validJSONValue2 = {
 };
 
 const neverFailsNode = 'neverFails';
-const neverFailsHistoryItem = 'Never fails'
+const neverFailsHistoryItem = 'Never fails';
 const endElement = 'end';
 
 test.beforeAll(async () => {
@@ -128,7 +128,10 @@ test.describe('Process Instance Modifications', () => {
     });
 
     await test.step('Move token to the end element to enable variable modification', async () => {
-      await operateProcessInstanceViewModificationModePage.moveInstanceFromSelectedFlowNodeToTarget(neverFailsNode, endElement);
+      await operateProcessInstanceViewModificationModePage.moveInstanceFromSelectedFlowNodeToTarget(
+        neverFailsNode,
+        endElement,
+      );
       await operateProcessInstanceViewModificationModePage.verifyModificationOverlay(
         neverFailsNode,
         -1,
@@ -236,7 +239,12 @@ test.describe('Process Instance Modifications', () => {
       await expect(
         operateProcessInstancePage.lastAddedModificationText,
       ).toBeVisible();
-      await expect(operateProcessInstancePage.getMoveInstanceModificationText(neverFailsHistoryItem, endElement)).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getMoveInstanceModificationText(
+          neverFailsHistoryItem,
+          endElement,
+        ),
+      ).toBeVisible();
       await expect(
         operateProcessInstancePage.getEditVariableFieldSelector('test'),
       ).toHaveValue('123');
@@ -276,7 +284,12 @@ test.describe('Process Instance Modifications', () => {
       await expect(
         operateProcessInstancePage.lastAddedModificationText,
       ).toBeVisible();
-      await expect(operateProcessInstancePage.getMoveInstanceModificationText(neverFailsHistoryItem, endElement)).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getMoveInstanceModificationText(
+          neverFailsHistoryItem,
+          endElement,
+        ),
+      ).toBeVisible();
       await expect(
         operateProcessInstancePage.getEditVariableFieldSelector('foo'),
       ).toHaveValue('"bar"');
@@ -306,7 +319,10 @@ test.describe('Process Instance Modifications', () => {
     await test.step('Enter modification mode and verify variables are not editable', async () => {
       await operateProcessInstancePage.enterModificationMode();
       await expect(operateProcessInstancePage.addVariableButton).toBeHidden();
-      await expect(operateProcessInstancePage.existingVariableByName('testVariableString').editVariableModal.button).toBeHidden();
+      await expect(
+        operateProcessInstancePage.existingVariableByName('testVariableString')
+          .editVariableModal.button,
+      ).toBeHidden();
     });
 
     await test.step('Select an element from the process diagram and verify variables are not addable', async () => {
@@ -567,12 +583,12 @@ test.describe('Process Instance Modifications', () => {
         const row =
           operateProcessInstanceViewModificationModePage.applyModificationDialogVariableModificationRowByIndex(
             i,
-        );
+          );
         if (!(await row.nameValue.isVisible())) {
           break;
         }
         const variableName = await row.nameValue.innerText();
-    
+
         expect(variableName).not.toContain('testVariableToMeow');
       }
 
@@ -874,8 +890,8 @@ test.describe('Process Instance Modifications', () => {
         const variableNameValue = await row.nameValue.innerText();
         const scope = await row.scope.innerText();
         if (scope === 'Never fails' && variableNameValue === 'test3: 1') {
-          expect(row.nameValue).toHaveText('test3: 1');
-          expect(row.scope).toHaveText('Never fails');
+          await expect(row.nameValue).toHaveText('test3: 1');
+          await expect(row.scope).toHaveText('Never fails');
           await row.deleteVariableModificationButton.click();
           variableModificationFound = true;
           break;
@@ -903,7 +919,7 @@ test.describe('Process Instance Modifications', () => {
         }
         const variableNameValue = await row.nameValue.innerText();
         const scope = await row.scope.innerText();
-        
+
         await expect(row.nameValue).toHaveText('test3: 1');
         await expect(row.scope).toHaveText('Without Incidents Process');
       }


### PR DESCRIPTION
## Description
This PR introduces additional test steps into "Should apply/remove edit variable modifications" and "Should apply/remove add variable modifications" tests. Those test steps including adding tokens to allow add/edit variables in a process instance view. 
Also it separates some functions for reusability.

## Related issues

related #41143 

## On demand workflow
[latest run](https://github.com/camunda/camunda/actions/runs/22108203272) is not all green. The failure is a flaky [test](https://camunda.testrail.com/index.php?/tests/view/2728494) that will be investigated and handled in separate PR.