### PR TITLE
Inject correct logout handler type

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -913,7 +913,7 @@ public class WebSecurityConfig {
         final OAuth2AuthorizedClientRepository authorizedClientRepository,
         final OAuth2AuthorizedClientManager authorizedClientManager,
         final OidcTokenEndpointCustomizer tokenEndpointCustomizer,
-        final CamundaOidcLogoutSuccessHandler logoutSuccessHandler,
+        final LogoutSuccessHandler logoutSuccessHandler,
         final OidcUserService oidcUserService)
         throws Exception {
       final var filterChainBuilder =


### PR DESCRIPTION
## Description
As success logout handler returns `LogoutSuccessHandler` type, this should also be injected into `oidcWebappSecurity`

Bean:
```
@Bean
    @ConditionalOnSecondaryStorageEnabled
    public LogoutSuccessHandler oidcLogoutSuccessHandler(
        final WebappRedirectStrategy redirectStrategy,
        final ClientRegistrationRepository repository,
        final SecurityConfiguration config) {
      final var oidcConfig = config.getAuthentication().getOidc();
      if (!oidcConfig.isIdpLogoutEnabled()) {
        return new NoContentResponseHandler();
      }

      final var handler = new CamundaOidcLogoutSuccessHandler(repository);
      handler.setPostLogoutRedirectUri("{baseUrl}/post-logout");
      handler.setRedirectStrategy(redirectStrategy);
      return handler;
    }
```

And injection:
```
@Order(ORDER_WEBAPP_API)
    @ConditionalOnSecondaryStorageEnabled
    public SecurityFilterChain oidcWebappSecurity(
        ...
        final LogoutSuccessHandler logoutSuccessHandler,
        ....
    )
```

This changes was test locally with Keycloak with both RP-initiated logout enabled and disabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
