### PR TITLE
fix: embedded form warning shown for user tasks with external form reference

### DIFF
--- a/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.test.ts
@@ -103,4 +103,22 @@ describe('hasEmbeddedForm', () => {
 
     expect(hasEmbeddedForm(businessObject)).toBe(false);
   });
+
+  it('should return false for formKey that is an external form reference', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:formDefinition',
+            formKey: 'localhost:3000/myForm',
+          },
+        ],
+      },
+    };
+
+    expect(hasEmbeddedForm(businessObject)).toBe(false);
+  });
 });

--- a/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasEmbeddedForm.ts
@@ -31,8 +31,10 @@ const hasEmbeddedForm = (businessObject?: BusinessObject): boolean => {
   const formDefinition = businessObject.extensionElements?.values?.find(
     (element) => element.$type === 'zeebe:formDefinition',
   );
-
-  return formDefinition?.formKey !== undefined;
+  return (
+    formDefinition?.formKey !== undefined &&
+    formDefinition?.formKey.toLowerCase().startsWith('camunda-forms:bpmn:')
+  );
 };
 
 export {hasEmbeddedForm};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The embedded form warning was shown when selecting a user task with external form reference since those are also saved in `formKey` for job worker user tasks. I added an extra check that verifies the `formKey` prefix used for embedded forms.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/40374