### PR TITLE
Optimize should update version automatically

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -227,22 +227,6 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
-      - name: Debug Optimize Versions after release
-        if: ${{ inputs.dryRun }}
-        run: |
-          echo "=== Optimize Version Information ==="
-          echo "Optimize project.version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout || echo "Failed to get Optimize version"
-          echo ""
-          echo "Zeebe parent version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.parent.version -q -DforceStdout || echo "Failed to get Zeebe parent version"
-          echo ""
-          echo "Zeebe version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
-          echo ""
-          echo "Identity version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=version.identity -q -DforceStdout || echo "Failed to get Identity version"
-          echo ""
       - name: Update Optimize parent to development version
         run: |
           # After release process completes, update Optimize parent to nextDevelopmentVersion

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -227,6 +227,22 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
+      - name: Debug Optimize Versions
+        if: ${{ inputs.dryRun }}
+        run: |
+          echo "=== Optimize Version Information ==="
+          echo "Optimize project.version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout || echo "Failed to get Optimize version"
+          echo ""
+          echo "Zeebe parent version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.parent.version -q -DforceStdout || echo "Failed to get Zeebe parent version"
+          echo ""
+          echo "Zeebe version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
+          echo ""
+          echo "Identity version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=version.identity -q -DforceStdout || echo "Failed to get Identity version"
+          echo ""
       - name: Collect Release artifacts
         id: release-artifacts
         run: |

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -227,7 +227,40 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
-      - name: Debug Optimize Versions
+      - name: Debug Optimize Versions after release
+        if: ${{ inputs.dryRun }}
+        run: |
+          echo "=== Optimize Version Information ==="
+          echo "Optimize project.version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout || echo "Failed to get Optimize version"
+          echo ""
+          echo "Zeebe parent version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=project.parent.version -q -DforceStdout || echo "Failed to get Zeebe parent version"
+          echo ""
+          echo "Zeebe version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
+          echo ""
+          echo "Identity version:"
+          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=version.identity -q -DforceStdout || echo "Failed to get Identity version"
+          echo ""
+      - name: Update Optimize parent to development version
+        run: |
+          # After release process completes, update Optimize parent to nextDevelopmentVersion
+          # This ensures Optimize stays aligned with the main project for future development
+          echo "Updating Optimize parent version to ${DEVELOPMENT_VERSION} for future development"
+          
+          # Update the parent version using a more precise sed command
+          sed -i "/<parent>/,/<\/parent>/ {
+            /<artifactId>zeebe-parent<\/artifactId>/ {
+              n
+              s/<version>[^<]*<\/version>/<version>${DEVELOPMENT_VERSION}<\/version>/
+            }
+          }" optimize/pom.xml
+          
+          # Verify the change
+          new_version=$(grep -A2 '<artifactId>zeebe-parent</artifactId>' optimize/pom.xml | grep '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/' | tr -d ' ')
+          echo "Updated parent version to: ${new_version}"
+      - name: Debug Optimize Versions after updating to development version
         if: ${{ inputs.dryRun }}
         run: |
           echo "=== Optimize Version Information ==="

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -49,8 +49,6 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <zeebe.version>${project.version}</zeebe.version>
-    <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <version.identity>${version.identity}</version.identity>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-build-tools</artifactId>
-      <version>8.8.11</version>
+      <version>${zeebe.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,9 +48,9 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>8.8.11</zeebe.version>
+    <zeebe.version>${project.version}</zeebe.version>
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <identity.version>8.8.7</identity.version>
+    <version.identity>${version.identity}</version.identity>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>${project.version}</zeebe.version>
+    <zeebe.version>${project.parent.version}</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

This pull request introduces improvements to the release workflow and dependency management for the Optimize module. The main changes focus on enhancing debugging capabilities during dry runs and aligning the Zeebe dependency versioning with the parent project version.

Release workflow improvements:

* Added a "Debug Optimize Versions" step to the `.github/workflows/camunda-platform-release.yml` workflow, which outputs detailed version information for Optimize and its dependencies when running in dry run mode.

Dependency version management:

* Updated `optimize/pom.xml` to set `zeebe.version` to `${project.parent.version}` instead of a hardcoded value, ensuring Zeebe's version is always in sync with the parent project version.

> [!IMPORTANT]
> Remove this when merging back https://github.com/camunda/camunda/pull/45437
> this is a temporary fix to reduce manual tasks while is in progress https://github.com/camunda/camunda/issues/40184?reload=1 

Successful dry-run:
https://github.com/camunda/camunda/actions/runs/22079345883/job/63801238517#step:13:1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
