### PR TITLE
[Backport stable/8.8] fix: added client methods for resource endpoints

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -104,6 +104,8 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
@@ -822,7 +824,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  .send();
    * </pre>
    *
-   * @param decisionDefinitionKey the key of the process definition
+   * @param processDefinitionKey the key of the process definition
    * @return a builder for the request to get the XML of a process definition
    */
   ProcessDefinitionGetXmlRequest newProcessDefinitionGetXmlRequest(long processDefinitionKey);
@@ -2724,4 +2726,34 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the correlated message subscription search request
    */
   CorrelatedMessageSubscriptionSearchRequest newCorrelatedMessageSubscriptionSearchRequest();
+
+  /**
+   * Retrieves a resource by key.
+   *
+   * <pre>
+   * long resourceKey = ...;
+   *
+   * camundaClient
+   *  .newResourceGetRequest(resourceKey)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the request to get a resource
+   */
+  ResourceGetRequest newResourceGetRequest(long resourceKey);
+
+  /**
+   * Retrieves a resource content by key.
+   *
+   * <pre>
+   * long resourceKey = ...;
+   *
+   * camundaClient
+   *  .newResourceContentGetRequest(resourceKey)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the request to get a resource content
+   */
+  ResourceContentGetRequest newResourceContentGetRequest(long resourceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceContentGetRequest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+
+public interface ResourceContentGetRequest extends FinalCommandStep<String> {}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ResourceGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.Resource;
+
+public interface ResourceGetRequest extends FinalCommandStep<Resource> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -115,6 +115,8 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
@@ -250,6 +252,8 @@ import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetCallHierarchyRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetRequestImpl;
+import io.camunda.client.impl.fetch.ResourceContentGetRequestImpl;
+import io.camunda.client.impl.fetch.ResourceGetRequestImpl;
 import io.camunda.client.impl.fetch.RoleGetRequestImpl;
 import io.camunda.client.impl.fetch.TenantGetRequestImpl;
 import io.camunda.client.impl.fetch.UserGetRequestImpl;
@@ -1345,6 +1349,16 @@ public final class CamundaClientImpl implements CamundaClient {
   public CorrelatedMessageSubscriptionSearchRequest
       newCorrelatedMessageSubscriptionSearchRequest() {
     return new CorrelatedMessageSubscriptionSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public ResourceGetRequest newResourceGetRequest(final long resourceKey) {
+    return new ResourceGetRequestImpl(httpClient, resourceKey);
+  }
+
+  @Override
+  public ResourceContentGetRequest newResourceContentGetRequest(final long resourceKey) {
+    return new ResourceContentGetRequestImpl(httpClient, resourceKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceContentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceContentGetRequestImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ResourceContentGetRequest;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResourceContentGetRequestImpl implements ResourceContentGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long resourceKey;
+
+  public ResourceContentGetRequestImpl(final HttpClient httpClient, final long resourceKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.resourceKey = resourceKey;
+  }
+
+  @Override
+  public ResourceContentGetRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<String> send() {
+    final HttpCamundaFuture<String> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/resources/%d/content", resourceKey),
+        httpRequestConfig.build(),
+        String.class,
+        s -> s,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ResourceGetRequestImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ResourceGetRequest;
+import io.camunda.client.api.response.Resource;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ResourceResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResourceGetRequestImpl implements ResourceGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long resourceKey;
+
+  public ResourceGetRequestImpl(final HttpClient httpClient, final long resourceKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.resourceKey = resourceKey;
+  }
+
+  @Override
+  public ResourceGetRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Resource> send() {
+    final HttpCamundaFuture<Resource> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/resources/%d", resourceKey),
+        httpRequestConfig.build(),
+        ResourceResult.class,
+        SearchResponseMapper::toResourceGetResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.response.Resource;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
@@ -50,6 +51,7 @@ import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.search.response.User;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.response.ResourceImpl;
 import io.camunda.client.impl.search.response.BatchOperationItemsImpl.BatchOperationItemImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.*;
@@ -81,6 +83,15 @@ public final class SearchResponseMapper {
 
   public static ProcessInstance toProcessInstanceGetResponse(final ProcessInstanceResult response) {
     return new ProcessInstanceImpl(response);
+  }
+
+  public static Resource toResourceGetResponse(final ResourceResult response) {
+    return new ResourceImpl(
+        response.getResourceId(),
+        Long.parseLong(response.getResourceKey()),
+        response.getVersion(),
+        response.getResourceName(),
+        response.getTenantId());
   }
 
   public static SearchResponse<ProcessInstance> toProcessInstanceSearchResponse(

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceContentTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import io.camunda.client.util.assertions.LoggedRequestAssert;
+import org.junit.jupiter.api.Test;
+
+public class GetResourceContentTest extends ClientRestTest {
+  @Test
+  void shouldGetResourceContent() {
+    // given
+    final String resourceContent = "test content";
+    gatewayService.onResourceContentGetRequest(123L, resourceContent);
+
+    // when
+    final String response = client.newResourceContentGetRequest(123L).execute();
+
+    // then
+    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.GET)
+        .hasUrl(RestGatewayPaths.getResourceContentUrl("123"));
+
+    assertThat(response).isEqualTo(resourceContent);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/GetResourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.response.Resource;
+import io.camunda.client.protocol.rest.ResourceResult;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import io.camunda.client.util.assertions.LoggedRequestAssert;
+import org.junit.jupiter.api.Test;
+
+public class GetResourceTest extends ClientRestTest {
+  @Test
+  void shouldGetResource() {
+    // given
+    gatewayService.onResourceGetRequest(
+        123L,
+        new ResourceResult()
+            .resourceKey("123")
+            .resourceId("test.bpmn")
+            .resourceName("Test process")
+            .version(1));
+
+    // when
+    final Resource response = client.newResourceGetRequest(123L).execute();
+
+    // then
+    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.GET)
+        .hasUrl(RestGatewayPaths.getResourceUrl("123"));
+
+    assertThat(response.getResourceKey()).isEqualTo(123);
+    assertThat(response.getResourceId()).isEqualTo("test.bpmn");
+    assertThat(response.getResourceName()).isEqualTo("Test process");
+    assertThat(response.getVersion()).isEqualTo(1);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -79,6 +79,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
   private static final String URL_VARIABLE = REST_API_PATH + "/variables/%s";
+  private static final String URL_RESOURCE = REST_API_PATH + "/resources/%s";
+  private static final String URL_RESOURCE_CONTENT = URL_RESOURCE + "/content";
 
   /**
    * @return the topology request URL
@@ -307,5 +309,13 @@ public class RestGatewayPaths {
 
   public static String getElementInstanceUrl(final long elementInstanceKey) {
     return String.format(URL_ELEMENT_INSTANCE, elementInstanceKey);
+  }
+
+  public static String getResourceUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE, resourceKey);
+  }
+
+  public static String getResourceContentUrl(final String resourceKey) {
+    return String.format(URL_RESOURCE_CONTENT, resourceKey);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -44,6 +44,7 @@ import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.protocol.rest.ProcessInstanceSequenceFlowsQueryResult;
+import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.client.protocol.rest.RoleUpdateResult;
@@ -364,5 +365,13 @@ public class RestGatewayService {
         .register(
             WireMock.get(RestGatewayPaths.getStatusUrl())
                 .willReturn(WireMock.aResponse().withStatus(statusCode)));
+  }
+
+  public void onResourceGetRequest(final long resourceKey, final ResourceResult response) {
+    registerGet(RestGatewayPaths.getResourceUrl(String.valueOf(resourceKey)), response);
+  }
+
+  public void onResourceContentGetRequest(final long resourceKey, final String response) {
+    registerGet(RestGatewayPaths.getResourceContentUrl(String.valueOf(resourceKey)), response);
   }
 }


### PR DESCRIPTION
# Description
Backport of #43086 to `stable/8.8`.

relates to camunda/camunda#31111