### PR TITLE
test: add QA acceptance tests for user task migration with forms

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -45,6 +45,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.statistics.response.GlobalJobStatistics;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
@@ -556,6 +557,19 @@ public final class TestHelper {
         "should have items with state",
         expectedCount,
         page -> client.newUserTaskSearchRequest().filter(filter).page(page).execute());
+  }
+
+  public static UserTask waitForUserTask(
+      final CamundaClient client, final Consumer<UserTaskFilter> filter) {
+    final UserTask[] migratedTask = new UserTask[1];
+    Awaitility.await("Should find user task with filter")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              migratedTask[0] =
+                  client.newUserTaskSearchRequest().filter(filter).send().join().singleItem();
+            });
+    return migratedTask[0];
   }
 
   public static void waitForBatchOperationWithCorrectTotalCount(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -80,14 +80,7 @@ public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTa
 
   @Override
   public void updateEntity(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
-    entity.setProcessInstanceId(String.valueOf(record.getValue().getProcessInstanceKey()));
-    entity.setAction(record.getValue().getAction());
-    entity.setKey(record.getKey());
     createTaskEntity(entity, record);
-    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
-    joinRelation.setName(TaskJoinRelationshipType.TASK.getType());
-    joinRelation.setParent(Long.parseLong(entity.getProcessInstanceId()));
-    entity.setJoin(joinRelation);
   }
 
   @Override
@@ -110,6 +103,7 @@ public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTa
     final var formKey = taskValue.getFormKey() > 0 ? String.valueOf(taskValue.getFormKey()) : null;
 
     entity
+        .setKey(record.getKey())
         .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
         .setState(TaskState.CREATING)
         .setFlowNodeInstanceId(String.valueOf(taskValue.getElementInstanceKey()))
@@ -153,6 +147,10 @@ public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTa
     if (rootProcessInstanceKey > 0) {
       entity.setRootProcessInstanceKey(rootProcessInstanceKey);
     }
+    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
+    joinRelation.setName(TaskJoinRelationshipType.TASK.getType());
+    joinRelation.setParent(Long.parseLong(entity.getProcessInstanceId()));
+    entity.setJoin(joinRelation);
   }
 
   private boolean refersToPreviousVersionRecord(final long key) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds user task interaction verification after migration and more form migration test cases, including verification for more properties (due date, followup date, candidate users and groups) and refactored the test slightly.

Also includes a small refactoring of the UserTaskCreatingHandler that was [noted in a previous PR](https://github.com/camunda/camunda/pull/45039#discussion_r2803916831).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/44635
