### PR TITLE
feat: show deprecation hint in Operate for job worker user tasks

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
@@ -13,6 +13,8 @@ import {
   mockJob,
   mockCalledProcessInstance,
   mockBusinessObject,
+  mockJobWorkerUserTaskBusinessObject,
+  mockCamundaUserTaskBusinessObject,
   TestWrapper,
 } from './mocks';
 import {Details} from './index';
@@ -83,6 +85,44 @@ describe('MetadataPopover <Details />', () => {
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('Element Instance Key')).toBeInTheDocument();
     expect(screen.getByText('123456789')).toBeInTheDocument();
+  });
+
+  it('should display deprecation warning for job worker user tasks', () => {
+    const userTaskInstance: ElementInstance = {
+      ...mockElementInstance,
+      type: 'USER_TASK',
+    };
+
+    render(
+      <Details
+        elementInstance={userTaskInstance}
+        businessObject={mockJobWorkerUserTaskBusinessObject}
+      />,
+      {wrapper: TestWrapper},
+    );
+
+    expect(
+      screen.getByText(/job worker implementation are deprecated/),
+    ).toBeInTheDocument();
+  });
+
+  it('should not display deprecation warning for Camunda user tasks', () => {
+    const userTaskInstance: ElementInstance = {
+      ...mockElementInstance,
+      type: 'USER_TASK',
+    };
+
+    render(
+      <Details
+        elementInstance={userTaskInstance}
+        businessObject={mockCamundaUserTaskBusinessObject}
+      />,
+      {wrapper: TestWrapper},
+    );
+
+    expect(
+      screen.queryByText(/job worker implementation are deprecated/),
+    ).not.toBeInTheDocument();
   });
 
   it('should display job retries when available', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -21,6 +21,7 @@ import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProcessInstancesSearch';
 import {useJobs} from 'modules/queries/jobs/useJobs';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
+import {isCamundaUserTask} from 'modules/bpmn-js/utils/isCamundaUserTask';
 
 type Props = {
   elementInstance: ElementInstance;
@@ -106,6 +107,15 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
         }}
       />
       <Stack gap={5}>
+        {!isCamundaUserTask(businessObject) && (
+          <Stack gap={3} as="dl">
+            <SummaryDataKey />
+            <SummaryDataValue>
+              User tasks with job worker implementation are deprecated. Consider
+              migrating to Camunda user tasks.
+            </SummaryDataValue>
+          </Stack>
+        )}
         <Stack gap={3} as="dl">
           <SummaryDataKey>Element Instance Key</SummaryDataKey>
           <SummaryDataValue>{elementInstanceKey}</SummaryDataValue>

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -13,7 +13,7 @@ import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
 import {Header} from '../Header';
-import {SummaryDataKey, SummaryDataValue} from '../styled';
+import {SummaryDataKey, SummaryDataValue, SummaryText} from '../styled';
 import {getExecutionDuration} from './getExecutionDuration';
 import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import {DetailsModal} from './DetailsModal';
@@ -108,13 +108,10 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
       />
       <Stack gap={5}>
         {!isCamundaUserTask(businessObject) && (
-          <Stack gap={3} as="dl">
-            <SummaryDataKey />
-            <SummaryDataValue>
-              User tasks with job worker implementation are deprecated. Consider
-              migrating to Camunda user tasks.
-            </SummaryDataValue>
-          </Stack>
+          <SummaryText>
+            User tasks with job worker implementation are deprecated. Consider
+            migrating to Camunda user tasks.
+          </SummaryText>
         )}
         <Stack gap={3} as="dl">
           <SummaryDataKey>Element Instance Key</SummaryDataKey>

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -79,9 +79,10 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
   const job = jobSearchResult?.[0];
 
   return (
-    <>
+    <section aria-labelledby="metadata-popover-details-title">
       <Header
         title="Details"
+        titleId="metadata-popover-details-title"
         link={
           !isNil(window.clientConfig?.tasklistUrl) && type === 'USER_TASK'
             ? {
@@ -186,7 +187,7 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
           onClose={() => setIsModalVisible(false)}
         />
       )}
-    </>
+    </section>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/mocks.tsx
@@ -76,6 +76,25 @@ const mockBusinessObject: BusinessObject = {
   $type: 'bpmn:ServiceTask',
 };
 
+const mockJobWorkerUserTaskBusinessObject: BusinessObject = {
+  id: 'UserTask_1',
+  name: 'Job Worker User Task',
+  $type: 'bpmn:UserTask',
+};
+
+const mockCamundaUserTaskBusinessObject: BusinessObject = {
+  id: 'UserTask_2',
+  name: 'Camunda User Task',
+  $type: 'bpmn:UserTask',
+  extensionElements: {
+    values: [
+      {
+        $type: 'zeebe:userTask',
+      },
+    ],
+  },
+};
+
 const TestWrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
   <MemoryRouter>
     <ProcessDefinitionKeyContext.Provider value="test-process-key">
@@ -92,4 +111,6 @@ export {
   mockJob,
   mockCalledProcessInstance,
   mockBusinessObject,
+  mockJobWorkerUserTaskBusinessObject,
+  mockCamundaUserTaskBusinessObject,
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Header/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Header/index.tsx
@@ -12,6 +12,7 @@ import {Header as BaseHeader, Title, Stack} from './styled';
 type Props = {
   variant?: 'default' | 'error';
   title: string;
+  titleId?: string;
   link?: {href: string; label: string; onClick: () => void};
   button?: {
     onClick: () => void;
@@ -22,13 +23,16 @@ type Props = {
 
 const Header: React.FC<Props> = ({
   title,
+  titleId,
   variant = 'default',
   link,
   button,
 }) => {
   return (
     <BaseHeader>
-      <Title $variant={variant}>{title}</Title>
+      <Title $variant={variant} id={titleId}>
+        {title}
+      </Title>
       {(button !== undefined || link !== undefined) && (
         <Stack orientation="horizontal" gap={3}>
           {link && (

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Incidents/multiIncidents.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Incidents/multiIncidents.tsx
@@ -12,10 +12,12 @@ import {SummaryText} from '../styled';
 type Props = {count: number; onButtonClick: () => void};
 
 const MultiIncidents: React.FC<Props> = ({count, onButtonClick}) => {
+  const labelId = 'metadata-popover-incidents-title';
   return (
-    <>
+    <section aria-labelledby={labelId}>
       <Header
         title="Incidents"
+        titleId={labelId}
         variant="error"
         button={{
           title: 'Show incidents',
@@ -24,7 +26,7 @@ const MultiIncidents: React.FC<Props> = ({count, onButtonClick}) => {
         }}
       />
       <SummaryText>{`${count} incidents occurred`}</SummaryText>
-    </>
+    </section>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Incidents/singleIncident.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Incidents/singleIncident.tsx
@@ -31,11 +31,13 @@ const SingleIncident: React.FC<Props> = ({incident, onButtonClick}) => {
 
   const rootCauseDecisionInstance = data?.items[0];
   const errorTypeName = getIncidentErrorName(incident.errorType);
+  const labelId = 'metadata-popover-incident-title';
 
   return (
-    <>
+    <section aria-labelledby={labelId}>
       <Header
         title="Incident"
+        titleId={labelId}
         variant="error"
         button={{
           onClick: onButtonClick,
@@ -92,7 +94,7 @@ const SingleIncident: React.FC<Props> = ({incident, onButtonClick}) => {
           </Stack>
         )}
       </Stack>
-    </>
+    </section>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -37,6 +37,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const {data} = useProcessInstanceXml({
     processDefinitionKey,
   });
+  const labelId = 'metadata-popover-instances-title';
 
   const businessObject = selectedElementId
     ? data?.businessObjects[selectedElementId]
@@ -75,15 +76,16 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
         {elementInstancesCount !== null &&
           elementInstancesCount > 1 &&
           !selectedElementInstanceKey && (
-            <>
+            <section aria-labelledby={labelId}>
               <Header
                 title={`This element instance triggered ${elementInstancesCount} times`}
+                titleId={labelId}
               />
               <Content>
                 To view details for any of these, select one Instance in the
                 Instance History.
               </Content>
-            </>
+            </section>
           )}
 
         {resolvedElementInstance && (

--- a/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {isCamundaUserTask} from './isCamundaUserTask';
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+describe('isCamundaUserTask', () => {
+  it('should return false for undefined', () => {
+    expect(isCamundaUserTask(undefined)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isCamundaUserTask(null)).toBe(false);
+  });
+
+  it('should return false for non-user task types', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:ServiceTask',
+      id: 'task1',
+      name: 'Task 1',
+    };
+
+    expect(isCamundaUserTask(businessObject)).toBe(false);
+  });
+
+  it('should return false for user tasks without extension elements', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+    };
+
+    expect(isCamundaUserTask(businessObject)).toBe(false);
+  });
+
+  it('should return false for user tasks with unrelated extension elements', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:taskDefinition',
+            type: 'myTaskType',
+          },
+        ],
+      },
+    };
+
+    expect(isCamundaUserTask(businessObject)).toBe(false);
+  });
+
+  it('should return true for user tasks with zeebe:userTask extension', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:userTask',
+          },
+        ],
+      },
+    };
+
+    expect(isCamundaUserTask(businessObject)).toBe(true);
+  });
+
+  it('should return true when zeebe:userTask is among multiple extensions', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:UserTask',
+      id: 'task1',
+      name: 'Task 1',
+      extensionElements: {
+        values: [
+          {
+            $type: 'zeebe:formDefinition',
+            formKey: 'camunda-forms:bpmn:myForm',
+          },
+          {
+            $type: 'zeebe:userTask',
+          },
+        ],
+      },
+    };
+
+    expect(isCamundaUserTask(businessObject)).toBe(true);
+  });
+});

--- a/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isCamundaUserTask.ts
@@ -14,8 +14,8 @@ import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
  * @param businessObject - The BPMN business object to check
  * @returns true if the element is a Camunda user task
  */
-const isCamundaUserTask = (businessObject?: BusinessObject): boolean => {
-  if (businessObject?.$type !== 'bpmn:UserTask') {
+const isCamundaUserTask = (businessObject?: BusinessObject | null): boolean => {
+  if (!businessObject || businessObject.$type !== 'bpmn:UserTask') {
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Show a deprecation hint in the process instance element popover when the element is a job worker based user task.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45816
