### PR TITLE
feat: add tenant filter support to commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.command;
 
+import io.camunda.client.api.command.enums.TenantFilter;
 import java.util.List;
 
 public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantStep<T> {
@@ -63,4 +64,19 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * @since 8.3
    */
   T tenantIds(String... tenantIds);
+
+  /**
+   * Sets the tenant filter strategy for this command. See {@link TenantFilter} for possible values.
+   *
+   * <p>When set to {@link TenantFilter#ASSIGNED}, the tenants assigned to the authenticated
+   * principal are resolved dynamically and any tenant IDs provided via {@link #tenantId(String)} or
+   * {@link #tenantIds(List)} are ignored.
+   *
+   * <p>When set to {@link TenantFilter#PROVIDED}, the tenant IDs supplied with this command are
+   * used.
+   *
+   * @param tenantFilter the tenant filter strategy
+   * @return the builder for this command with the tenant filter specified
+   */
+  T tenantFilter(TenantFilter tenantFilter);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -30,6 +30,10 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
    *
+   * <p>Note: when {@link TenantFilter} is set to {@link TenantFilter#ASSIGNED} the tenant IDs
+   * provided via this method are ignored and the tenants assigned to the authenticated principal
+   * are resolved dynamically.
+   *
    * @param tenantId the identifier of the tenant to specify for this command, e.g. {@code "ACME"}
    * @return the builder for this command with the tenant specified
    * @since 8.3
@@ -46,6 +50,10 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated
    * jobs will be owned by the tenant that owns the corresponding process instance.
    *
+   * <p>Note: when {@link TenantFilter} is set to {@link TenantFilter#ASSIGNED} the tenant IDs
+   * provided via this method are ignored and the tenants assigned to the authenticated principal
+   * are resolved dynamically.
+   *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}
    * @return the builder for this command with the tenants specified
@@ -56,6 +64,10 @@ public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantSte
 
   /**
    * Shorthand method for {@link #tenantIds(List)}.
+   *
+   * <p>Note: when {@link TenantFilter} is set to {@link TenantFilter#ASSIGNED} the tenant IDs
+   * provided via this method are ignored and the tenants assigned to the authenticated principal
+   * are resolved dynamically.
    *
    * @param tenantIds the identifiers of the tenants to specify for this command, e.g. {@code
    *     ["ACME", "OTHER"]}

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -271,6 +271,7 @@ public interface JobWorkerBuilderStep1 {
      *
      * @param tenantFilter the default filter to use for all workers
      */
+    @Override
     JobWorkerBuilderStep3 tenantFilter(TenantFilter tenantFilter);
 
     /**

--- a/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.StreamJobsCommandStep1;
 import io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep2;
 import io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.StreamJobsResponse;
 import io.camunda.client.impl.RetriableStreamingFutureImpl;
@@ -164,6 +165,12 @@ public final class StreamJobsCommandImpl
   @Override
   public StreamJobsCommandStep3 tenantIds(final String... tenantIds) {
     return tenantIds(Arrays.asList(tenantIds));
+  }
+
+  @Override
+  public StreamJobsCommandStep3 tenantFilter(final TenantFilter tenantFilter) {
+    // TODO: https://github.com/camunda/camunda/issues/45356
+    return this;
   }
 
   private void consumeJob(final GatewayOuterClass.ActivatedJob job) {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.worker;
 
 import io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.impl.Loggers;
@@ -39,6 +40,7 @@ public final class JobPollerImpl implements JobPoller {
   private final Duration timeout;
   private final List<String> fetchVariables;
   private final List<String> tenantIds;
+  private final TenantFilter tenantFilter;
 
   private int maxJobsToActivate;
 
@@ -56,6 +58,7 @@ public final class JobPollerImpl implements JobPoller {
       final Duration timeout,
       final List<String> fetchVariables,
       final List<String> tenantIds,
+      final TenantFilter tenantFilter,
       final int maxJobsToActivate) {
     this.requestTimeout = requestTimeout;
     this.jobClient = jobClient;
@@ -64,6 +67,7 @@ public final class JobPollerImpl implements JobPoller {
     this.timeout = timeout;
     this.fetchVariables = fetchVariables;
     this.tenantIds = tenantIds;
+    this.tenantFilter = tenantFilter;
     this.maxJobsToActivate = maxJobsToActivate;
   }
 
@@ -110,8 +114,9 @@ public final class JobPollerImpl implements JobPoller {
             .jobType(jobType)
             .maxJobsToActivate(maxJobsToActivate)
             .timeout(timeout)
+            .workerName(workerName)
             .tenantIds(tenantIds)
-            .workerName(workerName);
+            .tenantFilter(tenantFilter);
     if (fetchVariables != null) {
       activateCommand.fetchVariables(fetchVariables);
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -62,13 +62,13 @@ public final class JobWorkerBuilderImpl
   private List<String> fetchVariables;
   private final List<String> defaultTenantIds;
   private final List<String> customTenantIds;
+  private TenantFilter tenantFilter;
   private BackoffSupplier backoffSupplier;
   private BackoffSupplier streamNoJobsBackoffSupplier;
   private boolean enableStreaming;
   private Duration streamingTimeout;
   private JobWorkerMetrics metrics = JobWorkerMetrics.noop();
   private JobExceptionHandler jobExceptionHandler;
-  private TenantFilter tenantFilter;
 
   public JobWorkerBuilderImpl(
       final CamundaClientConfiguration configuration,
@@ -89,8 +89,8 @@ public final class JobWorkerBuilderImpl
     enableStreaming = configuration.getDefaultJobWorkerStreamEnabled();
     defaultTenantIds = configuration.getDefaultJobWorkerTenantIds();
     jobExceptionHandler = configuration.getDefaultJobWorkerExceptionHandler();
-    tenantFilter = configuration.getDefaultJobWorkerTenantFilter();
     customTenantIds = new ArrayList<>();
+    tenantFilter = configuration.getDefaultJobWorkerTenantFilter();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
     streamNoJobsBackoffSupplier = DEFAULT_STREAM_NO_JOBS_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
@@ -217,6 +217,7 @@ public final class JobWorkerBuilderImpl
             timeout,
             fetchVariables,
             getTenantIds(),
+            tenantFilter,
             maxJobsActive);
 
     final Executor jobExecutor;

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
@@ -113,6 +114,7 @@ public final class JobPollerImplTest extends ClientTest {
         Duration.ofSeconds(10),
         Collections.emptyList(),
         Collections.singletonList("test-tenant"),
+        TenantFilter.PROVIDED,
         10);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.worker;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -28,7 +29,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import org.awaitility.Awaitility;
@@ -101,6 +104,133 @@ public final class JobPollerImplTest extends ClientTest {
             });
   }
 
+  @Test
+  public void shouldUseProvidedTenantFilterWithTenantIds() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job(), TestData.job());
+    final List<String> tenantIds = Arrays.asList("tenant-a", "tenant-b");
+    final JobPoller poller = getJobPollerWithTenantFilter(tenantIds, TenantFilter.PROVIDED);
+
+    // when
+    poller.poll(5, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getTenantFilter())
+                  .isEqualTo(GatewayOuterClass.TenantFilter.PROVIDED);
+              assertThat(request.getTenantIdsList()).containsExactlyInAnyOrderElementsOf(tenantIds);
+            });
+  }
+
+  @Test
+  public void shouldUseAssignedTenantFilterWithoutTenantIds() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job(), TestData.job());
+    final JobPoller poller =
+        getJobPollerWithTenantFilter(Collections.emptyList(), TenantFilter.ASSIGNED);
+
+    // when
+    poller.poll(5, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getTenantFilter())
+                  .isEqualTo(GatewayOuterClass.TenantFilter.ASSIGNED);
+              assertThat(request.getTenantIdsList())
+                  .describedAs(
+                      "Tenant IDs should be empty when ASSIGNED filter is used as they are determined from authorized tenants")
+                  .isEmpty();
+            });
+  }
+
+  @Test
+  public void shouldIgnoreTenantIdsWhenUsingAssignedFilter() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job());
+    final List<String> tenantIds = Arrays.asList("tenant-a", "tenant-b", "tenant-c");
+    final JobPoller poller = getJobPollerWithTenantFilter(tenantIds, TenantFilter.ASSIGNED);
+
+    // when
+    poller.poll(3, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getTenantFilter())
+                  .isEqualTo(GatewayOuterClass.TenantFilter.ASSIGNED);
+              assertThat(request.getTenantIdsList())
+                  .describedAs("Provided tenant IDs should be ignored when ASSIGNED filter is used")
+                  .isEmpty();
+            });
+  }
+
+  @Test
+  public void shouldDefaultToProvidedTenantFilterWhenNotSpecified() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job());
+
+    // when
+    getJobPoller().poll(5, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getTenantFilter())
+                  .describedAs("Should default to PROVIDED when not explicitly set")
+                  .isEqualTo(GatewayOuterClass.TenantFilter.PROVIDED);
+            });
+  }
+
+  @Test
+  public void shouldConsistentlyUseTenantFilterAcrossMultiplePolls() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job());
+    final JobPoller poller =
+        getJobPollerWithTenantFilter(Collections.emptyList(), TenantFilter.ASSIGNED);
+
+    // when - poll first time
+    poller.poll(2, jobConsumer, doneCallback, errorCallback, () -> true);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> verify(doneCallback, times(1)).accept(any(Integer.class)));
+
+    final GatewayOuterClass.ActivateJobsRequest firstRequest = gatewayService.getLastRequest();
+
+    // when - poll second time
+    gatewayService.onActivateJobsRequest(TestData.job());
+    poller.poll(2, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then - both requests should use the same tenant filter
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              verify(doneCallback, times(2)).accept(any(Integer.class));
+              final GatewayOuterClass.ActivateJobsRequest secondRequest =
+                  gatewayService.getLastRequest();
+              assertThat(firstRequest.getTenantFilter())
+                  .describedAs("First poll should use ASSIGNED filter")
+                  .isEqualTo(GatewayOuterClass.TenantFilter.ASSIGNED);
+              assertThat(secondRequest.getTenantFilter())
+                  .describedAs("Second poll should consistently use ASSIGNED filter")
+                  .isEqualTo(GatewayOuterClass.TenantFilter.ASSIGNED);
+            });
+  }
+
   private JobPoller getJobPoller() {
     return getJobPoller(Duration.ofSeconds(10));
   }
@@ -115,6 +245,20 @@ public final class JobPollerImplTest extends ClientTest {
         Collections.emptyList(),
         Collections.singletonList("test-tenant"),
         TenantFilter.PROVIDED,
+        10);
+  }
+
+  private JobPoller getJobPollerWithTenantFilter(
+      final List<String> tenantIds, final TenantFilter tenantFilter) {
+    return new JobPollerImpl(
+        client,
+        Duration.ofSeconds(10),
+        "testJobType",
+        "testWorkerName",
+        Duration.ofSeconds(10),
+        Collections.emptyList(),
+        tenantIds,
+        tenantFilter,
         10);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR leverages the configuration added with https://github.com/camunda/camunda/pull/45957 to apply the tenant filter configuration to the commands ultimately sent into the APIs. The logic here remains the same as we have further down the stack i.e [here](https://github.com/camunda/camunda/blob/main/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java#L933-L942) where a value of `TenantFilter.ASSIGNED` results in no tenantIds being added to the command.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45349, closes https://github.com/camunda/camunda/issues/45350
