### PR TITLE
feat: support additional processes MCP endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/mcp/McpServersConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/mcp/McpServersConfiguration.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.zeebe.util.VersionUtil;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.server.transport.WebMvcStatelessServerTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Configuration for multiple MCP server instances with their own transports.
+ *
+ * <p>This configuration creates an MCP server programmatically:
+ *
+ * <ul>
+ *   <li>{@code /mcp/cluster} - Static tools from {@link CamundaMcpTool} annotated methods
+ * </ul>
+ *
+ * <p>Each server has its own transport provider and tool specifications, allowing independent
+ * configuration and management.
+ */
+@AutoConfiguration(
+    afterName = {
+      "org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration",
+      "org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration",
+      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebFluxAutoConfiguration",
+      "org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebMvcAutoConfiguration"
+    })
+@ConditionalOnMcpGatewayEnabled
+public class McpServersConfiguration {
+
+  @Bean
+  public McpJsonMapper mcpJsonMapper(final ObjectMapper objectMapper) {
+    return new JacksonMcpJsonMapper(objectMapper);
+  }
+
+  /**
+   * Transport provider for the cluster MCP server at {@code /mcp/cluster}.
+   *
+   * <p>Handles MCP protocol messages for cluster-wide operations and general Camunda API access.
+   */
+  @Bean(name = "clusterTransportProvider")
+  public WebMvcStatelessServerTransport clusterTransportProvider(
+      final McpJsonMapper mcpJsonMapper) {
+    return WebMvcStatelessServerTransport.builder()
+        .jsonMapper(mcpJsonMapper)
+        .messageEndpoint("/mcp/cluster")
+        .build();
+  }
+
+  @Bean
+  public RouterFunction<ServerResponse> clusterRouterFunction(
+      @Qualifier("clusterTransportProvider")
+          final WebMvcStatelessServerTransport clusterTransportProvider) {
+    return clusterTransportProvider.getRouterFunction();
+  }
+
+  /**
+   * MCP server for cluster operations at {@code /mcp/cluster}.
+   *
+   * <p>Provides static tools defined via {@link CamundaMcpTool} annotations.
+   */
+  @Bean
+  public McpStatelessSyncServer clusterMcpServer(
+      @Qualifier("clusterTransportProvider") final McpStatelessServerTransport clusterTransport,
+      @Qualifier("mcpGatewayToolSpecifications")
+          final List<SyncToolSpecification> toolSpecifications) {
+
+    final var capabilities = McpSchema.ServerCapabilities.builder().tools(false).build();
+
+    return McpServer.sync(clusterTransport)
+        .serverInfo("Camunda 8 Orchestration API MCP Server", VersionUtil.getVersion())
+        .capabilities(capabilities)
+        .tools(toolSpecifications)
+        .immediateExecution(true)
+        .build();
+  }
+
+  /**
+   * Transport provider for the cluster MCP server at {@code /mcp/cluster}.
+   *
+   * <p>Handles MCP protocol messages for cluster-wide operations and general Camunda API access.
+   */
+  @Bean(name = "processesTransportProvider")
+  public WebMvcStatelessServerTransport processesTransportProvider(
+      final McpJsonMapper mcpJsonMapper) {
+    return WebMvcStatelessServerTransport.builder()
+        .jsonMapper(mcpJsonMapper)
+        .messageEndpoint("/mcp/processes")
+        .build();
+  }
+
+  @Bean
+  public RouterFunction<ServerResponse> processesRouterFunction(
+      @Qualifier("processesTransportProvider")
+          final WebMvcStatelessServerTransport processesTransportProvider) {
+    return processesTransportProvider.getRouterFunction();
+  }
+
+  /**
+   * MCP server for cluster operations at {@code /mcp/cluster}.
+   *
+   * <p>Provides static tools defined via {@link CamundaMcpTool} annotations.
+   */
+  @Bean
+  public McpStatelessSyncServer processesMcpServer(
+      @Qualifier("processesTransportProvider") final McpStatelessServerTransport processesTransport,
+      @Qualifier("mcpGatewayToolSpecifications")
+          final List<SyncToolSpecification> toolSpecifications) {
+
+    final var capabilities = McpSchema.ServerCapabilities.builder().tools(false).build();
+
+    return McpServer.sync(processesTransport)
+        .serverInfo("Camunda 8 Orchestration API Processes MCP Server", VersionUtil.getVersion())
+        .capabilities(capabilities)
+        .tools(toolSpecifications)
+        .immediateExecution(true)
+        .build();
+  }
+}

--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -3,16 +3,11 @@ spring:
     mcp:
       server:
         enabled: true
-        name: Camunda 8 Orchestration API MCP Server
-        version: '${project.version}'
         type: sync
         protocol: stateless
         annotation-scanner:
           enabled: true
-        streamable-http:
-          mcp-endpoint: /mcp/cluster
-        capabilities:
-          completion: false
-          prompt: false
-          resource: false
-          tool: true
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
+      - org.springframework.ai.mcp.server.autoconfigure.McpServerStatelessWebMvcAutoConfiguration

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -35,7 +35,7 @@ public class CamundaMcpToolSpecificationsAutoConfiguration {
     return new CamundaJsonSchemaGenerator();
   }
 
-  @Bean
+  @Bean(name = "mcpGatewayToolSpecifications")
   public List<SyncToolSpecification> mcpGatewayToolSpecifications(
       final CamundaMcpToolAnnotatedBeans annotatedBeans,
       final CamundaJsonSchemaGenerator jsonSchemaGenerator) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -34,7 +34,7 @@ public class McpServerConfigurationIT {
     @Test
     public void mcpInitializeRequestReturnsInitializationResponse() {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER, "/mcp/cluster")) {
 
         final var initializeResult = mcpClient.initialize();
         assertThat(initializeResult).isNotNull();
@@ -69,7 +69,7 @@ public class McpServerConfigurationIT {
     @Test
     public void mcpInitializeRequestReturnsInitializationResponse() {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER, "/mcp/cluster")) {
 
         final var initializeResult = mcpClient.initialize();
         assertThat(initializeResult).isNotNull();
@@ -87,7 +87,7 @@ public class McpServerConfigurationIT {
     @Test
     public void mcpInitializeRequestReturnsNotFoundResponse() {
       try (final McpSyncClient mcpClient =
-          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER)) {
+          createMcpClient(TEST_INSTANCE, DEFAULT_REQUEST_CUSTOMIZER, "/mcp/cluster")) {
 
         final Throwable throwable = catchThrowable(mcpClient::initialize);
         assertThat(throwable.getCause())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerTest.java
@@ -7,30 +7,39 @@
  */
 package io.camunda.it.mcp;
 
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 
 public abstract class McpServerTest {
 
   public static final McpSyncHttpClientRequestCustomizer DEFAULT_REQUEST_CUSTOMIZER =
       (builder, method, endpoint, body, context) -> {};
 
-  protected McpSyncClient mcpClient;
+  McpSyncClient mcpClient;
 
-  @BeforeEach
-  void createMcpClient() {
-    mcpClient = createMcpClient(testInstance(), createMcpClientRequestCustomizer());
+  protected McpSyncClient getMcpClient(final String endpoint) {
+    return getMcpClient(endpoint, createMcpClientRequestCustomizer());
+  }
+
+  protected McpSyncClient getMcpClient(
+      final String endpoint, final McpSyncHttpClientRequestCustomizer httpClientRequestCustomizer) {
+    mcpClient = createMcpClient(testInstance(), httpClientRequestCustomizer, endpoint);
+    return mcpClient;
   }
 
   @AfterEach
   void closeMcpClient() {
     if (mcpClient != null) {
       mcpClient.close();
+      mcpClient = null;
     }
   }
 
@@ -40,12 +49,19 @@ public abstract class McpServerTest {
     return DEFAULT_REQUEST_CUSTOMIZER;
   }
 
+  public static Stream<Arguments> testClients() {
+    return Stream.of(
+        arguments("/mcp/cluster", "Camunda 8 Orchestration API MCP Server"),
+        arguments("/mcp/processes", "Camunda 8 Orchestration API Processes MCP Server"));
+  }
+
   public static McpSyncClient createMcpClient(
       final TestCamundaApplication testInstance,
-      final McpSyncHttpClientRequestCustomizer httpClientRequestCustomizer) {
+      final McpSyncHttpClientRequestCustomizer httpClientRequestCustomizer,
+      final String endpoint) {
     final HttpClientStreamableHttpTransport.Builder transportBuilder =
         HttpClientStreamableHttpTransport.builder("%s".formatted(testInstance.restAddress()))
-            .endpoint("/mcp/cluster")
+            .endpoint(endpoint)
             .openConnectionOnStartup(false);
 
     if (httpClientRequestCustomizer != null) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
@@ -9,15 +9,17 @@ package io.camunda.it.mcp.authentication;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
 
-  @Test
-  void failsOnUnauthenticatedRequest() {
+  @ParameterizedTest
+  @MethodSource("testClients")
+  void failsOnUnauthenticatedRequest(final String endpoint) {
     assertThatThrownBy(
             () -> {
-              try (final var client = createMcpClient(testInstance(), null)) {
+              try (final var client = getMcpClient(endpoint, DEFAULT_REQUEST_CUSTOMIZER)) {
                 client.listTools();
               }
             })

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.protocol.model.TopologyResponse;
 import io.camunda.it.mcp.McpServerTest;
+import io.camunda.zeebe.util.VersionUtil;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
@@ -19,20 +20,21 @@ import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.Objects;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 abstract class McpServerAuthenticationTest extends McpServerTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Test
-  void returnsConfiguredInfoAndCapabilities() {
-    final var initializeResult = mcpClient.initialize();
+  @ParameterizedTest
+  @MethodSource("testClients")
+  void returnsConfiguredInfoAndCapabilities(final String endpoint, final String name) {
+    final var initializeResult = getMcpClient(endpoint).initialize();
     assertThat(initializeResult).isNotNull();
 
-    assertThat(initializeResult.serverInfo().name())
-        .isEqualTo("Camunda 8 Orchestration API MCP Server");
-    assertThat(initializeResult.serverInfo().version()).startsWith("8.");
+    assertThat(initializeResult.serverInfo().name()).isEqualTo(name);
+    assertThat(initializeResult.serverInfo().version()).isEqualTo(VersionUtil.getVersion());
 
     assertThat(initializeResult.capabilities())
         .extracting(
@@ -48,18 +50,20 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
         .satisfies(tools -> assertThat(tools.listChanged()).isFalse());
   }
 
-  @Test
-  void registersAllExpectedTools() {
-    final ListToolsResult listToolsResult = mcpClient.listTools();
+  @ParameterizedTest
+  @MethodSource("testClients")
+  void registersAllExpectedTools(final String endpoint) {
+    final ListToolsResult listToolsResult = getMcpClient(endpoint).listTools();
     assertThat(listToolsResult.tools())
         .extracting(Tool::name)
         .contains("getClusterStatus", "getTopology");
   }
 
-  @Test
-  void fetchesClusterStatus() {
+  @ParameterizedTest
+  @MethodSource("testClients")
+  void fetchesClusterStatus(final String endpoint) {
     final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+        getMcpClient(endpoint).callTool(CallToolRequest.builder().name("getClusterStatus").build());
 
     assertThat(result.isError()).isFalse();
     assertThat(result.content())
@@ -69,10 +73,11 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
             TextContent.class, textContent -> assertThat(textContent.text()).isEqualTo("HEALTHY"));
   }
 
-  @Test
-  void fetchesTopology() {
+  @ParameterizedTest
+  @MethodSource("testClients")
+  void fetchesTopology(final String endpoint) {
     final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+        getMcpClient(endpoint).callTool(CallToolRequest.builder().name("getTopology").build());
 
     assertThat(result.isError()).isFalse();
     assertThat(result.structuredContent()).isNotNull();


### PR DESCRIPTION
## Description

Adds another MCP endpoint to the Spring application. Takes over configuration of MCP servers manually.
Disables auto-configuration of MCP server via Spring AI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to https://github.com/camunda/product-hub/issues/3353
