### PR TITLE
43189 export global listeners to rdbms

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -1115,6 +1115,29 @@
     </modifySql>
   </changeSet>
 
+  <changeSet id="create_global_listener_table" author="camunda">
+    <createTable tableName="${prefix}GLOBAL_LISTENER">
+      <column name="GLOBAL_LISTENER_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ID" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="TYPE" type="VARCHAR(${userCharColumnSize})"/>
+      <column name="RETRIES" type="SMALLINT"/>
+      <column name="AFTER_NON_GLOBAL" type="BOOLEAN"/>
+      <column name="PRIORITY" type="SMALLINT"/>
+      <column name="SOURCE" type="VARCHAR(50)"/>
+      <column name="LISTENER_TYPE" type="VARCHAR(50)"/>
+    </createTable>
+    
+    <createTable tableName="${prefix}GLOBAL_LISTENER_EVENT_TYPE">
+      <column name="GLOBAL_LISTENER_KEY" type="BIGINT">
+        <constraints foreignKeyName="${prefix}FK_EVENT_TYPE_GLOBAL_LISTENER" referencedTableName="${prefix}GLOBAL_LISTENER" referencedColumnNames="GLOBAL_LISTENER_KEY" deleteCascade="true"/>
+        />
+      </column>
+      <column name="EVENT_TYPE" type="VARCHAR(50)"/>
+    </createTable>
+  </changeSet>
+
   <changeSet id="create_variable_name_index" author="camunda">
     <createIndex tableName="${prefix}VARIABLE" indexName="${prefix}IDX_VARIABLE_NAME">
       <column name="VAR_NAME"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -41,6 +41,8 @@ public final class RdbmsTableNames {
           "EXPORTER_POSITION",
           "FLOW_NODE_INSTANCE",
           "FORM",
+          "GLOBAL_LISTENER",
+          "GLOBAL_LISTENER_EVENT_TYPE",
           "GROUP_MEMBER",
           "GROUP_",
           "HISTORY_DELETION",

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GlobalListenerMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GlobalListenerMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+
+public interface GlobalListenerMapper {
+
+  void insert(GlobalListenerDbModel variable);
+
+  void insertEventTypes(GlobalListenerDbModel variable);
+
+  void update(GlobalListenerDbModel variable);
+
+  void delete(GlobalListenerDbModel variable);
+
+  void deleteEventTypes(GlobalListenerDbModel variable);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -40,6 +40,7 @@ import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
 import io.camunda.db.rdbms.write.service.FormWriter;
+import io.camunda.db.rdbms.write.service.GlobalListenerWriter;
 import io.camunda.db.rdbms.write.service.GroupWriter;
 import io.camunda.db.rdbms.write.service.HistoryDeletionWriter;
 import io.camunda.db.rdbms.write.service.IncidentWriter;
@@ -171,6 +172,7 @@ public class RdbmsWriters {
     writers.put(
         HistoryDeletionWriter.class,
         new HistoryDeletionWriter(executionQueue, historyDeletionMapper));
+    writers.put(GlobalListenerWriter.class, new GlobalListenerWriter(executionQueue));
   }
 
   public AuthorizationWriter getAuthorizationWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -281,6 +281,10 @@ public class RdbmsWriters {
     return getWriter(HistoryDeletionWriter.class);
   }
 
+  public GlobalListenerWriter getGlobalListenerWriter() {
+    return getWriter(GlobalListenerWriter.class);
+  }
+
   public List<ProcessInstanceDependant> getProcessInstanceDependantWriters() {
     return writers.values().stream()
         .filter(ProcessInstanceDependant.class::isInstance)

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+
+public record GlobalListenerDbModel(
+    Long globalListenerKey,
+    String id,
+    String type,
+    Integer retries,
+    List<String> eventTypes,
+    boolean afterNonGlobal,
+    Integer priority,
+    GlobalListenerSource source,
+    GlobalListenerType listenerType) {
+
+  public static class GlobalListenerDbModelBuilder implements ObjectBuilder<GlobalListenerDbModel> {
+    private Long globalListenerKey;
+    private String id;
+    private String type;
+    private Integer retries;
+    private List<String> eventTypes;
+    private boolean afterNonGlobal;
+    private Integer priority;
+    private GlobalListenerSource source;
+    private GlobalListenerType listenerType;
+
+    public GlobalListenerDbModelBuilder globalListenerKey(final Long globalListenerKey) {
+      this.globalListenerKey = globalListenerKey;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder type(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder retries(final Integer retries) {
+      this.retries = retries;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder eventTypes(final List<String> eventTypes) {
+      this.eventTypes = eventTypes;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder afterNonGlobal(final boolean afterNonGlobal) {
+      this.afterNonGlobal = afterNonGlobal;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder priority(final Integer priority) {
+      this.priority = priority;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder source(final GlobalListenerSource source) {
+      this.source = source;
+      return this;
+    }
+
+    public GlobalListenerDbModelBuilder listenerType(final GlobalListenerType listenerType) {
+      this.listenerType = listenerType;
+      return this;
+    }
+
+    @Override
+    public GlobalListenerDbModel build() {
+      return new GlobalListenerDbModel(
+          globalListenerKey,
+          id,
+          type,
+          retries,
+          eventTypes,
+          afterNonGlobal,
+          priority,
+          source,
+          listenerType);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -34,7 +34,9 @@ public enum ContextType {
   USER(false),
   USER_TASK(true),
   VARIABLE(false),
-  CLUSTER_VARIABLE(false);
+  CLUSTER_VARIABLE(false),
+  GLOBAL_LISTENER(
+      true); // event types are updated through delete+insert, so order needs to be preserved
 
   private final boolean preserveOrder;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GlobalListenerWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GlobalListenerWriter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class GlobalListenerWriter implements RdbmsWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public GlobalListenerWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final GlobalListenerDbModel globalListener) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.INSERT,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.insert",
+            globalListener));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.INSERT,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.insertEventTypes",
+            globalListener));
+  }
+
+  public void update(final GlobalListenerDbModel globalListener) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.UPDATE,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.update",
+            globalListener));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.DELETE,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.deleteEventTypes",
+            globalListener));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.INSERT,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.insertEventTypes",
+            globalListener));
+  }
+
+  public void delete(final GlobalListenerDbModel globalListener) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.DELETE,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.deleteEventTypes",
+            globalListener));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.GLOBAL_LISTENER,
+            WriteStatementType.DELETE,
+            globalListener.globalListenerKey(),
+            "io.camunda.db.rdbms.sql.GlobalListenerMapper.delete",
+            globalListener));
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.GlobalListenerMapper">
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    INSERT INTO ${prefix}GLOBAL_LISTENER (GLOBAL_LISTENER_KEY,
+                                          ID,
+                                          TYPE,
+                                          RETRIES,
+                                          AFTER_NON_GLOBAL,
+                                          PRIORITY,
+                                          SOURCE,
+                                          LISTENER_TYPE)
+    VALUES (#{globalListenerKey},
+            #{id},
+            #{type},
+            #{retries},
+            #{afterNonGlobal},
+            #{priority},
+            #{source},
+            #{listenerType})
+  </insert>
+
+  <insert id="insertEventTypes" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    INSERT INTO ${prefix}GLOBAL_LISTENER_EVENT_TYPE (GLOBAL_LISTENER_KEY, EVENT_TYPE)
+    VALUES
+    <foreach collection="eventTypes" item="eventType" separator=", ">
+      (#{globalListenerKey}, #{eventType})
+    </foreach>
+  </insert>
+
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    UPDATE ${prefix}GLOBAL_LISTENER
+    SET ID = {#id},
+        TYPE = {#type},
+        RETRIES = {#retries},
+        AFTER_NON_GLOBAL = {#afterNonGlobal},
+        PRIORITY = {#priority},
+        SOURCE = {#source},
+        LISTENER_TYPE = {#listenerType},
+    WHERE GLOBAL_LISTENER_KEY = #{globalListenerKey}
+  </update>
+
+  <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    DELETE
+    FROM ${prefix}GLOBAL_LISTENER
+    WHERE GLOBAL_LISTENER_KEY = #{globalListenerKey}
+  </delete>
+
+  <delete id="deleteEventTypes" parameterType="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    DELETE
+    FROM ${prefix}GLOBAL_LISTENER_EVENT_TYPE
+    WHERE GLOBAL_LISTENER_KEY = #{globalListenerKey}
+  </delete>
+
+</mapper>
+

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
+import io.camunda.db.rdbms.sql.GlobalListenerMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -329,6 +330,12 @@ public class MyBatisConfiguration {
   MapperFactoryBean<PersistentWebSessionMapper> persistentWebSessionMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, PersistentWebSessionMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<GlobalListenerMapper> globalListenerMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, GlobalListenerMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerSource.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerSource.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.search.entities;
+
+public enum GlobalListenerSource {
+  CONFIGURATION,
+  API;
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerType.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.search.entities;
+
+public enum GlobalListenerType {
+  USER_TASK;
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -28,6 +28,7 @@ import io.camunda.exporter.rdbms.handlers.DecisionRequirementsExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceIncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.FormExportHandler;
+import io.camunda.exporter.rdbms.handlers.GlobalListenerExportHandler;
 import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
 import io.camunda.exporter.rdbms.handlers.HistoryDeletionDeletedHandler;
 import io.camunda.exporter.rdbms.handlers.IncidentExportHandler;
@@ -274,6 +275,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.JOB_METRICS_BATCH,
         new JobMetricsBatchExportHandler(rdbmsWriters.getJobMetricsBatchWriter()));
+    builder.withHandler(
+        ValueType.GLOBAL_LISTENER,
+        new GlobalListenerExportHandler(rdbmsWriters.getGlobalListenerWriter()));
 
     if (config.getAuditLog().isEnabled()) {
       registerAuditLogHandlers(rdbmsWriters, builder, config, partitionId);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GlobalListenerExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GlobalListenerExportHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.db.rdbms.write.service.GlobalListenerWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GlobalListenerIntent;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+
+public class GlobalListenerExportHandler implements RdbmsExportHandler<GlobalListenerRecordValue> {
+
+  private final GlobalListenerWriter globalListenerWriter;
+
+  public GlobalListenerExportHandler(final GlobalListenerWriter globalListenerWriter) {
+    this.globalListenerWriter = globalListenerWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<GlobalListenerRecordValue> record) {
+    return record.getValueType() == ValueType.GLOBAL_LISTENER
+        && (record.getIntent() == GlobalListenerIntent.CREATED
+            || record.getIntent() == GlobalListenerIntent.UPDATED
+            || record.getIntent() == GlobalListenerIntent.DELETED);
+  }
+
+  @Override
+  public void export(final Record<GlobalListenerRecordValue> record) {
+    if (record.getIntent() == GlobalListenerIntent.CREATED) {
+      globalListenerWriter.create(map(record));
+    } else if (record.getIntent() == GlobalListenerIntent.UPDATED) {
+      globalListenerWriter.update(map(record));
+    } else if (record.getIntent() == GlobalListenerIntent.DELETED) {
+      globalListenerWriter.delete(map(record));
+    }
+  }
+
+  private GlobalListenerDbModel map(final Record<GlobalListenerRecordValue> record) {
+    final var listener = record.getValue();
+    final var builder =
+        new GlobalListenerDbModel.GlobalListenerDbModelBuilder()
+            .globalListenerKey(listener.getGlobalListenerKey())
+            .id(listener.getId())
+            .type(listener.getType())
+            .retries(listener.getRetries())
+            .eventTypes(listener.getEventTypes())
+            .afterNonGlobal(listener.isAfterNonGlobal())
+            .priority(listener.getPriority())
+            .source(GlobalListenerSource.valueOf(listener.getSource().name()))
+            .listenerType(GlobalListenerType.valueOf(listener.getListenerType().name()));
+    return builder.build();
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces support for persisting global listeners in the RDBMS exporter. The changes add new database tables, mappers, domain models, writers, and export handlers to enable storing, updating, and deleting global listener records and their associated event types. The integration ensures that global listener events are properly handled during the export process.

**Database schema and mapping:**

- Added new tables `GLOBAL_LISTENER` and `GLOBAL_LISTENER_EVENT_TYPE` to store global listeners and their associated event types, including primary and foreign key constraints.
- Introduced a MyBatis mapper (`GlobalListenerMapper.java` and `GlobalListenerMapper.xml`) to define SQL operations for inserting, updating, and deleting global listeners and their event types.

**Domain model and writer logic:**

- Added the `GlobalListenerDbModel` record and builder to encapsulate global listener data for persistence.
- Implemented the `GlobalListenerWriter` service to enqueue create, update, and delete operations for global listeners and their event types, ensuring proper execution order.
- Updated the `ContextType` enum to include `GLOBAL_LISTENER` with order preservation for event type updates.

**Exporter integration:**

- Registered the `GlobalListenerWriter` in the writers map and exposed its getter in `RdbmsWriters`.
- Added the `GlobalListenerExportHandler` to map Zeebe global listener records to the database model and invoke the writer for create, update, and delete intents.
- Registered the new handler in the exporter wrapper to process `GLOBAL_LISTENER` value types.

**Table name registration:**

- Registered the new tables in the `RdbmsTableNames` class for schema management.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #43189
