### PR TITLE
Implement global listeners command api

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -52,6 +52,7 @@ import io.camunda.service.DocumentServices;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ExpressionServices;
 import io.camunda.service.FormServices;
+import io.camunda.service.GlobalListenerServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
@@ -592,6 +593,20 @@ public class CamundaServicesConfiguration {
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new TopologyServices(
+        brokerClient,
+        securityContextProvider,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Bean
+  public GlobalListenerServices globalListenerServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new GlobalListenerServices(
         brokerClient,
         securityContextProvider,
         null,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GlobalListenerMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GlobalListenerMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mapping.http.mapper;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
+import io.camunda.gateway.mapping.http.validator.GlobalListenerRequestValidator;
 import io.camunda.gateway.protocol.model.CreateGlobalTaskListenerRequest;
 import io.camunda.gateway.protocol.model.GlobalListenerBase;
 import io.camunda.gateway.protocol.model.GlobalListenerSourceEnum;
@@ -19,12 +20,14 @@ import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListener
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
 import io.camunda.zeebe.util.Either;
-import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class GlobalListenerMapper {
 
-  public GlobalListenerMapper() {
+  private final GlobalListenerRequestValidator requestValidator;
+
+  public GlobalListenerMapper(final GlobalListenerRequestValidator requestValidator) {
+    this.requestValidator = requestValidator;
   }
 
   //
@@ -34,7 +37,7 @@ public class GlobalListenerMapper {
   public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerCreateRequest(
       final CreateGlobalTaskListenerRequest request) {
     return RequestMapper.getResult(
-        Optional.empty(),
+        requestValidator.validateCreateRequest(request),
         () -> {
           final var record = new GlobalListenerRecord();
           fillDataFromGlobalTaskListenerRequest(record, request);
@@ -46,7 +49,7 @@ public class GlobalListenerMapper {
   public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerUpdateRequest(
       final String id, final UpdateGlobalTaskListenerRequest request) {
     return RequestMapper.getResult(
-        Optional.empty(),
+        requestValidator.validateUpdateRequest(id, request),
         () -> {
           final var record = new GlobalListenerRecord();
           fillDataFromGlobalTaskListenerRequest(record, request);
@@ -59,7 +62,7 @@ public class GlobalListenerMapper {
   public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerDeleteRequest(
       final String id) {
     return RequestMapper.getResult(
-        Optional.empty(),
+        requestValidator.validateDeleteRequest(id),
         () -> {
           final var record = new GlobalListenerRecord();
           // Ensure basic data for a task listener request is set

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GlobalListenerMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GlobalListenerMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.mapper;
+
+import io.camunda.gateway.mapping.http.RequestMapper;
+import io.camunda.gateway.protocol.model.CreateGlobalTaskListenerRequest;
+import io.camunda.gateway.protocol.model.GlobalListenerBase;
+import io.camunda.gateway.protocol.model.GlobalListenerSourceEnum;
+import io.camunda.gateway.protocol.model.GlobalTaskListenerBase;
+import io.camunda.gateway.protocol.model.GlobalTaskListenerEventTypeEnum;
+import io.camunda.gateway.protocol.model.GlobalTaskListenerResult;
+import io.camunda.gateway.protocol.model.UpdateGlobalTaskListenerRequest;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public class GlobalListenerMapper {
+
+  public GlobalListenerMapper() {
+  }
+
+  //
+  // Request mapping
+  //
+
+  public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerCreateRequest(
+      final CreateGlobalTaskListenerRequest request) {
+    return RequestMapper.getResult(
+        Optional.empty(),
+        () -> {
+          final var record = new GlobalListenerRecord();
+          fillDataFromGlobalTaskListenerRequest(record, request);
+          record.setId(request.getId());
+          return record;
+        });
+  }
+
+  public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerUpdateRequest(
+      final String id, final UpdateGlobalTaskListenerRequest request) {
+    return RequestMapper.getResult(
+        Optional.empty(),
+        () -> {
+          final var record = new GlobalListenerRecord();
+          fillDataFromGlobalTaskListenerRequest(record, request);
+          // Add ID from the actual request
+          record.setId(id);
+          return record;
+        });
+  }
+
+  public Either<ProblemDetail, GlobalListenerRecord> toGlobalTaskListenerDeleteRequest(
+      final String id) {
+    return RequestMapper.getResult(
+        Optional.empty(),
+        () -> {
+          final var record = new GlobalListenerRecord();
+          // Ensure basic data for a task listener request is set
+          fillDataFromGlobalTaskListenerRequest(record, new GlobalTaskListenerBase());
+          // Add ID from the actual request
+          record.setId(id);
+          return record;
+        });
+  }
+
+  private void fillDataFromGlobalListenerRequest(
+      final GlobalListenerRecord record, final GlobalListenerBase request) {
+    if (request.getType() != null) {
+      record.setType(request.getType());
+    }
+    if (request.getRetries() != null) {
+      record.setRetries(request.getRetries());
+    }
+    if (request.getAfterNonGlobal() != null) {
+      record.setAfterNonGlobal(request.getAfterNonGlobal());
+    }
+    if (request.getPriority() != null) {
+      record.setPriority(request.getPriority());
+    }
+
+    // All external requests generate API-defined listeners
+    record.setSource(GlobalListenerSource.API);
+  }
+
+  private void fillDataFromGlobalTaskListenerRequest(
+      final GlobalListenerRecord record, final GlobalTaskListenerBase request) {
+    fillDataFromGlobalListenerRequest(record, request);
+    if (request.getEventTypes() != null) {
+      record.setEventTypes(
+          request.getEventTypes().stream().map(GlobalTaskListenerEventTypeEnum::getValue).toList());
+    }
+
+    // All requests related to task listeners must have the listener type set to USER_TASK
+    record.setListenerType(GlobalListenerType.USER_TASK);
+  }
+
+  //
+  // Response mapping
+  //
+
+  public GlobalTaskListenerResult toGlobalListenerResponse(final GlobalListenerRecord record) {
+    return new GlobalTaskListenerResult()
+        .id(record.getId())
+        .type(record.getType())
+        .retries(record.getRetries())
+        .eventTypes(
+            record.getEventTypes().stream()
+                .map(GlobalTaskListenerEventTypeEnum::fromValue)
+                .toList())
+        .afterNonGlobal(record.isAfterNonGlobal())
+        .priority(record.getPriority())
+        .source(GlobalListenerSourceEnum.valueOf(record.getSource().name()));
+  }
+}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/GlobalListenerRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/GlobalListenerRequestValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.validator;
+
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.security.validation.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+
+import io.camunda.gateway.protocol.model.CreateGlobalTaskListenerRequest;
+import io.camunda.gateway.protocol.model.UpdateGlobalTaskListenerRequest;
+import io.camunda.security.validation.IdentifierValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public class GlobalListenerRequestValidator {
+
+  private final IdentifierValidator identifierValidator;
+
+  public GlobalListenerRequestValidator(final IdentifierValidator identifierValidator) {
+    this.identifierValidator = identifierValidator;
+  }
+
+  public Optional<ProblemDetail> validateCreateRequest(
+      final CreateGlobalTaskListenerRequest request) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+          identifierValidator.validateId(request.getId(), "id", violations);
+          identifierValidator.validateId(request.getType(), "type", violations);
+          if (request.getEventTypes() == null || request.getEventTypes().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("eventTypes"));
+          }
+          return violations;
+        });
+  }
+
+  public Optional<ProblemDetail> validateGetRequest(final String id) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+          identifierValidator.validateId(id, "id", violations);
+          return violations;
+        });
+  }
+
+  public Optional<ProblemDetail> validateUpdateRequest(
+      final String id, final UpdateGlobalTaskListenerRequest request) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+          identifierValidator.validateId(id, "id", violations);
+          identifierValidator.validateId(request.getType(), "type", violations);
+          if (request.getEventTypes() == null || request.getEventTypes().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("eventTypes"));
+          }
+          return violations;
+        });
+  }
+
+  public Optional<ProblemDetail> validateDeleteRequest(final String id) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+          identifierValidator.validateId(id, "id", violations);
+          return violations;
+        });
+  }
+}

--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateGlobalListenerRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteGlobalListenerRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateGlobalListenerRequest;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import java.util.concurrent.CompletableFuture;
+
+public final class GlobalListenerServices extends ApiServices<GlobalListenerServices> {
+
+  public GlobalListenerServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final CamundaAuthentication authentication,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Override
+  public GlobalListenerServices withAuthentication(final CamundaAuthentication authentication) {
+    return new GlobalListenerServices(
+        brokerClient,
+        securityContextProvider,
+        authentication,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public CompletableFuture<GlobalListenerRecord> createGlobalListener(
+      final GlobalListenerRecord request) {
+    return sendBrokerRequest(new BrokerCreateGlobalListenerRequest(request));
+  }
+
+  public CompletableFuture<GlobalListenerRecord> updateGlobalListener(
+      final GlobalListenerRecord request) {
+    return sendBrokerRequest(new BrokerUpdateGlobalListenerRequest(request));
+  }
+
+  public CompletableFuture<GlobalListenerRecord> deleteGlobalListener(
+      final GlobalListenerRecord request) {
+    return sendBrokerRequest(new BrokerDeleteGlobalListenerRequest(request));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
@@ -69,6 +69,11 @@ public final class GlobalListenerCreateProcessor
 
     emitChangeEvents(record);
 
+    writers
+        .response()
+        .writeEventOnCommand(
+            record.getGlobalListenerKey(), GlobalListenerIntent.CREATED, record, command);
+
     // Note: the configuration key is used as the command key for distribution, ensuring
     // configuration changes are applied in order
     distributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -67,6 +67,11 @@ public final class GlobalListenerDeleteProcessor
 
     emitChangeEvents(record);
 
+    writers
+        .response()
+        .writeEventOnCommand(
+            record.getGlobalListenerKey(), GlobalListenerIntent.DELETED, record, command);
+
     // Note: the configuration key is used as the command key for distribution, ensuring
     // configuration changes are applied in order
     distributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -67,6 +67,11 @@ public final class GlobalListenerUpdateProcessor
 
     emitChangeEvents(record);
 
+    writers
+        .response()
+        .writeEventOnCommand(
+            record.getGlobalListenerKey(), GlobalListenerIntent.UPDATED, record, command);
+
     // Note: the configuration key is used as the command key for distribution, ensuring
     // configuration changes are applied in order
     distributionBehavior

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -1,0 +1,202 @@
+## Endpoint definitions
+
+paths:
+  /global-listeners/user-task:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Global listener
+      operationId: createGlobalTaskListener
+      summary: Create global user task listener
+      description: Create a new global user task listener.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGlobalTaskListenerRequest'
+        required: true
+      responses:
+        "201":
+          description: The global user task listener was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalTaskListenerResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "409":
+          description: A global listener with this id already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+
+  /global-listeners/user-task/{id}:
+    put:
+      x-eventually-consistent: true
+      tags:
+        - Global listener
+      operationId: updateGlobalTaskListener
+      summary: Update global user task listener
+      description: Updates a global user task listener.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the global user task listener to update.
+          schema:
+            $ref: 'identifiers.yaml#/components/schemas/GlobalListenerId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGlobalTaskListenerRequest'
+        required: true
+      responses:
+        "200":
+          description: The global listener was updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalTaskListenerResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: The global user task listener was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+
+    delete:
+      x-eventually-consistent: true
+      tags:
+        - Global listener
+      operationId: deleteGlobalTaskListener
+      summary: Delete global user task listener
+      description: Deletes a global user task listener.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the global user task listener to delete.
+          schema:
+            $ref: 'identifiers.yaml#/components/schemas/GlobalListenerId'
+      responses:
+        "204":
+          description: The global listener was deleted successfully.
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: The global user task listener was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+
+## Schema definitions
+
+components:
+  schemas:
+    # Enumerations
+    GlobalListenerSourceEnum:
+      type: string
+      enum:
+        - CONFIGURATION
+        - API
+      description: How the global listener was defined.
+    GlobalTaskListenerEventTypeEnum:
+      type: string
+      enum:
+        - all
+        - creating
+        - assigning
+        - updating
+        - completing
+        - canceling
+      description: The event type that triggers the user task listener.
+
+    # Common
+    GlobalListenerBase:
+      type: object
+      properties:
+        type:
+          description: The name of the job type, used as a reference to specify which job workers request the respective listener job.
+          type: string
+          example: order-items
+        retries:
+          description: Number of retries for the listener job.
+          type: integer
+        afterNonGlobal:
+          description: Whether the listener should run after model-level listeners.
+          type: boolean
+        priority:
+          description: The priority of the listener. Higher priority listeners are executed before lower priority ones.
+          type: integer
+    GlobalTaskListenerBase:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/GlobalListenerBase'
+      properties:
+        eventTypes:
+          $ref: '#/components/schemas/GlobalTaskListenerEventTypes'
+    GlobalTaskListenerEventTypes:
+      description: List of user task event types that trigger the listener.
+      type: array
+      items:
+        $ref: '#/components/schemas/GlobalTaskListenerEventTypeEnum'
+
+    # CRUD Requests
+    CreateGlobalTaskListenerRequest:
+      type: object
+      required:
+        - id
+        - type
+        - eventTypes
+      allOf:
+        - $ref: '#/components/schemas/GlobalTaskListenerBase'
+      properties:
+        id:
+          $ref: 'identifiers.yaml#/components/schemas/GlobalListenerId'
+    UpdateGlobalTaskListenerRequest:
+      type: object
+      required:
+        - type
+        - eventTypes
+      allOf:
+        - $ref: '#/components/schemas/GlobalTaskListenerBase'
+
+    # CRUD Responses
+    GlobalTaskListenerResult:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/GlobalTaskListenerBase'
+      properties:
+        id:
+          $ref: 'identifiers.yaml#/components/schemas/GlobalListenerId'
+        source:
+          $ref: '#/components/schemas/GlobalListenerSourceEnum'

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -34,6 +34,13 @@ components:
       pattern: ^[A-Za-z0-9_@.+-]+$
       example: new-hire-onboarding-workflow
 
+    GlobalListenerId:
+      description: The user-defined id for the global listener
+      type: string
+      format: GlobalListenerId
+      x-semantic-type: GlobalListenerId
+      example: GlobalListener_1
+
     TenantId:
       example: customer-service
       description: The unique identifier of the tenant.

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -40,6 +40,7 @@ tags:
   - name: Document
   - name: Element instance
   - name: Expression
+  - name: Global listener
   - name: Group
   - name: Incident
   - name: Job
@@ -176,6 +177,12 @@ paths:
   # Expression endpoints
   /expression/evaluation:
     $ref: 'expression.yaml#/paths/~1expression~1evaluation'
+
+  # Global listeners endpoints
+  /global-listeners/user-task:
+    $ref: 'global-listeners.yaml#/paths/~1global-listeners~1user-task'
+  /global-listeners/user-task/{id}:
+    $ref: 'global-listeners.yaml#/paths/~1global-listeners~1user-task~1{id}'
 
   # Group endpoints
   /groups:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalListenerController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalListenerController.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.mapping.http.mapper.GlobalListenerMapper;
+import io.camunda.gateway.protocol.model.CreateGlobalTaskListenerRequest;
+import io.camunda.gateway.protocol.model.UpdateGlobalTaskListenerRequest;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.GlobalListenerServices;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/global-listeners")
+public class GlobalListenerController {
+
+  public static final String TASK_LISTENER_PATH = "/user-task";
+
+  private final GlobalListenerServices globalListenerServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final GlobalListenerMapper globalListenerMapper;
+
+  public GlobalListenerController(
+      final GlobalListenerServices globalListenerServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.globalListenerServices = globalListenerServices;
+    this.authenticationProvider = authenticationProvider;
+    globalListenerMapper = new GlobalListenerMapper();
+  }
+
+  @CamundaPostMapping(path = TASK_LISTENER_PATH)
+  public CompletableFuture<ResponseEntity<Object>> createGlobalTaskListener(
+      @RequestBody final CreateGlobalTaskListenerRequest request) {
+    return globalListenerMapper
+        .toGlobalTaskListenerCreateRequest(request)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGlobalListener);
+  }
+
+  @CamundaPutMapping(path = TASK_LISTENER_PATH + "/{id}")
+  public CompletableFuture<ResponseEntity<Object>> updateGlobalTaskListener(
+      @PathVariable("id") final String id,
+      @RequestBody final UpdateGlobalTaskListenerRequest request) {
+    return globalListenerMapper
+        .toGlobalTaskListenerUpdateRequest(id, request)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGlobalListener);
+  }
+
+  @CamundaDeleteMapping(path = TASK_LISTENER_PATH + "/{id}")
+  public CompletableFuture<ResponseEntity<Object>> deleteGlobalTaskListener(
+      @PathVariable("id") final String id) {
+    return globalListenerMapper
+        .toGlobalTaskListenerDeleteRequest(id)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deleteGlobalListener);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> createGlobalListener(
+      final GlobalListenerRecord request) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            globalListenerServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .createGlobalListener(request),
+        globalListenerMapper::toGlobalListenerResponse,
+        HttpStatus.CREATED);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> updateGlobalListener(
+      final GlobalListenerRecord request) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            globalListenerServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .updateGlobalListener(request),
+        globalListenerMapper::toGlobalListenerResponse,
+        HttpStatus.OK);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> deleteGlobalListener(
+      final GlobalListenerRecord request) {
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            globalListenerServices
+                .withAuthentication(authenticationProvider.getCamundaAuthentication())
+                .deleteGlobalListener(request));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalListenerController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalListenerController.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.gateway.mapping.http.mapper.GlobalListenerMapper;
+import io.camunda.gateway.mapping.http.validator.GlobalListenerRequestValidator;
 import io.camunda.gateway.protocol.model.CreateGlobalTaskListenerRequest;
 import io.camunda.gateway.protocol.model.UpdateGlobalTaskListenerRequest;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.security.validation.IdentifierValidator;
 import io.camunda.service.GlobalListenerServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
@@ -37,10 +39,12 @@ public class GlobalListenerController {
 
   public GlobalListenerController(
       final GlobalListenerServices globalListenerServices,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final IdentifierValidator identifierValidator) {
     this.globalListenerServices = globalListenerServices;
     this.authenticationProvider = authenticationProvider;
-    globalListenerMapper = new GlobalListenerMapper();
+    globalListenerMapper =
+        new GlobalListenerMapper(new GlobalListenerRequestValidator(identifierValidator));
   }
 
   @CamundaPostMapping(path = TASK_LISTENER_PATH)

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateGlobalListenerRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateGlobalListenerRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerCreateGlobalListenerRequest extends BrokerExecuteCommand<GlobalListenerRecord> {
+
+  private final GlobalListenerRecord requestDto;
+
+  public BrokerCreateGlobalListenerRequest(final GlobalListenerRecord record) {
+    super(ValueType.GLOBAL_LISTENER, GlobalListenerIntent.CREATE);
+    requestDto = record;
+    // Since this changes a global configuration, it is necessary to route all commands to the
+    // same partition, from which they will be distributed to the other ones.
+    // This ensures that the order of the commands is preserved, which is important for consistency.
+    // Using a distribution queue without this additional routing is not enough since ordering
+    // in the queue is based on a key which is partition-dependent, so commands for different
+    // partitions would be ordered differently in the queue.
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected GlobalListenerRecord toResponseDto(final DirectBuffer buffer) {
+    final GlobalListenerRecord responseDto = new GlobalListenerRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteGlobalListenerRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteGlobalListenerRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerDeleteGlobalListenerRequest extends BrokerExecuteCommand<GlobalListenerRecord> {
+
+  private final GlobalListenerRecord requestDto;
+
+  public BrokerDeleteGlobalListenerRequest(final GlobalListenerRecord record) {
+    super(ValueType.GLOBAL_LISTENER, GlobalListenerIntent.DELETE);
+    requestDto = record;
+    // Since this changes a global configuration, it is necessary to route all commands to the
+    // same partition, from which they will be distributed to the other ones.
+    // This ensures that the order of the commands is preserved, which is important for consistency.
+    // Using a distribution queue without this additional routing is not enough since ordering
+    // in the queue is based on a key which is partition-dependent, so commands for different
+    // partitions would be ordered differently in the queue.
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected GlobalListenerRecord toResponseDto(final DirectBuffer buffer) {
+    final GlobalListenerRecord responseDto = new GlobalListenerRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateGlobalListenerRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateGlobalListenerRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerUpdateGlobalListenerRequest extends BrokerExecuteCommand<GlobalListenerRecord> {
+
+  private final GlobalListenerRecord requestDto;
+
+  public BrokerUpdateGlobalListenerRequest(final GlobalListenerRecord record) {
+    super(ValueType.GLOBAL_LISTENER, GlobalListenerIntent.UPDATE);
+    requestDto = record;
+    // Since this changes a global configuration, it is necessary to route all commands to the
+    // same partition, from which they will be distributed to the other ones.
+    // This ensures that the order of the commands is preserved, which is important for consistency.
+    // Using a distribution queue without this additional routing is not enough since ordering
+    // in the queue is based on a key which is partition-dependent, so commands for different
+    // partitions would be ordered differently in the queue.
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected GlobalListenerRecord toResponseDto(final DirectBuffer buffer) {
+    final GlobalListenerRecord responseDto = new GlobalListenerRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -59,7 +59,8 @@ public final class ValueTypes {
           ValueType.HISTORY_DELETION,
           ValueType.CONDITIONAL_SUBSCRIPTION,
           ValueType.CONDITIONAL_EVALUATION,
-          ValueType.EXPRESSION);
+          ValueType.EXPRESSION,
+          ValueType.GLOBAL_LISTENER);
 
   private ValueTypes() {}
 


### PR DESCRIPTION
## Description
This pull request introduces a new set of REST API endpoints and supporting infrastructure for managing global user task listeners. It adds protocol definitions, validation, mapping, and service classes for creating, updating, and deleting global listeners, as well as updates to the engine processors to emit appropriate responses. The changes are grouped as follows:

**API and Protocol Additions:**

* Added new REST API endpoints for creating, updating, and deleting global user task listeners, along with schema definitions for request and response objects in `global-listeners.yaml`. Also introduced a new identifier type `GlobalListenerId` in `identifiers.yaml` and registered the endpoints in the main API spec.

**Request Validation and Mapping:**

* Implemented `GlobalListenerRequestValidator` to validate create, update, and delete requests for global listeners, ensuring required fields and proper identifier formats.
* Added `GlobalListenerMapper` to handle conversion between HTTP requests/responses and internal `GlobalListenerRecord` objects, including validation and field mapping logic.

**Service Layer:**

* Introduced `GlobalListenerServices`, providing asynchronous methods to create, update, and delete global listeners by sending broker requests.

**Engine Processor Enhancements:**

* Updated the global listener create, update, and delete processors to emit response events when handling respective commands, ensuring clients receive confirmation of these operations.

These changes collectively enable full lifecycle management of global user task listeners via the REST API, including validation, protocol support, service orchestration, and engine-level event emission.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #43188
