### PR TITLE
fix: Add missing support for custom headers

### DIFF
--- a/zeebe/exporters/app-integrations-exporter/README.md
+++ b/zeebe/exporters/app-integrations-exporter/README.md
@@ -65,9 +65,16 @@ Additional configuration options:
 
 ### Authentication
 
-The exporter supports API key authentication. You can provide the API key via the `apiKey` configuration property. The exporter will include the API key in the `Authorization` header of each HTTP request as a Bearer token:
+The exporter supports different authentication mechanisms.
+Currently, it supports API key authentication as well as no authentication (if the backend does not require it).
 
-```Authorization: Bearer myAPIKey```
+#### Example of API key authentication:
+
+You can provide the API key via the `apiKey` configuration property. The exporter will include the API key in the `x-api-key` header of each HTTP request:
+
+```
+x-api-key: myAPIKey
+```
 
 ## Development
 

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/Config.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/Config.java
@@ -20,9 +20,9 @@ public class Config {
   private long requestTimeoutMs = 5000;
 
   // Batch settings
-  private int maxBatchesInFlight = 2;
   private int batchSize = 50;
   private Long batchIntervalMs = 2000L;
+  private int maxBatchesInFlight = 2;
 
   public String getUrl() {
     return url;

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/event/Event.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/event/Event.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.appint.event;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public sealed interface Event {
@@ -28,6 +29,7 @@ public sealed interface Event {
   record UserTaskMetaData(
       String userTaskKey,
       Set<String> tags,
+      Map<String, String> customHeaders,
       String assignee,
       List<String> candidateGroups,
       List<String> candidateUsers,

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/mapper/SupportedRecordsMapper.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/mapper/SupportedRecordsMapper.java
@@ -79,6 +79,7 @@ public class SupportedRecordsMapper implements RecordMapper<Event> {
     return new Event.UserTaskMetaData(
         String.valueOf(record.getValue().getUserTaskKey()),
         record.getValue().getTags(),
+        record.getValue().getCustomHeaders(),
         record.getValue().getAssignee(),
         record.getValue().getCandidateGroupsList(),
         record.getValue().getCandidateUsersList(),


### PR DESCRIPTION
## Description

This PR adds missing support for exporting UserTask custom headers for the App Integrations exporter.

## Related issues

relates to #41956
