### PR TITLE
fix: exclude BPMN XML from search results in Elasticsearch and Opensearch

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -187,8 +187,45 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
   }
 
   @Test
+  public void testGetProcessByKeyExcludesBpmnXml() {
+    // Given - a process definition with BPMN XML exists
+    final Long processKey = secondProcessDefinition.getKey();
+
+    // When - we fetch the process by key
+    final ProcessEntity result = processStore.getProcessByKey(processKey);
+
+    // Then - the process entity is returned without BPMN XML
+    assertThat(result).isNotNull();
+    assertThat(result.getKey()).isEqualTo(processKey);
+    assertThat(result.getBpmnProcessId()).isEqualTo(secondProcessDefinition.getBpmnProcessId());
+    assertThat(result.getName()).isNotNull();
+
+    // Critical assertion: bpmnXml should be null (excluded from query)
+    assertThat(result.getBpmnXml()).isNull();
+  }
+
+  @Test
   public void testGetDiagramByKey() {
     final String xml = processStore.getDiagramByKey(secondProcessDefinition.getKey());
+    assertThat(xml)
+        .isEqualTo(testResourceManager.readResourceFileContentsAsString("demoProcess_v_1.bpmn"));
+  }
+
+  @Test
+  public void testGetDiagramByKeyReturnsBpmnXml() {
+    // Given - a process definition with BPMN XML exists
+    final Long processKey = secondProcessDefinition.getKey();
+
+    // When - we explicitly request the diagram
+    final String xml = processStore.getDiagramByKey(processKey);
+
+    // Then - the BPMN XML is returned
+    assertThat(xml).isNotNull();
+    assertThat(xml).isNotEmpty();
+    assertThat(xml).contains("<?xml");
+    assertThat(xml).contains("bpmn:process");
+
+    // Verify it matches the expected content
     assertThat(xml)
         .isEqualTo(testResourceManager.readResourceFileContentsAsString("demoProcess_v_1.bpmn"));
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -146,7 +146,11 @@ public class ElasticsearchProcessStore implements ProcessStore {
     try {
       final var res =
           esClient.search(
-              s -> s.index(processIndex.getAlias()).query(tenantAwareQuery), ProcessEntity.class);
+              s ->
+                  s.index(processIndex.getAlias())
+                      .query(tenantAwareQuery)
+                      .source(src -> src.filter(f -> f.excludes(ProcessIndex.BPMN_XML))),
+              ProcessEntity.class);
       if (res.hits().total().value() == 1) {
         return res.hits().hits().getFirst().source();
       } else if (res.hits().total().value() > 1) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -96,7 +96,8 @@ public class OpensearchProcessStore implements ProcessStore {
   public ProcessEntity getProcessByKey(final Long processDefinitionKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
-            .query(withTenantCheck(term(ProcessIndex.KEY, processDefinitionKey)));
+            .query(withTenantCheck(term(ProcessIndex.KEY, processDefinitionKey)))
+            .source(sourceExclude(ProcessIndex.BPMN_XML));
 
     return richOpenSearchClient
         .doc()

--- a/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchProcessStoreTest {
+
+  @Mock private ProcessIndex processIndex;
+
+  @Mock private RichOpenSearchClient richOpenSearchClient;
+
+  @Mock private OpenSearchDocumentOperations documentOperations;
+
+  @InjectMocks private OpensearchProcessStore underTest;
+
+  @BeforeEach
+  public void setup() {
+
+    when(richOpenSearchClient.doc()).thenReturn(documentOperations);
+    when(processIndex.getAlias()).thenReturn("process-index");
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesBpmnXml() {
+    // Given - mock document operations
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(123L);
+    mockProcess.setBpmnProcessId("test-process");
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When - getProcessByKey is called
+    final ProcessEntity result = underTest.getProcessByKey(123L);
+
+    // Then - verify the result is returned
+    assertThat(result).isNotNull();
+    assertThat(result.getKey()).isEqualTo(123L);
+
+    // Verify that searchUnique was called with a SearchRequest.Builder
+    final ArgumentCaptor<SearchRequest.Builder> captor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    verify(documentOperations).searchUnique(captor.capture(), eq(ProcessEntity.class), eq("123"));
+
+    // Verify the search request builder was configured
+    final SearchRequest.Builder requestBuilder = captor.getValue();
+    assertThat(requestBuilder).isNotNull();
+
+    // Build the request to inspect it
+    final SearchRequest builtRequest = requestBuilder.build();
+
+    // Verify source filtering is applied (excludes bpmnXml)
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void testGetDiagramByKeyIncludesBpmnXml() {
+    // Given - mock document operations
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(123L);
+    mockProcess.setBpmnXml("<?xml version=\"1.0\"?><process></process>");
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When - getDiagramByKey is called
+    final String result = underTest.getDiagramByKey(123L);
+
+    // Then - verify BPMN XML is returned
+    assertThat(result).isNotNull();
+    assertThat(result).contains("<?xml");
+
+    // Verify searchUnique was called
+    verify(documentOperations)
+        .searchUnique(any(SearchRequest.Builder.class), eq(ProcessEntity.class), eq("123"));
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesOnlyBpmnXmlNotOtherFields() {
+    // Given
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(456L);
+    mockProcess.setBpmnProcessId("another-process");
+    mockProcess.setName("Another Process");
+    mockProcess.setVersion(2);
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When
+    final ProcessEntity result = underTest.getProcessByKey(456L);
+
+    // Then - verify all other fields are present except bpmnXml
+    assertThat(result).isNotNull();
+    assertThat(result.getKey()).isEqualTo(456L);
+    assertThat(result.getBpmnProcessId()).isEqualTo("another-process");
+    assertThat(result.getName()).isEqualTo("Another Process");
+    assertThat(result.getVersion()).isEqualTo(2);
+
+    // Verify the request excludes ONLY bpmnXml
+    final ArgumentCaptor<SearchRequest.Builder> captor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    verify(documentOperations).searchUnique(captor.capture(), eq(ProcessEntity.class), eq("456"));
+
+    final SearchRequest builtRequest = captor.getValue().build();
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+
+    final List<String> excludes = builtRequest.source().filter().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(ProcessIndex.BPMN_XML);
+
+    // Verify no includes are set (all other fields should be returned)
+    assertThat(builtRequest.source().filter().includes()).isNullOrEmpty();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
@@ -43,7 +43,11 @@ public class ElasticsearchProcessDefinitionDao extends ElasticsearchDao<ProcessD
         buildQueryOn(query, ProcessDefinition.KEY, new SearchRequest.Builder(), true);
 
     try {
-      final var searchReq = searchReqBuilder.index(processIndex.getAlias()).build();
+      final var searchReq =
+          searchReqBuilder
+              .index(processIndex.getAlias())
+              .source(s -> s.filter(f -> f.excludes(BPMN_XML)))
+              .build();
 
       return searchWithResultsReturn(searchReq, ProcessDefinition.class);
     } catch (final Exception e) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -18,10 +18,13 @@ import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -81,6 +84,15 @@ public class OpensearchProcessDefinitionDao
     }
     throw new ResourceNotFoundException(
         String.format("Process definition for key %s not found.", key));
+  }
+
+  @Override
+  protected SearchRequest.Builder buildSearchRequest(
+      final Query<ProcessDefinition> query,
+      final org.opensearch.client.opensearch._types.query_dsl.Query filtering,
+      final ArrayList<SortOptions> sortOptions) {
+    return super.buildSearchRequest(query, filtering, sortOptions)
+        .source(queryDSLWrapper.sourceExclude(ProcessIndex.BPMN_XML));
   }
 
   @Override

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
@@ -8,15 +8,28 @@
 package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
 
 import static io.camunda.operate.util.ElasticsearchTestHelper.unwrapQueryVal;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_XML;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import io.camunda.operate.util.ElasticsearchTenantHelper;
 import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
 import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.entities.Results;
+import io.camunda.operate.webapp.api.v1.exceptions.APIException;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,8 +37,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ElasticsearchProcessDefinitionDaoTest {
 
-  @Spy
-  ElasticsearchProcessDefinitionDao processDefinitionDao = new ElasticsearchProcessDefinitionDao();
+  @Mock private ElasticsearchClient esClient;
+  @Mock private ElasticsearchTenantHelper tenantHelper;
+  @Mock private ProcessIndex processIndex;
+
+  @InjectMocks @Spy private ElasticsearchProcessDefinitionDao processDefinitionDao;
+
+  @BeforeEach
+  public void setup() {
+    // Configure tenantHelper to return query unchanged (no tenant filtering in tests)
+    // Using lenient() because not all tests call search() method that uses these mocks
+    lenient()
+        .when(
+            tenantHelper.makeQueryTenantAware(
+                any(co.elastic.clients.elasticsearch._types.query_dsl.Query.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // Configure processIndex to return an alias
+    lenient().when(processIndex.getAlias()).thenReturn("process-index");
+  }
 
   @Test
   public void shouldApplyFilters() {
@@ -76,5 +106,183 @@ public class ElasticsearchProcessDefinitionDaoTest {
 
     assertThat(queries.get(5).terms().field()).isEqualTo(ProcessDefinition.KEY);
     assertThat(unwrapQueryVal(queries.get(5), Long.class)).isEqualTo(processDefinition.getKey());
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearch() throws APIException, IOException {
+    // given
+    final Query<ProcessDefinition> query = new Query<>();
+
+    // Mock the searchWithResultsReturn method to avoid actual ES calls
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify that source exclusion is applied
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+    assertThat(capturedRequest.source().filter().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithFilters() throws APIException, IOException {
+    // given - query with filters applied
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setName("testProcess")
+            .setBpmnProcessId("process-123")
+            .setTenantId("<default>")
+            .setVersion(2);
+    final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+
+    // Mock the searchWithResultsReturn method
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is still excluded with filters
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+    assertThat(capturedRequest.source().filter().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithPagination() throws APIException, IOException {
+    // given - query with pagination parameters
+    // Note: We're testing that BPMN XML exclusion works regardless of pagination
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>().setSize(100).setSearchAfter(new Object[] {50L});
+
+    // Mock the searchWithResultsReturn method
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is excluded
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+    assertThat(capturedRequest.source().filter().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldOnlyExcludeBpmnXmlAndNotOtherFields() throws APIException, IOException {
+    // given - ensure only BPMN XML is excluded, not other process definition fields
+    final Query<ProcessDefinition> query = new Query<>();
+
+    // Mock the searchWithResultsReturn method
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify ONLY bpmnXml is excluded
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+
+    final var excludes = capturedRequest.source().filter().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(BPMN_XML);
+
+    // Verify no includes are set (we want all other fields)
+    assertThat(capturedRequest.source().filter().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlWithComplexQuery() throws APIException, IOException {
+    // given - complex query with all filter fields populated
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setKey(999L)
+            .setName("complexProcess")
+            .setBpmnProcessId("complex-process-id")
+            .setTenantId("complex-tenant")
+            .setVersion(10)
+            .setVersionTag("v2.0.0");
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setFilter(filter)
+            .setSize(25)
+            .setSort(Query.Sort.listOf(ProcessDefinition.VERSION, Query.Sort.Order.DESC));
+
+    // Mock the searchWithResultsReturn method
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is excluded even with complex query
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+    assertThat(capturedRequest.source().filter().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithSorting() throws APIException, IOException {
+    // given - query with custom sorting
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setSort(Query.Sort.listOf(ProcessDefinition.NAME, Query.Sort.Order.ASC));
+
+    // Mock the searchWithResultsReturn method
+    doReturn(new Results<ProcessDefinition>())
+        .when(processDefinitionDao)
+        .searchWithResultsReturn(any(), any());
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is excluded with sorting
+    final ArgumentCaptor<SearchRequest> searchRequestCaptor =
+        ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(processDefinitionDao)
+        .searchWithResultsReturn(searchRequestCaptor.capture(), any());
+
+    final SearchRequest capturedRequest = searchRequestCaptor.getValue();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().filter()).isNotNull();
+    assertThat(capturedRequest.source().filter().excludes()).contains(BPMN_XML);
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.opensearch.client.opensearch._types.query_dsl.Query.of;
 
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
@@ -18,10 +20,13 @@ import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchProcessDefinitionDaoTest {
@@ -67,5 +72,194 @@ public class OpensearchProcessDefinitionDaoTest {
     verify(wrapper, times(1))
         .term(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
     verify(wrapper, times(1)).term(ProcessDefinition.KEY, processDefinition.getKey());
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearch() {
+    // Given
+    final Query<ProcessDefinition> query = new Query<>();
+    final var filtering = of(q -> q.matchAll(new MatchAllQuery.Builder().build()));
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    // Create a real instance instead of mock to test the actual behavior
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that source filter excludes bpmnXml
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithFilter() {
+    // given - query with filters applied
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setName("testProcess")
+            .setBpmnProcessId("process-123")
+            .setTenantId("<default>");
+    final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that bpmnXml is still excluded even with filters
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithPagination() {
+    // given - query with pagination parameters set
+    // Note: buildSearchRequest() doesn't apply pagination - that's done by buildPaging()
+    // We're testing that BPMN XML exclusion works regardless of pagination settings
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>().setSize(50).setSearchAfter(new Object[] {100L});
+
+    final var filtering = of(q -> q.matchAll(new MatchAllQuery.Builder().build()));
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify BPMN XML exclusion is applied (pagination is applied separately)
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithSorting() {
+    // given - query with custom sorting
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setSort(Query.Sort.listOf(ProcessDefinition.NAME, Query.Sort.Order.ASC));
+
+    final var filtering = of(q -> q.matchAll(new MatchAllQuery.Builder().build()));
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify exclusion works with sorting
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldOnlyExcludeBpmnXmlFieldAndNotOthers() {
+    // given
+    final Query<ProcessDefinition> query = new Query<>();
+    final var filtering = of(q -> q.matchAll(new MatchAllQuery.Builder().build()));
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify ONLY bpmnXml is in the excludes list
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    final var excludes = builtRequest.source().filter().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(ProcessIndex.BPMN_XML);
+    // Verify no includes are set (we want all other fields)
+    assertThat(builtRequest.source().filter().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithComplexFilter() {
+    // given - query with multiple filters (corner case: all fields set)
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setKey(123L)
+            .setName("complexProcess")
+            .setBpmnProcessId("process-complex-123")
+            .setTenantId("tenant-42")
+            .setVersion(5)
+            .setVersionTag("v1.2.3");
+    final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    final var realWrapper = spy(new OpensearchQueryDSLWrapper());
+    final var realRequestWrapper = spy(new OpensearchRequestDSLWrapper());
+    final var realProcessDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            realWrapper,
+            realRequestWrapper,
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex("test-index", false));
+
+    // when
+    final var searchRequest =
+        realProcessDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that bpmnXml is excluded even with complex filters
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
   }
 }


### PR DESCRIPTION
## Description

The `/v1/process-definitions/search` endpoint in Operate API v1 was requesting the full `bpmnXML` field from `Elasticsearch/OpenSearch` even though the API response never returns this field to clients.

**Impact**
- Excessive memory consumption when many process definitions are deployed
- OutOfMemory (OOM) errors in production SaaS environments on operate-webapp pods
- Performance degradation due to unnecessary transfer of large XML documents
- Support case: [SUPPORT-24457](https://jira.camunda.com/browse/SUPPORT-24457)
- Affected versions: 8.7, 8.8, 8.9

**Solution**
Added source filtering to exclude the `bpmnXML` field from search queries at the database level. This prevents large XML documents from being retrieved when they're not needed.

**Performance Improvements**
⚡ Reduced memory usage - BPMN XML documents no longer loaded unnecessarily
⚡ Faster queries - Less data transfer between database and application
⚡ Prevents OOM errors - Critical for production environments with many process definitions

**Production Impact**
🎯 Solves OOM issues reported in SaaS environments
🎯 No deployment risks - backward compatible
🎯 No API changes - clients unaffectedThe /v1/process-definitions/search endpoint in Operate API v1 was requesting the full `bpmnXML` field from `Elasticsearch/OpenSearch` even though the API response never returns this field to clients.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #30372 
