### PR TITLE
test: fix process instance listeners e2e tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -39,6 +39,7 @@ class OperateProcessInstancePage {
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
   readonly metadataModal: Locator;
+  readonly metadataPopover: Locator;
   readonly modifyInstanceButton: Locator;
   readonly listenerTypeFilter: Locator;
   readonly editVariableButton: Locator;
@@ -147,6 +148,7 @@ class OperateProcessInstancePage {
     );
     this.listenersTabButton = page.getByTestId('listeners-tab-button');
     this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
+    this.metadataPopover = this.page.getByTestId('popover');
     this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
     this.listenerTypeFilter = page.getByTestId('listener-type-filter');
     this.variableAddedBanner = this.page.getByText('Variable added');
@@ -701,6 +703,10 @@ class OperateProcessInstancePage {
 
   async clickViewParentInstance(): Promise<void> {
     await this.viewParentInstanceLink.click();
+  }
+
+  async clickMoreMetadata(): Promise<void> {
+    await this.page.getByRole('button', {name: 'Show more metadata'}).click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -130,6 +130,9 @@ test.describe('Process Instance Listeners', () => {
       await operateProcessInstancePage.diagramHelper.clickFlowNode(
         'Service Task B',
       );
+      await expect(
+        operateProcessInstancePage.metadataPopover.getByText('Details'),
+      ).toBeVisible();
       await operateProcessInstancePage.openListenersTab();
       await expect(
         operateProcessInstancePage.getListenerRows('execution'),
@@ -147,20 +150,37 @@ test.describe('Process Instance Listeners', () => {
 
     await test.step('Wait for new instance to appear and verify listener count', async () => {
       await expect
-        .poll(async () => {
-          return operateProcessInstancePage.instanceHistory
-            .getByText('Service Task B')
-            .count();
-        })
+        .poll(
+          async () => {
+            return operateProcessInstancePage.instanceHistory
+              .getByText('Service Task B')
+              .count();
+          },
+          {timeout: 15000},
+        )
         .toBe(2);
 
-      await operateProcessInstancePage.diagramHelper.clickFlowNode(
-        'Service Task B',
-      );
-      await operateProcessInstancePage.openListenersTab();
-      await expect(
-        operateProcessInstancePage.getListenerRows('execution'),
-      ).toHaveCount(2);
+      await expect
+        .poll(
+          async () => {
+            // Deselect element
+            await operateProcessInstancePage.clickInstanceHistoryElement(
+              'processWithListener',
+            );
+
+            // Select element
+            await operateProcessInstancePage.diagramHelper.clickFlowNode(
+              'Service Task B',
+            );
+
+            await operateProcessInstancePage.openListenersTab();
+            return await operateProcessInstancePage
+              .getListenerRows('execution')
+              .count();
+          },
+          {intervals: [2000], timeout: 10000},
+        )
+        .toBe(2);
     });
 
     await test.step('Select specific flow node instance and verify single listener', async () => {
@@ -190,7 +210,7 @@ test.describe('Process Instance Listeners', () => {
         id: processInstanceKey,
       });
 
-      const responsePromise = page.waitForResponse('**/flow-node-metadata');
+      const responsePromise = page.waitForResponse('**/user-tasks/search');
 
       await expect(
         operateProcessInstancePage.diagramHelper.getFlowNode('Service Task B'),
@@ -198,12 +218,18 @@ test.describe('Process Instance Listeners', () => {
       await operateProcessInstancePage.diagramHelper.clickFlowNode(
         'Service Task B',
       );
+      await operateProcessInstancePage.clickMoreMetadata();
 
       const response = await responsePromise;
       const data = await response.json();
-      userTaskKey = String(data.instanceMetadata.userTaskKey);
+      userTaskKey = String(data.items[0].userTaskKey);
 
       expect(userTaskKey).toMatch(userTaskKeyRegex);
+
+      await operateProcessInstancePage.metadataModal
+        .getByRole('button', {name: 'Close'})
+        .click();
+
       await expect(operateProcessInstancePage.stateOverlayActive).toBeVisible();
     });
 
@@ -215,7 +241,12 @@ test.describe('Process Instance Listeners', () => {
       await expect(
         operateProcessInstancePage.stateOverlayCompletedEndEvents,
       ).toBeVisible();
-      await sleep(1000);
+
+      // Deselect element
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        'processWithUserTaskListener',
+      );
+
       await operateProcessInstancePage.clickInstanceHistoryElement(
         'Service Task B',
       );


### PR DESCRIPTION
## Description

Fix process instance listeners E2E tests.

> [!NOTE]
> The E2E tests did not trigger on this PR. Here's a manually triggered test run: https://github.com/camunda/camunda/actions/runs/22067133886

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45901 
