### PR TITLE
test: reenable skipped tests after element selection migration

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
@@ -15,6 +15,7 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
+import {LocationLog} from 'modules/utils/LocationLog';
 import {
   type ProcessInstance,
   type QueryElementInstancesResponseBody,
@@ -963,9 +964,12 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
             <Route
               path={Paths.processInstance()}
               element={
-                <TreeView label={'instance history'} hideLabel>
-                  {children}
-                </TreeView>
+                <>
+                  <TreeView label={'instance history'} hideLabel>
+                    {children}
+                  </TreeView>
+                  <LocationLog />
+                </>
               }
             />
           </Routes>

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/mocks.tsx
@@ -10,17 +10,16 @@ import {Route, MemoryRouter, Routes} from 'react-router-dom';
 import {createEnhancedIncident} from 'modules/testUtils';
 import {useEffect} from 'react';
 import {authenticationStore} from 'modules/stores/authentication';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {Paths} from 'modules/Routes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {LocationLog} from 'modules/utils/LocationLog';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => {
     return () => {
       authenticationStore.reset();
-      flowNodeSelectionStore.reset();
     };
   });
   return (
@@ -28,7 +27,15 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
       <QueryClientProvider client={getMockQueryClient()}>
         <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
           <Routes>
-            <Route path={Paths.processInstance()} element={children} />
+            <Route
+              path={Paths.processInstance()}
+              element={
+                <>
+                  {children}
+                  <LocationLog />
+                </>
+              }
+            />
           </Routes>
         </MemoryRouter>
       </QueryClientProvider>

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -11,9 +11,8 @@ import {
   waitForElementToBeRemoved,
   screen,
   waitFor,
-  fireEvent,
 } from 'modules/testing-library';
-import {MemoryRouter, Route, Routes, useNavigate} from 'react-router-dom';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {TopPanel} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {createIncident, searchResult} from 'modules/testUtils';
@@ -38,6 +37,10 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
+import {
+  SearchParamsUpdater,
+  updateSearchParams,
+} from 'modules/testUtils/SearchParamsUpdater';
 
 const mockIncidents = searchResult([
   createIncident({errorType: 'CONDITION_ERROR', elementId: 'Service5678'}),
@@ -121,24 +124,6 @@ const mockElementInstance: ElementInstance = {
   processDefinitionKey: '2',
   hasIncident: false,
   tenantId: '<default>',
-};
-
-/** Used to programmatically update search params after initial render. */
-const updateSearchParams = (params: Record<string, string>) => {
-  const paramsString = Object.entries(params)
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-  fireEvent.change(screen.getByTestId('new-search-params'), {
-    target: {value: paramsString},
-  });
-};
-const SearchParamsUpdater: React.FC = () => {
-  const navigate = useNavigate();
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    navigate({search: `?${event.currentTarget.value}`}, {replace: true});
-    event.currentTarget.value = '';
-  };
-  return <input data-testid="new-search-params" onChange={handleChange} />;
 };
 
 const getWrapper = (searchParams?: Record<string, string>) => {

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -16,8 +16,6 @@ import {
 } from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {LocationLog} from 'modules/utils/LocationLog';
-import {mockFetchProcess} from 'modules/mocks/api/processes/fetchProcess';
-import {mockProcess} from 'modules/mocks/api/mocks/process';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -112,7 +110,6 @@ const mockRequests = () => {
   mockSearchIncidentsByProcessInstance('4294980768').withSuccess(
     searchResult([]),
   );
-  mockFetchProcess().withSuccess(mockProcess);
   mockSearchJobs().withSuccess(searchResult([]));
   mockQueryBatchOperationItems().withSuccess(searchResult([]));
   mockQueryBatchOperationItems().withSuccess(searchResult([]));

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -8,15 +8,14 @@
 
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {testData} from './index.setup';
-import {createUser, createVariable} from 'modules/testUtils';
-import {createMemoryRouter, RouterProvider} from 'react-router-dom';
+import {createUser, createVariable, searchResult} from 'modules/testUtils';
+import {
+  createMemoryRouter,
+  RouterProvider,
+  useNavigate,
+} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {LocationLog} from 'modules/utils/LocationLog';
-import {
-  type Selection,
-  flowNodeSelectionStore,
-} from 'modules/stores/flowNodeSelection';
-import {useEffect} from 'react';
 import {mockFetchProcess} from 'modules/mocks/api/processes/fetchProcess';
 import {mockProcess} from 'modules/mocks/api/mocks/process';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
@@ -28,7 +27,6 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {type SequenceFlow} from '@camunda/camunda-api-zod-schemas/8.8';
 import {mockFetchCallHierarchy} from 'modules/mocks/api/v2/processInstances/fetchCallHierarchy';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
-import {selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
@@ -36,6 +34,7 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {fireEvent, screen} from 'modules/testing-library';
 
 const mockSequenceFlowsV2: SequenceFlow[] = [
   {
@@ -106,51 +105,37 @@ const mockRequests = () => {
       },
     ],
   });
-  mockSearchVariables().withSuccess({
-    items: [createVariable()],
-    page: {
-      totalItems: 1,
-    },
-  });
-  mockSearchIncidentsByProcessInstance('4294980768').withSuccess({
-    items: [],
-    page: {totalItems: 0},
-  });
-  mockSearchIncidentsByProcessInstance('4294980768').withSuccess({
-    items: [],
-    page: {totalItems: 0},
-  });
+  mockSearchVariables().withSuccess(searchResult([createVariable()]));
+  mockSearchIncidentsByProcessInstance('4294980768').withSuccess(
+    searchResult([]),
+  );
+  mockSearchIncidentsByProcessInstance('4294980768').withSuccess(
+    searchResult([]),
+  );
   mockFetchProcess().withSuccess(mockProcess);
-  mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
-  mockQueryBatchOperationItems().withSuccess({
-    items: [],
-    page: {totalItems: 0},
-  });
-  mockQueryBatchOperationItems().withSuccess({
-    items: [],
-    page: {totalItems: 0},
-  });
-  mockSearchElementInstances().withSuccess({
-    items: [],
-    page: {totalItems: 0},
-  });
+  mockSearchJobs().withSuccess(searchResult([]));
+  mockQueryBatchOperationItems().withSuccess(searchResult([]));
+  mockQueryBatchOperationItems().withSuccess(searchResult([]));
+  mockSearchElementInstances().withSuccess(searchResult([]));
 };
 
-type FlowNodeSelectorProps = {
-  selectableFlowNode: Selection;
+/** Used to programmatically update search params after initial render. */
+const updateSearchParams = (params: Record<string, string>) => {
+  const paramsString = Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  fireEvent.change(screen.getByTestId('new-search-params'), {
+    target: {value: paramsString},
+  });
 };
-
-const FlowNodeSelector: React.FC<FlowNodeSelectorProps> = ({
-  selectableFlowNode,
-}) => (
-  <button
-    onClick={() => {
-      selectFlowNode({}, selectableFlowNode);
-    }}
-  >
-    {`Select flow node`}
-  </button>
-);
+const SearchParamsUpdater: React.FC = () => {
+  const navigate = useNavigate();
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    navigate({search: `?${event.currentTarget.value}`}, {replace: true});
+    event.currentTarget.value = '';
+  };
+  return <input data-testid="new-search-params" onChange={handleChange} />;
+};
 
 type Props = {
   children?: React.ReactNode;
@@ -159,19 +144,20 @@ type Props = {
 function getWrapper(options?: {
   initialPath?: string;
   contextPath?: string;
-  selectableFlowNode?: Selection;
+  searchParams?: Record<string, string>;
 }) {
-  const {
+  let {
     initialPath = Paths.processInstance('4294980768'),
     contextPath,
-    selectableFlowNode,
+    searchParams,
   } = options ?? {};
 
-  const Wrapper: React.FC<Props> = ({children}) => {
-    useEffect(() => {
-      return flowNodeSelectionStore.reset;
-    }, []);
+  if (searchParams) {
+    const search = new URLSearchParams(searchParams).toString();
+    initialPath += `?${search}`;
+  }
 
+  const Wrapper: React.FC<Props> = ({children}) => {
     const router = createMemoryRouter(
       [
         {
@@ -179,9 +165,7 @@ function getWrapper(options?: {
           element: (
             <>
               {children}
-              {selectableFlowNode && (
-                <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
-              )}
+              <SearchParamsUpdater />
               <LocationLog />
             </>
           ),
@@ -218,6 +202,6 @@ function getWrapper(options?: {
   return Wrapper;
 }
 
-export {getWrapper};
+export {getWrapper, updateSearchParams};
 
 export {mockRequests};

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -9,13 +9,13 @@
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {testData} from './index.setup';
 import {createUser, createVariable, searchResult} from 'modules/testUtils';
-import {
-  createMemoryRouter,
-  RouterProvider,
-  useNavigate,
-} from 'react-router-dom';
+import {createMemoryRouter, RouterProvider} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {LocationLog} from 'modules/utils/LocationLog';
+import {
+  SearchParamsUpdater,
+  updateSearchParams,
+} from 'modules/testUtils/SearchParamsUpdater';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -32,7 +32,6 @@ import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
-import {fireEvent, screen} from 'modules/testing-library';
 
 const mockSequenceFlowsV2: SequenceFlow[] = [
   {
@@ -114,24 +113,6 @@ const mockRequests = () => {
   mockQueryBatchOperationItems().withSuccess(searchResult([]));
   mockQueryBatchOperationItems().withSuccess(searchResult([]));
   mockSearchElementInstances().withSuccess(searchResult([]));
-};
-
-/** Used to programmatically update search params after initial render. */
-const updateSearchParams = (params: Record<string, string>) => {
-  const paramsString = Object.entries(params)
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-  fireEvent.change(screen.getByTestId('new-search-params'), {
-    target: {value: paramsString},
-  });
-};
-const SearchParamsUpdater: React.FC = () => {
-  const navigate = useNavigate();
-  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    navigate({search: `?${event.currentTarget.value}`}, {replace: true});
-    event.currentTarget.value = '';
-  };
-  return <input data-testid="new-search-params" onChange={handleChange} />;
 };
 
 type Props = {

--- a/operate/client/src/modules/testUtils/SearchParamsUpdater.tsx
+++ b/operate/client/src/modules/testUtils/SearchParamsUpdater.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {fireEvent, screen} from 'modules/testing-library';
+import {useNavigate} from 'react-router-dom';
+
+/**
+ * Used to programmatically update search params after initial render in tests.
+ * Must be used together with a rendered {@linkcode SearchParamsUpdater}
+ * component to work.
+ */
+const updateSearchParams = (params: Record<string, string>) => {
+  const paramsString = Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  fireEvent.change(screen.getByTestId('new-search-params'), {
+    target: {value: paramsString},
+  });
+};
+
+const SearchParamsUpdater: React.FC = () => {
+  const navigate = useNavigate();
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    navigate({search: `?${event.currentTarget.value}`}, {replace: true});
+    event.currentTarget.value = '';
+  };
+  return <input data-testid="new-search-params" onChange={handleChange} />;
+};
+
+export {updateSearchParams, SearchParamsUpdater};


### PR DESCRIPTION
## Description

This PR migrates skipped tests listed in #45539 to work with the new element selection.

## Related issues

relates #45539
