### PR TITLE
test: add assertion

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -241,19 +241,31 @@ test.describe('Process Instances Table', () => {
         .scrollIntoViewIfNeeded();
       await sleep(500);
       await expect(instanceRows).toHaveCount(200);
-      await expect
-        .poll(() => instanceRows.nth(0).innerText())
-        .toContain(descendingInstanceIds[0].toString());
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect
+            .poll(() => instanceRows.nth(0).innerText())
+            .toContain(descendingInstanceIds[0].toString());
+        },
+        onFailure: async () => {
+          console.log('Polling is wrong, retrying...');
+        },
+        maxRetries: 6,
+      });
+
+      
       await expect
         .poll(() => instanceRows.nth(199).innerText())
         .toContain(descendingInstanceIds[199].toString());
-      await page
-        .getByRole('row', {name: `Instance ${descendingInstanceIds[199]}`})
-        .scrollIntoViewIfNeeded();
-      await expect(instanceRows).toHaveCount(200);
     });
 
     await test.step('Scroll to 250th instance', async () => {
+      await page
+        .getByRole('row', {name: `Instance ${descendingInstanceIds[199]}`})
+        .scrollIntoViewIfNeeded();
+      await sleep(500);
+      await expect(instanceRows).toHaveCount(200);
       await expect
         .poll(() => instanceRows.nth(0).innerText())
         .toContain(descendingInstanceIds[50].toString());


### PR DESCRIPTION
## Description

This PR provides additional assertion in [Process Instances Table › Scrolling of process instances](https://camunda.testrail.com/index.php?/tests/view/2626898).


## Related issues
Test failed on Nightly runs on 09.02, 12.02 and 13.02

## On demand workflow
[Was successful](https://github.com/camunda/camunda/actions/runs/22055472119) twice :) ([second run](https://github.com/camunda/camunda/actions/runs/22055832788))
