### PR TITLE
fix: update conditional logic for building load test images in workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -201,7 +201,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' && inputs.use-official-docker-images == true }}
+    if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -201,6 +201,9 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
+    # Build load test images when:
+    # 1. No reuse-tag is provided (building from scratch), OR
+    # 2. Using official docker images (since there are no official starter/worker images, we must build them)
     if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Small Fix:
This pull request includes a small change to the workflow condition in the `.github/workflows/camunda-load-test.yml` file. The logic for when the "Build Starter and Worker" job runs has been updated to trigger if either `reuse-tag` is empty or `use-official-docker-images` is true, instead of requiring both conditions.

Reference PR:
https://github.com/camunda/camunda/pull/44607
