### PR TITLE
AlwaysGreen: Add 8.6 SaaS Smoke Tests

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -385,7 +385,7 @@ jobs:
                       "c8Version": "8.6",
                       "zeebeVersion": "${{ needs.build-and-push-images.outputs.image-tag }}",
                       "operateVersion": "8.6-SNAPSHOT",
-                      "tasklistVersion": "8.6-SNAPSHOTT",
+                      "tasklistVersion": "8.6-SNAPSHOT",
                       "connectorsVersion": "8.6-SNAPSHOT",
                       "optimizeVersion": "8.6-SNAPSHOT"
                   }

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -342,3 +342,168 @@ jobs:
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
         secret/data/products/distribution/ci DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET;
 
+  trigger-saas-e2e:
+    name: Trigger SaaS E2E tests
+    runs-on: ubuntu-latest
+    needs: [build-and-push-images, format-identifier]
+    timeout-minutes: 30
+    permissions: { }
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Generate GitHub App Token (for dispatch)
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: GITHUB_APP_ID
+          github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          github-app-private-key-vault-key: GITHUB_APP_SECRET
+          github-app-private-key-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          owner: camunda
+          repositories: camunda,c8-cross-component-e2e-tests
+
+      - name: Trigger repository_dispatch for SaaS Monorepo
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/camunda/c8-cross-component-e2e-tests/dispatches \
+            -d '{
+                  "event_type": "run-saas-generation-smoke-mono",
+                  "client_payload": {
+                      "correlation_id": "'"$CORRELATION_ID"'",
+                      "source_repo": "${{ github.repository }}",
+                      "source_sha": "${{ github.sha }}",
+                      "c8Version": "8.6",
+                      "zeebeVersion": "${{ needs.build-and-push-images.outputs.image-tag }}",
+                      "operateVersion": "8.6-SNAPSHOT",
+                      "tasklistVersion": "8.6-SNAPSHOTT",
+                      "connectorsVersion": "8.6-SNAPSHOT",
+                      "optimizeVersion": "8.6-SNAPSHOT"
+                  }
+                }'
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: trigger-saas-e2e
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Wait for downstream workflow to finish
+        id: wait-downstream
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "Waiting for downstream E2E workflow run in camunda/c8-cross-component-e2e-tests for correlation id: $CORRELATION_ID"
+
+          TARGET_REPO="camunda/c8-cross-component-e2e-tests"
+          WORKFLOW_FILE="playwright_saas_pr_trigger_monorepo.yml"
+
+          gh_api_with_retry() {
+            local endpoint="$1"
+            local max_attempts="${2:-6}"
+            local sleep_s="${3:-2}"
+            local attempt=1
+            local out
+
+            while true; do
+              if out="$(gh api "$endpoint" 2>&1)"; then
+                printf '%s' "$out"
+                return 0
+              fi
+
+              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF'; then
+                if (( attempt >= max_attempts )); then
+                  echo "gh api failed after ${attempt}/${max_attempts} attempts for $endpoint" >&2
+                  echo "$out" >&2
+                  return 1
+                fi
+                echo "Transient gh/api error (attempt ${attempt}/${max_attempts}) for $endpoint:" >&2
+                echo "$out" >&2
+                sleep "$sleep_s"
+                attempt=$((attempt + 1))
+                sleep_s=$((sleep_s * 2))
+                continue
+              fi
+
+              echo "Non-retryable gh/api error for $endpoint:" >&2
+              echo "$out" >&2
+              return 1
+            done
+          }
+
+          RUN_ID=""
+
+          for _ in {1..80}; do
+            if [[ -z "$RUN_ID" ]]; then
+              RUN_ID=$(
+                gh_api_with_retry "/repos/$TARGET_REPO/actions/workflows/$WORKFLOW_FILE/runs?event=repository_dispatch&per_page=50" \
+                | jq -r --arg c "$CORRELATION_ID" '
+                    .workflow_runs
+                    | map(select(.display_title != null and (.display_title | contains($c))))
+                    | sort_by(.created_at)
+                    | last
+                    | .id // empty
+                  '
+              )
+
+              if [[ -z "$RUN_ID" ]]; then
+                echo "No downstream run found yet for correlation id. Sleeping..."
+                sleep 30
+                continue
+              fi
+
+              echo "Locked onto downstream run id: $RUN_ID"
+              echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> "$GITHUB_OUTPUT"
+            fi
+
+            RUN_JSON="$(gh_api_with_retry "/repos/$TARGET_REPO/actions/runs/$RUN_ID")"
+            STATUS="$(jq -r .status <<<"$RUN_JSON")"
+            CONCLUSION="$(jq -r .conclusion <<<"$RUN_JSON")"
+            echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"
+
+            if [[ "$STATUS" == "completed" ]]; then
+              if [[ "$CONCLUSION" == "success" ]]; then
+                echo "Downstream workflow succeeded!"
+                exit 0
+              else
+                echo "Downstream workflow failed: $CONCLUSION"
+                exit 1
+              fi
+            fi
+
+            sleep 30
+          done
+
+          echo "Timed out waiting for downstream workflow to complete."
+          exit 1
+
+      - name: Add SaaS downstream workflow link to Job Summary
+        if: always()
+        run: |
+          if [ -n "${{ steps.wait-downstream.outputs.downstream_run_url }}" ]; then
+            {
+              echo "### SaaS Downstream Workflow Run"
+              echo ""
+              echo "**Correlation ID:** \`${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}\`"
+              echo ""
+              echo "[Open the triggered SaaS E2E workflow run in camunda/c8-cross-component-e2e-tests](${{ steps.wait-downstream.outputs.downstream_run_url }})"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No downstream workflow run URL found." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the AlwaysGreen SaaS tests to be triggered on every 8.6.X PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
