### PR TITLE
fix: resolve maven-release-plugin failure on version property indirec…

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -334,6 +334,15 @@ jobs:
             -pl qa/util
             -am
 
+      - name: Override client version for compatibility testing
+        run: |
+          # Inject the specific client version into the POM to override the inherited version
+          ./mvnw -pl qa/acceptance-tests versions:use-dep-version \
+            -Dincludes=io.camunda:camunda-client-java \
+            -DdepVersion=${{ matrix.client }} \
+            -DforceVersion=true \
+            -DgenerateBackupPoms=false
+
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
@@ -342,7 +351,6 @@ jobs:
             -P compatibility-test
             -pl qa/acceptance-tests
             -Dcamunda.compatibility.test.version=${{ matrix.server }}
-            -Dcamunda.client.version=${{ matrix.client }}
             -DfailIfNoTests=false
 
       - name: Record tested combination

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -332,15 +332,22 @@ jobs:
             -pl qa/compatibility-test
             -am
 
+      - name: Override spring client version for compatibility testing
+        run: |
+          # Inject the specific spring client version into the POM to override the inherited version
+          ./mvnw -pl qa/compatibility-test versions:use-dep-version \
+            -Dincludes=io.camunda:camunda-spring-boot-starter \
+            -DdepVersion=${{ matrix.client }} \
+            -DforceVersion=true \
+            -DgenerateBackupPoms=false
+
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
           parameters: >-
             verify
             -pl qa/compatibility-test
-            -Pcompatibility-test
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
-            -Dcamunda.spring.client.version=${{ matrix.client }}
             -DfailIfNoTests=false
 
       - name: Record tested combination

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -338,6 +338,7 @@ jobs:
           parameters: >-
             verify
             -pl qa/compatibility-test
+            -Pcompatibility-test
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
             -Dcamunda.spring.client.version=${{ matrix.client }}
             -DfailIfNoTests=false

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -22,8 +22,6 @@
   <name>Camunda QA Acceptance Tests</name>
   <properties>
     <version.maven-surefire-junit5-tree-reporter>1.5.1</version.maven-surefire-junit5-tree-reporter>
-    <!-- Runtime client version for compatibility tests - can be overridden -->
-    <camunda.client.version>${project.version}</camunda.client.version>
   </properties>
 
   <dependencies>
@@ -70,7 +68,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-client-java</artifactId>
-      <version>${camunda.client.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -726,6 +723,19 @@
     -->
     <profile>
       <id>compatibility-test</id>
+      <properties>
+        <!-- Runtime client version for compatibility tests - override via -Dcamunda.client.version=X.Y.Z -->
+        <camunda.client.version>${project.version}</camunda.client.version>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>camunda-client-java</artifactId>
+            <version>${camunda.client.version}</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
       <build>
         <plugins>
           <plugin>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -715,27 +715,15 @@
     This profile will run all tests annotated with @Tag("compatibility-test").
     The profile is used to run tests against different versions of Camunda components.
 
-    To test with a specific client version:
-    ./mvnw verify -Pcompatibility-test -Dcamunda.client.version=8.8.0 -Dit.test=AuthorizationIT
+    To test with a specific client version, override the dependency version before running:
+    ./mvnw versions:use-dep-version -Dincludes=io.camunda:camunda-client-java -DdepVersion=8.8.0 -DforceVersion=true
+    ./mvnw verify -Pcompatibility-test -Dit.test=AuthorizationIT
 
     Tests compile against the current (SNAPSHOT) version but run with the specified client version.
     Tests that use APIs not available in the specified version will be automatically skipped.
     -->
     <profile>
       <id>compatibility-test</id>
-      <properties>
-        <!-- Runtime client version for compatibility tests - override via -Dcamunda.client.version=X.Y.Z -->
-        <camunda.client.version>${project.version}</camunda.client.version>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>io.camunda</groupId>
-            <artifactId>camunda-client-java</artifactId>
-            <version>${camunda.client.version}</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
       <build>
         <plugins>
           <plugin>

--- a/qa/compatibility-test/pom.xml
+++ b/qa/compatibility-test/pom.xml
@@ -117,23 +117,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>compatibility-test</id>
-      <properties>
-        <!-- Runtime spring client version for compatibility tests - override via -Dcamunda.spring.client.version=X.Y.Z -->
-        <camunda.spring.client.version>${project.version}</camunda.spring.client.version>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>io.camunda</groupId>
-            <artifactId>camunda-spring-boot-starter</artifactId>
-            <version>${camunda.spring.client.version}</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-    </profile>
-  </profiles>
-
 </project>

--- a/qa/compatibility-test/pom.xml
+++ b/qa/compatibility-test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Camunda QA Compatibility Tests</name>
 
-  <properties>
-    <!-- Runtime spring client version for compatibility tests - can be overridden -->
-    <camunda.spring.client.version>${project.version}</camunda.spring.client.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -28,7 +23,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-starter</artifactId>
-      <version>${camunda.spring.client.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,5 +116,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>compatibility-test</id>
+      <properties>
+        <!-- Runtime spring client version for compatibility tests - override via -Dcamunda.spring.client.version=X.Y.Z -->
+        <camunda.spring.client.version>${project.version}</camunda.spring.client.version>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>io.camunda</groupId>
+            <artifactId>camunda-spring-boot-starter</artifactId>
+            <version>${camunda.spring.client.version}</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
## Description

Fixes the `maven-release-plugin:2.5.3:prepare` failure:

```
The artifact (io.camunda:camunda-client-java) requires a different version (0.0.0-dryrun-minor)
than what is found (${project.version}) for the expression (camunda.client.version)
in the project (io.camunda:camunda-qa-acceptance-tests
```

### Solution

Remove the version property indirection from the POMs entirely. The compatibility test workflows now use `versions:use-dep-version` as a separate Maven invocation to inject the desired dependency version into the POM before running tests. This keeps the version override mechanism outside the POM where the release plugin cannot see it.

### Changes

| File | Change |
|---|---|
| `qa/acceptance-tests/pom.xml` | Removed `camunda.client.version` property and `dependencyManagement` from the `compatibility-test` profile |
| `qa/compatibility-test/pom.xml` | Removed `camunda.spring.client.version` property, `dependencyManagement`, and the `compatibility-test` profile |
| `.github/workflows/camunda-client-compatibility-test.yml` | Added `versions:use-dep-version` step to override `camunda-client-java` version before running tests |
| `.github/workflows/camunda-spring-boot-starter-compatibility-test.yml` | Added `versions:use-dep-version` step to override `camunda-spring-boot-starter` version before running tests |

### How compatibility testing now works

1. **Build step** — compiles all dependencies with the current SNAPSHOT version
2. **Version override step** — `mvn versions:use-dep-version` rewrites the dependency version in the POM on disk
3. **Test step** — Maven reads the updated POM and runs tests with the overridden dependency

This two-step approach is necessary because Maven reads the POM model into memory once at startup, so the version override must happen as a separate invocation before the test run.

### Testing

- The release workflow (`camunda-platform-release.yml`) should no longer fail on `release:prepare`
- Compatibility test workflows continue to work, using `versions:use-dep-version` instead of `-D` property overrides

## Related issues

related to https://camunda.slack.com/archives/C06UWQNCU7M/p1771013318468529
