### PR TITLE
Allow adding or remove node-id leases

### DIFF
--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/NodeIdProvider.java
@@ -16,6 +16,14 @@ public interface NodeIdProvider extends AutoCloseable {
   CompletableFuture<Void> initialize(int clusterSize);
 
   /**
+   * Scale the available node ids to the new cluster size.
+   *
+   * @param newClusterSize the new cluster size
+   * @return a CompletableFuture that completes when the scaling operation is done
+   */
+  CompletableFuture<Void> scale(int newClusterSize);
+
+  /**
    * @return the node instance. Null can be returned when the provider is shutting down
    */
   NodeInstance currentNodeInstance();
@@ -73,6 +81,11 @@ public interface NodeIdProvider extends AutoCloseable {
 
       @Override
       public CompletableFuture<Void> initialize(final int clusterSize) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public CompletableFuture<Void> scale(final int newClusterSize) {
         return CompletableFuture.completedFuture(null);
       }
 

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -30,6 +30,13 @@ public interface NodeIdRepository extends AutoCloseable {
   int initialize(int initialCount);
 
   /**
+   * Add or remove leases to match the new cluster size.
+   *
+   * @param newClusterSize the new cluster size
+   */
+  void scale(int newClusterSize);
+
+  /**
    * Get a lease without acquiring it. This can be used to verify the liveness of other nodes or
    * their view of the cluster
    *


### PR DESCRIPTION
## Description

Add functionality in node id provider and S3 NodeIdRepository to add and remove leases based on dynamic cluster sizes. For simplicity we do not allow gaps in the node ids. So the input is just the clusterSize instead of a list of broker ids. 

## Related issues

related #45812 
