### PR TITLE
Compatibility workflows fixes

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
       is-main: ${{ steps.branch-info.outputs.is-main }}
+      branch-name: ${{ steps.branch-info.outputs.branch-name }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -165,8 +166,8 @@ jobs:
           fi
 
           if [[ "$IS_MAIN" == "true" ]]; then
-            # On main, the only client is the SNAPSHOT
-            CLIENT_LIST="$NEXT_SNAPSHOT"$'\n'
+            # On main, the only client is the pom version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt
@@ -198,8 +199,8 @@ jobs:
               done
             fi
           else
-            # On main, SERVER_LIST same as CLIENT_LIST
-            SERVER_LIST="$CLIENT_LIST"
+            # On main, SERVER_LIST uses SNAPSHOT
+            SERVER_LIST="SNAPSHOT"$'\n'
           fi
 
           if [[ "$IS_MAIN" != "true" ]]; then
@@ -276,7 +277,7 @@ jobs:
                 COMBO="$client-$server"
 
                 # Skip SNAPSHOT client vs SNAPSHOT server - not a compatibility test (except on main)
-                if [[ "$GITHUB_REF_NAME" != "main" && "$client" =~ SNAPSHOT && "$server" =~ SNAPSHOT ]]; then
+                if [[ "${{ steps.branch-info.outputs.is-main }}" != "true" && "$client" =~ SNAPSHOT && "$server" =~ SNAPSHOT ]]; then
                   SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
                   continue
                 fi
@@ -317,6 +318,9 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-versions.outputs.branch-name }}
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-build
         with:
@@ -325,20 +329,20 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Build dependencies
+      - name: Build and compile tests
         uses: ./.github/actions/run-maven
         with:
           parameters: >-
             install
             -Dquickly
-            -pl qa/util
+            -pl qa/acceptance-tests
             -am
 
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
           parameters: >-
-            verify
+            failsafe:integration-test failsafe:verify
             -P compatibility-test
             -pl qa/acceptance-tests
             -Dcamunda.compatibility.test.version=${{ matrix.server }}
@@ -421,42 +425,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [prepare-versions, run-compatibility-tests]
-    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-    permissions: {}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-        with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-           {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Camunda Client Compatibility Tests Failed*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+#  notify-failure:
+#    name: Notify on failure
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 5
+#    needs: [prepare-versions, run-compatibility-tests]
+#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+#    permissions: {}
+#    steps:
+#      - uses: actions/checkout@v6
+#      - name: Notify failure
+#        uses: slackapi/slack-github-action@v2.1.1
+#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+#        env:
+#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#        with:
+#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#           {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": ":alarm: *Camunda Client Compatibility Tests Failed*"
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+#                  }
+#                }
+#              ]
+#            }
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -164,8 +164,8 @@ jobs:
           fi
 
           if [[ "$IS_MAIN" == "true" ]]; then
-            # On main, the only client is the SNAPSHOT
-            CLIENT_LIST="$NEXT_SNAPSHOT"$'\n'
+            # On main, the only client is the pom version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt
@@ -197,8 +197,8 @@ jobs:
               done
             fi
           else
-            # On main, SERVER_LIST same as CLIENT_LIST
-            SERVER_LIST="$CLIENT_LIST"
+            # On main, SERVER_LIST uses SNAPSHOT
+            SERVER_LIST="SNAPSHOT"$'\n'
           fi
 
           if [[ "$IS_MAIN" != "true" ]]; then
@@ -275,7 +275,7 @@ jobs:
                 COMBO="$client-$server"
 
                 # Skip SNAPSHOT client vs SNAPSHOT server - not a compatibility test (except on main)
-                if [[ "${GITHUB_REF_NAME}" != "main" && "$client" =~ SNAPSHOT && "$server" =~ SNAPSHOT ]]; then
+                if [[ "${{ steps.branch-info.outputs.is-main }}" != "true" && "$client" =~ SNAPSHOT && "$server" =~ SNAPSHOT ]]; then
                   SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
                   continue
                 fi
@@ -316,11 +316,11 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-versions.outputs.matrix) }}
     steps:
       - name: Checkout Camunda (main for SNAPSHOT)
-        if: matrix.client == 'SNAPSHOT'
+        if: endsWith(matrix.client, '-SNAPSHOT')
         uses: actions/checkout@v6
 
       - name: Checkout Camunda
-        if: matrix.client != 'SNAPSHOT'
+        if: ${{ !endsWith(matrix.client, '-SNAPSHOT') }}
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.client }}
@@ -343,6 +343,25 @@ jobs:
             -DskipUTs
             -DskipChecks
 
+      - name: Determine API version override
+        id: api-version
+        run: |
+          CLIENT_VERSION="${{ matrix.client }}"
+          EXTRA_PROPS=""
+          # For CPT versions < 8.8.5, we need to pin the API version
+          if [[ "$CLIENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            if (( MAJOR < 8 )) || \
+               (( MAJOR == 8 && MINOR < 8 )) || \
+               (( MAJOR == 8 && MINOR == 8 && PATCH < 5 )); then
+              EXTRA_PROPS="-Dapi.version=1.44"
+              echo "CPT version $CLIENT_VERSION < 8.8.5 - adding $EXTRA_PROPS"
+            fi
+          fi
+          echo "extra-props=$EXTRA_PROPS" >> "$GITHUB_OUTPUT"
+
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
@@ -353,6 +372,7 @@ jobs:
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
             -Dio.camunda.process.test.connectorsDockerImageVersion=${{ matrix.server }}
             -DfailIfNoTests=false
+            ${{ steps.api-version.outputs.extra-props }}
 
       - name: Record tested combination
         if: success()
@@ -434,42 +454,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [prepare-versions, run-cpt-tests]
-    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-    permissions: {}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-        with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-           {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+#  notify-failure:
+#    name: Notify on failure
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 5
+#    needs: [prepare-versions, run-cpt-tests]
+#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+#    permissions: {}
+#    steps:
+#      - uses: actions/checkout@v6
+#      - name: Notify failure
+#        uses: slackapi/slack-github-action@v2.1.1
+#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+#        env:
+#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#        with:
+#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#           {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+#                  }
+#                }
+#              ]
+#            }
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
       is-main: ${{ steps.branch-info.outputs.is-main }}
+      branch-name: ${{ steps.branch-info.outputs.branch-name }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -161,8 +162,8 @@ jobs:
           fi
 
           if [[ "$IS_MAIN" == "true" ]]; then
-            # On main, the only client is the SNAPSHOT
-            CLIENT_LIST="$NEXT_SNAPSHOT"$'\n'
+            # On main, the only client is the pom version
+            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
           fi
 
           echo "$CLIENT_LIST" > /tmp/client_list.txt
@@ -194,8 +195,8 @@ jobs:
               done
             fi
           else
-            # On main, SERVER_LIST same as CLIENT_LIST
-            SERVER_LIST="$CLIENT_LIST"
+            # On main, SERVER_LIST uses SNAPSHOT
+            SERVER_LIST="SNAPSHOT"$'\n'
           fi
 
           if [[ "$IS_MAIN" != "true" ]]; then
@@ -315,6 +316,9 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-versions.outputs.branch-name }}
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-build
         with:
@@ -418,42 +422,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  notify-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [prepare-versions, run-compatibility-tests]
-    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-    permissions: {}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-        with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-           {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Camunda Spring Boot Starter Compatibility Tests Failed*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+#  notify-failure:
+#    name: Notify on failure
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 5
+#    needs: [prepare-versions, run-compatibility-tests]
+#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+#    permissions: {}
+#    steps:
+#      - uses: actions/checkout@v6
+#      - name: Notify failure
+#        uses: slackapi/slack-github-action@v2.1.1
+#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+#        env:
+#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#        with:
+#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#           {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": ":alarm: *Camunda Spring Boot Starter Compatibility Tests Failed*"
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+#                  }
+#                }
+#              ]
+#            }
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

This PR addresses some issue in the client compatibility workflows:

- The camunda client workflow now checkouts to the correct branch instead of main
- The camunda client workflow now use correctly the version matrix
- Due to a [new command added to the stable/8.8 branch](https://github.com/camunda/camunda/pull/38679) some tests where failing because of the missing command. Added a wrapper to skip those tests. We should avoid to add feature on stable branches
- The CPT workflow now is fail tolerant to Docker 29 using the workaround `"-Dapi.version=1.44"`

For all the 3 workflows I removed the notification on failure step, I'll re-enable it once the CI is more stable to reduce the noise
