### PR TITLE
[Backport stable/8.7] fix: add configuration for maximum incident search groups

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/IncidentStatisticsIT.java
@@ -154,7 +154,7 @@ public class IncidentStatisticsIT extends OperateAbstractIT {
     assertThat(response).hasSize(1);
     final IncidentsByErrorMsgStatisticsDto incidentsByErrorStat = response.get(0);
     assertThat(incidentsByErrorStat.getErrorMessage()).isEqualTo(TestUtil.ERROR_MSG);
-    assertThat(incidentsByErrorStat.getProcesses()).hasSize(1);
+    assertThat(incidentsByErrorStat.getProcesses()).hasSize(2);
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/IncidentStatisticsReader.java
@@ -117,7 +117,7 @@ public class IncidentStatisticsReader extends AbstractReader
             .subAggregation(
                 terms(GROUP_BY_PROCESS_KEYS)
                     .field(IncidentTemplate.PROCESS_DEFINITION_KEY)
-                    .size(termsAggSize)
+                    .size(ElasticsearchUtil.TERMS_AGG_SIZE)
                     .subAggregation(
                         cardinality(UNIQ_PROCESS_INSTANCES)
                             .field(IncidentTemplate.PROCESS_INSTANCE_KEY)));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchIncidentStatisticsReader.java
@@ -110,7 +110,7 @@ public class OpensearchIncidentStatisticsReader implements IncidentStatisticsRea
     final var uniqueProcessInstances =
         cardinalityAggregation(IncidentTemplate.PROCESS_INSTANCE_KEY);
     final var groupByProcessKeys =
-        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, termsAggSize);
+        termAggregation(IncidentTemplate.PROCESS_DEFINITION_KEY, TERMS_AGG_SIZE);
     final var errorMessage =
         topHitsAggregation(List.of(IncidentTemplate.ERROR_MSG, IncidentTemplate.ERROR_MSG_HASH), 1);
     final var groupByErrorMessageHash =


### PR DESCRIPTION
Backport of https://github.com/camunda/camunda/pull/45022 to stable/8.7.

relates to https://github.com/camunda/camunda/issues/44596