### PR TITLE
fix: remove backup manager metrics on stepdown

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -75,7 +75,7 @@ public final class BackupService extends Actor implements BackupManager {
   @Override
   protected void onActorClosing() {
     internalBackupManager.close();
-    metrics.cancelInProgressOperations();
+    metrics.close();
   }
 
   @Override

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupManagerMetricsTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupManagerMetricsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.metrics.BackupManagerMetrics;
+import io.camunda.zeebe.backup.metrics.BackupManagerMetricsDoc;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+final class BackupManagerMetricsTest {
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldRegisterMetrics() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new BackupManagerMetrics(registry);
+
+    // when
+    metrics.startTakingBackup().complete(null, null);
+    metrics.startTakingBackup();
+    metrics.startDeleting().complete(null, null);
+    metrics.startDeleting();
+    metrics.startListingBackups().complete(null, null);
+    metrics.startListingBackups();
+
+    // then
+    assertThat(registry.find(BackupManagerMetricsDoc.BACKUP_OPERATIONS_LATENCY.getName()).timers())
+        .hasSize(3);
+    assertThat(
+            registry.find(BackupManagerMetricsDoc.BACKUP_OPERATIONS_IN_PROGRESS.getName()).gauges())
+        .hasSize(3);
+    assertThat(registry.find(BackupManagerMetricsDoc.BACKUP_OPERATIONS_TOTAL.getName()).counters())
+        .hasSize(3);
+  }
+
+  @Test
+  void shouldDeRegisterMetrics() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new BackupManagerMetrics(registry);
+    metrics.startTakingBackup().complete(null, null);
+    metrics.startTakingBackup();
+    metrics.startDeleting().complete(null, null);
+    metrics.startDeleting();
+    metrics.startListingBackups().complete(null, null);
+    metrics.startListingBackups();
+
+    // when
+    metrics.close();
+
+    // then
+    assertThat(registry.getMeters()).isEmpty();
+  }
+}


### PR DESCRIPTION
This ensures that backup metrics are deregistered when a leader steps down. Deregistering is important because we don't want our dashboards to show stale data.
