### PR TITLE
Use the `businessIdUniqueness` config to toggle validation logic in the engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -275,7 +275,8 @@ public final class BpmnProcessors {
             processingState.getProcessState(),
             elementInstanceState,
             authCheckBehavior,
-            bpmnBehaviors);
+            bpmnBehaviors,
+            config.isBusinessIdUniquenessEnabled());
     final ProcessInstanceCreationCreateProcessor createProcessor =
         new ProcessInstanceCreationCreateProcessor(
             keyGenerator, writers, metrics, processInstanceCreationHelper);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -65,18 +65,21 @@ public class ProcessInstanceCreationHelper {
   private final ProcessState processState;
   private final VariableBehavior variableBehavior;
   private final ElementActivationBehavior elementActivationBehavior;
+  private final boolean businessIdUniquenessEnabled;
   private final ElementInstanceState elementInstanceState;
 
   public ProcessInstanceCreationHelper(
       final ProcessState processState,
       final ElementInstanceState elementInstanceState,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final BpmnBehaviors bpmnBehaviors) {
+      final BpmnBehaviors bpmnBehaviors,
+      final boolean businessIdUniquenessEnabled) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
     this.authCheckBehavior = authCheckBehavior;
     variableBehavior = bpmnBehaviors.variableBehavior();
     elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
   }
 
   public Either<Rejection, DeployedProcess> findRelevantProcess(
@@ -425,8 +428,8 @@ public class ProcessInstanceCreationHelper {
 
   private Either<Rejection, ?> validateBusinessIdUniqueness(
       final String businessId, final long processDefinitionKey, final String tenantId) {
-    // If no business id is provided, skip validation
-    if (businessId == null || businessId.isEmpty()) {
+    // If the uniqueness check is disabled or if no business id is provided, skip validation
+    if (!businessIdUniquenessEnabled || businessId == null || businessId.isEmpty()) {
       return VALID;
     }
 


### PR DESCRIPTION
## Description
Updates the process instance creation logic to skip the `business id` uniqueness validation if the `BusinessIdUniquenessEnabled` config is not set to `true`.

Also Verifies that uniqueness is disabled by default, and moves the `BusinessIdUniqueness` to a separate test class with config enabled in the engine. 

## Related issues

closes #45715
