### PR TITLE
feat: add config flags to control webapps UIs and APIs

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -198,6 +198,10 @@
       <artifactId>dynamic-node-id-provider</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -27,6 +27,7 @@ public class Camunda {
   @NestedConfigurationProperty private Monitoring monitoring = new Monitoring();
   @NestedConfigurationProperty private Security security = new Security();
   @NestedConfigurationProperty private Expression expression = new Expression();
+  @NestedConfigurationProperty private Webapps webapps = new Webapps();
 
   @NestedConfigurationProperty
   private ProcessInstanceCreation processInstanceCreation = new ProcessInstanceCreation();
@@ -118,5 +119,13 @@ public class Camunda {
 
   public String getMode() {
     return mode;
+  }
+
+  public Webapps getWebapps() {
+    return webapps;
+  }
+
+  public void setWebapps(final Webapps webapps) {
+    this.webapps = webapps;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Webapp.java
+++ b/configuration/src/main/java/io/camunda/configuration/Webapp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+public class Webapp {
+
+  /** Whether the webapp is enabled or not. This also affects the webapp API. */
+  private boolean enabled = true;
+
+  /**
+   * Whether the webapp UI is enabled or not. If false, the webapp API will still be available, but
+   * the webapp itself will not be accessible with a web browser.
+   */
+  private boolean uiEnabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isUiEnabled() {
+    return uiEnabled;
+  }
+
+  public void setUiEnabled(final boolean uiEnabled) {
+    this.uiEnabled = uiEnabled;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Webapps.java
+++ b/configuration/src/main/java/io/camunda/configuration/Webapps.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+public class Webapps {
+  /** Configuration for the Tasklist webapp. */
+  @NestedConfigurationProperty private Webapp tasklist = new Webapp();
+
+  /** Configuration for the Operate webapp. */
+  @NestedConfigurationProperty private Webapp operate = new Webapp();
+
+  /** Configuration for the Identity webapp. */
+  @NestedConfigurationProperty private Webapp identity = new Webapp();
+
+  public Webapp getTasklist() {
+    return tasklist;
+  }
+
+  public void setTasklist(final Webapp tasklist) {
+    this.tasklist = tasklist;
+  }
+
+  public Webapp getOperate() {
+    return operate;
+  }
+
+  public void setOperate(final Webapp operate) {
+    this.operate = operate;
+  }
+
+  public Webapp getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(final Webapp identity) {
+    this.identity = identity;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnWebappEnabled.java
+++ b/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnWebappEnabled.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.conditions;
+
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled.OnWebappEnabledCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnWebappEnabledCondition.class)
+public @interface ConditionalOnWebappEnabled {
+
+  String[] value();
+
+  class OnWebappEnabledCondition implements Condition {
+
+    protected String getConditionalClassName() {
+      return ConditionalOnWebappEnabled.class.getName();
+    }
+
+    protected Set<String> getRequiredProperties(final String webappName) {
+      return Set.of(
+          "camunda." + webappName + ".webapp-enabled", // legacy
+          "camunda.webapps." + webappName + ".enabled"); // unified config
+    }
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Map<String, Object> attributes =
+          metadata.getAnnotationAttributes(getConditionalClassName());
+
+      if (attributes == null) {
+        throw new RuntimeException(
+            "Failed to retrieve annotation attributes for " + getConditionalClassName());
+      }
+
+      final String[] webappNames = (String[]) attributes.get("value");
+      if (webappNames == null || webappNames.length == 0) {
+        throw new RuntimeException(
+            "Failed to retrieve webapp name from " + getConditionalClassName() + " annotation");
+      }
+
+      for (String webappName : webappNames) {
+        webappName = webappName.trim().toLowerCase();
+        for (String property : getRequiredProperties(webappName)) {
+          final boolean value = context.getEnvironment().getProperty(property, Boolean.class, true);
+          if (!value) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnWebappUiEnabled.java
+++ b/configuration/src/main/java/io/camunda/configuration/conditions/ConditionalOnWebappUiEnabled.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.conditions;
+
+import com.google.common.collect.Sets;
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled.OnWebappEnabledCondition;
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled.OnWebappUiEnabledCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Set;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.Conditional;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnWebappUiEnabledCondition.class)
+public @interface ConditionalOnWebappUiEnabled {
+
+  String[] value();
+
+  class OnWebappUiEnabledCondition extends OnWebappEnabledCondition implements Condition {
+
+    @Override
+    protected String getConditionalClassName() {
+      return ConditionalOnWebappUiEnabled.class.getName();
+    }
+
+    @Override
+    protected Set<String> getRequiredProperties(final String webappName) {
+      return Sets.union(
+          super.getRequiredProperties(webappName),
+          Set.of("camunda.webapps." + webappName + ".ui-enabled"));
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/helpers/WebappsHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/helpers/WebappsHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.helpers;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+
+public class WebappsHelper {
+  private static final String OPERATE = "operate";
+  private static final String TASKLIST = "tasklist";
+  private static final String IDENTITY = "identity";
+  private static final String ADMIN = "admin";
+
+  public static boolean isOperateEnabled(final ConfigurableEnvironment environment) {
+    return isWebappEnabled(environment, OPERATE);
+  }
+
+  public static boolean isTasklistEnabled(final ConfigurableEnvironment environment) {
+    return isWebappEnabled(environment, TASKLIST);
+  }
+
+  public static boolean isIdentityEnabled(final ConfigurableEnvironment environment) {
+    return isWebappEnabled(environment, IDENTITY) && isWebappEnabled(environment, ADMIN);
+  }
+
+  public static boolean isOperateUiEnabled(final ConfigurableEnvironment environment) {
+    return isWebappUiEnabled(environment, OPERATE);
+  }
+
+  public static boolean isTasklistUiEnabled(final ConfigurableEnvironment environment) {
+    return isWebappUiEnabled(environment, TASKLIST);
+  }
+
+  public static boolean isIdentityUiEnabled(final ConfigurableEnvironment environment) {
+    return isWebappUiEnabled(environment, IDENTITY) && isWebappUiEnabled(environment, ADMIN);
+  }
+
+  private static boolean isWebappEnabled(
+      final ConfigurableEnvironment environment, final String webappName) {
+    return environment.getProperty("camunda." + webappName + ".webappEnabled", Boolean.class, true)
+        && environment.getProperty(
+            "camunda.webapps." + webappName + ".enabled", Boolean.class, true);
+  }
+
+  private static boolean isWebappUiEnabled(
+      final ConfigurableEnvironment environment, final String webapp) {
+    return isWebappEnabled(environment, webapp)
+        && environment.getProperty(
+            "camunda.webapps." + webapp + ".ui-enabled", Boolean.class, true);
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/conditions/ConditionalOnWebappEnabledTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/conditions/ConditionalOnWebappEnabledTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.conditions;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled.OnWebappEnabledCondition;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class ConditionalOnWebappEnabledTest {
+
+  private static final String TEST_WEBAPP_NAME = "testwebapp";
+  private static final String LEGACY_PROPERTY = "camunda." + TEST_WEBAPP_NAME + ".webapp-enabled";
+  private static final String UNIFIED_PROPERTY = "camunda.webapps." + TEST_WEBAPP_NAME + ".enabled";
+
+  private OnWebappEnabledCondition condition;
+  private ConditionContext context;
+  private Environment environment;
+  private AnnotatedTypeMetadata metadata;
+
+  @BeforeEach
+  void setup() {
+    condition = new OnWebappEnabledCondition();
+    context = mock(ConditionContext.class);
+    environment = mock(Environment.class);
+    metadata = mock(AnnotatedTypeMetadata.class);
+
+    when(context.getEnvironment()).thenReturn(environment);
+    when(metadata.getAnnotationAttributes(condition.getConditionalClassName()))
+        .thenReturn(Map.of("value", new String[] {TEST_WEBAPP_NAME}));
+  }
+
+  @Test
+  void testShouldMatchwhenAllPropertiesAreTrue() {
+    // given
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(true);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testShouldNotMatchWhenLegacyPropertyIsFalse() {
+    // given
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(false);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testShouldNotMatchWhenUnifiedPropertyIsFalse() {
+    // given
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(false);
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(true);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/conditions/ConditionalOnWebappUiEnabledTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/conditions/ConditionalOnWebappUiEnabledTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.conditions;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled.OnWebappUiEnabledCondition;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class ConditionalOnWebappUiEnabledTest {
+
+  private static final String TEST_WEBAPP_NAME = "testwebapp";
+  private static final String LEGACY_PROPERTY = "camunda." + TEST_WEBAPP_NAME + ".webapp-enabled";
+  private static final String UNIFIED_PROPERTY = "camunda.webapps." + TEST_WEBAPP_NAME + ".enabled";
+  private static final String UI_PROPERTY = "camunda.webapps." + TEST_WEBAPP_NAME + ".ui-enabled";
+
+  private OnWebappUiEnabledCondition condition;
+  private ConditionContext context;
+  private Environment environment;
+  private AnnotatedTypeMetadata metadata;
+
+  @BeforeEach
+  void setup() {
+    condition = new OnWebappUiEnabledCondition();
+    context = mock(ConditionContext.class);
+    environment = mock(Environment.class);
+    metadata = mock(AnnotatedTypeMetadata.class);
+
+    when(context.getEnvironment()).thenReturn(environment);
+    when(metadata.getAnnotationAttributes(condition.getConditionalClassName()))
+        .thenReturn(Map.of("value", new String[] {TEST_WEBAPP_NAME}));
+  }
+
+  @Test
+  void testShouldMatchWhenAllPropertiesAreTrue() {
+    // given
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UI_PROPERTY, Boolean.class, true)).thenReturn(true);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testShouldNotMatchWhenLegacyPropertyIsFalse() {
+    // given
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(false);
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UI_PROPERTY, Boolean.class, true)).thenReturn(true);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testShouldNotMatchWhenUnifiedPropertyIsFalse() {
+    // given
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(false);
+    when(environment.getProperty(UI_PROPERTY, Boolean.class, true)).thenReturn(true);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testShouldNotMatchWhenUIPropertyIsFalse() {
+    // given
+    when(environment.getProperty(LEGACY_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UNIFIED_PROPERTY, Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty(UI_PROPERTY, Boolean.class, true)).thenReturn(false);
+
+    // when
+    final boolean result = condition.matches(context, metadata);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.identity;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.identity;
 
-import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.identity.webapp.controllers;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled;
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@ConditionalOnWebappUiEnabled({"identity", "admin"})
 public class AdminIndexController {
   private final ServletContext context;
 

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
@@ -9,6 +9,7 @@ package io.camunda.identity.webapp.controllers;
 
 import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  */
 @Controller
 @Deprecated
+@ConditionalOnWebappUiEnabled({"identity", "admin"})
 public class IdentityIndexController {
 
   @GetMapping({"/identity", "/identity/", "/identity/index.html"})

--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.controllers;
 
 import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled;
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@ConditionalOnWebappUiEnabled("operate")
 public class OperateIndexController {
 
   @Autowired private ServletContext context;

--- a/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
+++ b/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.webapp.controllers;
 
 import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappUiEnabled;
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@ConditionalOnWebappUiEnabled("tasklist")
 public class TasklistIndexController {
 
   @Autowired private ServletContext context;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModesWithOperateDisabledIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModesWithOperateDisabledIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.modules;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.operate.WebappModuleConfiguration;
+import io.camunda.operate.util.apps.modules.ModulesTestApplication;
+import io.camunda.operate.webapp.controllers.OperateIndexController;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@TestPropertySource(
+    properties = {"camunda.mode=all-in-one", "camunda.webapps.operate.enabled=false"})
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {
+      ModulesTestApplication.class,
+      UnifiedConfigurationHelper.class,
+      UnifiedConfiguration.class
+    })
+public class ModesWithOperateDisabledIT extends ModuleAbstractIT {
+
+  @LocalServerPort private int port;
+  @Autowired private WebApplicationContext context;
+
+  private TestRestTemplate restTemplate;
+  private MockMvc mockMvc;
+
+  @Before
+  public void setUp() {
+    restTemplate = new TestRestTemplate();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+
+  @Test
+  public void testWebappModuleConfigurationIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> context.getBean(WebappModuleConfiguration.class));
+  }
+
+  @Test
+  public void testOperateIndexControllerIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> context.getBean(OperateIndexController.class));
+  }
+
+  @Test
+  public void testOperatePageReturnsError() {
+    final String baseUrl = "http://localhost:" + port;
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl + "/operate", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testOperateApiReturnsError() throws Exception {
+    final MvcResult result =
+        mockMvc
+            .perform(post("/v1/process-instances/search"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModesWithOperateUiDisabledIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/modules/ModesWithOperateUiDisabledIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.modules;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.operate.WebappModuleConfiguration;
+import io.camunda.operate.util.apps.modules.ModulesTestApplication;
+import io.camunda.operate.webapp.controllers.OperateIndexController;
+import io.camunda.operate.webapp.security.permission.PermissionsService;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@TestPropertySource(
+    properties = {"camunda.mode=all-in-one", "camunda.webapps.operate.ui-enabled=false"})
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {
+      ModulesTestApplication.class,
+      UnifiedConfigurationHelper.class,
+      UnifiedConfiguration.class
+    })
+public class ModesWithOperateUiDisabledIT extends ModuleAbstractIT {
+
+  @LocalServerPort private int port;
+  @Autowired private WebApplicationContext context;
+  @MockitoBean private CamundaAuthenticationProvider camundaAuthenticationProvider;
+  @MockitoBean private PermissionsService permissionsService;
+
+  private TestRestTemplate restTemplate;
+  private MockMvc mockMvc;
+
+  @Before
+  public void setUp() {
+    restTemplate = new TestRestTemplate();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+
+  @Test
+  public void testWebappModuleConfigurationIsPresent() {
+    assertThatNoException().isThrownBy(() -> context.getBean(WebappModuleConfiguration.class));
+  }
+
+  @Test
+  public void testOperateIndexControllerIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> context.getBean(OperateIndexController.class));
+  }
+
+  @Test
+  public void testOperatePageReturnsError() {
+    final String baseUrl = "http://localhost:" + port;
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl + "/operate", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testOperateApiReturnsOk() throws Exception {
+    final var result =
+        mockMvc
+            .perform(
+                post("/v1/process-instances/search")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+            .andReturn();
+
+    /* If we get this error, it means that the API is working as expected */
+    assertThat(result.getResolvedException().getMessage())
+        .isEqualTo("Error in reading process instances");
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
@@ -20,9 +20,9 @@ import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.store.ScrollException;
 import io.camunda.operate.store.elasticsearch.ElasticsearchIncidentStore;
@@ -58,18 +58,13 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Conditional(ElasticsearchCondition.class)
-@ConditionalOnProperty(
-    prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("operate")
 public class ElasticsearchChecks {
 
   @Autowired UserTaskReader userTaskReader;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
@@ -17,9 +17,9 @@ import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
@@ -52,18 +52,13 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Conditional(OpensearchCondition.class)
-@ConditionalOnProperty(
-    prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("operate")
 public class OpensearchChecks {
 
   @Autowired UserTaskReader userTaskReader;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/SearchCheckPredicatesHolder.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/SearchCheckPredicatesHolder.java
@@ -7,19 +7,14 @@
  */
 package io.camunda.operate.util.j5templates;
 
-import io.camunda.operate.property.OperateProperties;
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import java.util.function.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty(
-    prefix = OperateProperties.PREFIX,
-    name = "webappEnabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("operate")
 public class SearchCheckPredicatesHolder {
   @Autowired
   @Qualifier("processInstancesAreStartedCheck")

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -99,10 +99,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
     <dependency>
@@ -301,6 +297,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
     </dependency>
   </dependencies>
 

--- a/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/WebappModuleConfiguration.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.operate;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -19,10 +19,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ComponentScan(
     basePackages = "io.camunda.operate.webapp",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.operate.webapp-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("operate")
 public class WebappModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebappModuleConfiguration.class);

--- a/tasklist/data-generator/pom.xml
+++ b/tasklist/data-generator/pom.xml
@@ -16,6 +16,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>tasklist-common</artifactId>
     </dependency>
 
@@ -33,11 +38,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 
     <!-- ZEEBE -->

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.data.es;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
@@ -17,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("dev-data")
 @Conditional(ElasticSearchCondition.class)
-@ConditionalOnProperty(value = "camunda.tasklist.webapp-enabled", matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 @DependsOn("searchEngineSchemaInitializer")
 public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
     implements DataGenerator {

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.data.os;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
@@ -17,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Profile("dev-data")
 @Conditional(OpenSearchCondition.class)
-@ConditionalOnProperty(value = "camunda.tasklist.webapp-enabled", matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 @DependsOn("searchEngineSchemaInitializer")
 public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract implements DataGenerator {
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -461,6 +461,11 @@
       <artifactId>zeebe-broker</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModesWithTasklistDisabledIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModesWithTasklistDisabledIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.modules;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.WebappModuleConfiguration;
+import io.camunda.tasklist.util.MockMvcHelper;
+import io.camunda.tasklist.webapp.controllers.TasklistIndexController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@TestPropertySource(
+    properties = {"camunda.mode=all-in-one", "camunda.webapps.tasklist.enabled=false"})
+public class ModesWithTasklistDisabledIT extends ModuleIntegrationTest {
+
+  @LocalServerPort private int port;
+  @Autowired private WebApplicationContext context;
+  @Autowired private ObjectMapper objectMapper;
+
+  private TestRestTemplate restTemplate;
+  private MockMvcHelper mockMvcHelper;
+
+  @BeforeEach
+  public void setUp() {
+    restTemplate = new TestRestTemplate();
+    mockMvcHelper =
+        new MockMvcHelper(MockMvcBuilders.webAppContextSetup(context).build(), objectMapper);
+  }
+
+  @Test
+  public void testWebappModuleConfigurationIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(WebappModuleConfiguration.class));
+  }
+
+  @Test
+  public void testTasklistIndexControllerIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(TasklistIndexController.class));
+  }
+
+  @Test
+  public void testTasklistPageReturnsError() {
+    final String baseUrl = "http://localhost:" + port;
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl + "/tasklist", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testTasklistApiReturnsError() {
+    final var result = mockMvcHelper.doRequest(post("/v1/tasks/search"));
+    assertThat(result.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModesWithTasklistUiDisabledIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModesWithTasklistUiDisabledIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.modules;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.tasklist.WebappModuleConfiguration;
+import io.camunda.tasklist.qa.util.TestUtil;
+import io.camunda.tasklist.store.TaskStore;
+import io.camunda.tasklist.util.MockMvcHelper;
+import io.camunda.tasklist.webapp.controllers.TasklistIndexController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@TestPropertySource(
+    properties = {"camunda.mode=all-in-one", "camunda.webapps.tasklist.ui-enabled=false"})
+public class ModesWithTasklistUiDisabledIT extends ModuleIntegrationTest {
+  // NOTE: To run the following tests locally, you need an elasticsearch container active.
+
+  @LocalServerPort private int port;
+  @Autowired private WebApplicationContext context;
+  @Autowired private ObjectMapper objectMapper;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean private TaskStore taskStore;
+
+  private TestRestTemplate restTemplate;
+  private MockMvcHelper mockMvcHelper;
+
+  @BeforeEach
+  public void setUp() {
+    assumeTrue(TestUtil.isElasticSearch());
+    restTemplate = new TestRestTemplate();
+
+    mockMvcHelper =
+        new MockMvcHelper(MockMvcBuilders.webAppContextSetup(context).build(), objectMapper);
+
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(CamundaAuthentication.of(b -> b.user("demo")));
+  }
+
+  @Test
+  public void testWebappModuleConfigurationIsPresent() {
+    assertThatNoException()
+        .isThrownBy(() -> applicationContext.getBean(WebappModuleConfiguration.class));
+  }
+
+  @Test
+  public void testTasklistIndexControllerIsMissing() {
+    assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+        .isThrownBy(() -> applicationContext.getBean(TasklistIndexController.class));
+  }
+
+  @Test
+  public void testTasklistPageReturnsError() {
+    final String baseUrl = "http://localhost:" + port;
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl + "/tasklist", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void testTasklistApiReturnsOk() {
+    final var result = mockMvcHelper.doRequest(post("/v1/tasks/search"));
+    // This can fail if the schema is not ready, but the important thing is that we get either a
+    // 200 or a 500, and not a 404, meaning that the endpoint is present and can be reached.
+    assertThat(result.getStatus()).isNotEqualTo(HttpStatus.NOT_FOUND.value());
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
@@ -10,8 +10,8 @@ package io.camunda.tasklist.util;
 import static io.camunda.tasklist.util.TestCheck.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
@@ -19,17 +19,12 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(
-    prefix = TasklistProperties.PREFIX,
-    name = "webappEnabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 @Conditional(ElasticSearchCondition.class)
 public class ElasticsearchChecks {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
@@ -10,8 +10,8 @@ package io.camunda.tasklist.util;
 import static io.camunda.tasklist.util.TestCheck.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskState;
@@ -19,17 +19,12 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(
-    prefix = TasklistProperties.PREFIX,
-    name = "webappEnabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 @Conditional(OpenSearchCondition.class)
 public class OpenSearchChecks {
 

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -371,6 +371,10 @@
       <artifactId>camunda-security-protocol</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>configuration</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.tasklist;
 
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -25,10 +25,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
           pattern = "io\\.camunda\\.tasklist\\.webapp\\.management\\..*")
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.tasklist.webapp-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 public class WebappModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebappModuleConfiguration.class);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.management;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import io.camunda.configuration.conditions.ConditionalOnWebappEnabled;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -16,8 +16,5 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @ComponentScan(
     basePackages = "io.camunda.tasklist.webapp.management",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@ConditionalOnProperty(
-    name = "camunda.tasklist.webapp-enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnWebappEnabled("tasklist")
 public class WebappManagementModuleConfiguration {}


### PR DESCRIPTION
## Description

Context:
https://github.com/camunda/camunda/issues/40920

Caveats:
* I couldn't find identity tests directories, so I tested operate and tasklist only
* There is a project going on that aims at renaming Identity with Admin. This PR is already rebased on some of its content, but more is expected to come. For context: https://camunda.slack.com/archives/C08QKAZNSR0/p1771415607153999

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/40920
