### PR TITLE
[Backport stable/8.8] fix: use sed to manually override client versions

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -340,12 +340,8 @@ jobs:
 
       - name: Override client version for compatibility testing
         run: |
-          # Inject the specific client version into the POM to override the inherited version
-          ./mvnw -pl qa/acceptance-tests versions:use-dep-version \
-            -Dincludes=io.camunda:camunda-client-java \
-            -DdepVersion=${{ matrix.client }} \
-            -DforceVersion=true \
-            -DgenerateBackupPoms=false
+          # Inject an explicit <version> on camunda-client-java to override the parent-managed version
+          sed -i '/<artifactId>camunda-client-java<\/artifactId>/a\      <version>${{ matrix.client }}<\/version>' qa/acceptance-tests/pom.xml
 
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -338,12 +338,8 @@ jobs:
 
       - name: Override spring client version for compatibility testing
         run: |
-          # Inject the specific spring client version into the POM to override the inherited version
-          ./mvnw -pl qa/compatibility-test versions:use-dep-version \
-            -Dincludes=io.camunda:camunda-spring-boot-starter \
-            -DdepVersion=${{ matrix.client }} \
-            -DforceVersion=true \
-            -DgenerateBackupPoms=false
+          # Inject an explicit <version> on camunda-spring-boot-starter to override the parent-managed version
+          sed -i '/<artifactId>camunda-spring-boot-starter<\/artifactId>/a\      <version>${{ matrix.client }}<\/version>' qa/compatibility-test/pom.xml
 
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven


### PR DESCRIPTION
# Description
Backport of #45953 to `stable/8.8`.

relates to 