### PR TITLE
feat: initialize leases only during bootstrap

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/dynamicnodeid/DynamicNodeIdIT.java
@@ -132,7 +132,8 @@ public class DynamicNodeIdIT {
     // then
     final var objectsInBucket = s3Client.listObjects(b -> b.bucket(BUCKET_NAME)).contents();
 
-    assertThat(objectsInBucket).hasSize(CLUSTER_SIZE);
+    // there should be one object per broker with a valid lease plus a marker file
+    assertThat(objectsInBucket).hasSize(CLUSTER_SIZE + 1);
     final var leases = readLeases(objectsInBucket);
 
     // Verify the mapping nodeId -> taskId is consistent with the nodeId from the cluster

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -80,8 +80,8 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
 
   @Override
   public CompletableFuture<Void> initialize(final int clusterSize) {
-    nodeIdRepository.initialize(clusterSize);
-    return CompletableFuture.runAsync(() -> acquireInitialLease(clusterSize), executor)
+    final var availableNodeIdCount = nodeIdRepository.initialize(clusterSize);
+    return CompletableFuture.runAsync(() -> acquireInitialLease(availableNodeIdCount), executor)
         .thenRun(this::startRenewalTimer)
         .thenRun(() -> scheduleReadinessCheck(clusterSize));
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -19,11 +19,15 @@ import java.util.Optional;
 public interface NodeIdRepository extends AutoCloseable {
 
   /**
-   * Initialize the leases if they haven't been created yet.
+   * Initialize the leases if they haven't been created yet. The parameter initialCount is used only
+   * when bootstrapping the cluster for the first time. After that new lease objects are not created
+   * even if a different count is provided.
    *
-   * @param count the number of leases to create
+   * @param initialCount the number of leases to create
+   * @return the number of available leases after initialization. This can be different from the
+   *     provided count if the repository was already initialized before.
    */
-  void initialize(int count);
+  int initialize(int initialCount);
 
   /**
    * Get a lease without acquiring it. This can be used to verify the liveness of other nodes or

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -32,17 +32,19 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 public class S3NodeIdRepository implements NodeIdRepository {
 
   private static final Logger LOG = LoggerFactory.getLogger(S3NodeIdRepository.class);
+  private static final String NODEID_INITIALIZATION_MARKER_KEY = "node-ids-initialized";
+  private static final String NODE_ID_KEY_PATTERN = "\\d+\\.json";
   private final S3Client client;
   private final Config config;
   private final InstantSource clock;
   private final boolean closeClient;
-  private volatile boolean initialized = false;
 
   public S3NodeIdRepository(
       final S3Client s3Client,
@@ -63,11 +65,17 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   @Override
-  public void initialize(final int count) {
+  public int initialize(final int initialCount) {
+    final var initialized = isInitialized();
     if (!initialized) {
-      IntStream.range(0, count).forEach(this::initializeForNode);
+      IntStream.range(0, initialCount).forEach(this::initializeForNode);
+
+      // We need a marker object to mark the completion of initialization.
+      // In case the initialization fails halfway, marker file does not exist and the retries will
+      // complete the initialization.
+      markInitialized();
     }
-    initialized = true;
+    return getAvailableLeaseCount();
   }
 
   @Override
@@ -185,6 +193,66 @@ public class S3NodeIdRepository implements NodeIdRepository {
     }
   }
 
+  private void markInitialized() {
+    // concurrent puts to these object is fine as the content is not relevant.
+    final var request =
+        PutObjectRequest.builder()
+            .bucket(config.bucketName)
+            .key(NODEID_INITIALIZATION_MARKER_KEY)
+            .build();
+    try {
+      client.putObject(request, RequestBody.empty());
+      LOG.debug("Node ID repository initialized successfully");
+    } catch (final Exception e) {
+      LOG.warn("Failed to mark node ID repository as initialized", e);
+      throw e;
+    }
+  }
+
+  // returns true if the marker object exists, false if it doesn't exist, and throws exception if
+  // the check failed for other reasons (e.g. permissions, network error, etc.)
+  private boolean isInitialized() {
+    final var request =
+        GetObjectRequest.builder()
+            .bucket(config.bucketName)
+            .key(NODEID_INITIALIZATION_MARKER_KEY)
+            .build();
+    try {
+      client.getObject(request);
+      return true;
+    } catch (final S3Exception e) {
+      if (e.statusCode() == 404) {
+        LOG.debug("Node ID repository is not initialized yet");
+        return false;
+      }
+      LOG.warn("Failed to check if node ID repository is initialized", e);
+      throw e;
+    }
+  }
+
+  private int getAvailableLeaseCount() {
+    final var request = ListObjectsRequest.builder().bucket(config.bucketName).build();
+    try {
+      final var response = client.listObjects(request);
+      if (response.hasContents() && !response.contents().isEmpty()) {
+        return (int) response.contents().stream().filter(o -> isNodeIdLease(o.key())).count();
+      }
+      return 0;
+    } catch (final S3Exception e) {
+      if (e.statusCode() == 404) {
+        LOG.warn("Bucket {} does not exist", config.bucketName);
+        throw e;
+      }
+      LOG.warn("Failed to list objects in bucket {}", config.bucketName, e);
+      throw e;
+    }
+  }
+
+  private boolean isNodeIdLease(final String key) {
+    // key is of pattern "<nodeId>.json"
+    return key.matches(NODE_ID_KEY_PATTERN);
+  }
+
   private String getRestoreStatusKey(final String restoreId) {
     return "restore/%s".formatted(restoreId);
   }
@@ -202,12 +270,21 @@ public class S3NodeIdRepository implements NodeIdRepository {
         if (s3Exception.statusCode() == 404) {
           throw new IllegalArgumentException(
               "Cannot create file for node " + nodeId + " in bucket " + config.bucketName, e);
+        } else if (s3Exception.statusCode() == 412) {
+          // Precondition failed is returned when the object already exists, which can happen in
+          // case of multiple nodes starting at the same time, so we can ignore it here.
+          LOG.debug(
+              "File for nodeId {} already exists, likely created by another node starting at the same time.",
+              nodeId);
+          return;
         }
       }
       LOG.debug(
           "File creation failed for nodeId {}: {}",
           nodeId,
           e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+      // Need to fail so that initialization is retried.
+      throw e;
     }
   }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -231,9 +231,9 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   private int getAvailableLeaseCount() {
-    final var request = ListObjectsRequest.builder().bucket(config.bucketName).build();
+    final var request = ListObjectsV2Request.builder().bucket(config.bucketName).build();
     try {
-      final var response = client.listObjects(request);
+      final var response = client.listObjectsV2(request);
       if (response.hasContents() && !response.contents().isEmpty()) {
         return (int) response.contents().stream().filter(o -> isNodeIdLease(o.key())).count();
       }


### PR DESCRIPTION
## Description

This PR prepares the node-id-provider to support dynamic cluster sizes.

Remove dependency on statically configured clusterSize for determining available leases, enabling broker scaling support. Leases are now initialized using cluster size only at bootstrap. After initialization, existing leases are reused. A scaling API for modifying available leases will be added in a future commit.

Initialization now returns the number of available leases. Nodes can acquire node-ids from 0 up to the available lease count. For simplicity, gaps in node-ids are not yet supported.

## Related issues

related to #45812 
