### PR TITLE
feat: allow parameter `--to` to be optional by using unbounded `Interval`

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -656,6 +656,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,6 +72,7 @@
     <version.jackson3>3.0.4</version.jackson3>
     <version.json-base>3.0.0</version.json-base>
     <version.json-flattener>0.18.0</version.json-flattener>
+    <version.jspecify>1.0.0</version.jspecify>
     <version.junit>6.0.3</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.3</version.log4j>
@@ -2036,6 +2037,12 @@
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
         <version>${version.jakarta-activation}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${version.jspecify}</version>
       </dependency>
 
       <!-- required between me.dinowernli:java-grpc-prometheus and com.google.guava:guava -->

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -121,6 +121,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
@@ -13,11 +13,14 @@ import io.camunda.zeebe.backup.common.CheckpointIdGenerator;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Similar to {@link BackupIdentifier} but fields that are omitted should be interpreted as a
  * wildcard.
  */
+@NullMarked
 public interface BackupIdentifierWildcard {
   /**
    * @return id of the broker which took this backup.
@@ -109,7 +112,7 @@ public interface BackupIdentifierWildcard {
       return new Exact(checkpointId);
     }
 
-    static CheckpointPattern of(final String pattern) {
+    static CheckpointPattern of(@Nullable final String pattern) {
       if (pattern == null || pattern.isEmpty() || "*".equals(pattern)) {
         return new Any();
       } else if (pattern.endsWith("*")) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/Interval.java
@@ -7,24 +7,39 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import com.esotericsoftware.kryo.util.Null;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a generic range with a start and end value, with configurable inclusiveness for each
- * bound.
+ * bound. Supports unbounded intervals by allowing null values for start and/or end.
+ *
+ * <p>Unbounded intervals:
+ *
+ * <ul>
+ *   <li>{@code start = null}: represents negative infinity (-infinity)
+ *   <li>{@code end = null}: represents positive infinity (infinity)
+ *   <li>Both null: represents the entire domain (-infinity, infinity)
+ * </ul>
+ *
+ * <p>When a bound is null (unbounded), the inclusiveness flag is ignored since infinity is not a
+ * reachable value. Unbounded ends are always treated as exclusive.
  *
  * @param <T> the type of the range values, must be comparable
- * @param start the first value in the range
- * @param startInclusive whether the start bound is inclusive
- * @param end the last value in the range
- * @param endInclusive whether the end bound is inclusive
+ * @param start the first value in the range, or null for negative infinity
+ * @param startInclusive whether the start bound is inclusive (ignored if start is null)
+ * @param end the last value in the range, or null for positive infinity
+ * @param endInclusive whether the end bound is inclusive (ignored if end is null)
  */
-public record Interval<T extends Comparable<T>>(
+@NullMarked
+public record Interval<T extends @Nullable Comparable<T>>(
     T start, boolean startInclusive, T end, boolean endInclusive) {
 
   /** For start bounds, inclusive is "before" exclusive when values are equal. */
@@ -34,18 +49,19 @@ public record Interval<T extends Comparable<T>>(
   private static final int END_INCLUSIVE_SIGN = 1;
 
   public Interval {
-    Objects.requireNonNull(start, "start must not be null");
-    Objects.requireNonNull(end, "end must not be null");
-    final var comparison = start.compareTo(end);
-    if (comparison > 0) {
-      throw new IllegalArgumentException(
-          "Expected start <= end, but got start = %s, end = %s".formatted(start, end));
-    }
-    // For equal bounds, both must be inclusive or the interval is empty/invalid
-    if (comparison == 0 && (!startInclusive || !endInclusive)) {
-      throw new IllegalArgumentException(
-          "Interval with equal bounds must be inclusive on both sides, got %s%s, %s%s"
-              .formatted(startInclusive ? "[" : "(", start, end, endInclusive ? "]" : ")"));
+    // Both bounds can be null (unbounded), but if both are present, start must be <= end
+    if (start != null && end != null) {
+      final var comparison = start.compareTo(end);
+      if (comparison > 0) {
+        throw new IllegalArgumentException(
+            "Expected start <= end, but got start = %s, end = %s".formatted(start, end));
+      }
+      // For equal bounds, both must be inclusive or the interval is empty/invalid
+      if (comparison == 0 && (!startInclusive || !endInclusive)) {
+        throw new IllegalArgumentException(
+            "Interval with equal bounds must be inclusive on both sides, got %s%s, %s%s"
+                .formatted(startInclusive ? "[" : "(", start, end, endInclusive ? "]" : ")"));
+      }
     }
   }
 
@@ -55,7 +71,7 @@ public record Interval<T extends Comparable<T>>(
    * @param start the first value in the range (inclusive)
    * @param end the last value in the range (inclusive)
    */
-  public Interval(final T start, final T end) {
+  public Interval(@Nullable final T start, @Null final T end) {
     this(start, true, end, true);
   }
 
@@ -66,7 +82,7 @@ public record Interval<T extends Comparable<T>>(
    * @param end the last value in the range (inclusive)
    * @return a new closed interval
    */
-  public static <T extends Comparable<T>> Interval<T> closed(final T start, final T end) {
+  public static <T extends @Nullable Comparable<T>> Interval<T> closed(final T start, final T end) {
     return new Interval<>(start, true, end, true);
   }
 
@@ -77,7 +93,7 @@ public record Interval<T extends Comparable<T>>(
    * @param end the last value in the range (exclusive)
    * @return a new open interval
    */
-  public static <T extends Comparable<T>> Interval<T> open(final T start, final T end) {
+  public static <T extends @Nullable Comparable<T>> Interval<T> open(final T start, final T end) {
     return new Interval<>(start, false, end, false);
   }
 
@@ -88,7 +104,8 @@ public record Interval<T extends Comparable<T>>(
    * @param end the last value in the range (exclusive)
    * @return a new half-open interval
    */
-  public static <T extends Comparable<T>> Interval<T> closedOpen(final T start, final T end) {
+  public static <T extends @Nullable Comparable<T>> Interval<T> closedOpen(
+      final T start, final T end) {
     return new Interval<>(start, true, end, false);
   }
 
@@ -99,7 +116,8 @@ public record Interval<T extends Comparable<T>>(
    * @param end the last value in the range (inclusive)
    * @return a new half-open interval
    */
-  public static <T extends Comparable<T>> Interval<T> openClosed(final T start, final T end) {
+  public static <T extends @Nullable Comparable<T>> Interval<T> openClosed(
+      final T start, final T end) {
     return new Interval<>(start, false, end, true);
   }
 
@@ -114,7 +132,7 @@ public record Interval<T extends Comparable<T>>(
    * @return A new Interval instance with the updated end value, while preserving the start, start
    *     inclusion, and end inclusion properties of the original interval.
    */
-  public Interval<T> withEnd(final T newEnd) {
+  public Interval<T> withEnd(@Nullable final T newEnd) {
     return new Interval<>(start, startInclusive, newEnd, endInclusive);
   }
 
@@ -125,7 +143,7 @@ public record Interval<T extends Comparable<T>>(
    * @param newStart the new start value for the interval
    * @return a new Interval instance with the updated start value
    */
-  public Interval<T> withStart(final T newStart) {
+  public Interval<T> withStart(@Nullable final T newStart) {
     return new Interval<>(newStart, startInclusive, end, endInclusive);
   }
 
@@ -135,6 +153,13 @@ public record Interval<T extends Comparable<T>>(
 
   public Interval<T> withEndInclusive(final boolean endInclusive) {
     return new Interval<>(start, startInclusive, end, endInclusive);
+  }
+
+  /**
+   * @return if the interval is unbounded in at least one direction
+   */
+  public boolean isUnbounded() {
+    return start == null || end == null;
   }
 
   /**
@@ -186,12 +211,15 @@ public record Interval<T extends Comparable<T>>(
     }
 
     // Check if the resulting interval is valid
-    final var comparison = maxStart.compareTo(minEnd);
-    if (comparison > 0) {
-      return Optional.empty();
-    }
-    if (comparison == 0 && (!maxStartInclusive || !minEndInclusive)) {
-      return Optional.empty();
+    // If either bound is null (unbounded), the interval is valid
+    if (maxStart != null && minEnd != null) {
+      final var comparison = maxStart.compareTo(minEnd);
+      if (comparison > 0) {
+        return Optional.empty();
+      }
+      if (comparison == 0 && (!maxStartInclusive || !minEndInclusive)) {
+        return Optional.empty();
+      }
     }
 
     return Optional.of(new Interval<>(maxStart, maxStartInclusive, minEnd, minEndInclusive));
@@ -202,7 +230,7 @@ public record Interval<T extends Comparable<T>>(
    *
    * @see #smallestCover(List, Function)
    */
-  public List<T> smallestCover(final List<T> sortedPoints) {
+  public List<T> smallestCover(final List<@NonNull T> sortedPoints) {
     return smallestCover(sortedPoints, Function.identity());
   }
 
@@ -224,6 +252,13 @@ public record Interval<T extends Comparable<T>>(
    * point at or after the interval end. If the points cannot cover the interval, an empty list is
    * returned.
    *
+   * <p>For unbounded intervals:
+   *
+   * <ul>
+   *   <li>If start is null (-infinity), start coverage is always satisfied
+   *   <li>If end is null (+infinity), end coverage is always satisfied
+   * </ul>
+   *
    * <p>Examples:
    *
    * <ul>
@@ -233,6 +268,8 @@ public record Interval<T extends Comparable<T>>(
    *       after 6)
    *   <li>Interval [4, 6], points [1, 3, 7, 9] &rarr; [3, 7] (no points within, neighbors cover)
    *   <li>Interval [10, 20], points [1, 3, 5] &rarr; [] (no coverage at end)
+   *   <li>Interval [5, infinity), points [1, 3, 7, 9] &rarr; [3, 7, 9] (all from lastBefore onward)
+   *   <li>Interval (-infinity, 5], points [1, 3, 7, 9] &rarr; [1, 3, 7] (all up to firstAfter)
    * </ul>
    *
    * <p>This is useful when the points are of a different type than the interval bounds. For
@@ -245,7 +282,8 @@ public record Interval<T extends Comparable<T>>(
    * @return the subset of points that covers this interval, or empty if no cover exists
    * @param <S> the type of the points
    */
-  public <S> List<S> smallestCover(final List<S> sortedPoints, final Function<S, T> mapper) {
+  public <S> List<S> smallestCover(
+      final List<S> sortedPoints, final Function<S, @NonNull T> mapper) {
     S lastBefore = null;
     S firstAfter = null;
     final var within = new ArrayList<S>();
@@ -259,25 +297,44 @@ public record Interval<T extends Comparable<T>>(
                 .formatted(value, previousValue));
       }
       previousValue = value;
-      if (value.compareTo(start) < 0) {
+
+      // Determine where this point falls relative to the interval
+      final boolean beforeStart = start != null && value.compareTo(start) < 0;
+      final boolean afterEnd = end != null && value.compareTo(end) > 0;
+
+      if (beforeStart) {
         lastBefore = point;
-      } else if (value.compareTo(end) > 0) {
+      } else if (afterEnd) {
         if (firstAfter == null) {
           firstAfter = point;
         }
       } else {
+        // Point is within the interval (or unbounded on that side)
         within.add(point);
       }
     }
 
-    // A valid cover requires at least one point at-or-before start
-    // and at least one point at-or-after end
-    final var hasStartCoverage =
-        lastBefore != null
-            || (!within.isEmpty() && mapper.apply(within.getFirst()).compareTo(start) <= 0);
-    final var hasEndCoverage =
-        firstAfter != null
-            || (!within.isEmpty() && mapper.apply(within.getLast()).compareTo(end) >= 0);
+    // A valid cover requires at least one point at-or-before start (or start is unbounded)
+    // and at least one point at-or-after end (or end is unbounded)
+    final boolean hasStartCoverage;
+    if (start == null) {
+      // Unbounded start: always covered
+      hasStartCoverage = true;
+    } else {
+      hasStartCoverage =
+          lastBefore != null
+              || (!within.isEmpty() && mapper.apply(within.getFirst()).compareTo(start) <= 0);
+    }
+
+    final boolean hasEndCoverage;
+    if (end == null) {
+      // Unbounded end: always covered
+      hasEndCoverage = true;
+    } else {
+      hasEndCoverage =
+          firstAfter != null
+              || (!within.isEmpty() && mapper.apply(within.getLast()).compareTo(end) >= 0);
+    }
 
     if (!hasStartCoverage || !hasEndCoverage) {
       return List.of();
@@ -286,17 +343,19 @@ public record Interval<T extends Comparable<T>>(
     final var result = new ArrayList<S>();
 
     // Include last point before start if no point has an exact match at start
-    if (lastBefore != null
-        && (within.isEmpty() || mapper.apply(within.getFirst()).compareTo(start) != 0)) {
-      result.add(lastBefore);
+    if (lastBefore != null) {
+      if (within.isEmpty() || mapper.apply(within.getFirst()).compareTo(start) != 0) {
+        result.add(lastBefore);
+      }
     }
 
     result.addAll(within);
 
     // Include first point after end if no point has an exact match at end
-    if (firstAfter != null
-        && (within.isEmpty() || mapper.apply(within.getLast()).compareTo(end) != 0)) {
-      result.add(firstAfter);
+    if (firstAfter != null) {
+      if (within.isEmpty() || mapper.apply(within.getLast()).compareTo(end) != 0) {
+        result.add(firstAfter);
+      }
     }
 
     return result;
@@ -314,15 +373,27 @@ public record Interval<T extends Comparable<T>>(
   }
 
   /**
-   * @param value the value to check
+   * @param value the value to check (must not be null)
    * @return true if the value is within this interval
    */
-  public boolean contains(final T value) {
-    final var startComparison = value.compareTo(start);
-    final var endComparison = value.compareTo(end);
+  public boolean contains(final @NonNull T value) {
+    // Null start means -infinity, so any value is after start
+    final boolean afterStart;
+    if (start == null) {
+      afterStart = true;
+    } else {
+      final var startComparison = value.compareTo(start);
+      afterStart = startInclusive ? startComparison >= 0 : startComparison > 0;
+    }
 
-    final var afterStart = startInclusive ? startComparison >= 0 : startComparison > 0;
-    final var beforeEnd = endInclusive ? endComparison <= 0 : endComparison < 0;
+    // Null end means +infinity, so any value is before end
+    final boolean beforeEnd;
+    if (end == null) {
+      beforeEnd = true;
+    } else {
+      final var endComparison = value.compareTo(end);
+      beforeEnd = endInclusive ? endComparison <= 0 : endComparison < 0;
+    }
 
     return afterStart && beforeEnd;
   }
@@ -359,6 +430,14 @@ public record Interval<T extends Comparable<T>>(
    * @return true if this interval is entirely before the other (no overlap)
    */
   public boolean isBefore(final Interval<T> other) {
+    // If this interval extends to +infinity, it can never be entirely before another
+    if (end == null) {
+      return false;
+    }
+    // If other interval extends from -infinity, this can never be before it
+    if (other.start == null) {
+      return false;
+    }
     final var comparison = end.compareTo(other.start);
     return comparison < 0 || (comparison == 0 && (!endInclusive || !other.startInclusive));
   }
@@ -381,43 +460,89 @@ public record Interval<T extends Comparable<T>>(
 
   /**
    * Maps this interval to a new interval by applying the given function to both start and end
-   * values.
+   * values. Null bounds (representing infinity) are preserved as null in the result.
    *
    * @param <U> the type of the resulting interval values
-   * @param mapper the function to apply to start and end values
+   * @param mapper the function to apply to start and end values (not called for null bounds)
    * @return a new interval with transformed values
    */
-  public <U extends Comparable<U>> Interval<U> map(final Function<T, U> mapper) {
-    return new Interval<>(mapper.apply(start), startInclusive, mapper.apply(end), endInclusive);
+  public <U extends @Nullable Comparable<U>> Interval<U> map(final Function<@NonNull T, U> mapper) {
+    return new Interval<>(
+        Optional.ofNullable(start).map(mapper).orElse(null),
+        startInclusive,
+        Optional.ofNullable(end).map(mapper).orElse(null),
+        endInclusive);
   }
 
   /**
    * Returns the mathematical notation for this interval.
    *
+   * <p>Unbounded intervals use "infinity" notation:
+   *
+   * <ul>
+   *   <li>{@code (-infinity, 10]} - left-unbounded
+   *   <li>{@code [5, infinity)} - right-unbounded
+   *   <li>{@code (-infinity, infinity)} - fully unbounded
+   * </ul>
+   *
    * @return string representation using [ ] for inclusive and ( ) for exclusive bounds
    */
   @Override
   public String toString() {
-    return "%s%s, %s%s".formatted(startInclusive ? "[" : "(", start, end, endInclusive ? "]" : ")");
+    // Null bounds are always exclusive (infinity is not reachable)
+    final var startBracket = (start == null || !startInclusive) ? "(" : "[";
+    final var endBracket = (end == null || !endInclusive) ? ")" : "]";
+    final var startStr = start != null ? start.toString() : "-infinity";
+    final var endStr = end != null ? end.toString() : "infinity";
+    return "%s%s, %s%s".formatted(startBracket, startStr, endStr, endBracket);
   }
 
   /**
-   * Compares bounds considering inclusiveness.
+   * Compares bounds considering inclusiveness and null values (representing infinity).
    *
-   * @param bound1 the first bound value
-   * @param inclusive1 whether the first bound is inclusive
-   * @param bound2 the second bound value
-   * @param inclusive2 whether the second bound is inclusive
+   * <p>For start bounds (inclusiveSign = -1):
+   *
+   * <ul>
+   *   <li>null represents -infinity (smallest possible value)
+   *   <li>null is always "before" any non-null value
+   * </ul>
+   *
+   * <p>For end bounds (inclusiveSign = +1):
+   *
+   * <ul>
+   *   <li>null represents +infinity (largest possible value)
+   *   <li>null is always "after" any non-null value
+   * </ul>
+   *
+   * @param bound1 the first bound value (null for infinity)
+   * @param inclusive1 whether the first bound is inclusive (ignored if null)
+   * @param bound2 the second bound value (null for infinity)
+   * @param inclusive2 whether the second bound is inclusive (ignored if null)
    * @param inclusiveSign -1 for start bounds (inclusive is "before"), +1 for end bounds (inclusive
    *     is "after")
    * @return negative if first bound is "before", positive if "after", 0 if equal
    */
   private static <T extends Comparable<T>> int compareBound(
-      final T bound1,
+      @Nullable final T bound1,
       final boolean inclusive1,
-      final T bound2,
+      @Nullable final T bound2,
       final boolean inclusive2,
       final int inclusiveSign) {
+    // Handle null (infinity) cases
+    if (bound1 == null && bound2 == null) {
+      return 0; // Both are infinity (same direction based on inclusiveSign)
+    }
+    if (bound1 == null) {
+      // For start bounds: null (-infinity) is before any value -> negative
+      // For end bounds: null (+infinity) is after any value -> positive
+      return inclusiveSign;
+    }
+    if (bound2 == null) {
+      // Opposite of above
+      return -inclusiveSign;
+    }
+
+    // Both bounds are non-null, compare normally
     final var comparison = bound1.compareTo(bound2);
     if (comparison != 0) {
       return comparison;

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalPropertyTest.java
@@ -20,6 +20,8 @@ import net.jqwik.api.Combinators;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Property-based tests for {@link Interval} that verify mathematical properties hold for all valid
@@ -29,8 +31,9 @@ final class IntervalPropertyTest {
 
   // ==================== Arbitrary Providers ====================
 
+  /** Generates bounded intervals with non-null start and end. */
   @Provide
-  Arbitrary<Interval<Integer>> intervals() {
+  Arbitrary<Interval<@NonNull Integer>> boundedIntervals() {
     final var start = Arbitraries.integers().between(-1000, 1000);
     final var length = Arbitraries.integers().between(0, 500);
     final var startInclusive = Arbitraries.of(true, false);
@@ -46,6 +49,44 @@ final class IntervalPropertyTest {
               }
               return new Interval<>(s, si, end, ei);
             });
+  }
+
+  /** Generates left-unbounded intervals: (-infinity, end]. */
+  @Provide
+  Arbitrary<Interval<Integer>> leftUnboundedIntervals() {
+    final var end = Arbitraries.integers().between(-1000, 1000);
+    final var endInclusive = Arbitraries.of(true, false);
+
+    return Combinators.combine(end, endInclusive).as((e, ei) -> new Interval<>(null, false, e, ei));
+  }
+
+  /** Generates right-unbounded intervals: [start, +infinity). */
+  @Provide
+  Arbitrary<Interval<Integer>> rightUnboundedIntervals() {
+    final var start = Arbitraries.integers().between(-1000, 1000);
+    final var startInclusive = Arbitraries.of(true, false);
+
+    return Combinators.combine(start, startInclusive)
+        .as((s, si) -> new Interval<>(s, si, null, false));
+  }
+
+  /** Generates fully unbounded intervals: (-infinity, +infinity). */
+  @Provide
+  Arbitrary<Interval<Integer>> fullyUnboundedIntervals() {
+    return Arbitraries.just(new Interval<>(null, false, null, false));
+  }
+
+  /**
+   * Generates all types of intervals: bounded, left-unbounded, right-unbounded, and fully
+   * unbounded. The distribution is weighted to include ~20% unbounded intervals.
+   */
+  @Provide
+  Arbitrary<Interval<Integer>> intervals() {
+    return Arbitraries.frequencyOf(
+        Tuple.of(8, boundedIntervals()),
+        Tuple.of(1, leftUnboundedIntervals()),
+        Tuple.of(1, rightUnboundedIntervals()),
+        Tuple.of(1, fullyUnboundedIntervals()));
   }
 
   @Provide
@@ -239,8 +280,8 @@ final class IntervalPropertyTest {
   }
 
   @Property(tries = 100)
-  void mapPreservesBoundBehavior(@ForAll("intervals") final Interval<Integer> a) {
-    // Mapping should preserve the bound behavior
+  void mapPreservesBoundBehavior(@ForAll("boundedIntervals") final Interval<Integer> a) {
+    // Mapping should preserve the bound behavior (only for bounded intervals)
     final var mapped = a.map(x -> x * 2L);
 
     // Start bound behavior preserved
@@ -265,18 +306,24 @@ final class IntervalPropertyTest {
   // ==================== Contains Value ====================
 
   @Property(tries = 100)
-  void containsValueAtStartDependsOnInclusiveness(@ForAll("intervals") final Interval<Integer> a) {
+  void containsValueAtStartDependsOnInclusiveness(
+      @ForAll("boundedIntervals") final Interval<Integer> a) {
+    // Only test for bounded intervals where start is non-null
     assertThat(a.contains(a.start())).isEqualTo(a.startInclusive());
   }
 
   @Property(tries = 100)
-  void containsValueAtEndDependsOnInclusiveness(@ForAll("intervals") final Interval<Integer> a) {
+  void containsValueAtEndDependsOnInclusiveness(
+      @ForAll("boundedIntervals") final Interval<Integer> a) {
+    // Only test for bounded intervals where end is non-null
     assertThat(a.contains(a.end())).isEqualTo(a.endInclusive());
   }
 
   @Property(tries = 100)
   void valuesOutsideIntervalAreNeverContained(
-      @ForAll("intervals") final Interval<Integer> a, @ForAll("values") final Integer value) {
+      @ForAll("boundedIntervals") final Interval<Integer> a,
+      @ForAll("values") final Integer value) {
+    // Only test for bounded intervals where bounds are non-null
     if (value < a.start() || value > a.end()) {
       assertThat(a.contains(value)).isFalse();
     }
@@ -284,7 +331,9 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void valuesStrictlyInsideIntervalAreAlwaysContained(
-      @ForAll("intervals") final Interval<Integer> a, @ForAll("values") final Integer value) {
+      @ForAll("boundedIntervals") final Interval<Integer> a,
+      @ForAll("values") final Integer value) {
+    // Only test for bounded intervals where bounds are non-null
     if (value > a.start() && value < a.end()) {
       assertThat(a.contains(value)).isTrue();
     }
@@ -363,9 +412,10 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void smallestCoverContainsAllPointsWithinIntervalWhenCoverExists(
-      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("boundedIntervals") final Interval<Integer> query,
       @ForAll("sortedPoints") final List<Integer> points) {
     // When a cover exists, all points within the interval must be in the result
+    // Only test for bounded intervals where bounds are non-null
     final var result = query.smallestCover(points);
 
     if (!result.isEmpty()) {
@@ -381,10 +431,11 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void smallestCoverIsEmptyWhenPointsCannotCover(
-      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("boundedIntervals") final Interval<Integer> query,
       @ForAll("sortedPoints") final List<Integer> points) {
     // A cover exists iff there is at least one point at-or-before start
     // AND at least one point at-or-after end
+    // Only test for bounded intervals where bounds are non-null
     final var hasStartCoverage = points.stream().anyMatch(p -> p.compareTo(query.start()) <= 0);
     final var hasEndCoverage = points.stream().anyMatch(p -> p.compareTo(query.end()) >= 0);
     final var canCover = hasStartCoverage && hasEndCoverage;
@@ -421,8 +472,9 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void smallestCoverIncludesAtMostOnePointBeforeStart(
-      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("boundedIntervals") final Interval<Integer> query,
       @ForAll("sortedPoints") final List<Integer> points) {
+    // Only test for bounded intervals where start is non-null
     final var result = query.smallestCover(points);
 
     // Count points before interval start in result
@@ -435,8 +487,9 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void smallestCoverIncludesAtMostOnePointAfterEnd(
-      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("boundedIntervals") final Interval<Integer> query,
       @ForAll("sortedPoints") final List<Integer> points) {
+    // Only test for bounded intervals where end is non-null
     final var result = query.smallestCover(points);
 
     // Count points after interval end in result
@@ -449,8 +502,9 @@ final class IntervalPropertyTest {
 
   @Property(tries = 100)
   void smallestCoverNeighborOnlyIncludedWhenNoExactMatch(
-      @ForAll("intervals") final Interval<Integer> query,
+      @ForAll("boundedIntervals") final Interval<Integer> query,
       @ForAll("sortedPoints") final List<Integer> points) {
+    // Only test for bounded intervals where bounds are non-null
     final var result = query.smallestCover(points);
     final var withinPoints =
         points.stream()
@@ -570,5 +624,94 @@ final class IntervalPropertyTest {
           .describedAs("Intersection of %s (container) and %s (contained) should be %s", a, b, b)
           .contains(b);
     }
+  }
+
+  // ==================== Unbounded Interval Properties ====================
+
+  @Property(tries = 100)
+  void fullyUnboundedContainsAllBoundedIntervals(
+      @ForAll("fullyUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("boundedIntervals") final Interval<Integer> bounded) {
+    // (-infinity, +infinity) contains any bounded interval
+    assertThat(unbounded.contains(bounded)).isTrue();
+  }
+
+  @Property(tries = 100)
+  void fullyUnboundedContainsAllValues(
+      @ForAll("fullyUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("values") final Integer value) {
+    // (-infinity, +infinity) contains any value
+    assertThat(unbounded.contains(value)).isTrue();
+  }
+
+  @Property(tries = 100)
+  void leftUnboundedContainsValuesUpToEnd(
+      @ForAll("leftUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("values") final Integer value) {
+    // (-infinity, end] or (-infinity, end) contains values up to end
+    final var expected =
+        unbounded.endInclusive() ? value <= unbounded.end() : value < unbounded.end();
+    assertThat(unbounded.contains(value)).isEqualTo(expected);
+  }
+
+  @Property(tries = 100)
+  void rightUnboundedContainsValuesFromStart(
+      @ForAll("rightUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("values") final Integer value) {
+    // [start, +infinity) or (start, +infinity) contains values from start
+    final var expected =
+        unbounded.startInclusive() ? value >= unbounded.start() : value > unbounded.start();
+    assertThat(unbounded.contains(value)).isEqualTo(expected);
+  }
+
+  @Property(tries = 100)
+  void rightUnboundedIsNeverBeforeAnyInterval(
+      @ForAll("rightUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("intervals") final Interval<Integer> other) {
+    // An interval extending to +infinity is never before another interval
+    assertThat(unbounded.isBefore(other)).isFalse();
+  }
+
+  @Property(tries = 100)
+  void leftUnboundedIsNeverAfterAnyInterval(
+      @ForAll("leftUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("intervals") final Interval<Integer> other) {
+    // An interval extending to -infinity is never after another interval
+    assertThat(unbounded.isAfter(other)).isFalse();
+  }
+
+  @Property(tries = 100)
+  void fullyUnboundedAlwaysOverlaps(
+      @ForAll("fullyUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("intervals") final Interval<Integer> other) {
+    // (-infinity, +infinity) overlaps with everything
+    assertThat(unbounded.overlapsWith(other)).isTrue();
+  }
+
+  @Property(tries = 100)
+  void mapPreservesNullBounds(@ForAll("intervals") final Interval<Integer> a) {
+    final var mapped = a.map(x -> x * 2L);
+    // Null bounds should remain null after mapping
+    assertThat(mapped.start() == null).isEqualTo(a.start() == null);
+    assertThat(mapped.end() == null).isEqualTo(a.end() == null);
+  }
+
+  @Property(tries = 100)
+  void unboundedToStringUsesInfinityNotation(
+      @ForAll("leftUnboundedIntervals") final Interval<Integer> left,
+      @ForAll("rightUnboundedIntervals") final Interval<Integer> right,
+      @ForAll("fullyUnboundedIntervals") final Interval<Integer> fully) {
+    assertThat(left.toString()).contains("-infinity");
+    assertThat(right.toString()).contains("infinity").doesNotContain("-infinity");
+    assertThat(fully.toString()).contains("-infinity").contains("infinity");
+  }
+
+  @Property(tries = 100)
+  void smallestCoverWithUnboundedAlwaysCoversNonEmptyPoints(
+      @ForAll("fullyUnboundedIntervals") final Interval<Integer> unbounded,
+      @ForAll("sortedPoints") final List<Integer> points) {
+    // Fully unbounded interval should always have a cover if points is non-empty
+    final var result = unbounded.smallestCover(points);
+    assertThat(result).isEqualTo(points);
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/IntervalTest.java
@@ -57,20 +57,6 @@ public class IntervalTest {
       assertThat(interval.contains(5)).isTrue();
     }
 
-    @Test
-    void shouldThrowWhenStartIsNull() {
-      assertThatThrownBy(() -> new Interval<>(null, 5))
-          .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("start must not be null");
-    }
-
-    @Test
-    void shouldThrowWhenEndIsNull() {
-      assertThatThrownBy(() -> new Interval<>(1, null))
-          .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("end must not be null");
-    }
-
     @ParameterizedTest
     @CsvSource({"false, true", "true, false", "false, false"})
     void shouldThrowWhenEqualBoundsNotFullyInclusive(
@@ -751,6 +737,92 @@ public class IntervalTest {
       final var expected =
           expectedBracket(startInclusive, true) + "1, 10" + expectedBracket(endInclusive, false);
       assertThat(interval.toString()).isEqualTo(expected);
+    }
+  }
+
+  /**
+   * Basic smoke tests for unbounded intervals (null bounds). Comprehensive property-based testing
+   * for unbounded intervals is done in {@link IntervalPropertyTest}.
+   */
+  @Nested
+  class UnboundedIntervals {
+
+    @Test
+    void nullStartRepresentsNegativeInfinity() {
+      final var interval = new Interval<>(null, false, 10, true);
+
+      assertThat(interval.contains(Integer.MIN_VALUE)).isTrue();
+      assertThat(interval.contains(10)).isTrue();
+      assertThat(interval.contains(11)).isFalse();
+      assertThat(interval.toString()).isEqualTo("(-infinity, 10]");
+    }
+
+    @Test
+    void nullEndRepresentsPositiveInfinity() {
+      final var interval = new Interval<>(5, true, null, false);
+
+      assertThat(interval.contains(4)).isFalse();
+      assertThat(interval.contains(5)).isTrue();
+      assertThat(interval.contains(Integer.MAX_VALUE)).isTrue();
+      assertThat(interval.toString()).isEqualTo("[5, infinity)");
+    }
+
+    @Test
+    void fullyUnboundedIntervalContainsEverything() {
+      final var interval = new Interval<Integer>(null, false, null, false);
+
+      assertThat(interval.contains(Integer.MIN_VALUE)).isTrue();
+      assertThat(interval.contains(Integer.MAX_VALUE)).isTrue();
+      assertThat(interval.contains(Interval.closed(-1000, 1000))).isTrue();
+      assertThat(interval.toString()).isEqualTo("(-infinity, infinity)");
+    }
+
+    @Test
+    void mapPreservesNullBounds() {
+      final var interval = new Interval<>(null, false, 10, true);
+      final var mapped = interval.map(x -> x * 2L);
+
+      assertThat(mapped.start()).isNull();
+      assertThat(mapped.end()).isEqualTo(20L);
+    }
+
+    @Test
+    void intersectionNarrowsUnboundedIntervals() {
+      final var leftUnbounded = new Interval<>(null, false, 10, true);
+      final var rightUnbounded = new Interval<>(5, true, null, false);
+
+      final var result = Interval.intersection(List.of(leftUnbounded, rightUnbounded));
+
+      assertThat(result).isPresent();
+      assertThat(result.get()).isEqualTo(Interval.closed(5, 10));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      // null start = unbounded
+      "true,  false, true",
+      // null end = unbounded
+      "false, true,  true",
+      // both null = unbounded
+      "true,  true,  true",
+      // both non-null = bounded
+      "false, false, false"
+    })
+    void isUnboundedReturnsTrueWhenEitherBoundIsNull(
+        final boolean nullStart, final boolean nullEnd, final boolean expectedUnbounded) {
+      final Integer start = nullStart ? null : 1;
+      final Integer end = nullEnd ? null : 10;
+      final var interval = new Interval<>(start, true, end, true);
+
+      assertThat(interval.isUnbounded()).isEqualTo(expectedUnbounded);
+    }
+
+    @Test
+    void smallestCoverWithUnboundedIntervalsIncludesAllRelevantPoints() {
+      final var fullyUnbounded = new Interval<Integer>(null, false, null, false);
+      final var points = List.of(1, 3, 5, 7, 9);
+
+      assertThat(fullyUnbounded.smallestCover(points)).containsExactly(1, 3, 5, 7, 9);
     }
   }
 }

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -123,6 +123,11 @@
       <artifactId>camunda-db-rdbms</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -34,6 +34,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * {@link BackupStore} to fetch and manage backup data required for restoring partitions or
  * determining safe starting checkpoints.
  */
+@NullMarked
 public final class BackupRangeResolver {
 
   private static final Logger LOG = LoggerFactory.getLogger(BackupRangeResolver.class);
@@ -57,7 +60,8 @@ public final class BackupRangeResolver {
    *     per task
    */
   public CompletableFuture<GlobalRestoreInfo> getRestoreInfoForAllPartitions(
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final int partitionCount,
       final Map<Integer, Long> exportedPositions,
       final CheckpointIdGenerator checkpointIdGenerator,
@@ -85,7 +89,8 @@ public final class BackupRangeResolver {
                     () ->
                         getInformationPerPartition(
                             partition,
-                            interval,
+                            from,
+                            to,
                             exportedPositions.get(partition),
                             checkpointIdGenerator),
                     executor))
@@ -102,7 +107,8 @@ public final class BackupRangeResolver {
 
   public PartitionRestoreInfo getInformationPerPartition(
       final int partition,
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final long exporterPosition,
       final CheckpointIdGenerator checkpointIdGenerator) {
     final var rangeMarkers = store.rangeMarkers(partition).join();
@@ -110,18 +116,26 @@ public final class BackupRangeResolver {
 
     // finds the BackupRange that entirely covers the interval `[from, to]`
     final var statusInterval =
-        findBackupRangeCoveringInterval(interval, ranges, partition)
+        findBackupRangeCoveringInterval(from, to, ranges, partition)
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "No complete backup range found for partition %d in interval %s, ranges=%s, timeInterval=%s"
+                        "No complete backup range found for partition %d in interval [%s, %s], ranges=%s, timeInterval=%s"
                             .formatted(
                                 partition,
-                                interval,
+                                from,
+                                to,
                                 ranges,
                                 ranges.stream()
                                     .map(r -> r.timeInterval(checkpointIdGenerator))
                                     .toList())));
+
+    // if to was not set, then the interval can be computed with `from` and the last backup
+    final var interval =
+        to != null
+            ? Interval.closed(from, to)
+            : Interval.closed(
+                from, statusInterval.getRight().end().descriptor().get().checkpointTimestamp());
 
     // Retrieve all BackupStatus in the BackupRange
     // note that all backups must be retrieved as we only know the extremes, not every backup inside
@@ -155,17 +169,21 @@ public final class BackupRangeResolver {
    * interval. If such a range is found, it is returned along with its corresponding backup status
    * interval. If no range meets the criteria, an empty {@code Optional} is returned.
    *
-   * @param interval the target time interval that needs to be covered
+   * @param from the target start of time interval that needs to be covered
+   * @param to the target end of time interval that needs to be covered (optional, the end of the
+   *     backup range will be used instead)
    * @param ranges a chronologically ordered collection of backup ranges to search
    * @param partitionId the partition ID used for mapping backup checkpoints to their statuses
    * @return an {@code Optional} containing a tuple of the matching complete backup range and its
    *     corresponding status interval if found; otherwise, an empty {@code Optional}
    */
   public Optional<Tuple<Complete, Interval<BackupStatus>>> findBackupRangeCoveringInterval(
-      final Interval<Instant> interval,
+      final Instant from,
+      @Nullable final Instant to,
       final SequencedCollection<BackupRange> ranges,
       final int partitionId) {
     // ranges are ordered chronologically, so we start from the latest one, going backwards in time
+    final var interval = to != null ? Interval.closed(from, to) : null;
     for (final var range : ranges.reversed()) {
       if (range instanceof final BackupRange.Complete completeRange) {
         // get the BackupStatuses from the store
@@ -178,7 +196,9 @@ public final class BackupRangeResolver {
           // ignore this backup
           continue;
         }
-        if (timeInterval.contains(interval)) {
+        if (interval != null && timeInterval.contains(interval)) {
+          return Optional.of(new Tuple<>(completeRange, statusInterval));
+        } else if (timeInterval.contains(from)) {
           return Optional.of(new Tuple<>(completeRange, statusInterval));
         }
       }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/BackupRangeResolver.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +59,7 @@ public final class BackupRangeResolver {
    *     per task
    */
   public CompletableFuture<GlobalRestoreInfo> getRestoreInfoForAllPartitions(
-      final Instant from,
-      @Nullable final Instant to,
+      final Interval<Instant> interval,
       final int partitionCount,
       final Map<Integer, Long> exportedPositions,
       final CheckpointIdGenerator checkpointIdGenerator,
@@ -89,8 +87,7 @@ public final class BackupRangeResolver {
                     () ->
                         getInformationPerPartition(
                             partition,
-                            from,
-                            to,
+                            interval,
                             exportedPositions.get(partition),
                             checkpointIdGenerator),
                     executor))
@@ -107,8 +104,7 @@ public final class BackupRangeResolver {
 
   public PartitionRestoreInfo getInformationPerPartition(
       final int partition,
-      final Instant from,
-      @Nullable final Instant to,
+      final Interval<Instant> interval,
       final long exporterPosition,
       final CheckpointIdGenerator checkpointIdGenerator) {
     final var rangeMarkers = store.rangeMarkers(partition).join();
@@ -116,26 +112,18 @@ public final class BackupRangeResolver {
 
     // finds the BackupRange that entirely covers the interval `[from, to]`
     final var statusInterval =
-        findBackupRangeCoveringInterval(from, to, ranges, partition)
+        findBackupRangeCoveringInterval(interval, ranges, partition)
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "No complete backup range found for partition %d in interval [%s, %s], ranges=%s, timeInterval=%s"
+                        "No complete backup range found for partition %d in interval %s, ranges=%s, timeInterval=%s"
                             .formatted(
                                 partition,
-                                from,
-                                to,
+                                interval,
                                 ranges,
                                 ranges.stream()
                                     .map(r -> r.timeInterval(checkpointIdGenerator))
                                     .toList())));
-
-    // if to was not set, then the interval can be computed with `from` and the last backup
-    final var interval =
-        to != null
-            ? Interval.closed(from, to)
-            : Interval.closed(
-                from, statusInterval.getRight().end().descriptor().get().checkpointTimestamp());
 
     // Retrieve all BackupStatus in the BackupRange
     // note that all backups must be retrieved as we only know the extremes, not every backup inside
@@ -169,21 +157,17 @@ public final class BackupRangeResolver {
    * interval. If such a range is found, it is returned along with its corresponding backup status
    * interval. If no range meets the criteria, an empty {@code Optional} is returned.
    *
-   * @param from the target start of time interval that needs to be covered
-   * @param to the target end of time interval that needs to be covered (optional, the end of the
-   *     backup range will be used instead)
+   * @param interval the target time interval that needs to be covered
    * @param ranges a chronologically ordered collection of backup ranges to search
    * @param partitionId the partition ID used for mapping backup checkpoints to their statuses
    * @return an {@code Optional} containing a tuple of the matching complete backup range and its
    *     corresponding status interval if found; otherwise, an empty {@code Optional}
    */
   public Optional<Tuple<Complete, Interval<BackupStatus>>> findBackupRangeCoveringInterval(
-      final Instant from,
-      @Nullable final Instant to,
+      final Interval<Instant> interval,
       final SequencedCollection<BackupRange> ranges,
       final int partitionId) {
     // ranges are ordered chronologically, so we start from the latest one, going backwards in time
-    final var interval = to != null ? Interval.closed(from, to) : null;
     for (final var range : ranges.reversed()) {
       if (range instanceof final BackupRange.Complete completeRange) {
         // get the BackupStatuses from the store
@@ -196,9 +180,9 @@ public final class BackupRangeResolver {
           // ignore this backup
           continue;
         }
-        if (interval != null && timeInterval.contains(interval)) {
+        if (timeInterval.contains(interval)) {
           return Optional.of(new Tuple<>(completeRange, statusInterval));
-        } else if (timeInterval.contains(from)) {
+        } else if (interval.isUnbounded() && timeInterval.overlapsWith(interval)) {
           return Optional.of(new Tuple<>(completeRange, statusInterval));
         }
       }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -64,9 +64,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.agrona.collections.MutableBoolean;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NullMarked
 public class RestoreManager implements CloseableSilently {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
   private final BrokerCfg configuration;
@@ -74,7 +77,7 @@ public class RestoreManager implements CloseableSilently {
   private final BackupRangeResolver rangeResolver;
   private final MeterRegistry meterRegistry;
   private final CheckpointIdGenerator checkpointIdGenerator;
-  private final ExporterPositionMapper exporterPositionMapper;
+  @Nullable private final ExporterPositionMapper exporterPositionMapper;
   private final ExecutorService executor;
 
   @VisibleForTesting
@@ -88,7 +91,7 @@ public class RestoreManager implements CloseableSilently {
   public RestoreManager(
       final BrokerCfg configuration,
       final BackupStore backupStore,
-      final ExporterPositionMapper exporterPositionMapper,
+      @Nullable final ExporterPositionMapper exporterPositionMapper,
       final MeterRegistry meterRegistry) {
     checkpointIdGenerator =
         new CheckpointIdGenerator(configuration.getData().getBackup().getOffset());
@@ -109,12 +112,12 @@ public class RestoreManager implements CloseableSilently {
 
   public void restore(
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
     if (exporterPositionMapper == null) {
-      restoreTimeRange(from, to, validateConfig, ignoreFilesInTarget);
+      restoreTimeRange(from, to != null ? to : Instant.now(), validateConfig, ignoreFilesInTarget);
     } else {
       restoreRdbms(from, to, validateConfig, ignoreFilesInTarget);
     }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -125,7 +125,7 @@ public class RestoreManager implements CloseableSilently {
 
   private void restoreRdbms(
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
@@ -137,7 +137,7 @@ public class RestoreManager implements CloseableSilently {
     final var restoreInfos =
         rangeResolver
             .getRestoreInfoForAllPartitions(
-                interval, partitionCount, exportedPositions, checkpointIdGenerator, executor)
+                from, to, partitionCount, exportedPositions, checkpointIdGenerator, executor)
             .join();
 
     LOG.info(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -112,12 +112,12 @@ public class RestoreManager implements CloseableSilently {
 
   public void restore(
       final Instant from,
-      @Nullable final Instant to,
+      final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
     if (exporterPositionMapper == null) {
-      restoreTimeRange(from, to != null ? to : Instant.now(), validateConfig, ignoreFilesInTarget);
+      restoreTimeRange(from, to, validateConfig, ignoreFilesInTarget);
     } else {
       restoreRdbms(from, to, validateConfig, ignoreFilesInTarget);
     }
@@ -125,7 +125,7 @@ public class RestoreManager implements CloseableSilently {
 
   private void restoreRdbms(
       final Instant from,
-      @Nullable final Instant to,
+      final Instant to,
       final boolean validateConfig,
       final List<String> ignoreFilesInTarget)
       throws IOException, ExecutionException, InterruptedException {
@@ -137,7 +137,7 @@ public class RestoreManager implements CloseableSilently {
     final var restoreInfos =
         rangeResolver
             .getRestoreInfoForAllPartitions(
-                from, to, partitionCount, exportedPositions, checkpointIdGenerator, executor)
+                interval, partitionCount, exportedPositions, checkpointIdGenerator, executor)
             .join();
 
     LOG.info(

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.backup.api.BackupRangeMarker;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.api.Interval;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
@@ -40,12 +39,15 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@NullMarked
 final class BackupRangeResolverTest {
 
   private static final int NODE_ID = 0;
@@ -163,6 +165,25 @@ final class BackupRangeResolverTest {
   }
 
   @Test
+  void shouldRestoreToEndOfRangeWhenToIsMissing() {
+    // given
+    store
+        .forPartition(1)
+        .withRange(100, 400)
+        .addBackup(100, 1000, 1, minutesAfterBase(0))
+        .addBackup(200, 2000, 1001, minutesAfterBase(20))
+        .addBackup(300, 3000, 2001, minutesAfterBase(40))
+        .addBackup(400, 4000, 3001, minutesAfterBase(60));
+
+    // when - time interval [20, 40] covers only checkpoints 200 and 300
+    final var result = resolve(1, minutesAfterBase(20), null, Map.of(1, 2500L));
+
+    // then - only backups within time interval are returned
+    assertThat(result.globalCheckpointId()).isEqualTo(400L);
+    assertThat(result.backupsByPartitionId().get(1)).containsExactly(200L, 300L, 400L);
+  }
+
+  @Test
   void shouldHandleDifferentSafeStartsPerPartition() {
     // given - partitions have different exported positions, so different safe starts
     store
@@ -200,8 +221,8 @@ final class BackupRangeResolverTest {
             () -> resolve(1, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L)))
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[]");
+        .hasRootCauseMessage(
+            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[], timeInterval=[]");
   }
 
   @Test
@@ -289,11 +310,11 @@ final class BackupRangeResolverTest {
 
     // when/then
     assertThatThrownBy(
-            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(60), Map.of(1, 2500L, 2, 2500L)))
+            () -> resolve(2, minutesAfterBase(0), minutesAfterBase(30), Map.of(1, 2500L, 2, 2500L)))
         .isInstanceOf(CompletionException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "No complete backup range found for partition 1 in interval [2026-01-20T10:00:00Z, 2026-01-20T11:00:00Z], ranges=[Complete[checkpointInterval=[100, 200]]");
+        .hasRootCauseMessage(
+            "No complete backup range found for partition 2 in interval [2026-01-20T10:00:00Z, 2026-01-20T10:30:00Z], ranges=[Complete[checkpointInterval=[100, 200]]], timeInterval=[[1970-01-01T00:00:00.100Z, 1970-01-01T00:00:00.200Z]]");
   }
 
   @Test
@@ -461,18 +482,12 @@ final class BackupRangeResolverTest {
   private GlobalRestoreInfo resolve(
       final int partitionCount,
       final Instant from,
-      final Instant to,
+      @Nullable final Instant to,
       final Map<Integer, Long> exportedPositions) {
-    final var value =
-        resolver
-            .getRestoreInfoForAllPartitions(
-                Interval.closed(from, to),
-                partitionCount,
-                exportedPositions,
-                checkIdGenerator,
-                DIRECT_EXECUTOR)
-            .join();
-    return value;
+    return resolver
+        .getRestoreInfoForAllPartitions(
+            from, to, partitionCount, exportedPositions, checkIdGenerator, DIRECT_EXECUTOR)
+        .join();
   }
 
   private static Instant minutesAfterBase(final int minutes) {
@@ -605,7 +620,7 @@ final class BackupRangeResolverTest {
           backups.values().stream()
               .filter(backup -> wildcard.matches(backup.id()))
               .map(this::toStatus)
-              .map(s -> (BackupStatus) s)
+              .map(BackupStatus.class::cast)
               .toList();
       return CompletableFuture.completedFuture(matchingBackups);
     }
@@ -619,6 +634,12 @@ final class BackupRangeResolverTest {
     @Override
     public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
       return CompletableFuture.completedFuture(backups.get(id));
+    }
+
+    @Override
+    public CompletableFuture<BackupStatusCode> markFailed(
+        final BackupIdentifier id, final String failureReason) {
+      return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
     }
 
     @Override
@@ -647,12 +668,6 @@ final class BackupRangeResolverTest {
     @Override
     public CompletableFuture<Void> closeAsync() {
       return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
-    public CompletableFuture<BackupStatusCode> markFailed(
-        final BackupIdentifier id, final String failureReason) {
-      return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
     }
 
     private BackupStatusImpl toStatus(final Backup backup) {

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.backup.api.BackupRangeMarker;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.api.Interval;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
@@ -486,7 +487,11 @@ final class BackupRangeResolverTest {
       final Map<Integer, Long> exportedPositions) {
     return resolver
         .getRestoreInfoForAllPartitions(
-            from, to, partitionCount, exportedPositions, checkIdGenerator, DIRECT_EXECUTOR)
+            Interval.closed(from, to),
+            partitionCount,
+            exportedPositions,
+            checkIdGenerator,
+            DIRECT_EXECUTOR)
         .join();
   }
 


### PR DESCRIPTION
## Description
When start or end (or both) is null, the interval is considered   unbounded.

An unbounded interval is used when restoring.
If an unbounded interval is used, we don't check that the backup
interval contains the user provided interval, but we just verify that
there is an overlap.
Because the interval is unbouded, if there's an overlap it means that
the backup startedBefore/endedAfter which is what we want to check.

PR #45803 took a different approach by constructing the interval with the backups extremes.