### PR TITLE
test: Test RDBMS and Elasticsearch exporters in parallel

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -369,6 +369,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.backup.repository.SnapshotNameProvider;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
@@ -103,6 +104,26 @@ public interface DocumentClient extends AutoCloseable {
    * @throws IOException if bulk indexing fails
    */
   void bulkIndex(String indexName, Collection<DocumentWithId> documents) throws IOException;
+
+  /**
+   * Perform a search on the given index with the specified size and return the hits as a list of
+   * maps.
+   *
+   * @param indexName the name of the index
+   * @param size the maximum number of results
+   * @return list of document maps
+   * @throws IOException if the search fails
+   */
+  List<Map<String, Object>> search(String indexName, int size) throws IOException;
+
+  /**
+   * Set the maximum result window for the specified index to allow retrieving more search results.
+   *
+   * @param indexName the name of the index
+   * @param maxResultWindow the maximum number of search results to retrieve
+   * @throws IOException if updating the index settings fails
+   */
+  void setMaxResultWindow(String indexName, int maxResultWindow) throws IOException;
 
   /** Helper record to represent a document with its ID for bulk operations. */
   record DocumentWithId(String id, Object document) {}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
@@ -116,15 +116,6 @@ public interface DocumentClient extends AutoCloseable {
    */
   List<Map<String, Object>> search(String indexName, int size) throws IOException;
 
-  /**
-   * Set the maximum result window for the specified index to allow retrieving more search results.
-   *
-   * @param indexName the name of the index
-   * @param maxResultWindow the maximum number of search results to retrieve
-   * @throws IOException if updating the index settings fails
-   */
-  void setMaxResultWindow(String indexName, int maxResultWindow) throws IOException;
-
   /** Helper record to represent a document with its ID for bulk operations. */
   record DocumentWithId(String id, Object document) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
@@ -168,14 +168,6 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
-  public void setMaxResultWindow(final String indexName, final int maxResultWindow)
-      throws IOException {
-    esClient
-        .indices()
-        .putSettings(b -> b.index(indexName).settings(s -> s.maxResultWindow(maxResultWindow)));
-  }
-
-  @Override
   public void close() throws Exception {
     restClient.close();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
@@ -14,6 +14,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.cat.indices.IndicesRecord;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.RefreshRequest;
 import co.elastic.clients.elasticsearch.snapshot.Repository;
@@ -27,6 +28,7 @@ import io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRep
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
@@ -150,6 +152,27 @@ public class ESClient implements DocumentClient {
       throw new IOException(
           "Bulk indexing failed for " + errorCount + " documents in index: " + indexName);
     }
+  }
+
+  @Override
+  public List<Map<String, Object>> search(final String indexName, final int size)
+      throws IOException {
+    return esClient
+        .search(b -> b.index(indexName).size(size), java.util.Map.class)
+        .hits()
+        .hits()
+        .stream()
+        .map(Hit::source)
+        .map(doc -> (Map<String, Object>) doc)
+        .toList();
+  }
+
+  @Override
+  public void setMaxResultWindow(final String indexName, final int maxResultWindow)
+      throws IOException {
+    esClient
+        .indices()
+        .putSettings(b -> b.index(indexName).settings(s -> s.maxResultWindow(maxResultWindow)));
   }
 
   @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -174,14 +174,6 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
-  public void setMaxResultWindow(final String indexName, final int maxResultWindow)
-      throws IOException {
-    opensearchClient
-        .indices()
-        .putSettings(b -> b.index(indexName).settings(s -> s.maxResultWindow(maxResultWindow)));
-  }
-
-  @Override
   public void close() throws Exception {
     transport.close();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import org.apache.hc.core5.http.HttpHost;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -25,6 +26,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.RefreshRequest;
 import org.opensearch.client.opensearch.snapshot.Repository;
@@ -156,6 +158,27 @@ public class OSClient implements DocumentClient {
       throw new IOException(
           "Bulk indexing failed for " + errorCount + " documents in index: " + indexName);
     }
+  }
+
+  @Override
+  public List<Map<String, Object>> search(final String indexName, final int size)
+      throws IOException {
+    return opensearchClient
+        .search(b -> b.index(indexName).size(size), Map.class)
+        .hits()
+        .hits()
+        .stream()
+        .map(Hit::source)
+        .map(doc -> (Map<String, Object>) doc)
+        .toList();
+  }
+
+  @Override
+  public void setMaxResultWindow(final String indexName, final int maxResultWindow)
+      throws IOException {
+    opensearchClient
+        .indices()
+        .putSettings(b -> b.index(indexName).settings(s -> s.maxResultWindow(maxResultWindow)));
   }
 
   @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
@@ -144,7 +144,6 @@ public class MultiExporterIT {
       return Set.of();
     }
 
-    documentClient.setMaxResultWindow(indexName, 10000);
     documentClient.refresh(indexName);
 
     return documentClient.search(indexName, 10000).stream()
@@ -308,7 +307,6 @@ public class MultiExporterIT {
             .newClientBuilder()
             .defaultRequestTimeout(Duration.ofSeconds(1))
             .build();
-
   }
 
   public enum ExporterType {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.cat.indices.IndicesRecord;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbConfigurator;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.agrona.CloseHelper;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test for verifying that process instances are correctly exported to RDBMS and
+ * Elasticsearch.
+ *
+ * <p>This is intentionally no {@link io.camunda.qa.util.multidb.MultiDbTest}, as it always tests
+ * the combination of RDBMS as secondary storage and Elasticsearch as exporter, and does not need to
+ * be run with different database combinations.
+ *
+ * <p>This test sets up a Camunda process engine, using RDBMS as secondary storage and an
+ * Elasticsearch Testcontainer, deploys a process, starts an instance, and verifies that the process
+ * instance is both visible in the RDBMS and indexed in Elasticsearch.
+ */
+@Testcontainers
+@ZeebeIntegration
+public class MultiExporterIT {
+  private static final String PROCESS_ID = "PROCESS_WITH_JOB_BASED_USERTASK";
+
+  @Container
+  private static final GenericContainer<?> SEARCH_CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer()
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("path.repo", "~/");
+
+  protected CamundaClient camundaClient;
+
+  @TestZeebe(autoStart = false)
+  protected TestStandaloneApplication<?> testStandaloneApplication;
+
+  protected TestEsClient documentClient;
+
+  @AfterEach
+  public void tearDown() {
+    CloseHelper.quietCloseAll(documentClient, camundaClient);
+  }
+
+  @Test
+  void name() throws Exception {
+    setup();
+
+    // Deploy the process definition
+    camundaClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("process/process_job_based_user_task.bpmn")
+        .send()
+        .join();
+
+    // Start 5 process instances and collect their keys
+    final Set<Long> expectedProcessInstanceKeys =
+        java.util.stream.IntStream.range(0, 5)
+            .mapToObj(
+                i ->
+                    camundaClient
+                        .newCreateInstanceCommand()
+                        .bpmnProcessId(PROCESS_ID)
+                        .latestVersion()
+                        .send()
+                        .join()
+                        .getProcessInstanceKey())
+            .collect(Collectors.toSet());
+
+    // Wait until all process instances are visible in the RDBMS
+    await()
+        .alias("Wait until all process instances are visible in RDBMS")
+        .untilAsserted(
+            () -> {
+              final var rdbmsSearchResult =
+                  camundaClient.newProcessInstanceSearchRequest().send().join();
+              assertThat(rdbmsSearchResult.items()).hasSize(5);
+              final var foundKeys =
+                  rdbmsSearchResult.items().stream()
+                      .map(item -> item.getProcessInstanceKey())
+                      .collect(Collectors.toSet());
+              assertThat(foundKeys)
+                  .containsExactlyInAnyOrderElementsOf(expectedProcessInstanceKeys);
+            });
+
+    // Wait until all process instances are indexed in Elasticsearch
+    await()
+        .alias("Wait until all process instances are visible in Elasticsearch")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              final var esKeys = fetchProcessInstanceKeysFromElasticsearch();
+              assertThat(esKeys).hasSize(5);
+              assertThat(esKeys).containsExactlyInAnyOrderElementsOf(expectedProcessInstanceKeys);
+            });
+  }
+
+  /**
+   * Fetches all processInstanceKey values from the first process-instance index in Elasticsearch.
+   *
+   * @return Set of processInstanceKey values (as Longs if possible)
+   */
+  private Set<Object> fetchProcessInstanceKeysFromElasticsearch() throws IOException {
+    final String indexName = findProcessInstanceIndexName();
+    if (indexName == null) {
+      return Set.of();
+    }
+
+    // Increase max_result_window to ensure we can fetch all documents in one query (for testing
+    // purposes)
+    documentClient
+        .esClient
+        .indices()
+        .putSettings(b -> b.index(indexName).settings(s -> s.maxResultWindow(10000)));
+
+    return documentClient
+        .esClient
+        .search(b -> b.index(indexName).size(10000), Map.class)
+        .hits()
+        .hits()
+        .stream()
+        .map(Hit::source)
+        .map(source -> source.get("value"))
+        .map(value -> value instanceof Map ? ((Map<?, ?>) value).get("processInstanceKey") : null)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Finds the first Elasticsearch index containing process-instance documents.
+   *
+   * @return Index name or null if not found
+   */
+  private String findProcessInstanceIndexName() {
+    try {
+      return documentClient.esClient.cat().indices().valueBody().stream()
+          .map(IndicesRecord::index)
+          .filter(name -> name != null && name.contains("process-instance"))
+          .findFirst()
+          .orElse(null);
+    } catch (final IOException e) {
+      return null;
+    }
+  }
+
+  private void setup() throws Exception {
+    testStandaloneApplication =
+        new TestCamundaApplication()
+            .withAuthenticationMethod(AuthenticationMethod.BASIC)
+            .withUnauthenticatedAccess();
+
+    final MultiDbConfigurator configurator = new MultiDbConfigurator(testStandaloneApplication);
+
+    // configure the app to use RDBMS as secondary storage, with an in-memory H2 database
+    configurator.configureRDBMSSupport(false, "jdbc:h2:mem:camunda", "sa", "", "org.h2.Driver");
+
+    final String elasticsearchUrl =
+        String.format(
+            "http://%s:%d", SEARCH_CONTAINER.getHost(), SEARCH_CONTAINER.getMappedPort(9200));
+
+    // configure the app to use the Elasticsearch exporter, pointing to the Testcontainer
+    testStandaloneApplication.withExporter(
+        ElasticsearchExporter.class.getSimpleName().toLowerCase(),
+        cfg -> {
+          cfg.setClassName(ElasticsearchExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "url", elasticsearchUrl,
+                  "index", Map.of("prefix", "zeebe-index"),
+                  "bulk", Map.of("size", 1)));
+        });
+
+    testStandaloneApplication.start().awaitCompleteTopology();
+
+    camundaClient =
+        testStandaloneApplication
+            .newClientBuilder()
+            .defaultRequestTimeout(Duration.ofSeconds(1))
+            .build();
+
+    documentClient = new TestEsClient(elasticsearchUrl);
+
+    // Ensure Elasticsearch is clean before starting the test
+    documentClient.deleteAllIndices();
+  }
+
+  public static class TestEsClient implements AutoCloseable {
+
+    final RestClient restClient;
+    final ElasticsearchClient esClient;
+
+    public TestEsClient(final String url) {
+      restClient = RestClient.builder(HttpHost.create(url)).build();
+      esClient =
+          new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
+    }
+
+    public void deleteAllIndices() throws IOException {
+      esClient.indices().delete(DeleteIndexRequest.of(b -> b.index("*")));
+    }
+
+    @Override
+    public void close() throws Exception {
+      restClient.close();
+    }
+  }
+}


### PR DESCRIPTION
## Description

* Adds an ITest, that verifies that data is exported to RDBMS and Elasticsearch

## Related issues

closes #41432
