### PR TITLE
[Backport main] fix: use extra underscore to differentiate Zeebe exporter indexes from Camunda exporter indexes

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterClient.java
@@ -302,7 +302,9 @@ class ElasticsearchExporterClient implements AutoCloseable {
               .indices()
               .putSettings(
                   b ->
-                      b.index(configuration.index.prefix + "*")
+                      // camunda exporter indexes have a slightly different format (dash instead of
+                      // underscore after prefix) so using that to avoid accidentally updating them
+                      b.index(configuration.index.prefix + RecordIndexRouter.INDEX_DELIMITER + "*")
                           .allowNoIndices(true)
                           .withJson(new StringReader(json)));
       return response.acknowledged();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
 final class RecordIndexRouter {
-  public static final String INDEX_DELIMITER = "_";
+  static final String INDEX_DELIMITER = "_";
   private static final String ALIAS_DELIMITER = "-";
 
   private final DateTimeFormatter formatter;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
 final class RecordIndexRouter {
-  private static final String INDEX_DELIMITER = "_";
+  public static final String INDEX_DELIMITER = "_";
   private static final String ALIAS_DELIMITER = "-";
 
   private final DateTimeFormatter formatter;

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -166,6 +166,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -293,7 +293,12 @@ public class OpensearchClient implements AutoCloseable {
   public boolean bulkAddISMPolicyToAllZeebeIndices() {
     try {
       final var request =
-          new Request("POST", "/_plugins/_ism/add/" + configuration.index.prefix + "*");
+          new Request(
+              "POST",
+              "/_plugins/_ism/add/"
+                  + configuration.index.prefix
+                  + RecordIndexRouter.INDEX_DELIMITER
+                  + "*");
       final var requestEntity = new AddPolicyRequest(configuration.retention.getPolicyName());
       request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
       final var response = sendRequest(request, IndexPolicyResponse.class);
@@ -306,7 +311,12 @@ public class OpensearchClient implements AutoCloseable {
   public boolean bulkRemoveISMPolicyToAllZeebeIndices() {
     try {
       final var request =
-          new Request("POST", "/_plugins/_ism/remove/" + configuration.index.prefix + "*");
+          new Request(
+              "POST",
+              "/_plugins/_ism/remove/"
+                  + configuration.index.prefix
+                  + RecordIndexRouter.INDEX_DELIMITER
+                  + "*");
       final var response = sendRequest(request, IndexPolicyResponse.class);
       return !response.failures();
     } catch (final IOException e) {
@@ -330,7 +340,8 @@ public class OpensearchClient implements AutoCloseable {
             configuration.retention.getPolicyDescription(),
             ISM_INITIAL_STATE,
             List.of(initialState, deleteState),
-            new IsmTemplate(List.of(configuration.index.prefix + "*"), 1));
+            new IsmTemplate(
+                List.of(configuration.index.prefix + RecordIndexRouter.INDEX_DELIMITER + "*"), 1));
     return new PutIndexStateManagementPolicyRequest(policy);
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -308,7 +308,7 @@ public class OpensearchClient implements AutoCloseable {
     }
   }
 
-  public boolean bulkRemoveISMPolicyToAllZeebeIndices() {
+  public boolean bulkRemoveISMPolicyFromAllZeebeIndices() {
     try {
       final var request =
           new Request(

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -232,7 +232,7 @@ public class OpensearchExporterSchemaManager {
     if (configuration.retention.isEnabled()) {
       successful = client.bulkAddISMPolicyToAllZeebeIndices();
     } else {
-      successful = client.bulkRemoveISMPolicyToAllZeebeIndices();
+      successful = client.bulkRemoveISMPolicyFromAllZeebeIndices();
     }
 
     if (!successful) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -16,9 +16,9 @@ import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
 final class RecordIndexRouter {
+  public static final String INDEX_DELIMITER = "_";
   private static final DateTimeFormatter DEFAULT_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
-  private static final String INDEX_DELIMITER = "_";
   private static final String ALIAS_DELIMITER = "-";
 
   private final DateTimeFormatter formatter;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
 final class RecordIndexRouter {
-  public static final String INDEX_DELIMITER = "_";
+  static final String INDEX_DELIMITER = "_";
   private static final DateTimeFormatter DEFAULT_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
   private static final String ALIAS_DELIMITER = "-";

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -15,8 +15,8 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
-final class RecordIndexRouter {
-  static final String INDEX_DELIMITER = "_";
+public final class RecordIndexRouter {
+  public static final String INDEX_DELIMITER = "_";
   private static final DateTimeFormatter DEFAULT_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
   private static final String ALIAS_DELIMITER = "-";

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.RecordIndexRouter;
 import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse.Policy.IsmTemplate;
 import java.util.List;
 
@@ -64,7 +65,9 @@ public record GetIndexStateManagementPolicyResponse(
 
     final var indexPattern = ismTemplate.get().indexPatterns.stream().findFirst();
 
-    return indexPattern.map(s -> s.equals(configuration.index.prefix + "*")).orElse(false);
+    return indexPattern
+        .map(s -> s.equals(configuration.index.prefix + RecordIndexRouter.INDEX_DELIMITER + "*"))
+        .orElse(false);
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -150,7 +150,7 @@ public class OpensearchClientIT {
     // given
 
     // when
-    createISMPolicyIfNeeded();
+    recreateISMPolicyIfNeeded();
 
     // then
     final var ismPolicyResponse = SEARCH_DB.client().getIndexStateManagementPolicy();
@@ -177,7 +177,7 @@ public class OpensearchClientIT {
     // camunda exporter indexes have a slightly different format
     final var camundaExporterIndexName = config.index.prefix + "-operate-variable-2024-01-01";
 
-    createISMPolicyIfNeeded();
+    recreateISMPolicyIfNeeded();
 
     final var osClient = SEARCH_DB.testClient().getOsClient();
     osClient.indices().create(b -> b.index(ownedIndexName));
@@ -205,7 +205,7 @@ public class OpensearchClientIT {
         indexRouter.indexPrefixForValueType(ValueType.VARIABLE, VersionUtil.getVersionLowerCase())
             + "_2024-01-01";
 
-    createISMPolicyIfNeeded();
+    recreateISMPolicyIfNeeded();
 
     final var osClient = SEARCH_DB.testClient().getOsClient();
     osClient.indices().create(b -> b.index(ownedIndexName));
@@ -226,11 +226,12 @@ public class OpensearchClientIT {
         .untilAsserted(() -> assertThat(getISMPolicyIdForIndex(osClient, ownedIndexName)).isNull());
   }
 
-  private static void createISMPolicyIfNeeded() {
+  private static void recreateISMPolicyIfNeeded() {
     final var policyOptional = SEARCH_DB.client().getIndexStateManagementPolicy();
-    if (policyOptional.isEmpty()) {
-      SEARCH_DB.client().createIndexStateManagementPolicy();
+    if (!policyOptional.isEmpty()) {
+      SEARCH_DB.client().deleteIndexStateManagementPolicy();
     }
+    SEARCH_DB.client().createIndexStateManagementPolicy();
   }
 
   private String getISMPolicyIdForIndex(final OpenSearchClient osClient, final String indexName)

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -11,43 +11,48 @@ import static io.camunda.zeebe.exporter.opensearch.SearchDBExtension.TEST_INTEGR
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
 import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.generic.Requests;
 
 public class OpensearchClientIT {
 
   private static final int PARTITION_ID = 1;
 
-  @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
 
   @Test
   void shouldThrowExceptionIfFailToFlushBulk() {
     // given - a record with a negative timestamp will not be indexed because its field in ES is a
     // date, which must be a positive number of milliseconds since the UNIX epoch
     final var invalidRecord =
-        searchDB
+        SEARCH_DB
             .recordFactory()
             .generateRecord(
                 ValueType.VARIABLE,
                 b ->
                     b.withTimestamp(Long.MIN_VALUE)
                         .withBrokerVersion(VersionUtil.getVersionLowerCase()));
-    searchDB.client().index(invalidRecord, new RecordSequence(PARTITION_ID, 1));
-    searchDB.client().putComponentTemplate();
-    searchDB.client().putIndexTemplate(ValueType.VARIABLE);
+    SEARCH_DB.client().index(invalidRecord, new RecordSequence(PARTITION_ID, 1));
+    SEARCH_DB.client().putComponentTemplate();
+    SEARCH_DB.client().putIndexTemplate(ValueType.VARIABLE);
 
     // when/then
-    assertThatThrownBy(searchDB.client()::flush)
+    assertThatThrownBy(SEARCH_DB.client()::flush)
         .isInstanceOf(OpensearchExporterException.class)
         .hasMessageContaining(
             "Failed to flush bulk request: [Failed to flush 1 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse field [timestamp]");
@@ -58,29 +63,29 @@ public class OpensearchClientIT {
     // given
     final var valueType = ValueType.VARIABLE;
     final String indexTemplateName =
-        searchDB
+        SEARCH_DB
             .indexRouter()
             .indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
-    final String indexTemplateAlias = searchDB.indexRouter().aliasNameForValueType(valueType);
+    final String indexTemplateAlias = SEARCH_DB.indexRouter().aliasNameForValueType(valueType);
     final Template expectedTemplate =
-        searchDB
+        SEARCH_DB
             .templateReader()
             .readIndexTemplate(
                 valueType,
-                searchDB
+                SEARCH_DB
                     .indexRouter()
                     .searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase()),
                 indexTemplateAlias);
 
     // required since all index templates are composed with it
-    searchDB.client().putComponentTemplate();
+    SEARCH_DB.client().putComponentTemplate();
 
     // when
-    searchDB.client().putIndexTemplate(valueType);
+    SEARCH_DB.client().putIndexTemplate(valueType);
 
     // then
     final var templateWrapper =
-        searchDB.testClient().getIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
+        SEARCH_DB.testClient().getIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
     assertThat(templateWrapper)
         .as("should have created template for value type %s", valueType)
         .isPresent()
@@ -95,19 +100,19 @@ public class OpensearchClientIT {
   @Test
   void shouldPutComponentTemplate() {
     // given
-    final Template expectedTemplate = searchDB.templateReader().readComponentTemplate();
+    final Template expectedTemplate = SEARCH_DB.templateReader().readComponentTemplate();
 
     // when
-    searchDB.client().putComponentTemplate();
+    SEARCH_DB.client().putComponentTemplate();
 
     // then
-    final var templateWrapper = searchDB.testClient().getComponentTemplate();
+    final var templateWrapper = SEARCH_DB.testClient().getComponentTemplate();
     assertThat(templateWrapper)
         .as("should have created component template")
         .isPresent()
         .get()
         .extracting(ComponentTemplateWrapper::name)
-        .isEqualTo(searchDB.config().index.prefix + "-" + VersionUtil.getVersionLowerCase());
+        .isEqualTo(SEARCH_DB.config().index.prefix + "-" + VersionUtil.getVersionLowerCase());
 
     final var template = templateWrapper.get().template();
     assertIndexTemplate(template, expectedTemplate);
@@ -120,24 +125,131 @@ public class OpensearchClientIT {
       disabledReason = "AWS OS IT runners currently support only STS-based authentication")
   void shouldAuthenticateWithBasicAuth() {
     // given
-    searchDB.testClient().putUser("user", "^AHq>z@)&l;RJU=\"", List.of("admin"));
-    searchDB.config().getAuthentication().setUsername("user");
-    searchDB.config().getAuthentication().setPassword("^AHq>z@)&l;RJU=\"");
+    SEARCH_DB.testClient().putUser("user", "^AHq>z@)&l;RJU=\"", List.of("admin"));
+    SEARCH_DB.config().getAuthentication().setUsername("user");
+    SEARCH_DB.config().getAuthentication().setPassword("^AHq>z@)&l;RJU=\"");
 
     // when
     // force recreating the client
     final var authenticatedClient =
         new OpensearchClient(
-            searchDB.config(),
-            searchDB.bulkRequest(),
-            RestClientFactory.of(searchDB.config(), true),
-            searchDB.indexRouter(),
-            searchDB.templateReader(),
+            SEARCH_DB.config(),
+            SEARCH_DB.bulkRequest(),
+            RestClientFactory.of(SEARCH_DB.config(), true),
+            SEARCH_DB.indexRouter(),
+            SEARCH_DB.templateReader(),
             new OpensearchMetrics(new SimpleMeterRegistry()));
     authenticatedClient.putComponentTemplate();
 
     // then
-    assertThat(searchDB.testClient().getComponentTemplate()).isPresent();
+    assertThat(SEARCH_DB.testClient().getComponentTemplate()).isPresent();
+  }
+
+  @Test
+  void shouldCreateIndexStateManagementPolicyWithoutTouchingCamundaExporterIndexes() {
+    // given
+
+    // when
+    createISMPolicyIfNeeded();
+
+    // then
+    final var ismPolicyResponse = SEARCH_DB.client().getIndexStateManagementPolicy();
+    assertThat(ismPolicyResponse).isPresent();
+    final var policy = ismPolicyResponse.get().policy();
+    assertThat(policy.ismTemplate()).isNotEmpty();
+    for (final var ismTemplate : policy.ismTemplate()) {
+      assertThat(ismTemplate.indexPatterns())
+          .as("ISM template should only apply to zeebe indices")
+          .allMatch(pattern -> pattern.startsWith(SEARCH_DB.config().index.prefix + "_*"));
+    }
+  }
+
+  @Test
+  void shouldBulkAddISMPolicyToAllZeebeIndicesWithoutTouchingCamundaExporterIndexesWithSamePrefix()
+      throws IOException {
+    // given
+    final var config = SEARCH_DB.config();
+    final var indexRouter = SEARCH_DB.indexRouter();
+    final var ownedIndexName =
+        indexRouter.indexPrefixForValueType(ValueType.VARIABLE, VersionUtil.getVersionLowerCase())
+            + "_2024-01-01";
+
+    // camunda exporter indexes have a slightly different format
+    final var camundaExporterIndexName = config.index.prefix + "-operate-variable-2024-01-01";
+
+    createISMPolicyIfNeeded();
+
+    final var osClient = SEARCH_DB.testClient().getOsClient();
+    osClient.indices().create(b -> b.index(ownedIndexName));
+    osClient.indices().create(b -> b.index(camundaExporterIndexName));
+
+    // when
+    SEARCH_DB.client().bulkAddISMPolicyToAllZeebeIndices();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(getISMPolicyIdForIndex(osClient, ownedIndexName))
+                  .isEqualTo("zeebe-record-retention-policy");
+              assertThat(getISMPolicyIdForIndex(osClient, camundaExporterIndexName)).isNull();
+            });
+  }
+
+  @Test
+  void shouldBulkRemoveISMPolicyToAllZeebeIndices() throws IOException {
+    // given
+    final var config = SEARCH_DB.config();
+    final var indexRouter = SEARCH_DB.indexRouter();
+    final var ownedIndexName =
+        indexRouter.indexPrefixForValueType(ValueType.VARIABLE, VersionUtil.getVersionLowerCase())
+            + "_2024-01-01";
+
+    createISMPolicyIfNeeded();
+
+    final var osClient = SEARCH_DB.testClient().getOsClient();
+    osClient.indices().create(b -> b.index(ownedIndexName));
+
+    SEARCH_DB.client().bulkAddISMPolicyToAllZeebeIndices();
+
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(getISMPolicyIdForIndex(osClient, ownedIndexName))
+                    .isEqualTo("zeebe-record-retention-policy"));
+
+    // when
+    SEARCH_DB.client().bulkRemoveISMPolicyToAllZeebeIndices();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(() -> assertThat(getISMPolicyIdForIndex(osClient, ownedIndexName)).isNull());
+  }
+
+  private static void createISMPolicyIfNeeded() {
+    final var policyOptional = SEARCH_DB.client().getIndexStateManagementPolicy();
+    if (policyOptional.isEmpty()) {
+      SEARCH_DB.client().createIndexStateManagementPolicy();
+    }
+  }
+
+  private String getISMPolicyIdForIndex(final OpenSearchClient osClient, final String indexName)
+      throws IOException {
+    final var response =
+        osClient
+            .generic()
+            .execute(
+                Requests.builder()
+                    .endpoint("/_plugins/_ism/explain/" + indexName)
+                    .method("GET")
+                    .build());
+
+    final Map<String, Object> json =
+        new ObjectMapper().readValue(response.getBody().get().bodyAsString(), Map.class);
+    assertThat(json).containsKey(indexName);
+    final Map<String, Object> policyDetails = (Map) json.get(indexName);
+    assertThat(policyDetails).containsKey("index.plugins.index_state_management.policy_id");
+    return (String) policyDetails.get("index.plugins.index_state_management.policy_id");
   }
 
   private void assertIndexTemplate(final Template actualTemplate, final Template expectedTemplate) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -197,7 +197,7 @@ public class OpensearchClientIT {
   }
 
   @Test
-  void shouldBulkRemoveISMPolicyToAllZeebeIndices() throws IOException {
+  void shouldBulkRemoveISMPolicyFromAllZeebeIndices() throws IOException {
     // given
     final var config = SEARCH_DB.config();
     final var indexRouter = SEARCH_DB.indexRouter();
@@ -219,7 +219,7 @@ public class OpensearchClientIT {
                     .isEqualTo("zeebe-record-retention-policy"));
 
     // when
-    SEARCH_DB.client().bulkRemoveISMPolicyToAllZeebeIndices();
+    SEARCH_DB.client().bulkRemoveISMPolicyFromAllZeebeIndices();
 
     // then
     Awaitility.await()

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -160,7 +160,7 @@ public class OpensearchClientIT {
     for (final var ismTemplate : policy.ismTemplate()) {
       assertThat(ismTemplate.indexPatterns())
           .as("ISM template should only apply to zeebe indices")
-          .allMatch(pattern -> pattern.startsWith(SEARCH_DB.config().index.prefix + "_*"));
+          .containsOnly(SEARCH_DB.config().index.prefix + "_*");
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -316,7 +316,7 @@ final class OpensearchExporterIT {
     final var ismTemplate = policy.ismTemplate().getFirst();
     assertThat(ismTemplate.indexPatterns())
         .as("Has 1 configured index pattern")
-        .containsOnly(config.index.prefix + "*");
+        .containsOnly(config.index.prefix + "_*");
     assertThat(ismTemplate.priority()).as("Has low priority").isEqualTo(1);
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponseTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/dto/GetIndexStateManagementPolicyResponseTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 final class GetIndexStateManagementPolicyResponseTest {
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
+  private final String indexPattern = config.index.prefix + "_*";
 
   @Test
   void shouldEqualConfiguration() {
@@ -32,7 +33,7 @@ final class GetIndexStateManagementPolicyResponseTest {
             config.retention.getPolicyName(),
             config.retention.getPolicyDescription(),
             config.retention.getMinimumAge(),
-            config.index.prefix + "*");
+            indexPattern);
 
     // when
     final var equal = response.equalsConfiguration(config);
@@ -49,7 +50,7 @@ final class GetIndexStateManagementPolicyResponseTest {
             "name",
             config.retention.getPolicyDescription(),
             config.retention.getMinimumAge(),
-            config.index.prefix + "*");
+            indexPattern);
 
     // when
     final var equal = response.equalsConfiguration(config);
@@ -66,7 +67,7 @@ final class GetIndexStateManagementPolicyResponseTest {
             config.retention.getPolicyName(),
             "description",
             config.retention.getMinimumAge(),
-            config.index.prefix + "*");
+            indexPattern);
 
     // when
     final var equal = response.equalsConfiguration(config);
@@ -83,7 +84,7 @@ final class GetIndexStateManagementPolicyResponseTest {
             config.retention.getPolicyName(),
             config.retention.getPolicyDescription(),
             "100d",
-            config.index.prefix + "*");
+            indexPattern);
 
     // when
     final var equal = response.equalsConfiguration(config);


### PR DESCRIPTION
# Description
Backport of #45805 to `main`.

relates to #45705