### PR TITLE
43189 export global listeners to es os

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -24,6 +24,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
@@ -147,7 +148,8 @@ public class BackupPriorityConfiguration {
             new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
-            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch));
+            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
+            new GlobalListenerIndex(indexPrefix, isElasticsearch));
 
     LOG.debug("Prio1 are {}", prio1);
     LOG.debug("Prio2 are {}", prio2);

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -178,7 +178,8 @@ class BackupPrioritiesTest {
             "camunda-usage-metric-tu-8.8.0_",
             "camunda-audit-log-8.9.0_",
             "camunda-cluster-variable-8.9.0_",
-            "camunda-job-metrics-batch-8.9.0_");
+            "camunda-job-metrics-batch-8.9.0_",
+            "camunda-global-listener-8.9.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1004,6 +1004,7 @@ public class SchemaManagerIT {
             newPrefix + "-camunda-authorization-8.8.0_",
             newPrefix + "-camunda-cluster-variable-8.9.0_",
             newPrefix + "-camunda-correlated-message-subscription-8.8.0_",
+            newPrefix + "-camunda-global-listener-8.9.0_",
             newPrefix + "-camunda-group-8.8.0_",
             newPrefix + "-camunda-mapping-rule-8.8.0_",
             newPrefix + "-camunda-role-8.8.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -12,6 +12,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
@@ -90,7 +91,8 @@ public class IndexDescriptors {
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
                 new AuditLogTemplate(indexPrefix, isElasticsearch),
                 new HistoryDeletionIndex(indexPrefix, isElasticsearch),
-                new JobMetricsBatchTemplate(indexPrefix, isElasticsearch))
+                new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
+                new GlobalListenerIndex(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GlobalListenerIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GlobalListenerIndex.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.index;
+
+import static io.camunda.webapps.schema.descriptors.ComponentNames.CAMUNDA;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+
+public class GlobalListenerIndex extends AbstractIndexDescriptor implements Prio5Backup {
+
+  public static final String INDEX_NAME = "global-listener";
+  public static final String INDEX_VERSION = "8.9.0";
+
+  public static final String ID = "id";
+  public static final String LISTENER_ID = "listenerId";
+  public static final String TYPE = "type";
+  public static final String RETRIES = "retries";
+  public static final String EVENT_TYPES = "eventTypes";
+  public static final String AFTER_NON_GLOBAL = "afterNonGlobal";
+  public static final String PRIORITY = "priority";
+  public static final String SOURCE = "source";
+  public static final String LISTENER_TYPE = "listenerType";
+
+  public GlobalListenerIndex(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/globallistener/GlobalListenerEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/globallistener/GlobalListenerEntity.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.globallistener;
+
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerType;
+import java.util.List;
+import java.util.Objects;
+
+public final class GlobalListenerEntity implements ExporterEntity<GlobalListenerEntity> {
+
+  /**
+   * Unique identifier of the global listener entity in the exporter store, is mapped from {@link
+   * GlobalListenerRecordValue#getGlobalListenerKey()}
+   */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String id;
+
+  /**
+   * The global listener identifier, unique within the cluster when combined with the {@link
+   * #listenerType}. It is mapped from {@link GlobalListenerRecordValue#getId()}.
+   */
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String listenerId;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private String type;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int retries;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private List<String> eventTypes;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private boolean afterNonGlobal;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private int priority;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private GlobalListenerSource source;
+
+  @SinceVersion(value = "8.9.0", requireDefault = false)
+  private GlobalListenerType listenerType;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public GlobalListenerEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getListenerId() {
+    return listenerId;
+  }
+
+  public GlobalListenerEntity setListenerId(final String listenerId) {
+    this.listenerId = listenerId;
+    return this;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public GlobalListenerEntity setType(final String type) {
+    this.type = type;
+    return this;
+  }
+
+  public int getRetries() {
+    return retries;
+  }
+
+  public GlobalListenerEntity setRetries(final int retries) {
+    this.retries = retries;
+    return this;
+  }
+
+  public List<String> getEventTypes() {
+    return eventTypes;
+  }
+
+  public GlobalListenerEntity setEventTypes(final List<String> eventTypes) {
+    this.eventTypes = eventTypes;
+    return this;
+  }
+
+  public boolean isAfterNonGlobal() {
+    return afterNonGlobal;
+  }
+
+  public GlobalListenerEntity setAfterNonGlobal(final boolean afterNonGlobal) {
+    this.afterNonGlobal = afterNonGlobal;
+    return this;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public GlobalListenerEntity setPriority(final int priority) {
+    this.priority = priority;
+    return this;
+  }
+
+  public GlobalListenerSource getSource() {
+    return source;
+  }
+
+  public GlobalListenerEntity setSource(final GlobalListenerSource source) {
+    this.source = source;
+    return this;
+  }
+
+  public GlobalListenerType getListenerType() {
+    return listenerType;
+  }
+
+  public GlobalListenerEntity setListenerType(final GlobalListenerType listenerType) {
+    this.listenerType = listenerType;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id, listenerId, type, retries, eventTypes, afterNonGlobal, priority, source, listenerType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final GlobalListenerEntity that = (GlobalListenerEntity) o;
+    return retries == that.retries
+        && afterNonGlobal == that.afterNonGlobal
+        && priority == that.priority
+        && Objects.equals(id, that.id)
+        && Objects.equals(listenerId, that.listenerId)
+        && Objects.equals(type, that.type)
+        && Objects.equals(eventTypes, that.eventTypes)
+        && source == that.source
+        && listenerType == that.listenerType;
+  }
+
+  @Override
+  public String toString() {
+    return "GlobalListenerEntity["
+        + "id="
+        + id
+        + ", listenerId='"
+        + listenerId
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", retries="
+        + retries
+        + ", eventTypes="
+        + eventTypes
+        + ", afterNonGlobal="
+        + afterNonGlobal
+        + ", priority="
+        + priority
+        + ", source="
+        + source
+        + ", listenerType="
+        + listenerType
+        + ']';
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-global-listener.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-global-listener.json
@@ -1,0 +1,34 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "listenerId": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "retries": {
+        "type": "integer"
+      },
+      "eventTypes": {
+        "type": "keyword"
+      },
+      "afterNonGlobal": {
+        "type": "boolean"
+      },
+      "priority": {
+        "type": "integer"
+      },
+      "source": {
+        "type": "keyword"
+      },
+      "listenerType": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-global-listener.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-global-listener.json
@@ -1,0 +1,34 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "listenerId": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "retries": {
+        "type": "integer"
+      },
+      "eventTypes": {
+        "type": "keyword"
+      },
+      "afterNonGlobal": {
+        "type": "boolean"
+      },
+      "priority": {
+        "type": "integer"
+      },
+      "source": {
+        "type": "keyword"
+      },
+      "listenerType": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -18,6 +18,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
 import static io.camunda.zeebe.protocol.record.ValueType.FORM;
+import static io.camunda.zeebe.protocol.record.ValueType.GLOBAL_LISTENER;
 import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.HISTORY_DELETION;
 import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
@@ -380,7 +381,8 @@ public class CamundaExporter implements Exporter {
             USAGE_METRIC,
             CLUSTER_VARIABLE,
             HISTORY_DELETION,
-            JOB_METRICS_BATCH);
+            JOB_METRICS_BATCH,
+            GLOBAL_LISTENER);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -31,6 +31,8 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FormHandler;
+import io.camunda.exporter.handlers.GlobalListenerCreatedUpdatedHandler;
+import io.camunda.exporter.handlers.GlobalListenerDeletedHandler;
 import io.camunda.exporter.handlers.GroupCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.GroupDeletedHandler;
 import io.camunda.exporter.handlers.GroupEntityAddedHandler;
@@ -98,6 +100,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
@@ -371,7 +374,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandler(
                 indexDescriptors
                     .get(CorrelatedMessageSubscriptionTemplate.class)
-                    .getFullQualifiedName())));
+                    .getFullQualifiedName()),
+            new GlobalListenerCreatedUpdatedHandler(
+                indexDescriptors.get(GlobalListenerIndex.class).getFullQualifiedName()),
+            new GlobalListenerDeletedHandler(
+                indexDescriptors.get(GlobalListenerIndex.class).getFullQualifiedName())));
 
     if (configuration.getAuditLog().isEnabled()) {
       addAuditLogHandlers(configuration.getAuditLog(), partitionId);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import java.util.List;
+import java.util.Set;
+
+public class GlobalListenerCreatedUpdatedHandler
+    implements ExportHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
+
+  private static final Set<Intent> SUPPORTED_INTENTS =
+      Set.of(GlobalListenerIntent.CREATED, GlobalListenerIntent.UPDATED);
+  private final String indexName;
+
+  public GlobalListenerCreatedUpdatedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.GLOBAL_LISTENER;
+  }
+
+  @Override
+  public Class<GlobalListenerEntity> getEntityType() {
+    return GlobalListenerEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<GlobalListenerRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<GlobalListenerRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getGlobalListenerKey()));
+  }
+
+  @Override
+  public GlobalListenerEntity createNewEntity(final String id) {
+    return new GlobalListenerEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<GlobalListenerRecordValue> record, final GlobalListenerEntity entity) {
+    final var listener = record.getValue();
+
+    entity
+        .setListenerId(listener.getId())
+        .setType(listener.getType())
+        .setRetries(listener.getRetries())
+        .setEventTypes(listener.getEventTypes())
+        .setAfterNonGlobal(listener.isAfterNonGlobal())
+        .setPriority(listener.getPriority())
+        .setSource(listener.getSource())
+        .setListenerType(listener.getListenerType());
+  }
+
+  @Override
+  public void flush(final GlobalListenerEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import java.util.List;
+
+public class GlobalListenerDeletedHandler
+    implements ExportHandler<GlobalListenerEntity, GlobalListenerRecordValue> {
+
+  private static final GlobalListenerIntent SUPPORTED_INTENT = GlobalListenerIntent.DELETED;
+  private final String indexName;
+
+  public GlobalListenerDeletedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.GLOBAL_LISTENER;
+  }
+
+  @Override
+  public Class<GlobalListenerEntity> getEntityType() {
+    return GlobalListenerEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<GlobalListenerRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENT.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<GlobalListenerRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getGlobalListenerKey()));
+  }
+
+  @Override
+  public GlobalListenerEntity createNewEntity(final String id) {
+    return new GlobalListenerEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<GlobalListenerRecordValue> record, final GlobalListenerEntity entity) {
+    // no-op since the entity will be deleted
+  }
+
+  @Override
+  public void flush(final GlobalListenerEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(indexName, entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces support for "Global Listener" entities in the Camunda schema and exporter. The changes add new schema definitions, entity classes, and exporter handlers to manage the lifecycle of global listener records, including creation, update, and deletion. The integration ensures that these records are properly indexed and handled in both Elasticsearch and OpenSearch environments.

Schema and Entity Additions:

* Added `GlobalListenerEntity` class to represent global listener records, including fields for listener ID, type, retries, event types, priority, source, and listener type. (`webapps-schema/src/main/java/io/camunda/webapps/schema/entities/globallistener/GlobalListenerEntity.java`)
* Introduced `GlobalListenerIndex` descriptor for schema management and indexing of global listener entities. (`webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GlobalListenerIndex.java`)
* Created Elasticsearch and OpenSearch schema mapping files for the global listener index. (`webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-global-listener.json`, `webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-global-listener.json`)

Exporter Integration:

* Registered `GlobalListenerCreatedUpdatedHandler` and `GlobalListenerDeletedHandler` in the exporter resource provider to handle creation, update, and deletion of global listener records. (`zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java`)
* Implemented handlers for processing global listener records: `GlobalListenerCreatedUpdatedHandler` for create/update and `GlobalListenerDeletedHandler` for delete operations. (`zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java`, `zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java`) [[1]](diffhunk://#diff-413a84dd5a8968662c5e32b5c015d8553876eed731f96551bddd09ce039f9deaR1-R84) [[2]](diffhunk://#diff-0825d51f9d8fbebf0017003c6c65556c0b9a3b8463712eb27dc1ad5eb52c7b8eR1-R71)

Record Filtering and Index Registration:

* Updated record filter and index descriptor registration to support the new global listener value type and index. (`zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java`, `webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java`) [[1]](diffhunk://#diff-e1aaa4fbcdde6f63783de04372ec576964311d8995ee5361277105413ddb4eceL383-R385) [[2]](diffhunk://#diff-2c004f64242ed2ee844a610f60a507322c648e081a630994b56eae67511cd49cL93-R95)

Test Coverage:

* Extended schema manager integration tests to verify creation of harmonized schema for global listener entities. (`schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java`)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #43189
