### PR TITLE
test: add missing network mocks to element-instances-tree tests

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
@@ -8,6 +8,7 @@
 
 import {render, screen} from 'modules/testing-library';
 import {open} from 'modules/mocks/diagrams';
+import {searchResult} from 'modules/testUtils';
 import {
   Wrapper,
   adHocNodeElementInstances,
@@ -32,10 +33,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process', () => {
     mockFetchProcessInstance().withSuccess(mockAdHocSubProcessesInstance);
     mockFetchProcessDefinitionXml().withSuccess(open('AdHocProcess.bpmn'));
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
     mockSearchElementInstances().withSuccess(adHocNodeElementInstances.level1);
   });
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
@@ -18,6 +18,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {parseDiagramXML} from 'modules/utils/bpmn';
 import {businessObjectsParser} from 'modules/queries/processDefinitions/useBusinessObjects';
@@ -57,6 +58,9 @@ describe('ElementInstancesTree - Ad Hoc Sub Process', () => {
     expect(screen.queryByText('Task A')).not.toBeInTheDocument();
 
     mockSearchElementInstances().withSuccess(adHocNodeElementInstances.level2);
+    mockFetchElementInstance(':id').withSuccess(
+      adHocNodeElementInstances.level1.items[1]!,
+    );
 
     await user.type(
       await screen.findByLabelText('Ad Hoc Sub Process', {

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
@@ -17,6 +17,7 @@ import {eventSubProcess} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {parseDiagramXML} from 'modules/utils/bpmn';
@@ -59,6 +60,9 @@ describe('ElementInstancesTree - Event Subprocess', () => {
 
     mockSearchElementInstances().withSuccess(
       eventSubProcessElementInstances.level2,
+    );
+    mockFetchElementInstance(':id').withSuccess(
+      eventSubProcessElementInstances.level1.items[2]!,
     );
 
     await user.type(

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
@@ -13,7 +13,7 @@ import {
   Wrapper,
   mockEventSubprocessInstance,
 } from './mocks';
-import {eventSubProcess} from 'modules/testUtils';
+import {eventSubProcess, searchResult} from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
@@ -31,10 +31,7 @@ describe('ElementInstancesTree - Event Subprocess', () => {
     mockFetchProcessInstance().withSuccess(mockEventSubprocessInstance);
     mockFetchProcessDefinitionXml().withSuccess(eventSubProcess);
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
     mockSearchElementInstances().withSuccess(
       eventSubProcessElementInstances.level1,
     );

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
@@ -29,6 +29,7 @@ import {
 import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {parseDiagramXML} from 'modules/utils/bpmn';
 import {businessObjectsParser} from 'modules/queries/processDefinitions/useBusinessObjects';
@@ -125,6 +126,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithNoRunningScopeMock.secondLevel1,
     );
+    mockFetchElementInstance('1').withSuccess(
+      multipleSubprocessesWithNoRunningScopeMock.firstLevel.items[0]!,
+    );
 
     const [expandFirstScope, expandSecondScope, expandNewScope] =
       screen.getAllByRole('treeitem', {
@@ -147,6 +151,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithNoRunningScopeMock.thirdLevel1,
     );
+    mockFetchElementInstance('1_2').withSuccess(
+      multipleSubprocessesWithNoRunningScopeMock.secondLevel1.items[1]!,
+    );
 
     await user.type(
       screen.getByRole('treeitem', {
@@ -162,6 +169,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithNoRunningScopeMock.secondLevel2,
     );
+    mockFetchElementInstance('2').withSuccess(
+      multipleSubprocessesWithNoRunningScopeMock.firstLevel.items[1]!,
+    );
 
     await user.type(expandSecondScope!, '{arrowright}');
 
@@ -173,6 +183,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
 
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithNoRunningScopeMock.thirdLevel2,
+    );
+    mockFetchElementInstance('2_2').withSuccess(
+      multipleSubprocessesWithNoRunningScopeMock.secondLevel2.items[1]!,
     );
 
     await user.type(
@@ -495,6 +508,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithOneRunningScopeMock.secondLevel1,
     );
+    mockFetchElementInstance('1').withSuccess(
+      multipleSubprocessesWithOneRunningScopeMock.firstLevel.items[0]!,
+    );
 
     const [expandFirstScope, expandSecondScope] = screen.getAllByRole(
       'treeitem',
@@ -517,6 +533,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithOneRunningScopeMock.thirdLevel1,
     );
+    mockFetchElementInstance('1_2').withSuccess(
+      multipleSubprocessesWithOneRunningScopeMock.secondLevel1.items[1]!,
+    );
 
     await user.type(
       screen.getByRole('treeitem', {
@@ -533,6 +552,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithOneRunningScopeMock.secondLevel2,
     );
+    mockFetchElementInstance('2').withSuccess(
+      multipleSubprocessesWithOneRunningScopeMock.firstLevel.items[1]!,
+    );
 
     await user.type(expandSecondScope!, '{arrowright}');
 
@@ -544,6 +566,9 @@ describe('ElementInstancesTree - Modification placeholders', () => {
 
     mockSearchElementInstances().withSuccess(
       multipleSubprocessesWithOneRunningScopeMock.thirdLevel2,
+    );
+    mockFetchElementInstance('2_2').withSuccess(
+      multipleSubprocessesWithOneRunningScopeMock.secondLevel2.items[1]!,
     );
 
     await user.type(

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
@@ -9,7 +9,7 @@
 import {act} from 'react';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {modificationsStore} from 'modules/stores/modifications';
-import {multiInstanceProcess} from 'modules/testUtils';
+import {multiInstanceProcess, searchResult} from 'modules/testUtils';
 import {generateUniqueID} from 'modules/utils/generateUniqueID';
 import {ElementInstancesTree} from './index';
 import {
@@ -50,10 +50,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
   });
 
   it('should create new parent scopes for a new placeholder if there are no running scopes', async () => {
@@ -253,8 +250,8 @@ describe('ElementInstancesTree - Modification placeholders', () => {
 
   it('should show and remove two add modification flow nodes', async () => {
     mockFetchProcessInstance().withSuccess(mockMultiInstanceProcessInstance);
-    mockSearchElementInstances().withSuccess({
-      items: [
+    mockSearchElementInstances().withSuccess(
+      searchResult([
         {
           elementInstanceKey: '2251799813686130',
           processInstanceKey: '2251799813686118',
@@ -282,9 +279,8 @@ describe('ElementInstancesTree - Modification placeholders', () => {
           tenantId: '<default>',
           startDate: '2020-08-18T12:07:34.205+0000',
         },
-      ],
-      page: {totalItems: 2},
-    });
+      ]),
+    );
 
     render(
       <ElementInstancesTree
@@ -364,8 +360,8 @@ describe('ElementInstancesTree - Modification placeholders', () => {
 
   it('should show and remove one cancel modification flow nodes', async () => {
     mockFetchProcessInstance().withSuccess(mockMultiInstanceProcessInstance);
-    mockSearchElementInstances().withSuccess({
-      items: [
+    mockSearchElementInstances().withSuccess(
+      searchResult([
         {
           elementInstanceKey: '2251799813686130',
           processInstanceKey: '2251799813686118',
@@ -393,9 +389,8 @@ describe('ElementInstancesTree - Modification placeholders', () => {
           tenantId: '<default>',
           startDate: '2020-08-18T12:07:33.953+0000',
         },
-      ],
-      page: {totalItems: 2},
-    });
+      ]),
+    );
 
     render(
       <ElementInstancesTree

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import {render, screen, within} from 'modules/testing-library';
-import {multiInstanceProcess} from 'modules/testUtils';
+import {multiInstanceProcess, searchResult} from 'modules/testUtils';
 import {ElementInstancesTree} from './index';
 import {Wrapper, mockMultiInstanceProcessInstance} from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -55,13 +55,10 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
   beforeEach(async () => {
     mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
 
-    mockQueryBatchOperationItems().withSuccess({
-      items: [],
-      page: {totalItems: 0},
-    });
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
 
-    mockSearchElementInstances().withSuccess({
-      items: [
+    mockSearchElementInstances().withSuccess(
+      searchResult([
         MULTI_INSTANCE_BODY_ELEMENT,
         {
           elementInstanceKey: '2251799813686130',
@@ -77,9 +74,8 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
           startDate: '2020-08-18T12:07:33.953+0000',
           endDate: '2020-08-18T12:07:34.034+0000',
         },
-      ],
-      page: {totalItems: 2},
-    });
+      ]),
+    );
   });
 
   it('should load the instance history', async () => {
@@ -130,10 +126,9 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Start Filter-Map')).not.toBeInTheDocument();
 
-    mockSearchElementInstances().withSuccess({
-      items: [SUB_PROCESS_ELEMENT],
-      page: {totalItems: 1},
-    });
+    mockSearchElementInstances().withSuccess(
+      searchResult([SUB_PROCESS_ELEMENT]),
+    );
     mockFetchElementInstance(
       MULTI_INSTANCE_BODY_ELEMENT.elementInstanceKey,
     ).withSuccess(MULTI_INSTANCE_BODY_ELEMENT);
@@ -153,8 +148,8 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
 
     expect(screen.queryByText('Start Filter-Map')).not.toBeInTheDocument();
 
-    mockSearchElementInstances().withSuccess({
-      items: [
+    mockSearchElementInstances().withSuccess(
+      searchResult([
         {
           elementInstanceKey: '2251799813686204',
           processInstanceKey: '2251799813686118',
@@ -169,9 +164,8 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
           startDate: '2020-08-18T12:07:34.337+0000',
           endDate: '2020-08-18T12:07:34.445+0000',
         },
-      ],
-      page: {totalItems: 1},
-    });
+      ]),
+    );
     mockFetchElementInstance(
       SUB_PROCESS_ELEMENT.elementInstanceKey,
     ).withSuccess(SUB_PROCESS_ELEMENT);
@@ -243,8 +237,8 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
 
     mockFetchProcessInstance().withSuccess(mockMultiInstanceProcessInstance);
 
-    mockSearchElementInstances().withSuccess({
-      items: [
+    mockSearchElementInstances().withSuccess(
+      searchResult([
         {
           elementInstanceKey: '2251799813686130',
           processInstanceKey: '2251799813686118',
@@ -273,9 +267,8 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
           startDate: '2020-08-18T12:07:34.205+0000',
           endDate: '2020-08-18T12:07:34.034+0000',
         },
-      ],
-      page: {totalItems: 2},
-    });
+      ]),
+    );
 
     vi.runOnlyPendingTimers();
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
@@ -14,12 +14,42 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {parseDiagramXML} from 'modules/utils/bpmn';
 import {businessObjectsParser} from 'modules/queries/processDefinitions/useBusinessObjects';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 
 const diagramModel = await parseDiagramXML(multiInstanceProcess);
 const businessObjects = businessObjectsParser({diagramModel});
+
+const MULTI_INSTANCE_BODY_ELEMENT: ElementInstance = {
+  elementInstanceKey: '2251799813686156',
+  processInstanceKey: '2251799813686118',
+  processDefinitionKey: '2251799813686038',
+  processDefinitionId: 'multiInstanceProcess',
+  state: 'ACTIVE',
+  type: 'MULTI_INSTANCE_BODY',
+  elementId: 'filterMapSubProcess',
+  elementName: 'Filter-Map Sub Process',
+  hasIncident: true,
+  tenantId: '<default>',
+  startDate: '2020-08-18T12:07:34.205+0000',
+};
+
+const SUB_PROCESS_ELEMENT: ElementInstance = {
+  elementInstanceKey: '2251799813686166',
+  processInstanceKey: '2251799813686118',
+  processDefinitionKey: '2251799813686038',
+  processDefinitionId: 'multiInstanceProcess',
+  state: 'ACTIVE',
+  type: 'SUB_PROCESS',
+  elementId: 'filterMapSubProcess',
+  elementName: 'Filter-Map Sub Process',
+  hasIncident: true,
+  tenantId: '<default>',
+  startDate: '2020-08-18T12:07:34.281+0000',
+};
 
 describe('ElementInstancesTree - Multi Instance Subprocess', () => {
   beforeEach(async () => {
@@ -32,6 +62,7 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
 
     mockSearchElementInstances().withSuccess({
       items: [
+        MULTI_INSTANCE_BODY_ELEMENT,
         {
           elementInstanceKey: '2251799813686130',
           processInstanceKey: '2251799813686118',
@@ -45,19 +76,6 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
           tenantId: '<default>',
           startDate: '2020-08-18T12:07:33.953+0000',
           endDate: '2020-08-18T12:07:34.034+0000',
-        },
-        {
-          elementInstanceKey: '2251799813686156',
-          processInstanceKey: '2251799813686118',
-          processDefinitionKey: '2251799813686038',
-          processDefinitionId: 'multiInstanceProcess',
-          state: 'ACTIVE',
-          type: 'MULTI_INSTANCE_BODY',
-          elementId: 'filterMapSubProcess',
-          elementName: 'Filter-Map Sub Process',
-          hasIncident: true,
-          tenantId: '<default>',
-          startDate: '2020-08-18T12:07:34.205+0000',
         },
       ],
       page: {totalItems: 2},
@@ -113,23 +131,12 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
     expect(screen.queryByText('Start Filter-Map')).not.toBeInTheDocument();
 
     mockSearchElementInstances().withSuccess({
-      items: [
-        {
-          elementInstanceKey: '2251799813686166',
-          processInstanceKey: '2251799813686118',
-          processDefinitionKey: '2251799813686038',
-          processDefinitionId: 'multiInstanceProcess',
-          state: 'ACTIVE',
-          type: 'SUB_PROCESS',
-          elementId: 'filterMapSubProcess',
-          elementName: 'Filter-Map Sub Process',
-          hasIncident: true,
-          tenantId: '<default>',
-          startDate: '2020-08-18T12:07:34.281+0000',
-        },
-      ],
+      items: [SUB_PROCESS_ELEMENT],
       page: {totalItems: 1},
     });
+    mockFetchElementInstance(
+      MULTI_INSTANCE_BODY_ELEMENT.elementInstanceKey,
+    ).withSuccess(MULTI_INSTANCE_BODY_ELEMENT);
 
     await user.type(
       await screen.findByLabelText('Filter-Map Sub Process (Multi Instance)', {
@@ -165,6 +172,9 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
       ],
       page: {totalItems: 1},
     });
+    mockFetchElementInstance(
+      SUB_PROCESS_ELEMENT.elementInstanceKey,
+    ).withSuccess(SUB_PROCESS_ELEMENT);
 
     await user.type(
       await screen.findByLabelText('Filter-Map Sub Process', {


### PR DESCRIPTION
## Description

For #45539 I noticed that some element-instances-tree tests where missing network mocks with the new element selection. This PR adds mocks so MSW no longer prints errors for these tests.

## Checklist

- [ ] This PR is stacked on https://github.com/camunda/camunda/pull/45912.

## Related issues

closes #45539
