### PR TITLE
45500 related zod schema

### DIFF
--- a/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/client-components/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.39
+
+### 🚀 Enhancements
+
+update zod schema for audit log endpoint with `agentElementId` ([#45500](https://github.com/camunda/camunda/issues/45500))
+
+### ❤️ Contributors
+
+- Luca Arienti ([@arienzIT](https://github.com/arienzIT))
+
 ## v0.0.38
 
 ### 🚀 Enhancements

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -92,6 +92,7 @@ const auditLogSchema = z.object({
 	relatedEntityKey: z.string().optional(),
 	relatedEntityType: auditLogEntityTypeSchema.optional(),
 	entityDescription: z.string().optional(),
+  agentElementId: z.string().optional(),
 });
 type AuditLog = z.infer<typeof auditLogSchema>;
 

--- a/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
+++ b/client-components/packages/camunda-api-zod-schemas/lib/8.9/audit-log.ts
@@ -92,7 +92,7 @@ const auditLogSchema = z.object({
 	relatedEntityKey: z.string().optional(),
 	relatedEntityType: auditLogEntityTypeSchema.optional(),
 	entityDescription: z.string().optional(),
-  agentElementId: z.string().optional(),
+	agentElementId: z.string().optional(),
 });
 type AuditLog = z.infer<typeof auditLogSchema>;
 


### PR DESCRIPTION
## Description

Add new `agentElementId` to the `AuditLog` schema (see [API changes](https://github.com/camunda/camunda/issues/44634))

### Extra

- Updated CHANGELOG

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #45500 
