### PR TITLE
[Backport stable/8.7] fix: apply requestTimeout for createProcessInstanceWithResult in REST API and Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
-import io.camunda.zeebe.client.api.command.CommandWithTenantStep;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep2;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3;
@@ -57,6 +56,7 @@ public final class CreateProcessInstanceCommandImpl
   private RequestConfig.Builder httpRequestConfig;
   private final io.camunda.zeebe.client.protocol.rest.CreateProcessInstanceRequest
       httpRequestObject = new io.camunda.zeebe.client.protocol.rest.CreateProcessInstanceRequest();
+  private final ZeebeClientConfiguration config;
 
   public CreateProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
@@ -66,6 +66,7 @@ public final class CreateProcessInstanceCommandImpl
       final HttpClient httpClient,
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
+    this.config = config;
     this.asyncStub = asyncStub;
     requestTimeout = config.getDefaultRequestTimeout();
     this.retryPredicate = retryPredicate;
@@ -76,32 +77,6 @@ public final class CreateProcessInstanceCommandImpl
     httpRequestConfig = httpClient.newRequestConfig();
     requestTimeout(requestTimeout);
     useRest = preferRestOverGrpc;
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link
-   *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub asyncStub,
-   *     JsonMapper jsonMapper, ZeebeClientConfiguration config, Predicate retryPredicate)}
-   */
-  @Deprecated
-  public CreateProcessInstanceCommandImpl(
-      final GatewayStub asyncStub,
-      final JsonMapper jsonMapper,
-      final Duration requestTimeout,
-      final Predicate<StatusCode> retryPredicate) {
-    super(jsonMapper);
-    this.asyncStub = asyncStub;
-    this.requestTimeout = requestTimeout;
-    this.retryPredicate = retryPredicate;
-    this.jsonMapper = jsonMapper;
-    grpcRequestObjectBuilder = CreateProcessInstanceRequest.newBuilder();
-    tenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override
@@ -140,7 +115,8 @@ public final class CreateProcessInstanceCommandImpl
         requestTimeout,
         httpClient,
         useRest,
-        httpRequestObject);
+        httpRequestObject,
+        config);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -82,6 +82,7 @@ public final class CreateProcessInstanceWithResultCommandImpl
     this.requestTimeout = requestTimeout;
     grpcRequestObject.setRequestTimeout(requestTimeout.toMillis());
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.impl.command;
 
 import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceWithResultCommandStep1;
@@ -54,6 +55,7 @@ public final class CreateProcessInstanceWithResultCommandImpl
   private final RequestConfig.Builder httpRequestConfig;
   private final io.camunda.zeebe.client.protocol.rest.CreateProcessInstanceRequest
       httpRequestObject;
+  private final ZeebeClientConfiguration config;
 
   public CreateProcessInstanceWithResultCommandImpl(
       final JsonMapper jsonMapper,
@@ -63,7 +65,9 @@ public final class CreateProcessInstanceWithResultCommandImpl
       final Duration requestTimeout,
       final HttpClient httpClient,
       final boolean preferRestOverGrpc,
-      final io.camunda.zeebe.client.protocol.rest.CreateProcessInstanceRequest httpRequestObject) {
+      final io.camunda.zeebe.client.protocol.rest.CreateProcessInstanceRequest httpRequestObject,
+      final ZeebeClientConfiguration config) {
+    this.config = config;
     this.jsonMapper = jsonMapper;
     this.asyncStub = asyncStub;
     createProcessInstanceRequestBuilder = grpcRequestObject;
@@ -81,8 +85,11 @@ public final class CreateProcessInstanceWithResultCommandImpl
   public FinalCommandStep<ProcessInstanceResult> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     grpcRequestObject.setRequestTimeout(requestTimeout.toMillis());
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
+    // increment response timeout so client doesn't time out before the server
+    final long offsetMillis = config.getDefaultRequestTimeoutOffset().toMillis();
+    httpRequestConfig.setResponseTimeout(
+        requestTimeout.toMillis() + offsetMillis, TimeUnit.MILLISECONDS);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CreateProcessInstanceWithResultRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/CreateProcessInstanceWithResultRestTest.java
@@ -42,6 +42,7 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
         gatewayService.getLastRequest(CreateProcessInstanceRequest.class);
     assertThat(request.getVariables()).isEmpty();
     assertThat(request.getProcessDefinitionKey()).isEqualTo(123);
+    assertThat(request.getRequestTimeout()).isEqualTo(123000L);
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -60,24 +61,41 @@ public abstract class ApiServices<T extends ApiServices<T>> {
     return sendBrokerRequestWithFullResponse(brokerRequest).thenApply(BrokerResponse::getResponse);
   }
 
+  protected <R> CompletableFuture<R> sendBrokerRequest(
+      final BrokerRequest<R> brokerRequest, final Duration requestTimeout) {
+    return sendBrokerRequestWithFullResponse(brokerRequest, requestTimeout)
+        .thenApplyAsync(BrokerResponse::getResponse);
+  }
+
   protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
       final BrokerRequest<R> brokerRequest) {
     brokerRequest.setAuthorization(authentication.token());
+    return brokerClient.sendRequest(brokerRequest).handleAsync(handleBrokerResponse());
+  }
+
+  protected <R> CompletableFuture<BrokerResponse<R>> sendBrokerRequestWithFullResponse(
+      final BrokerRequest<R> brokerRequest, final Duration requestTimeout) {
+    brokerRequest.setAuthorization(authentication.token());
     return brokerClient
-        .sendRequest(brokerRequest)
-        .handleAsync(
-            (response, error) -> {
-              if (error != null) {
-                throw new CamundaServiceException(error);
-              }
-              if (response.isError()) {
-                throw new CamundaServiceException(response.getError());
-              }
-              if (response.isRejection()) {
-                throw new CamundaServiceException(response.getRejection());
-              }
-              return response;
-            });
+        .sendRequest(brokerRequest, requestTimeout)
+        .handleAsync(handleBrokerResponse());
+  }
+
+  private <R>
+      java.util.function.BiFunction<BrokerResponse<R>, Throwable, BrokerResponse<R>>
+          handleBrokerResponse() {
+    return (response, error) -> {
+      if (error != null) {
+        throw new CamundaServiceException(error);
+      }
+      if (response.isError()) {
+        throw new CamundaServiceException(response.getError());
+      }
+      if (response.isRejection()) {
+        throw new CamundaServiceException(response.getRejection());
+      }
+      return response;
+    };
   }
 
   protected DirectBuffer getDocumentOrEmpty(final Map<String, Object> value) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -469,6 +469,58 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldCreateProcessInstancesWithResultAndCustomRequestTimeout() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+    final var mockResponse =
+        new ProcessInstanceResultRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(123L)
+            .setTenantId("tenantId");
+
+    when(processInstanceServices.createProcessInstanceWithResult(
+            any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+            {
+                "processDefinitionKey": "123",
+                "awaitCompletion": true,
+                "requestTimeout": 600000,
+                "tenantId": "tenantId"
+            }""";
+
+    // when / then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(PROCESS_INSTANCES_START_URL)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus()
+                    .isOk());
+
+    response
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_START_RESPONSE);
+
+    verify(processInstanceServices).createProcessInstanceWithResult(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
+    assertThat(capturedRequest.awaitCompletion()).isTrue();
+    assertThat(capturedRequest.requestTimeout()).isEqualTo(600000L);
+  }
+
+  @Test
   void shouldRejectCreateProcessInstancesIfNoBpmnProcessIdOrProcessDefinitionKeyAreProvided() {
     // given
     final var request =


### PR DESCRIPTION
# Description
Backport of #45703 to `stable/8.7`.

relates to #43991