### PR TITLE
test: temp disable GlobalJobStastisticsTenancyIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
@@ -31,14 +31,16 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "AWS_OS") // test is flaky on AWS OS
+// @DisabledIfSystemProperty(
+//    named = "test.integration.camunda.database.type",
+//    matches = "AWS_OS") // test is flaky on AWS OS
+@Disabled(
+    "Flaky test, will be fixed in the context of https://github.com/camunda/camunda/issues/42928")
 public class GlobalJobStatisticsIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();


### PR DESCRIPTION
## Description

This pull request disables the `GlobalJobStatisticsTenancyIT` test due to flakiness and removes the logic related to testing the "max unique keys exceeded" scenario. It also makes minor adjustments to test constants and cleans up unused imports and variables.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
