### PR TITLE
feat: add Identity operations log primary details

### DIFF
--- a/identity/client/src/pages/operations-log/CellProperty.tsx
+++ b/identity/client/src/pages/operations-log/CellProperty.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.9/audit-log";
+import { OwnerInfo, PropertyText } from "./components/styled";
+import { CodeSnippet } from "@carbon/react";
+import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";
+import { AuditLogOperationType } from "@camunda/camunda-api-zod-schemas/8.9";
+import useTranslate from "src/utility/localization";
+
+type Props = {
+  item: AuditLog;
+};
+
+const assignOperations: AuditLogOperationType[] = ["ASSIGN", "UNASSIGN"];
+
+const CellProperty: React.FC<Props> = ({ item }) => {
+  const { t } = useTranslate("operationsLog");
+
+  const showProperty =
+    (item.entityType === "AUTHORIZATION" && item.operationType === "CREATE") ||
+    assignOperations.includes(item.operationType);
+
+  if (item.result === "FAIL") {
+    return (
+      <div>
+        <PropertyText>{t("errorCode")}</PropertyText>
+        {item.entityDescription}
+      </div>
+    );
+  } else if (showProperty) {
+    return (
+      <div>
+        <PropertyText>
+          {item.entityType === "AUTHORIZATION" ? t("owner") : t("assignee")}
+        </PropertyText>
+        <OwnerInfo>
+          {item.relatedEntityType
+            ? spaceAndCapitalize(item.relatedEntityType)
+            : "-"}{" "}
+          <CodeSnippet type="inline" hideCopyButton>
+            {item.relatedEntityKey}
+          </CodeSnippet>
+        </OwnerInfo>
+      </div>
+    );
+  } else {
+    return "-";
+  }
+};
+
+export { CellProperty };

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -44,6 +44,8 @@ import {
 } from "@camunda/camunda-api-zod-schemas/8.9";
 import useDebounce from "react-debounced";
 import { useForm } from "react-hook-form";
+import { CellProperty } from "src/pages/operations-log/CellProperty";
+import { User } from "@carbon/react/icons";
 
 type AuditLogSort = { field: string; order: "asc" | "desc" };
 
@@ -176,7 +178,7 @@ const List: FC = () => {
         <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>
           <Section level={4}>
             <Stack gap={5}>
-              <Heading>{t("operation")}</Heading>
+              <Heading>{t("filter")}</Heading>
               <MultiSelect
                 id="operationType"
                 items={ALLOWED_OPERATION_TYPES}
@@ -245,7 +247,7 @@ const List: FC = () => {
                 }}
                 size="sm"
               />
-              <FormLabel>{t("time")}</FormLabel>
+              <FormLabel>{t("date")}</FormLabel>
               <DatePickerWrapper>
                 <DatePicker
                   datePickerType="range"
@@ -314,39 +316,42 @@ const List: FC = () => {
             data={
               auditLogs?.items.map((log) => ({
                 id: log.auditLogKey,
+                result:
+                  log.result === "SUCCESS" ? (
+                    <SuccessIcon size={20} />
+                  ) : (
+                    <ErrorIcon size={20} />
+                  ),
                 operationType: (
                   <OperationLogName>
-                    {spaceAndCapitalize(log.operationType)}{" "}
-                    {spaceAndCapitalize(log.entityType)}
+                    {spaceAndCapitalize(log.operationType)}
                   </OperationLogName>
                 ),
                 entityType: spaceAndCapitalize(log.entityType),
-                result: (
+                reference: log.entityKey,
+                property: <CellProperty item={log} />,
+                actorId: log.actorId ? (
                   <OperationLogName>
-                    {log.result === "SUCCESS" ? (
-                      <SuccessIcon size={20} />
-                    ) : (
-                      <ErrorIcon size={20} />
-                    )}
-                    {spaceAndCapitalize(log.result)}
+                    <User /> {log.actorId}
                   </OperationLogName>
+                ) : (
+                  "-"
                 ),
-                appliedTo: log.entityKey,
-                actorId: log.actorId,
                 timestamp: new Date(log.timestamp).toLocaleString(),
               })) || []
             }
             headers={[
+              { header: "", key: "result" },
               {
-                header: t("operation"),
+                header: t("operationType"),
                 key: "operationType",
                 isSortable: true,
               },
-              { header: t("entity"), key: "entityType", isSortable: true },
-              { header: t("status"), key: "result" },
-              { header: t("appliedTo"), key: "appliedTo" },
+              { header: t("entityType"), key: "entityType", isSortable: true },
+              { header: t("reference"), key: "reference" },
+              { header: t("property"), key: "property" },
               { header: t("actor"), key: "actorId", isSortable: true },
-              { header: t("time"), key: "timestamp", isSortable: true },
+              { header: t("date"), key: "timestamp", isSortable: true },
             ]}
             loading={loading}
             setSort={handleSort}

--- a/identity/client/src/pages/operations-log/components/styled.tsx
+++ b/identity/client/src/pages/operations-log/components/styled.tsx
@@ -12,6 +12,7 @@ import {
   ErrorFilled as BaseErrorFilled,
 } from "@carbon/react/icons";
 import { Column, Grid as CarbonGrid } from "@carbon/react";
+import { styles } from "@carbon/elements";
 
 const OperationLogName = styled.div`
   display: flex;
@@ -62,6 +63,14 @@ const DatePickerWrapper = styled.div`
   }
 `;
 
+const PropertyText = styled.div`
+  ${styles.caption01}
+`;
+
+const OwnerInfo = styled.div`
+  white-space: nowrap;
+`;
+
 export {
   OperationLogName,
   SuccessIcon,
@@ -70,4 +79,6 @@ export {
   ColumnRightPadding,
   CenteredRow,
   DatePickerWrapper,
+  PropertyText,
+  OwnerInfo,
 };

--- a/identity/client/src/utility/localization/en/operationsLog.json
+++ b/identity/client/src/utility/localization/en/operationsLog.json
@@ -1,17 +1,20 @@
 {
   "operationsLog": "Operations log",
-  "operation": "Operation",
   "operationType": "Operation type",
-  "entity": "Entity",
   "entityType": "Entity type",
   "status": "Status",
-  "appliedTo": "Applied to",
+  "reference": "Reference to entity",
+  "property": "Property",
   "actor": "Actor",
   "actorPlaceholder": "Username or client ID",
-  "time": "Time",
+  "date": "Date",
   "operationsLogCouldNotLoad": "Operations log could not be loaded",
   "selectLabel": "Choose option",
   "multiSelectLabel": "Choose option(s)",
   "selectAll": "All",
-  "reset": "Reset filters"
+  "filter": "Filter",
+  "reset": "Reset filters",
+  "errorCode": "Error code",
+  "owner": "Owner",
+  "assignee": "Assignee"
 }


### PR DESCRIPTION
## Description

- Add Identity operations log primary details
- Add `CellProperty` component for displaying entity properties.
- Introduce new columns: `reference`, `property`, and `errorCode`.
- Replace `time` column with `date` and update corresponding logic.
- Update localization keys and adjust table headers for consistency.
- Refactor data population logic to include enhanced formatting and styling.

## Related issues

closes https://github.com/camunda/camunda/issues/44947
