### PR TITLE
Feat/check name field length in engine

### DIFF
--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -21,6 +21,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-xml-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-impl</artifactId>
       <scope>test</scope>

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NamedBpmnElementValidatorsArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NamedBpmnElementValidatorsArchTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
+import io.camunda.zeebe.model.bpmn.instance.dc.Font;
+import io.camunda.zeebe.model.bpmn.instance.di.Diagram;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * ArchUnit test to ensure all direct sub-interfaces of {@link NamedBpmnElement} are validated in
+ * {@link ZeebeConfigurationValidators}.
+ *
+ * <p>This test verifies that for each interface that directly extends {@link NamedBpmnElement},
+ * there is a corresponding {@code NameLengthValidator} entry in the {@link
+ * ZeebeConfigurationValidators#getValidators} method.
+ */
+@AnalyzeClasses(
+    packages = {
+      "io.camunda.zeebe.engine.processing.deployment.model.validation",
+      "io.camunda.zeebe.model.bpmn.instance"
+    },
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class NamedBpmnElementValidatorsArchTest {
+
+  @ArchTest
+  static final ArchRule ALL_NAMED_BPMN_ELEMENT_SUB_INTERFACES_MUST_BE_REGISTERED =
+      ArchRuleDefinition.classes()
+          .that()
+          .areAssignableTo(ZeebeConfigurationValidators.class)
+          .should(new AllNamedBpmnElementsAreValidatedCondition());
+
+  private static class AllNamedBpmnElementsAreValidatedCondition extends ArchCondition<JavaClass> {
+
+    public AllNamedBpmnElementsAreValidatedCondition() {
+      super("register NameLengthValidator for all direct sub-interfaces of NamedBpmnElement");
+    }
+
+    @Override
+    public void check(final JavaClass item, final ConditionEvents events) {
+      // Import all classes from the BPMN model package
+      final var bpmnClasses =
+          new ClassFileImporter().importPackages("io.camunda.zeebe.model.bpmn.instance");
+
+      // Find the NamedBpmnElement interface
+      final JavaClass namedBpmnElement = bpmnClasses.get(NamedBpmnElement.class);
+
+      // Find all direct sub-interfaces (interfaces that directly extend
+      // NamedBpmnElement)
+      final Set<JavaClass> directSubInterfaces =
+          bpmnClasses.stream()
+              .filter(
+                  clazz ->
+                      clazz.isInterface()
+                          && !clazz.equals(namedBpmnElement)
+                          && clazz.getRawInterfaces().contains(namedBpmnElement))
+              .collect(Collectors.toSet());
+
+      // Font is a special case from the dc package that can be excluded
+      directSubInterfaces.removeIf(clazz -> clazz.isEquivalentTo(Font.class));
+      directSubInterfaces.removeIf(clazz -> clazz.isEquivalentTo(Diagram.class));
+
+      // Use reflection to call getValidators and extract registered types
+      final var validators =
+          ZeebeConfigurationValidators.getValidators(BpmnValidatorConfig.builder().build());
+
+      final Set<String> registeredTypes =
+          validators.stream()
+              .filter(NameLengthValidator.class::isInstance)
+              .map(v -> ((NameLengthValidator<?>) v).getElementType().getName())
+              .collect(Collectors.toSet());
+
+      // Check that all direct sub-interfaces are registered
+      final List<String> missingTypes =
+          directSubInterfaces.stream()
+              .filter(subInterface -> !registeredTypes.contains(subInterface.getName()))
+              .map(JavaClass::getSimpleName)
+              .toList();
+
+      if (!missingTypes.isEmpty()) {
+        events.add(
+            violated(
+                item,
+                String.format(
+                    "ZeebeConfigurationValidators.getValidators() must register NameLengthValidator for all direct "
+                        + "sub-interfaces of NamedBpmnElement. Missing validators for: %s",
+                    String.join(", ", missingTypes))));
+      }
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CallableElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CallableElement.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Daniel Meyer
  */
-public interface CallableElement extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface CallableElement extends RootElement, NamedBpmnElement {
 
   Collection<Interface> getSupportedInterfaces();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Category.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Category.java
@@ -18,11 +18,7 @@ package io.camunda.zeebe.model.bpmn.instance;
 
 import java.util.Collection;
 
-public interface Category extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Category extends RootElement, NamedBpmnElement {
 
   Collection<CategoryValue> getCategoryValues();
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Collaboration.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Collaboration.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Collaboration extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Collaboration extends RootElement, NamedBpmnElement {
 
   boolean isClosed();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ConversationLink.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ConversationLink.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface ConversationLink extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface ConversationLink extends BaseElement, NamedBpmnElement {
 
   InteractionNode getSource();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ConversationNode.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ConversationNode.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface ConversationNode extends BaseElement, InteractionNode {
-
-  String getName();
-
-  void setName(String name);
+public interface ConversationNode extends BaseElement, InteractionNode, NamedBpmnElement {
 
   Collection<Participant> getParticipants();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CorrelationKey.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CorrelationKey.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface CorrelationKey extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface CorrelationKey extends BaseElement, NamedBpmnElement {
 
   Collection<CorrelationProperty> getCorrelationProperties();
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CorrelationProperty.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/CorrelationProperty.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface CorrelationProperty extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface CorrelationProperty extends RootElement, NamedBpmnElement {
 
   ItemDefinition getType();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataInput.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataInput.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface DataInput extends ItemAwareElement {
-
-  String getName();
-
-  void setName(String name);
+public interface DataInput extends ItemAwareElement, NamedBpmnElement {
 
   boolean isCollection();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataOutput.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataOutput.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface DataOutput extends ItemAwareElement {
-
-  String getName();
-
-  void setName(String name);
+public interface DataOutput extends ItemAwareElement, NamedBpmnElement {
 
   boolean isCollection();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataState.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataState.java
@@ -21,9 +21,4 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface DataState extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
-}
+public interface DataState extends BaseElement, NamedBpmnElement {}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataStore.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/DataStore.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Falko Menge
  */
-public interface DataStore extends RootElement, ItemAwareElement {
-
-  String getName();
-
-  void setName(String name);
+public interface DataStore extends RootElement, ItemAwareElement, NamedBpmnElement {
 
   Integer getCapacity();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Definitions.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Definitions.java
@@ -24,11 +24,7 @@ import java.util.Collection;
  *
  * @author Daniel Meyer
  */
-public interface Definitions extends IdentifiableBpmnElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Definitions extends IdentifiableBpmnElement, NamedBpmnElement {
 
   String getTargetNamespace();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Error.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Error.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface Error extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Error extends RootElement, NamedBpmnElement {
 
   String getErrorCode();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Escalation.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Escalation.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface Escalation extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Escalation extends RootElement, NamedBpmnElement {
 
   String getEscalationCode();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/FlowElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/FlowElement.java
@@ -24,11 +24,7 @@ import java.util.Collection;
  * @author Daniel Meyer
  * @author Sebastian Menski
  */
-public interface FlowElement extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface FlowElement extends BaseElement, NamedBpmnElement {
 
   Auditing getAuditing();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/InputSet.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/InputSet.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface InputSet extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface InputSet extends BaseElement, NamedBpmnElement {
 
   Collection<DataInput> getDataInputs();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Interface.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Interface.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Interface extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Interface extends RootElement, NamedBpmnElement {
 
   String getImplementationRef();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Lane.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Lane.java
@@ -25,11 +25,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Lane extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Lane extends BaseElement, NamedBpmnElement {
 
   PartitionElement getPartitionElement();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/LaneSet.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/LaneSet.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface LaneSet extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface LaneSet extends BaseElement, NamedBpmnElement {
 
   Collection<Lane> getLanes();
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Message.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Message.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface Message extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Message extends RootElement, NamedBpmnElement {
 
   ItemDefinition getItem();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/MessageFlow.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/MessageFlow.java
@@ -23,11 +23,7 @@ import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnEdge;
  *
  * @author Sebastian Menski
  */
-public interface MessageFlow extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface MessageFlow extends BaseElement, NamedBpmnElement {
 
   InteractionNode getSource();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/NamedBpmnElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/NamedBpmnElement.java
@@ -16,18 +16,24 @@
 
 package io.camunda.zeebe.model.bpmn.instance;
 
-import java.util.Collection;
-
 /**
- * The BPMN linkEventDefinition element
+ * Represents a BPMN model element that has a name.
  *
- * @author Sebastian Menski
+ * @author Christian Thiel
  */
-public interface LinkEventDefinition extends EventDefinition, NamedBpmnElement {
+public interface NamedBpmnElement extends BpmnModelElementInstance {
 
-  Collection<LinkEventDefinition> getSources();
+  /**
+   * Gets the name of this BPMN element.
+   *
+   * @return the element's name
+   */
+  String getName();
 
-  LinkEventDefinition getTarget();
-
-  void setTarget(LinkEventDefinition target);
+  /**
+   * Sets the name for this BPMN element.
+   *
+   * @param name the name to set
+   */
+  void setName(String name);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Operation.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Operation.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Operation extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Operation extends BaseElement, NamedBpmnElement {
 
   String getImplementationRef();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/OutputSet.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/OutputSet.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface OutputSet extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface OutputSet extends BaseElement, NamedBpmnElement {
 
   Collection<DataOutput> getDataOutputRefs();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Participant.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Participant.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Participant extends BaseElement, InteractionNode {
-
-  String getName();
-
-  void setName(String name);
+public interface Participant extends BaseElement, InteractionNode, NamedBpmnElement {
 
   Process getProcess();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Property.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Property.java
@@ -21,9 +21,4 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface Property extends ItemAwareElement {
-
-  String getName();
-
-  void setName(String name);
-}
+public interface Property extends ItemAwareElement, NamedBpmnElement {}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Resource.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Resource.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface Resource extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Resource extends RootElement, NamedBpmnElement {
 
   Collection<ResourceParameter> getResourceParameters();
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ResourceParameter.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ResourceParameter.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface ResourceParameter extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface ResourceParameter extends BaseElement, NamedBpmnElement {
 
   ItemDefinition getType();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ResourceRole.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/ResourceRole.java
@@ -23,11 +23,7 @@ import java.util.Collection;
  *
  * @author Sebastian Menski
  */
-public interface ResourceRole extends BaseElement {
-
-  String getName();
-
-  void setName(String name);
+public interface ResourceRole extends BaseElement, NamedBpmnElement {
 
   Resource getResource();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Signal.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/Signal.java
@@ -21,11 +21,7 @@ package io.camunda.zeebe.model.bpmn.instance;
  *
  * @author Sebastian Menski
  */
-public interface Signal extends RootElement {
-
-  String getName();
-
-  void setName(String name);
+public interface Signal extends RootElement, NamedBpmnElement {
 
   ItemDefinition getStructure();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/dc/Font.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/dc/Font.java
@@ -17,17 +17,14 @@
 package io.camunda.zeebe.model.bpmn.instance.dc;
 
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
 
 /**
  * The DC font element
  *
  * @author Sebastian Menski
  */
-public interface Font extends BpmnModelElementInstance {
-
-  String getName();
-
-  void setName(String name);
+public interface Font extends BpmnModelElementInstance, NamedBpmnElement {
 
   Double getSize();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/di/Diagram.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/di/Diagram.java
@@ -17,17 +17,14 @@
 package io.camunda.zeebe.model.bpmn.instance.di;
 
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
 
 /**
  * The DI Diagram element
  *
  * @author Sebastian Menski
  */
-public interface Diagram extends BpmnModelElementInstance {
-
-  String getName();
-
-  void setName(String name);
+public interface Diagram extends BpmnModelElementInstance, NamedBpmnElement {
 
   String getDocumentation();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeProperty.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeProperty.java
@@ -16,12 +16,9 @@
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
 
-public interface ZeebeProperty extends BpmnModelElementInstance {
-
-  String getName();
-
-  void setName(String name);
+public interface ZeebeProperty extends BpmnModelElementInstance, NamedBpmnElement {
 
   String getValue();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NameLengthValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NameLengthValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class NameLengthValidator<T extends NamedBpmnElement> implements ModelElementValidator<T> {
+
+  private final Class<T> elementClass;
+  private final int maxFieldLength;
+
+  public NameLengthValidator(final Class<T> elementClass, final int maxFieldLength) {
+    this.elementClass = elementClass;
+    this.maxFieldLength = maxFieldLength;
+  }
+
+  @Override
+  public Class<T> getElementType() {
+    return elementClass;
+  }
+
+  @Override
+  public void validate(final T element, final ValidationResultCollector validationResultCollector) {
+
+    if (element.getName() != null && element.getName().length() > maxFieldLength) {
+      validationResultCollector.addError(
+          0,
+          "Names must not be longer than the configured max-name-length of "
+              + maxFieldLength
+              + " characters.");
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
@@ -8,6 +8,37 @@
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.model.bpmn.instance.CallableElement;
+import io.camunda.zeebe.model.bpmn.instance.Category;
+import io.camunda.zeebe.model.bpmn.instance.Collaboration;
+import io.camunda.zeebe.model.bpmn.instance.ConversationLink;
+import io.camunda.zeebe.model.bpmn.instance.ConversationNode;
+import io.camunda.zeebe.model.bpmn.instance.CorrelationKey;
+import io.camunda.zeebe.model.bpmn.instance.CorrelationProperty;
+import io.camunda.zeebe.model.bpmn.instance.DataInput;
+import io.camunda.zeebe.model.bpmn.instance.DataOutput;
+import io.camunda.zeebe.model.bpmn.instance.DataState;
+import io.camunda.zeebe.model.bpmn.instance.DataStore;
+import io.camunda.zeebe.model.bpmn.instance.Definitions;
+import io.camunda.zeebe.model.bpmn.instance.Error;
+import io.camunda.zeebe.model.bpmn.instance.Escalation;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.InputSet;
+import io.camunda.zeebe.model.bpmn.instance.Interface;
+import io.camunda.zeebe.model.bpmn.instance.Lane;
+import io.camunda.zeebe.model.bpmn.instance.LaneSet;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Message;
+import io.camunda.zeebe.model.bpmn.instance.MessageFlow;
+import io.camunda.zeebe.model.bpmn.instance.Operation;
+import io.camunda.zeebe.model.bpmn.instance.OutputSet;
+import io.camunda.zeebe.model.bpmn.instance.Participant;
+import io.camunda.zeebe.model.bpmn.instance.Property;
+import io.camunda.zeebe.model.bpmn.instance.Resource;
+import io.camunda.zeebe.model.bpmn.instance.ResourceParameter;
+import io.camunda.zeebe.model.bpmn.instance.ResourceRole;
+import io.camunda.zeebe.model.bpmn.instance.Signal;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -16,6 +47,38 @@ public final class ZeebeConfigurationValidators {
 
   public static Collection<ModelElementValidator<?>> getValidators(
       final BpmnValidatorConfig config) {
-    return List.of(new IdLengthValidator(config.maxIdFieldLength()));
+    return List.of(
+        new IdLengthValidator(config.maxIdFieldLength()),
+        new NameLengthValidator<>(CallableElement.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Category.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Collaboration.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(ConversationLink.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(ConversationNode.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(CorrelationKey.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(CorrelationProperty.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(DataInput.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(DataOutput.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(DataState.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(DataStore.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Definitions.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Error.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Escalation.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(InputSet.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Interface.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Lane.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(LaneSet.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(LinkEventDefinition.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Message.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(MessageFlow.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Operation.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(OutputSet.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Participant.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Property.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Resource.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(ResourceParameter.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(ResourceRole.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(Signal.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(ZeebeProperty.class, config.maxNameFieldLength()),
+        new NameLengthValidator<>(FlowElement.class, config.maxNameFieldLength()));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NameLengthTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NameLengthTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import io.camunda.zeebe.model.bpmn.instance.ParallelGateway;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class NameLengthTest {
+
+  @ParameterizedTest
+  @MethodSource("nameLengthTestCases")
+  void nameLengthExceeded(
+      final Class<? extends BpmnModelElementInstance> expectedElementClass,
+      final ProcessBuilder processBuilder) {
+
+    final var name = "a".repeat(ProcessValidationUtil.MAX_NAME_FIELD_LENGTH + 1);
+
+    // when
+    final var process = processBuilder.build(name);
+
+    // then
+    ProcessValidationUtil.validateProcess(
+        process,
+        ExpectedValidationResult.expect(
+            expectedElementClass,
+            "Names must not be longer than the configured max-name-length of %s characters"
+                .formatted(ProcessValidationUtil.MAX_NAME_FIELD_LENGTH)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nameLengthTestCases")
+  void nameLengthNotExceeded(
+      final Class<? extends BpmnModelElementInstance> expectedElementClass,
+      final ProcessBuilder processBuilder) {
+
+    final var name = "a".repeat(ProcessValidationUtil.MAX_NAME_FIELD_LENGTH);
+
+    // when
+    final var process = processBuilder.build(name);
+
+    // then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  private static Stream<Arguments> nameLengthTestCases() {
+    return Stream.of(
+        Arguments.of(
+            Process.class,
+            (ProcessBuilder)
+                name ->
+                    Bpmn.createExecutableProcess("process")
+                        .name(name)
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeJobType("test"))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            ServiceTask.class,
+            (ProcessBuilder)
+                name ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent()
+                        .serviceTask("task", t -> t.name(name).zeebeJobType("test"))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            UserTask.class,
+            (ProcessBuilder)
+                name ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent()
+                        .userTask("task", t -> t.name(name))
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            ParallelGateway.class,
+            (ProcessBuilder)
+                name ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent()
+                        .userTask("task", t -> t.name(name))
+                        .parallelGateway()
+                        .name(name)
+                        .endEvent()
+                        .done()),
+        Arguments.of(
+            StartEvent.class,
+            (ProcessBuilder)
+                name ->
+                    Bpmn.createExecutableProcess("process")
+                        .startEvent()
+                        .name(name)
+                        .serviceTask("task", t -> t.zeebeJobType("test"))
+                        .endEvent()
+                        .done()));
+  }
+
+  @FunctionalInterface
+  private interface ProcessBuilder {
+    BpmnModelInstance build(String name);
+  }
+}


### PR DESCRIPTION
## Description

Introduce length validator for all name fields in BPMN.
- added `NamedBpmnElement` interface to mark all BPMN elements which have can a name
- added NameLengthValidator to validate the name of every named BPMN element
- added arch-unit test to verify, that also future named elements are added to the validator

closes #45680 
