### PR TITLE
Add a pre-scaling operation to the planned changes

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
@@ -246,6 +247,15 @@ final class ClusterApiUtils {
               .brokerId(Integer.parseInt(updateRoutingState.memberId().id()));
       case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
           new Operation().operation(OperationEnum.UPDATE_INCARNATION_NUMBER);
+      case final PreScalingOperation preScalingOperation ->
+          new Operation()
+              .operation(OperationEnum.PRE_SCALING)
+              .brokerId(Integer.parseInt(preScalingOperation.memberId().id()))
+              .brokers(
+                  preScalingOperation.clusterMembers().stream()
+                      .map(MemberId::id)
+                      .map(Integer::parseInt)
+                      .toList());
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }
@@ -507,6 +517,15 @@ final class ClusterApiUtils {
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_INCARNATION_NUMBER)
                   .brokerId(Integer.parseInt(updateIncarnationNumberOperation.memberId().id()));
+          case final PreScalingOperation preScalingOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.PRE_SCALING)
+                  .brokerId(Integer.parseInt(preScalingOperation.memberId().id()))
+                  .brokers(
+                      preScalingOperation.clusterMembers().stream()
+                          .map(MemberId::id)
+                          .map(Integer::parseInt)
+                          .toList());
           default ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -329,6 +329,7 @@ schemas:
           - DELETE_HISTORY
           - PARTITION_DELETE_EXPORTER
           - UPDATE_INCARNATION_NUMBER
+          - PRE_SCALING
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
@@ -296,9 +297,12 @@ final class ClusterApiUtilsTest {
         new MemberJoinOperation(memberId1),
         new MemberLeaveOperation(memberId1),
         new MemberRemoveOperation(memberId1, memberId2),
+
+        // General cluster operations
         new DeleteHistoryOperation(memberId1),
         new UpdateRoutingState(memberId1, emptyRoutingState),
         new UpdateIncarnationNumberOperation(memberId1),
+        new PreScalingOperation(memberId1, memberCollection),
 
         // Scale up operations
         new StartPartitionScaleUp(memberId1, 8),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +54,12 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
         });
 
     return result;
+  }
+
+  @Override
+  public ActorFuture<Void> preScaling(final Set<MemberId> clusterMembers) {
+    // TODO: implement actual logic
+    return concurrencyControl.createCompletedFuture();
   }
 
   private void purgeExporter(final String id, final ExporterDescriptor descriptor) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Set;
 
 public interface ClusterChangeExecutor {
 
@@ -25,9 +27,25 @@ public interface ClusterChangeExecutor {
    */
   ActorFuture<Void> deleteHistory();
 
+  /**
+   * This method will start an asynchronous pre-scaling operation, preparing the member for a
+   * cluster scaling event.
+   *
+   * <p>This operation should be idempotent, as it may be retried multiple times until successful.
+   *
+   * @param clusterMembers the set of member ids that will be part of the cluster after scaling
+   * @return future when the operation is completed
+   */
+  ActorFuture<Void> preScaling(Set<MemberId> clusterMembers);
+
   final class NoopClusterChangeExecutor implements ClusterChangeExecutor {
     @Override
     public ActorFuture<Void> deleteHistory() {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public ActorFuture<Void> preScaling(final Set<MemberId> clusterMembers) {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
@@ -119,6 +120,11 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
           new UpdateRoutingStateApplier(updateRoutingState, partitionScalingChangeExecutor);
       case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
           new UpdateIncarnationNumberApplier();
+      case final PreScalingOperation preScalingOperation ->
+          new PreScalingApplier(
+              preScalingOperation.memberId(),
+              preScalingOperation.clusterMembers(),
+              clusterChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Applier for the PreScalingOperation. This applier prepares a member for scaling by invoking the
+ * pre-scaling callback on the ClusterChangeExecutor.
+ */
+final class PreScalingApplier implements ClusterOperationApplier {
+  private final MemberId memberId;
+  private final Set<MemberId> clusterMembers;
+  private final ClusterChangeExecutor clusterChangeExecutor;
+
+  public PreScalingApplier(
+      final MemberId memberId,
+      final Set<MemberId> clusterMembers,
+      final ClusterChangeExecutor clusterChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembers = clusterMembers;
+    this.clusterChangeExecutor = clusterChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    // Validate that the member applying this operation is part of the cluster
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot apply pre-scaling operation: member "
+                  + memberId
+                  + " is not part of the current cluster configuration."));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    return clusterChangeExecutor
+        .preScaling(clusterMembers)
+        .thenApply(ignore -> UnaryOperator.identity());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -71,6 +71,21 @@ public sealed interface ClusterConfigurationChangeOperation {
   record UpdateIncarnationNumberOperation(MemberId memberId)
       implements ClusterConfigurationChangeOperation {}
 
+  /**
+   * Operation to prepare a member for scaling. This operation is executed before scaling starts.
+   *
+   * @param memberId the member id of the member that will apply this operation
+   * @param clusterMembers the list of member ids that will be part of the cluster after scaling is
+   *     completed
+   */
+  record PreScalingOperation(MemberId memberId, SortedSet<MemberId> clusterMembers)
+      implements ClusterConfigurationChangeOperation {
+
+    public PreScalingOperation(final MemberId memberId, final Set<MemberId> clusterMembers) {
+      this(memberId, ImmutableSortedSet.copyOf(clusterMembers));
+    }
+  }
+
   sealed interface ScaleUpOperation extends ClusterConfigurationChangeOperation {
     /**
      * Operation to initiate partition scale up. This instructs the cluster to redistribute

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -106,6 +106,7 @@ message TopologyChangeOperation {
     UpdateRoutingState updateRoutingState = 16;
     PartitionDeleteExporterOperation partitionDeleteExporter = 17;
     UpdateIncarnationNumberOperation updateIncarnationNumber = 18;
+    PreScalingOperation preScaling = 19;
   }
 }
 
@@ -174,6 +175,10 @@ message UpdateRoutingState{
 }
 
 message UpdateIncarnationNumberOperation {}
+
+message PreScalingOperation {
+  repeated string clusterMembers = 1;
+}
 
 message DeleteHistoryOperation { int32 memberId = 1; }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
@@ -247,6 +248,7 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
+            new PreScalingOperation(id0, Set.of(id0, id1)),
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1));
@@ -268,9 +270,9 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .hasSize(4)
-        .startsWith(new MemberJoinOperation(id1))
-        .contains(new PartitionJoinOperation(id1, 2, 2))
+        .hasSize(5)
+        .startsWith(new PreScalingOperation(id0, Set.of(id0, id1)))
+        .contains(new MemberJoinOperation(id1), new PartitionJoinOperation(id1, 2, 2))
         .containsSequence(
             new PartitionJoinOperation(id1, 1, 1),
             new PartitionReconfigurePriorityOperation(id0, 1, 2));
@@ -370,6 +372,7 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
+            new PreScalingOperation(id0, Set.of(id0, id1)),
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),
@@ -397,6 +400,7 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
+            new PreScalingOperation(id0, Set.of(id0, id1)),
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -67,6 +68,9 @@ final class ConfigurationChangeAppliersImplTest {
         Arguments.of(
             new PartitionEnableExporterOperation(localMemberId, 1, "expId", Optional.empty()),
             PartitionEnableExporterApplier.class),
-        Arguments.of(new DeleteHistoryOperation(localMemberId), DeleteHistoryApplier.class));
+        Arguments.of(new DeleteHistoryOperation(localMemberId), DeleteHistoryApplier.class),
+        Arguments.of(
+            new PreScalingOperation(localMemberId, Set.of(localMemberId, MemberId.from("2"))),
+            PreScalingApplier.class));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class PreScalingApplierTest {
+
+  @Test
+  void shouldSucceedOnInitIfMemberExists() {
+    // given
+    final var memberId = MemberId.from("1");
+    final var newMemberId = MemberId.from("2");
+    final var newClusterMembers = Set.of(memberId, newMemberId);
+    final var clusterChangeExecutor = new ClusterChangeExecutor.NoopClusterChangeExecutor();
+    final var preScalingApplier =
+        new PreScalingApplier(memberId, newClusterMembers, clusterChangeExecutor);
+
+    final var clusterConfigurationWithMember =
+        ClusterConfiguration.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = preScalingApplier.init(clusterConfigurationWithMember);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldFailOnInitIfMemberDoesNotExist() {
+    // given
+    final var memberId = MemberId.from("1");
+    final var otherMemberId = MemberId.from("2");
+    final var newClusterMembers = Set.of(memberId, otherMemberId);
+    final var clusterChangeExecutor = new ClusterChangeExecutor.NoopClusterChangeExecutor();
+    final var preScalingApplier =
+        new PreScalingApplier(memberId, newClusterMembers, clusterChangeExecutor);
+
+    final var clusterConfigWithoutMember =
+        ClusterConfiguration.init()
+            .addMember(otherMemberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = preScalingApplier.init(clusterConfigWithoutMember);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+  }
+
+  @Test
+  void shouldPreserveSameConfigurationAfterApply() {
+    // given
+    final var member1Id = MemberId.from("1");
+    final var member2Id = MemberId.from("2");
+    final var newClusterMembers = Set.of(member1Id, member2Id);
+    final var clusterChangeExecutor = new ClusterChangeExecutor.NoopClusterChangeExecutor();
+
+    final var initialConfiguration =
+        ClusterConfiguration.init()
+            .addMember(member1Id, MemberState.initializeAsActive(Map.of()))
+            .addMember(member2Id, MemberState.initializeAsActive(Map.of()));
+    final var preScalingApplier =
+        new PreScalingApplier(member1Id, newClusterMembers, clusterChangeExecutor);
+    final var initializedConfiguration =
+        preScalingApplier.init(initialConfiguration).get().apply(initialConfiguration);
+    final var updater = preScalingApplier.apply().join();
+    final var updatedConfiguration = updater.apply(initializedConfiguration);
+
+    // when
+    ClusterConfigurationAssert.assertThatClusterTopology(updatedConfiguration)
+        .isEqualTo(initialConfiguration);
+  }
+
+  @Test
+  void shouldFailFutureIfApplyFails() {
+    // given
+    final var member1Id = MemberId.from("1");
+    final var member2Id = MemberId.from("2");
+    final var newClusterMembers = Set.of(member1Id, member2Id);
+    final var failingExecutor =
+        new ClusterChangeExecutor() {
+          @Override
+          public ActorFuture<Void> deleteHistory() {
+            return null;
+          }
+
+          @Override
+          public ActorFuture<Void> preScaling(final Set<MemberId> clusterMembers) {
+            return CompletableActorFuture.completedExceptionally(
+                new RuntimeException("Failed to execute operation"));
+          }
+        };
+
+    final var initialConfiguration =
+        ClusterConfiguration.init()
+            .addMember(member1Id, MemberState.initializeAsActive(Map.of()))
+            .addMember(member2Id, MemberState.initializeAsActive(Map.of()));
+    final var preScalingApplier =
+        new PreScalingApplier(member1Id, newClusterMembers, failingExecutor);
+    preScalingApplier.init(initialConfiguration);
+
+    // when
+    final var applyFuture = preScalingApplier.apply();
+
+    // then
+    assertThat(applyFuture)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Failed to execute operation");
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a `PreScalingOperation` to the planned changes for scaling. The operation takes a set of members that will be part of the cluster after the scaling operation. It takes a set instead of the final cluster size for extendability. In future, we may want to suppose lease with gaps in node-ids. In that case we have to know the exact node-ids to use. 

The operation applier is a no-op right now. It will be wired to NodeIdProvider in a followup PR. 

## Related issues

related to #45812
