### PR TITLE
feat: add TenantFilter enum to camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/enums/TenantFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/enums/TenantFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command.enums;
+
+/**
+ * Protocol agnostic tenant filter. See {@link
+ * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TenantFilter} and {@link
+ * io.camunda.client.protocol.rest.TenantFilterEnum}.
+ *
+ * <p>Used only during job activation.
+ */
+public enum TenantFilter {
+  /**
+   * When set, the tenants assigned to the authenticated principal (for example, a user or client)
+   * are resolved dynamically when the job is activated. This means you don't need to know in
+   * advance which tenants to use; instead, the activated jobs depend on the tenant assignments
+   * configured for the authenticated principal in your identity and authorization setup.
+   */
+  ASSIGNED,
+  /**
+   * When set, the command uses the tenant IDs supplied with the request (for example, those
+   * configured via {@link
+   * io.camunda.client.api.command.CommandWithOneOrMoreTenantsStep#tenantIds(java.util.List)} or
+   * client defaults), and only jobs associated with those tenants, if any, will be activated.
+   */
+  PROVIDED
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds in a Camunda Client scoped enum for the new `TenantFilter` feature support implemented in the issues related and captured under the linked issues parent.

As each path (REST/gRPC) maintain their own separated implementation of the TenantFilter enum, we provide helper methods to handle the conversion into the expected format for downstream. 

I have separated out this change as the next change will be a bit larger where I will use this TenantFilter and wire it into the configuration for the various builders and spring client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45347
