### PR TITLE
Feat/check dmn id length in engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -67,7 +67,11 @@ public final class DeploymentTransformer {
             expressionLanguageMetrics);
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
-            keyGenerator, stateWriter, checksumGenerator, processingState.getDecisionState());
+            keyGenerator,
+            stateWriter,
+            checksumGenerator,
+            processingState.getDecisionState(),
+            config);
 
     final var formResourceTransformer =
         new FormResourceTransformer(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -81,9 +81,9 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
     if (parsedDrg.isValid()) {
       return checkForDuplicateIds(resource, parsedDrg, deployment)
-          .flatMap(valid -> checkDrdIdNameLength(parsedDrg))
-          .flatMap(valid -> checkDecisionIdLength(parsedDrg))
-          .flatMap(valid -> checkDecisionNameLength(parsedDrg))
+          .flatMap(valid -> checkDrdIdNameLength(resource, parsedDrg))
+          .flatMap(valid -> checkDecisionIdLength(resource, parsedDrg))
+          .flatMap(valid -> checkDecisionNameLength(resource, parsedDrg))
           .map(
               valid -> {
                 appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
@@ -226,7 +226,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         .orElse(NO_VALIDATION_ERROR);
   }
 
-  private Either<Failure, ?> checkDrdIdNameLength(final ParsedDecisionRequirementsGraph parsedDrg) {
+  private Either<Failure, ?> checkDrdIdNameLength(
+      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
     final var decisionRequirementsId = parsedDrg.getId();
     final var decisionRequirementsName = parsedDrg.getName();
 
@@ -234,15 +235,19 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         && decisionRequirementsId.length() > engineConfiguration.getMaxIdFieldLength()) {
       final var failureMessage =
           String.format(
-              "The ID of a DRD must not be longer than the configured max-id-length of %s characters",
-              engineConfiguration.getMaxIdFieldLength());
+              "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+              engineConfiguration.getMaxIdFieldLength(),
+              decisionRequirementsId,
+              resource.getResourceName());
       return Either.left(new Failure(failureMessage));
     } else if (decisionRequirementsName != null
         && decisionRequirementsName.length() > engineConfiguration.getMaxNameFieldLength()) {
       final var failureMessage =
           String.format(
-              "The name of a DRD must not be longer than the configured max-id-length of %s characters",
-              engineConfiguration.getMaxNameFieldLength());
+              "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was '%s' in DRG '%s'",
+              engineConfiguration.getMaxNameFieldLength(),
+              decisionRequirementsName,
+              resource.getResourceName());
       return Either.left(new Failure(failureMessage));
     } else {
       return NO_VALIDATION_ERROR;
@@ -250,7 +255,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   private Either<Failure, ?> checkDecisionIdLength(
-      final ParsedDecisionRequirementsGraph parsedDrg) {
+      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
     return parsedDrg.getDecisions().stream()
         .map(ParsedDecision::getId)
         .filter(id -> id != null && id.length() > engineConfiguration.getMaxIdFieldLength())
@@ -260,13 +265,15 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 Either.left(
                     new Failure(
                         String.format(
-                            "The ID of a decision must not be longer than the configured max-id-length of %s characters",
-                            engineConfiguration.getMaxIdFieldLength()))))
+                            "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+                            engineConfiguration.getMaxIdFieldLength(),
+                            id,
+                            resource.getResourceName()))))
         .orElse(NO_VALIDATION_ERROR);
   }
 
   private Either<Failure, ?> checkDecisionNameLength(
-      final ParsedDecisionRequirementsGraph parsedDrg) {
+      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
     return parsedDrg.getDecisions().stream()
         .map(ParsedDecision::getName)
         .filter(name -> name != null && name.length() > engineConfiguration.getMaxNameFieldLength())
@@ -276,8 +283,10 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 Either.left(
                     new Failure(
                         String.format(
-                            "The name of a decision must not be longer than the configured max-name-length of %s characters",
-                            engineConfiguration.getMaxNameFieldLength()))))
+                            "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
+                            engineConfiguration.getMaxNameFieldLength(),
+                            name,
+                            resource.getResourceName()))))
         .orElse(NO_VALIDATION_ERROR);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -644,8 +644,8 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a DRD must not be longer than the configured max-id-length of %s characters",
-                MAX_ID_FIELD_LENGTH));
+                "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_requirements_graph' in resource '%s'",
+                MAX_ID_FIELD_LENGTH, DRG_ID_LENGTH_EXCEEDED));
   }
 
   @Test
@@ -667,8 +667,8 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a DRD must not be longer than the configured max-id-length of %s characters",
-                MAX_ID_FIELD_LENGTH));
+                "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was 'This is a very long name for a decision requirements graph' in DRG '%s'",
+                MAX_NAME_FIELD_LENGTH, DRG_NAME_LENGTH_EXCEEDED));
   }
 
   @Test
@@ -690,8 +690,8 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a decision must not be longer than the configured max-id-length of %s characters",
-                MAX_ID_FIELD_LENGTH));
+                "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision1' in resource '%s'",
+                MAX_ID_FIELD_LENGTH, DECISION_ID_LENGTH_EXCEEDED));
   }
 
   @Test
@@ -713,8 +713,8 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a decision must not be longer than the configured max-name-length of %s characters",
-                MAX_NAME_FIELD_LENGTH));
+                "The name of a decision must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision table' in resource '%s'",
+                MAX_NAME_FIELD_LENGTH, DECISION_NAME_LENGTH_EXCEEDED));
   }
 
   private byte[] getChecksum(final String resourceName) {

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="this_is_an_extreme_and_very_long_id_for_a_decision1" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+      <dmndi:DMNShape dmnElementRef="this_is_an_extreme_and_very_long_id_for_a_decision1">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+      <dmndi:DMNShape dmnElementRef="jediOrSith">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jediOrSith" name="This is an extreme and very long name for a decision table">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe/engine/src/test/resources/dmn/drg-id-length-exceeded.dmn
+++ b/zeebe/engine/src/test/resources/dmn/drg-id-length-exceeded.dmn
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="this_is_an_extreme_and_very_long_id_for_a_decision_requirements_graph" name="force_users" namespace="http://camunda.org/schema/1.0/dmn"
+  exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <extensionElements>
+      <zeebe:versionTag value="v1.0" />
+    </extensionElements>
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="force_user" name="Which force user?">
+    <extensionElements>
+      <zeebe:versionTag value="v2.0" />
+    </extensionElements>
+    <informationRequirement id="InformationRequirement_1o8esai">
+      <requiredDecision href="#jedi_or_sith" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_07g94t1" hitPolicy="FIRST">
+      <input id="InputClause_0qnqj25" label="Jedi or Sith">
+        <inputExpression id="LiteralExpression_00lcyt5" typeRef="string">
+          <text>jedi_or_sith</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1xjidd8">
+          <text>"Jedi","Sith"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0k64hys" label="Body height">
+        <inputExpression id="LiteralExpression_0ib6fnk" typeRef="number">
+          <text>height</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0hhe1yo" label="Force user" name="force_user" typeRef="string" />
+      <rule id="DecisionRule_13zidc5">
+        <inputEntry id="UnaryTests_056skcq">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l4xksq">
+          <text>&gt; 190</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0hclhw3">
+          <text>"Mace Windu"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0uin2hk">
+        <description></description>
+        <inputEntry id="UnaryTests_16maepk">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rv0nwf">
+          <text>&gt; 180</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t82c11">
+          <text>"Obi-Wan Kenobi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0mpio0p">
+        <inputEntry id="UnaryTests_09eicyc">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bekl8k">
+          <text>&lt; 70</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0brx3vt">
+          <text>"Yoda"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06paffx">
+        <inputEntry id="UnaryTests_1baiid4">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fcdq0i">
+          <text>&gt; 200</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02oibi4">
+          <text>"Darth Vader"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ua4pcl">
+        <inputEntry id="UnaryTests_1s1h3nm">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pnvw8p">
+          <text>&gt; 170</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1w1n2rc">
+          <text>"Darth Sidius"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00ew25e">
+        <inputEntry id="UnaryTests_07uxyug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1he6fym">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07i3sc8">
+          <text>"unknown"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force_user">
+        <dc:Bounds height="80" width="180" x="280" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0gt1p1u" dmnElementRef="InformationRequirement_1o8esai">
+        <di:waypoint x="250" y="280" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe/engine/src/test/resources/dmn/drg-name-length-exceeded.dmn
+++ b/zeebe/engine/src/test/resources/dmn/drg-name-length-exceeded.dmn
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+  xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+  xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0"
+  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="force_users" name="This is a very long name for a decision requirements graph" namespace="http://camunda.org/schema/1.0/dmn"
+  exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <extensionElements>
+      <zeebe:versionTag value="v1.0" />
+    </extensionElements>
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="force_user" name="Which force user?">
+    <extensionElements>
+      <zeebe:versionTag value="v2.0" />
+    </extensionElements>
+    <informationRequirement id="InformationRequirement_1o8esai">
+      <requiredDecision href="#jedi_or_sith" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_07g94t1" hitPolicy="FIRST">
+      <input id="InputClause_0qnqj25" label="Jedi or Sith">
+        <inputExpression id="LiteralExpression_00lcyt5" typeRef="string">
+          <text>jedi_or_sith</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1xjidd8">
+          <text>"Jedi","Sith"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0k64hys" label="Body height">
+        <inputExpression id="LiteralExpression_0ib6fnk" typeRef="number">
+          <text>height</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0hhe1yo" label="Force user" name="force_user" typeRef="string" />
+      <rule id="DecisionRule_13zidc5">
+        <inputEntry id="UnaryTests_056skcq">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l4xksq">
+          <text>&gt; 190</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0hclhw3">
+          <text>"Mace Windu"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0uin2hk">
+        <description></description>
+        <inputEntry id="UnaryTests_16maepk">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rv0nwf">
+          <text>&gt; 180</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t82c11">
+          <text>"Obi-Wan Kenobi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0mpio0p">
+        <inputEntry id="UnaryTests_09eicyc">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bekl8k">
+          <text>&lt; 70</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0brx3vt">
+          <text>"Yoda"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06paffx">
+        <inputEntry id="UnaryTests_1baiid4">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fcdq0i">
+          <text>&gt; 200</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02oibi4">
+          <text>"Darth Vader"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ua4pcl">
+        <inputEntry id="UnaryTests_1s1h3nm">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pnvw8p">
+          <text>&gt; 170</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1w1n2rc">
+          <text>"Darth Sidius"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00ew25e">
+        <inputEntry id="UnaryTests_07uxyug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1he6fym">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07i3sc8">
+          <text>"unknown"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force_user">
+        <dc:Bounds height="80" width="180" x="280" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0gt1p1u" dmnElementRef="InformationRequirement_1o8esai">
+        <di:waypoint x="250" y="280" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

Limit the length of ID and name in DMN elements "definition" (DRG) and "decision".
- added checks in DmnDeploymentTransformer to check:
  - ID and name of a DRG (`<deployment />` in DMN)
  - ID and name of a decision (`<decision />` in DMN)

closes #45680 