### PR TITLE
perf: write `<data>` fields in SBE without calling `getLength`

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -167,19 +167,18 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    {
-      final var authInfoHeaderPosition = encoder.limit();
-      final var length =
-          authorization.write(
-              buffer, authInfoHeaderPosition + RecordMetadataEncoder.authorizationHeaderLength());
-      buffer.putInt(authInfoHeaderPosition, length, RecordMetadataEncoder.BYTE_ORDER);
-      encoder.limit(
-          authInfoHeaderPosition + RecordMetadataEncoder.authorizationHeaderLength() + length);
-    }
+    BufferUtil.writeLengthPrefixed(
+        authorization,
+        encoder,
+        RecordMetadataEncoder.authorizationHeaderLength(),
+        RecordMetadataEncoder.BYTE_ORDER);
 
     if (agent != null) {
-      final var bb = agent.toDirectBuffer();
-      encoder.putAgent(bb, 0, bb.capacity());
+      BufferUtil.writeLengthPrefixed(
+          agent,
+          encoder,
+          RecordMetadataEncoder.agentHeaderLength(),
+          RecordMetadataEncoder.BYTE_ORDER);
     } else {
       encoder.agent("");
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -167,8 +167,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    final var authorizationBuffer = authorization.toDirectBuffer();
-    encoder.putAuthorization(authorizationBuffer, 0, authorizationBuffer.capacity());
+    {
+      final var authInfoHeaderPosition = encoder.limit();
+      final var length =
+          authorization.write(
+              buffer, authInfoHeaderPosition + RecordMetadataEncoder.authorizationHeaderLength());
+      buffer.putInt(authInfoHeaderPosition, length, RecordMetadataEncoder.BYTE_ORDER);
+      encoder.limit(
+          authInfoHeaderPosition + RecordMetadataEncoder.authorizationHeaderLength() + length);
+    }
 
     if (agent != null) {
       final var bb = agent.toDirectBuffer();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -10,11 +10,13 @@ package io.camunda.zeebe.util.buffer;
 import static io.camunda.zeebe.util.EnsureUtil.ensureGreaterThanOrEqual;
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.sbe.MessageEncoderFlyweight;
 
 public final class BufferUtil {
   public static final int NO_WRAP = 1;
@@ -206,6 +208,30 @@ public final class BufferUtil {
 
   public static MutableDirectBuffer wrapArray(final byte[] array) {
     return new UnsafeBuffer(array);
+  }
+
+  /**
+   * Writes a {@link BufferWriter} into an SBE encoder as a variable-length field.
+   *
+   * <p>At the encoder's current limit, writes the content length as a 4-byte integer header (using
+   * {@code byteOrder}), followed by the content bytes, then advances the encoder's limit by {@code
+   * headerLength + contentLength}.
+   *
+   * @param writer the writer whose content to encode
+   * @param encoder the SBE encoder to write into; its limit is advanced after writing
+   * @param headerLength the byte width of the length prefix field (typically 4, as returned by
+   *     e.g. {@code RecordMetadataEncoder.authorizationHeaderLength()})
+   * @param byteOrder the byte order for the length header
+   */
+  public static void writeLengthPrefixed(
+      final BufferWriter writer,
+      final MessageEncoderFlyweight encoder,
+      final int headerLength,
+      final ByteOrder byteOrder) {
+    final var offset = encoder.limit();
+    final var length = writer.write(encoder.buffer(), offset + headerLength);
+    encoder.buffer().putInt(offset, length, byteOrder);
+    encoder.limit(offset + headerLength + length);
   }
 
   /**

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -211,16 +211,13 @@ public final class BufferUtil {
   }
 
   /**
-   * Writes a {@link BufferWriter} into an SBE encoder as a variable-length field.
-   *
-   * <p>At the encoder's current limit, writes the content length as a 4-byte integer header (using
-   * {@code byteOrder}), followed by the content bytes, then advances the encoder's limit by {@code
-   * headerLength + contentLength}.
+   * Writes a {@link BufferWriter} into an SBE encoder as a variable-length field. The content
+   * length is written at `encoder.limit()` and the content itself is written at `encoder.limit() +
+   * headerLength`. Then, the `encoder.limit` is increased by the written bytes
    *
    * @param writer the writer whose content to encode
-   * @param encoder the SBE encoder to write into; its limit is advanced after writing
-   * @param headerLength the byte width of the length prefix field (typically 4, as returned by e.g.
-   *     {@code RecordMetadataEncoder.authorizationHeaderLength()})
+   * @param encoder the SBE encoder to write into
+   * @param headerLength the byte width of the length prefix field (typically 4)
    * @param byteOrder the byte order for the length header
    */
   public static void writeLengthPrefixed(

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -219,8 +219,8 @@ public final class BufferUtil {
    *
    * @param writer the writer whose content to encode
    * @param encoder the SBE encoder to write into; its limit is advanced after writing
-   * @param headerLength the byte width of the length prefix field (typically 4, as returned by
-   *     e.g. {@code RecordMetadataEncoder.authorizationHeaderLength()})
+   * @param headerLength the byte width of the length prefix field (typically 4, as returned by e.g.
+   *     {@code RecordMetadataEncoder.authorizationHeaderLength()})
    * @param byteOrder the byte order for the length header
    */
   public static void writeLengthPrefixed(


### PR DESCRIPTION

## Description
In the previous version, AuthInfo.toByteBuffer was calling first `AuthInfo.getLength()` and then allocating a `byte[]` with the exact size.
However, we can just write directly in the buffer without any copies and without calling `getLength` before.

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] PR #44818
