### PR TITLE
feat: Dynamic child process mock

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /** The injected context for a process test. */
 public interface CamundaProcessTestContext {
@@ -139,6 +140,21 @@ public interface CamundaProcessTestContext {
    * @param variables a map of variables to set for the mocked child process
    */
   void mockChildProcess(final String childProcessId, final Map<String, Object> variables);
+
+  /**
+   * Mocks a child process with the specified ID and sets the variables provided by the given
+   * function. The function receives the variables of the parent process as input and should return
+   * the variables to set for the mocked child process. This allows you to dynamically determine the
+   * variables for the child process based on the parent process at the time the child process is
+   * called.
+   *
+   * @param childProcessId the ID of the child process to mock
+   * @param variablesSupplier a function that supplies the variables to set for the mocked child
+   *     process
+   */
+  void mockChildProcess(
+      final String childProcessId,
+      final Function<Map<String, Object>, Map<String, Object>> variablesSupplier);
 
   /**
    * Completes a job of the specified type.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -23,7 +23,6 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
 import io.camunda.client.api.command.CompleteUserTaskJobResultStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
-import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.JobKind;
@@ -754,28 +753,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         .stream()
         .filter(jobSelector::test)
         .findFirst();
-  }
-
-  private ActivatedJob getActivatedJob(final String jobType, final CamundaClient client) {
-    return awaitBehavior.until(
-        () ->
-            client
-                .newActivateJobsCommand()
-                .jobType(jobType)
-                .maxJobsToActivate(1)
-                .requestTimeout(Duration.ofSeconds(1)) // avoid long blocking call
-                .send()
-                .join()
-                .getJobs()
-                .stream()
-                .findFirst()
-                .orElse(null),
-        job ->
-            assertThat(job)
-                .withFailMessage(
-                    "Expected to complete a job with the type '%s' but no job is available.",
-                    jobType)
-                .isNotNull());
   }
 
   private void awaitIncident(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Decision;
@@ -250,6 +251,41 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
     final String resourceName = childProcessId + ".bpmn";
     client.newDeployResourceCommand().addProcessModel(processModel, resourceName).send().join();
+  }
+
+  @Override
+  public void mockChildProcess(
+      final String childProcessId,
+      final Function<Map<String, Object>, Map<String, Object>> variablesSupplier) {
+
+    final String variableSupplierJobType = "variableSupplier_" + childProcessId;
+    final BpmnModelInstance processModel =
+        Bpmn.createExecutableProcess(childProcessId)
+            .startEvent()
+            .serviceTask("variableSupplier", t -> t.zeebeJobType(variableSupplierJobType))
+            .endEvent()
+            .done();
+
+    LOGGER.debug("Mock: Deploy a child process '{}' with variables supplier", childProcessId);
+
+    try (final CamundaClient client = createClient()) {
+      final String resourceName = childProcessId + ".bpmn";
+      client.newDeployResourceCommand().addProcessModel(processModel, resourceName).send().join();
+    }
+
+    mockJobWorker(variableSupplierJobType)
+        .withHandler(
+            (jobClient, job) -> {
+              final Map<String, Object> inputVariables = job.getVariablesAsMap();
+              final Map<String, Object> outputVariables = variablesSupplier.apply(inputVariables);
+
+              LOGGER.debug(
+                  "Mock: Complete child process '{}' with variables {}",
+                  childProcessId,
+                  outputVariables);
+
+              jobClient.newCompleteCommand(job.getKey()).variables(outputVariables).send().join();
+            });
   }
 
   @Override
@@ -575,6 +611,60 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
+  public void updateVariables(
+      final ProcessInstanceSelector processInstanceSelector, final Map<String, Object> variables) {
+    final CamundaClient client = createClient();
+
+    awaitProcessInstance(
+        processInstanceSelector,
+        client,
+        pi -> {
+          LOGGER.debug(
+              "Update variables for process instance [{}, processInstanceKey: '{}'] with variables {}",
+              processInstanceSelector.describe(),
+              pi.getProcessInstanceKey(),
+              variables);
+
+          client
+              .newSetVariablesCommand(pi.getProcessInstanceKey())
+              .variables(variables)
+              .send()
+              .join();
+        });
+  }
+
+  @Override
+  public void updateLocalVariables(
+      final ProcessInstanceSelector processInstanceSelector,
+      final ElementSelector elementSelector,
+      final Map<String, Object> variables) {
+    final CamundaClient client = createClient();
+
+    awaitProcessInstance(
+        processInstanceSelector,
+        client,
+        pi ->
+            awaitElementInstance(
+                pi.getProcessInstanceKey(),
+                elementSelector,
+                client,
+                ei -> {
+                  LOGGER.debug(
+                      "Update local variables for element [{}, elementInstanceKey: '{}'] in process instance [processInstanceKey: '{}'] with variables {}",
+                      elementSelector.describe(),
+                      ei.getElementInstanceKey(),
+                      pi.getProcessInstanceKey(),
+                      variables);
+
+                  client
+                      .newSetVariablesCommand(ei.getElementInstanceKey())
+                      .variables(variables)
+                      .send()
+                      .join();
+                }));
+  }
+
+  @Override
   public void completeJobOfUserTaskListener(
       final JobSelector jobSelector, final Consumer<CompleteUserTaskJobResultStep1> jobResult) {
     final CamundaClient client = createClient();
@@ -722,60 +812,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         .stream()
         .filter(incidentSelector::test)
         .findFirst();
-  }
-
-  @Override
-  public void updateVariables(
-      final ProcessInstanceSelector processInstanceSelector, final Map<String, Object> variables) {
-    final CamundaClient client = createClient();
-
-    awaitProcessInstance(
-        processInstanceSelector,
-        client,
-        pi -> {
-          LOGGER.debug(
-              "Update variables for process instance [{}, processInstanceKey: '{}'] with variables {}",
-              processInstanceSelector.describe(),
-              pi.getProcessInstanceKey(),
-              variables);
-
-          client
-              .newSetVariablesCommand(pi.getProcessInstanceKey())
-              .variables(variables)
-              .send()
-              .join();
-        });
-  }
-
-  @Override
-  public void updateLocalVariables(
-      final ProcessInstanceSelector processInstanceSelector,
-      final ElementSelector elementSelector,
-      final Map<String, Object> variables) {
-    final CamundaClient client = createClient();
-
-    awaitProcessInstance(
-        processInstanceSelector,
-        client,
-        pi ->
-            awaitElementInstance(
-                pi.getProcessInstanceKey(),
-                elementSelector,
-                client,
-                ei -> {
-                  LOGGER.debug(
-                      "Update local variables for element [{}, elementInstanceKey: '{}'] in process instance [processInstanceKey: '{}'] with variables {}",
-                      elementSelector.describe(),
-                      ei.getElementInstanceKey(),
-                      pi.getProcessInstanceKey(),
-                      variables);
-
-                  client
-                      .newSetVariablesCommand(ei.getElementInstanceKey())
-                      .variables(variables)
-                      .send()
-                      .join();
-                }));
   }
 
   private Optional<ProcessInstance> findProcessInstance(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -302,6 +303,49 @@ public class CamundaProcessTestContextIT {
     assertThatProcessInstance(processInstanceEvent).isCompleted();
     assertThatProcessInstance(processInstanceEvent).hasCompletedElements("success-end");
     assertThatProcessInstance(processInstanceEvent).hasVariables(variables);
+  }
+
+  @Test
+  void shouldMockChildProcessWithVariableSupplier() {
+    // given: a parent process with a multi-instance call activity
+    final String childProcessId = "child-process";
+    final String parentVariableName = "item";
+    final String childVariableName = "result";
+
+    deployProcessModel(
+        Bpmn.createExecutableProcess("parent-process")
+            .startEvent()
+            .callActivity(
+                "call-activity",
+                c ->
+                    c.zeebeProcessId(childProcessId)
+                        .zeebeOutputExpression(childVariableName, childVariableName)
+                        .multiInstance()
+                        .zeebeInputCollectionExpression("[1,2]")
+                        .zeebeInputElement(parentVariableName)
+                        .zeebeOutputCollection("results")
+                        .zeebeOutputElementExpression(childVariableName))
+            .endEvent()
+            .done());
+
+    // the child process returns a dynamic variable based on the parent variable
+    processTestContext.mockChildProcess(
+        childProcessId,
+        parentVariables ->
+            Collections.singletonMap(
+                childVariableName, 2 * (int) parentVariables.get(parentVariableName)));
+
+    // when
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("parent-process")
+            .latestVersion()
+            .send()
+            .join();
+
+    // then: verify the child process mock using the multi-instance output collection variable
+    assertThatProcessInstance(processInstanceEvent).hasVariable("results", Arrays.asList(2, 4));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds a new option to mock a child process with dynamic return variables.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42027 
