### PR TITLE
feat: include automated Optimize snyk check for releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -942,6 +942,7 @@ jobs:
   # - With releaseProcessDryRun=true: Runs security tests instead of monitoring (E2E testing mode)
   # - When either flag is active: Builds Docker images locally since they won't be pushed to registry
   # Uses concurrency control to prevent multiple Snyk jobs from running simultaneously for the same version
+  # Note: This job scans the main Zeebe/Camunda components. For Optimize-specific scanning, see snyk-optimize job below.
   snyk:
     name: Snyk Monitor
     needs: [ zeebe-docker, release ]
@@ -962,6 +963,28 @@ jobs:
       build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
     secrets: inherit
+
+  snyk-optimize:
+    name: Snyk Monitor Optimize
+    needs: [ optimize-docker, release ]
+    # Only for stable releases (no '-' in version), and only when Optimize is part of the release
+    if: ${{ !contains(inputs.releaseVersion, '-') && inputs.includeOptimize }}
+    concurrency:
+      group: release-snyk-optimize-${{ inputs.releaseVersion }}
+      cancel-in-progress: false
+    uses: ./.github/workflows/optimize-snyk.yml
+    with:
+      # Can't reference env.RELEASE_BRANCH directly due to https://github.com/actions/runner/issues/2372
+      ref: ${{ needs.release.outputs.releaseBranch }}
+      version: ${{ inputs.releaseVersion }}
+      useMinorVersion: true
+      # In real releases, we use monitor=true; in any dry-run mode, we want test only
+      monitor: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+      # the docker image will not be pushed during a dry-run, so we need to build it locally
+      build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
+      dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/optimize:{0}', inputs.releaseVersion) }}
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   # GitHub release job creates a GitHub release with artifacts, changelog, and proper versioning.
   # Flags impact:
@@ -1173,7 +1196,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, snyk-optimize, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release succeeded
     if: ${{ always() && (
@@ -1185,6 +1208,7 @@ jobs:
       (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
       needs.camunda-docker.result == 'success' &&
       (needs.snyk.result == 'success' || needs.snyk.result == 'skipped') &&
+      (needs.snyk-optimize.result == 'success' || needs.snyk-optimize.result == 'skipped') &&
       (needs.fossa-release.result == 'success' || needs.fossa-release.result == 'skipped')
       ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5
@@ -1224,7 +1248,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, fossa-release]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk, snyk-optimize, fossa-release]
     # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
     # else => send slack notification as an actual release failed
     if: ${{ always() && (
@@ -1236,6 +1260,7 @@ jobs:
         needs.optimize-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
         needs.snyk.result == 'failure' ||
+        needs.snyk-optimize.result == 'failure' ||
         needs.fossa-release.result == 'failure'
         ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
     timeout-minutes: 5

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -967,8 +967,8 @@ jobs:
   snyk-optimize:
     name: Snyk Monitor Optimize
     needs: [ optimize-docker, release ]
-    # Only for stable releases (no '-' in version), and only when Optimize is part of the release
-    if: ${{ !contains(inputs.releaseVersion, '-') && inputs.includeOptimize }}
+    # Run for: actual releases (X.Y.Z), or dryrun versions (but exclude alpha, specific old versions like 86/87), and only when Optimize is part of the release
+    if: ${{ ((!contains(inputs.releaseVersion, '-') || (contains(inputs.releaseVersion, '-dryrun-') && !contains(inputs.releaseVersion, '-dryrun-alpha') && !contains(inputs.releaseVersion, '-dryrun-87') && !contains(inputs.releaseVersion, '-dryrun-86'))) && inputs.includeOptimize) }}
     concurrency:
       group: release-snyk-optimize-${{ inputs.releaseVersion }}
       cancel-in-progress: false
@@ -978,8 +978,8 @@ jobs:
       ref: ${{ needs.release.outputs.releaseBranch }}
       version: ${{ inputs.releaseVersion }}
       useMinorVersion: true
-      # In real releases, we use monitor=true; in any dry-run mode, we want test only
-      monitor: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+      # For actual releases: monitor based on releaseProcessDryRun; for dryrun versions: always test only
+      monitor: ${{ !(contains(inputs.releaseVersion, '-dryrun-') && !contains(inputs.releaseVersion, '-dryrun-alpha') && !contains(inputs.releaseVersion, '-dryrun-87') && !contains(inputs.releaseVersion, '-dryrun-86')) && !inputs.dryRun && !inputs.releaseProcessDryRun }}
       # the docker image will not be pushed during a dry-run, so we need to build it locally
       build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/optimize:{0}', inputs.releaseVersion) }}

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -983,8 +983,7 @@ jobs:
       # the docker image will not be pushed during a dry-run, so we need to build it locally
       build: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       dockerImage: ${{ (inputs.dryRun || inputs.releaseProcessDryRun) && '' || format('camunda/optimize:{0}', inputs.releaseVersion) }}
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    secrets: inherit
 
   # GitHub release job creates a GitHub release with artifacts, changelog, and proper versioning.
   # Flags impact:

--- a/.github/workflows/optimize-snyk.yml
+++ b/.github/workflows/optimize-snyk.yml
@@ -1,0 +1,244 @@
+# description: This workflow scans Optimize Docker images with Snyk and uploads snapshots to the Snyk servers
+# type: Project Management
+# owner: @camunda/team-optimize
+name: Optimize Snyk
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The project version; defaults to the version as defined by the root POM
+        required: false
+        type: string
+      target:
+        description: Allows overriding the project target reference directly; defaults to the current branch
+        required: false
+        type: string
+      dockerImage:
+        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, builds image locally using release artifacts.
+        required: false
+        type: string
+      monitor:
+        description: Upload Snyk snapshot instead of test
+        required: false
+        type: boolean
+        default: false
+      build:
+        description: Whether to build the Docker image locally instead of using a remote image
+        required: false
+        type: boolean
+        default: false
+      useMinorVersion:
+        description: Uses the major and minor version only for target and version
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: The reference to checkout
+        required: false
+        type: string
+  workflow_call:
+    secrets:
+      SNYK_TOKEN:
+        required: true
+    inputs:
+      version:
+        description: The project version; defaults to the version as defined by the root POM
+        required: false
+        type: string
+      target:
+        description: Allows overriding the project target reference directly; defaults to the current branch
+        required: false
+        type: string
+      dockerImage:
+        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, builds image locally using release artifacts.
+        required: false
+        type: string
+      monitor:
+        description: Upload Snyk snapshot instead of test
+        required: false
+        type: boolean
+        default: false
+      build:
+        description: Whether to build the Docker image locally instead of using a remote image
+        required: false
+        type: boolean
+        default: false
+      useMinorVersion:
+        description: Uses the major and minor version only for target and version
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: The reference to checkout
+        required: false
+        type: string
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  scan:
+    name: Snyk Scan
+    timeout-minutes: 15
+    runs-on: gcp-perf-core-8-default
+    permissions:
+      security-events: write # required to upload SARIF files
+    steps:
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@master
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          maven-cache-key-modifier: snyk
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      # Prepares the bash environment for the step which will actually run Snyk, to avoid mixing too
+      # much the GitHub Action contexts/syntax and bash itself.
+      - name: Build Snyk Environment
+        id: info
+        run: |
+          set -x
+
+          if [ -n "${{ inputs.target }}" ]; then
+             TARGET="${{ inputs.target }}"
+          else
+            TARGET="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          fi
+          export TARGET
+          
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # shellcheck disable=SC2016
+            VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec 2>/dev/null)
+          fi
+          export VERSION
+          
+          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
+            VERSION_TAG="development"
+            LIFECYCLE="development"
+          else
+            # For production releases (monitor=true), version tag uses underscores instead of dots/dashes, e.g. 8_9_0 or 8_9_0_alpha1
+            if [[ "${{ inputs.monitor }}" == "true" ]]; then
+              VERSION_TAG="${VERSION//[.-]/_}"
+            else
+              # For test-only, use simple version since no tag is uploaded to Snyk
+              VERSION_TAG="${VERSION}"
+            fi
+            LIFECYCLE="production"
+          fi
+          export VERSION_TAG
+          export LIFECYCLE
+
+          # Use inputs.dockerImage if present; otherwise infer from version and default repository camunda/optimize
+          if [ -n "${{ inputs.dockerImage }}" ]; then
+            DOCKER_IMAGE="${{ inputs.dockerImage }}"
+          else
+            DOCKER_IMAGE="camunda/optimize:${VERSION}"
+          fi
+          export DOCKER_IMAGE
+
+          # IMPORTANT: apply useMinorVersion BEFORE composing SNYK_ARGS, like Zeebe
+          if [[ '${{ inputs.useMinorVersion }}' == 'true' ]]; then
+            TARGET="$(echo "$VERSION" | sed -E -e 's/\.[^.]*$//')"
+            export TARGET
+          fi
+
+          {
+            echo "SNYK_ARGS=" \
+              "--show-vulnerable-paths=all" \
+              "--severity-threshold=high" \
+              "--org=team-optimize" \
+              "--project-lifecycle=${LIFECYCLE}" \
+              "--project-tags=version=${VERSION_TAG}" \
+              "--target-reference=${TARGET}"
+            echo "TARGET=${TARGET}"
+            echo "SNYK_COMMAND=${{ (inputs.monitor && 'monitor') || 'test' }}"
+            echo "SARIF=${{ (inputs.monitor && 'false') || 'true' }}"
+            echo "DOCKER_IMAGE=${DOCKER_IMAGE}"
+            echo "VERSION=${VERSION}"
+          } >> "$GITHUB_ENV"
+      # Build Optimize Docker image locally if needed (for dry runs when image isn't published)
+      - name: Download Release Artifacts
+        if: ${{ inputs.build }}
+        uses: actions/download-artifact@v7
+        with:
+          name: release-artifacts-${{ env.VERSION }}
+      - name: Build Optimize Docker Image locally
+        if: ${{ inputs.build }}
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: camunda/optimize
+          version: ${{ env.VERSION }}
+          # Use a placeholder revision since we're building locally for scanning
+          revision: "local-scan"
+          push: false
+          distball: camunda-optimize-${{ env.VERSION }}-production.tar.gz
+          platforms: linux/amd64
+          dockerfile: optimize.Dockerfile
+          debug: 'true'
+      - name: Run Snyk (Optimize Docker image)
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        # This step scans the Optimize Docker image in Snyk (team-optimize org).
+        # If we later want to scan additional artifacts (e.g., Maven modules), they
+        # should be added in a separate step.
+        run: |
+          set -e
+          mkdir -p sarif-results || true
+
+          PROJECT_NAME="optimize(${TARGET}):Dockerfile"
+
+          # Optional SARIF output, same pattern as Zeebe
+          function output() {
+            local sarif="$1"
+            local name="$2"
+            [ "${sarif}" == 'true' ] && echo "--sarif-file-output=sarif-results/${name}.sarif"
+          }
+
+          function ensureExists() {
+            local projectFile="$1"
+            if [ ! -f "${projectFile}" ]; then
+              echo "Cannot find project file to scan: [ ${projectFile} ]"
+              exit 1
+            fi
+          }
+
+          # Print out command if debug logging is enabled
+          set -x
+
+          # The `container` command does not yet support setting a target reference, as this is a beta
+          # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
+          ensureExists "optimize.Dockerfile"
+          # shellcheck disable=SC2086,SC2046,SC2153
+          snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" \
+            --file=optimize.Dockerfile \
+            --project-name="${PROJECT_NAME}" \
+            ${SNYK_ARGS} $(output "${SARIF}" 'docker')
+      - name: Code Scanning summary
+        if: ${{ ! inputs.monitor }}
+        run: |
+          PR_NUMBER=$(echo "$GITHUB_REF" | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          export PR_NUMBER
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+            ## Result Links
+            - [Snyk projects](https://app.snyk.io/org/team-optimize/projects)
+          EOF
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-snyk.yml
+++ b/.github/workflows/optimize-snyk.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       dockerImage:
-        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, builds image locally using release artifacts.
+        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, defaults to 'camunda/optimize:<version>'. Use the 'build' input to control local image building.
         required: false
         type: string
       monitor:
@@ -41,6 +41,12 @@ on:
     secrets:
       SNYK_TOKEN:
         required: true
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
     inputs:
       version:
         description: The project version; defaults to the version as defined by the root POM
@@ -51,7 +57,7 @@ on:
         required: false
         type: string
       dockerImage:
-        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, builds image locally using release artifacts.
+        description: The full name of the Docker image to scan; if provided, scans the published image from registry. If empty, defaults to 'camunda/optimize:<version>'. Use the 'build' input to control local image building.
         required: false
         type: string
       monitor:
@@ -86,7 +92,8 @@ jobs:
     timeout-minutes: 15
     runs-on: gcp-perf-core-8-default
     permissions:
-      security-events: write # required to upload SARIF files
+      contents: read # required for actions/checkout
+      actions: read # required for actions/download-artifact
     steps:
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master
@@ -105,18 +112,24 @@ jobs:
       # much the GitHub Action contexts/syntax and bash itself.
       - name: Build Snyk Environment
         id: info
+        env:
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+          INPUT_MONITOR: ${{ inputs.monitor }}
+          INPUT_USE_MINOR_VERSION: ${{ inputs.useMinorVersion }}
         run: |
           set -x
 
-          if [ -n "${{ inputs.target }}" ]; then
-             TARGET="${{ inputs.target }}"
+          if [ -n "${INPUT_TARGET}" ]; then
+             TARGET="${INPUT_TARGET}"
           else
             TARGET="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           fi
           export TARGET
           
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ -n "${INPUT_VERSION}" ]; then
+            VERSION="${INPUT_VERSION}"
           else
             # shellcheck disable=SC2016
             VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec 2>/dev/null)
@@ -128,7 +141,7 @@ jobs:
             LIFECYCLE="development"
           else
             # For production releases (monitor=true), version tag uses underscores instead of dots/dashes, e.g. 8_9_0 or 8_9_0_alpha1
-            if [[ "${{ inputs.monitor }}" == "true" ]]; then
+            if [[ "${INPUT_MONITOR}" == "true" ]]; then
               VERSION_TAG="${VERSION//[.-]/_}"
             else
               # For test-only, use simple version since no tag is uploaded to Snyk
@@ -140,17 +153,24 @@ jobs:
           export LIFECYCLE
 
           # Use inputs.dockerImage if present; otherwise infer from version and default repository camunda/optimize
-          if [ -n "${{ inputs.dockerImage }}" ]; then
-            DOCKER_IMAGE="${{ inputs.dockerImage }}"
+          if [ -n "${INPUT_DOCKER_IMAGE}" ]; then
+            DOCKER_IMAGE="${INPUT_DOCKER_IMAGE}"
           else
             DOCKER_IMAGE="camunda/optimize:${VERSION}"
           fi
           export DOCKER_IMAGE
 
           # IMPORTANT: apply useMinorVersion BEFORE composing SNYK_ARGS, like Zeebe
-          if [[ '${{ inputs.useMinorVersion }}' == 'true' ]]; then
-            TARGET="$(echo "$VERSION" | sed -E -e 's/\.[^.]*$//')"
+          if [[ "${INPUT_USE_MINOR_VERSION}" == "true" ]]; then
+            TARGET="$(echo "${VERSION}" | sed -E -e 's/\.[^.]*$//')"
             export TARGET
+          fi
+
+          # Determine SNYK_COMMAND based on monitor input
+          if [[ "${INPUT_MONITOR}" == "true" ]]; then
+            SNYK_COMMAND="monitor"
+          else
+            SNYK_COMMAND="test"
           fi
 
           {
@@ -162,8 +182,7 @@ jobs:
               "--project-tags=version=${VERSION_TAG}" \
               "--target-reference=${TARGET}"
             echo "TARGET=${TARGET}"
-            echo "SNYK_COMMAND=${{ (inputs.monitor && 'monitor') || 'test' }}"
-            echo "SARIF=${{ (inputs.monitor && 'false') || 'true' }}"
+            echo "SNYK_COMMAND=${SNYK_COMMAND}"
             echo "DOCKER_IMAGE=${DOCKER_IMAGE}"
             echo "VERSION=${VERSION}"
           } >> "$GITHUB_ENV"
@@ -194,16 +213,8 @@ jobs:
         # should be added in a separate step.
         run: |
           set -e
-          mkdir -p sarif-results || true
 
           PROJECT_NAME="optimize(${TARGET}):Dockerfile"
-
-          # Optional SARIF output, same pattern as Zeebe
-          function output() {
-            local sarif="$1"
-            local name="$2"
-            [ "${sarif}" == 'true' ] && echo "--sarif-file-output=sarif-results/${name}.sarif"
-          }
 
           function ensureExists() {
             local projectFile="$1"
@@ -219,11 +230,11 @@ jobs:
           # The `container` command does not yet support setting a target reference, as this is a beta
           # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
           ensureExists "optimize.Dockerfile"
-          # shellcheck disable=SC2086,SC2046,SC2153
+          # shellcheck disable=SC2086,SC2153
           snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" \
             --file=optimize.Dockerfile \
             --project-name="${PROJECT_NAME}" \
-            ${SNYK_ARGS} $(output "${SARIF}" 'docker')
+            ${SNYK_ARGS}
       - name: Code Scanning summary
         if: ${{ ! inputs.monitor }}
         run: |

--- a/.github/workflows/optimize-snyk.yml
+++ b/.github/workflows/optimize-snyk.yml
@@ -29,7 +29,7 @@ on:
         type: boolean
         default: false
       useMinorVersion:
-        description: Uses the major and minor version only for target and version
+        description: Uses the major and minor version only for the target reference
         required: false
         type: boolean
         default: false
@@ -71,7 +71,7 @@ on:
         type: boolean
         default: false
       useMinorVersion:
-        description: Uses the major and minor version only for target and version
+        description: Uses the major and minor version only for the target reference
         required: false
         type: boolean
         default: false
@@ -136,19 +136,31 @@ jobs:
           fi
           export VERSION
           
-          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
-            VERSION_TAG="development"
-            LIFECYCLE="development"
-          else
-            # For production releases (monitor=true), version tag uses underscores instead of dots/dashes, e.g. 8_9_0 or 8_9_0_alpha1
-            if [[ "${INPUT_MONITOR}" == "true" ]]; then
-              VERSION_TAG="${VERSION//[.-]/_}"
-            else
-              # For test-only, use simple version since no tag is uploaded to Snyk
-              VERSION_TAG="${VERSION}"
-            fi
-            LIFECYCLE="production"
+          # Prevent monitoring SNAPSHOT versions (operational safety check)
+          if [[ "${INPUT_MONITOR}" == "true" && "${VERSION}" == *-SNAPSHOT ]]; then
+            echo "Cannot monitor SNAPSHOT versions"
+            exit 1
           fi
+          
+          # Determine lifecycle based on monitor input
+          if [[ "${INPUT_MONITOR}" == "true" ]]; then
+            LIFECYCLE="production"
+          else
+            LIFECYCLE="development"
+          fi
+          
+          # Determine version tag based on version type and monitor mode
+          if [[ "${VERSION}" == *-SNAPSHOT ]]; then
+            # All SNAPSHOT versions use development tag
+            VERSION_TAG="development"
+          elif [[ "${INPUT_MONITOR}" == "true" ]]; then
+            # Production releases use underscores instead of dots/dashes, e.g. 8_9_0 or 8_9_0_alpha1
+            VERSION_TAG="${VERSION//[.-]/_}"
+          else
+            # Test-only releases use simple version since no tag is uploaded to Snyk
+            VERSION_TAG="${VERSION}"
+          fi
+          
           export VERSION_TAG
           export LIFECYCLE
 
@@ -185,6 +197,7 @@ jobs:
             echo "SNYK_COMMAND=${SNYK_COMMAND}"
             echo "DOCKER_IMAGE=${DOCKER_IMAGE}"
             echo "VERSION=${VERSION}"
+            echo "LIFECYCLE=${LIFECYCLE}"
           } >> "$GITHUB_ENV"
       # Build Optimize Docker image locally if needed (for dry runs when image isn't published)
       - name: Download Release Artifacts
@@ -214,7 +227,7 @@ jobs:
         run: |
           set -e
 
-          PROJECT_NAME="optimize(${TARGET}):Dockerfile"
+          PROJECT_NAME="${VERSION}"
 
           function ensureExists() {
             local projectFile="$1"
@@ -226,6 +239,15 @@ jobs:
 
           # Print out command if debug logging is enabled
           set -x
+
+          echo "=== SNYK CONTEXT ==="
+          echo "Project: ${PROJECT_NAME}"
+          echo "Command: ${SNYK_COMMAND}"
+          echo "Target: ${TARGET}"
+          echo "Version: ${VERSION}"
+          echo "Lifecycle: ${LIFECYCLE}"
+          echo "Docker Image: ${DOCKER_IMAGE}"
+          echo "====================="
 
           # The `container` command does not yet support setting a target reference, as this is a beta
           # feature at the moment. It's added here anyway for now, and hopefully support will come soon.


### PR DESCRIPTION
## Description

This pull request adds dedicated Snyk security scanning for the Optimize Docker image as part of the Camunda Platform release workflow and the [Optimize introduction to the unified release project](https://github.com/camunda/camunda/issues/40184?reload=1). It introduces a new reusable workflow for Optimize-specific Snyk scans, integrates it into the main release pipeline, and updates Slack notification jobs to account for the new scan step.

**Security scanning improvements:**

* Added a new `snyk-optimize` job to `.github/workflows/camunda-platform-release.yml` to perform Snyk security scans specifically for the Optimize Docker image during stable releases when Optimize is included.
* Created a new reusable workflow `.github/workflows/optimize-snyk.yml` that builds or pulls the Optimize Docker image as needed, runs Snyk scans, uploads results, and supports both monitoring and test modes.

> [!NOTE]
> One thing that’s not covered by the new Snyk integration is the 18‑month cleanup rule.
> We now automatically create/update the Optimize Docker project in Snyk with lifecycle=production and a version tag using underscores, but we do not demote or delete older projects after 18 months. That part remains a manual step, as it was before.
>
> I picked up this work to help move things forward, but long‑term the ownership of the Optimize Snyk workflow should sit with the Optimize team, in the same way the Zeebe Snyk workflow is owned by the Zeebe team. I’m happy to support and clarify the current setup, but future policy decisions and maintenance for Optimize’s Snyk integration should come from Optimize side. 

**Release notification updates:**

* Updated the `notify-on-success` and `notify-if-failed` jobs to depend on the new `snyk-optimize` job, and included its status in the notification logic to ensure accurate release reporting. [[1]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L1176-R1199) [[2]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3L1227-R1251) [[3]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R1211) [[4]](diffhunk://#diff-8a0673665c10dffaabece9be7c0f129ac4e6e883fe85f114d1b76d76ce9736c3R1263)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
