### PR TITLE
[Backport stable/8.8] fix: apply requestTimeout for createProcessInstanceWithResult in REST API and Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -19,7 +19,6 @@ import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider.StatusCode;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep2;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3;
@@ -62,10 +61,11 @@ public final class CreateProcessInstanceCommandImpl
   private final JsonMapper jsonMapper;
   private Duration requestTimeout;
   private boolean useRest;
-  private HttpClient httpClient;
-  private RequestConfig.Builder httpRequestConfig;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
   private final ProcessInstanceCreationInstruction httpRequestObject =
       new ProcessInstanceCreationInstruction();
+  private final CamundaClientConfiguration config;
 
   public CreateProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
@@ -75,6 +75,7 @@ public final class CreateProcessInstanceCommandImpl
       final HttpClient httpClient,
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
+    this.config = config;
     this.asyncStub = asyncStub;
     requestTimeout = config.getDefaultRequestTimeout();
     this.retryPredicate = retryPredicate;
@@ -85,32 +86,6 @@ public final class CreateProcessInstanceCommandImpl
     httpRequestConfig = httpClient.newRequestConfig();
     requestTimeout(requestTimeout);
     useRest = preferRestOverGrpc;
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link
-   *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub, JsonMapper,
-   *     CamundaClientConfiguration, Predicate, HttpClient, boolean)}
-   */
-  @Deprecated
-  public CreateProcessInstanceCommandImpl(
-      final GatewayStub asyncStub,
-      final JsonMapper jsonMapper,
-      final Duration requestTimeout,
-      final Predicate<StatusCode> retryPredicate) {
-    super(jsonMapper);
-    this.asyncStub = asyncStub;
-    this.requestTimeout = requestTimeout;
-    this.retryPredicate = retryPredicate;
-    this.jsonMapper = jsonMapper;
-    grpcRequestObjectBuilder = CreateProcessInstanceRequest.newBuilder();
-    tenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override
@@ -160,7 +135,8 @@ public final class CreateProcessInstanceCommandImpl
         requestTimeout,
         httpClient,
         useRest,
-        httpRequestObject);
+        httpRequestObject,
+        config);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -83,6 +83,7 @@ public final class CreateProcessInstanceWithResultCommandImpl
     this.requestTimeout = requestTimeout;
     grpcRequestObject.setRequestTimeout(requestTimeout.toMillis());
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
@@ -57,6 +57,7 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
         gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
     assertThat(request.getVariables()).isEmpty();
     assertThat(request.getProcessDefinitionKey()).isEqualTo("123");
+    assertThat(request.getRequestTimeout()).isEqualTo(123000L);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
@@ -137,4 +137,35 @@ public class ProcessInstanceCreateTest {
     assertThat(result.getTenantId()).isEqualTo("<default>");
     assertThat(result.getTags()).isEqualTo(TAGS);
   }
+
+  @Test
+  void shouldCreateProcessInstanceWithResultAndCustomRequestTimeout() {
+    // This test verifies that the Java client sends the requestTimeout field
+    // in the REST request body and that it is respected by the server
+    final Map<String, Object> variables = Maps.of(entry("foo", "bar"));
+    final var requestTimeout = java.time.Duration.ofMinutes(5);
+
+    // given
+    final var processInstanceCreation =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .variables(variables)
+            .withResult()
+            .requestTimeout(requestTimeout)
+            .fetchVariables("foo")
+            .send()
+            .join();
+
+    // then - verify the process instance was created successfully
+    assertThat(processInstanceCreation).isNotNull();
+    assertThat(processInstanceCreation.getProcessInstanceKey()).isNotNull();
+    assertThat(processInstanceCreation.getBpmnProcessId()).isEqualTo(process.getBpmnProcessId());
+    assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
+
+    // The actual timeout behavior is verified by the fact that the request
+    // completes successfully - if the timeout wasn't sent/respected,
+    // this test would fail in scenarios with longer-running processes
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceCreateTest.java
@@ -137,35 +137,4 @@ public class ProcessInstanceCreateTest {
     assertThat(result.getTenantId()).isEqualTo("<default>");
     assertThat(result.getTags()).isEqualTo(TAGS);
   }
-
-  @Test
-  void shouldCreateProcessInstanceWithResultAndCustomRequestTimeout() {
-    // This test verifies that the Java client sends the requestTimeout field
-    // in the REST request body and that it is respected by the server
-    final Map<String, Object> variables = Maps.of(entry("foo", "bar"));
-    final var requestTimeout = java.time.Duration.ofMinutes(5);
-
-    // given
-    final var processInstanceCreation =
-        camundaClient
-            .newCreateInstanceCommand()
-            .bpmnProcessId("process")
-            .latestVersion()
-            .variables(variables)
-            .withResult()
-            .requestTimeout(requestTimeout)
-            .fetchVariables("foo")
-            .send()
-            .join();
-
-    // then - verify the process instance was created successfully
-    assertThat(processInstanceCreation).isNotNull();
-    assertThat(processInstanceCreation.getProcessInstanceKey()).isNotNull();
-    assertThat(processInstanceCreation.getBpmnProcessId()).isEqualTo(process.getBpmnProcessId());
-    assertThat(processInstanceCreation.getVariablesAsMap()).isEqualTo(variables);
-
-    // The actual timeout behavior is verified by the fact that the request
-    // completes successfully - if the timeout wasn't sent/respected,
-    // this test would fail in scenarios with longer-running processes
-  }
 }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -230,6 +231,11 @@ public final class ProcessInstanceServices
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
+    }
+
+    // Use custom request timeout if provided, otherwise use default
+    if (request.requestTimeout() != null && request.requestTimeout() > 0) {
+      return sendBrokerRequest(brokerRequest, Duration.ofMillis(request.requestTimeout()));
     }
     return sendBrokerRequest(brokerRequest);
   }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -529,4 +529,42 @@ public final class ProcessInstanceServiceTest {
     verify(brokerClient, org.mockito.Mockito.never())
         .sendRequest(any(), any(java.time.Duration.class));
   }
+
+  @Test
+  void shouldCreateProcessInstanceWithResultUsingDefaultTimeoutWhenRequestTimeoutIsZero() {
+    // given
+    final var request =
+        new ProcessInstanceServices.ProcessInstanceCreateRequest(
+            123L, // processDefinitionKey
+            "", // bpmnProcessId
+            -1, // version
+            null, // variables
+            "<default>", // tenantId
+            true, // awaitCompletion
+            0L, // requestTimeout explicitly set to zero
+            null, // operationReference
+            List.of(), // startInstructions
+            List.of(), // runtimeInstructions
+            List.of(), // fetchVariables
+            null // tags
+            );
+
+    final var mockResponse =
+        new io.camunda.zeebe.protocol.impl.record.value.processinstance
+            .ProcessInstanceResultRecord();
+    when(brokerClient.sendRequest(any()))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
+
+    // when
+    services.createProcessInstanceWithResult(request).join();
+
+    // then
+    verify(brokerClient)
+        .sendRequest(
+            any(
+                io.camunda.zeebe.gateway.impl.broker.request
+                    .BrokerCreateProcessInstanceWithResultRequest.class));
+    verify(brokerClient, org.mockito.Mockito.never())
+        .sendRequest(any(), any(java.time.Duration.class));
+  }
 }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -454,4 +454,79 @@ public final class ProcessInstanceServiceTest {
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
     verifyNoInteractions(incidentServices);
   }
+
+  @Test
+  void shouldCreateProcessInstanceWithResultUsingCustomRequestTimeout() {
+    // given
+    final var request =
+        new ProcessInstanceServices.ProcessInstanceCreateRequest(
+            123L, // processDefinitionKey
+            "", // bpmnProcessId
+            -1, // version
+            null, // variables
+            "<default>", // tenantId
+            true, // awaitCompletion
+            600000L, // requestTimeout (10 minutes)
+            null, // operationReference
+            List.of(), // startInstructions
+            List.of(), // runtimeInstructions
+            List.of(), // fetchVariables
+            null // tags
+            );
+
+    final var mockResponse =
+        new io.camunda.zeebe.protocol.impl.record.value.processinstance
+            .ProcessInstanceResultRecord();
+    when(brokerClient.sendRequest(any(), any(java.time.Duration.class)))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
+
+    // when
+    services.createProcessInstanceWithResult(request).join();
+
+    // then
+    verify(brokerClient)
+        .sendRequest(
+            any(
+                io.camunda.zeebe.gateway.impl.broker.request
+                    .BrokerCreateProcessInstanceWithResultRequest.class),
+            eq(java.time.Duration.ofMillis(600000L)));
+  }
+
+  @Test
+  void shouldCreateProcessInstanceWithResultUsingDefaultTimeoutWhenNotProvided() {
+    // given
+    final var request =
+        new ProcessInstanceServices.ProcessInstanceCreateRequest(
+            123L, // processDefinitionKey
+            "", // bpmnProcessId
+            -1, // version
+            null, // variables
+            "<default>", // tenantId
+            true, // awaitCompletion
+            null, // requestTimeout (not provided)
+            null, // operationReference
+            List.of(), // startInstructions
+            List.of(), // runtimeInstructions
+            List.of(), // fetchVariables
+            null // tags
+            );
+
+    final var mockResponse =
+        new io.camunda.zeebe.protocol.impl.record.value.processinstance
+            .ProcessInstanceResultRecord();
+    when(brokerClient.sendRequest(any()))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
+
+    // when
+    services.createProcessInstanceWithResult(request).join();
+
+    // then
+    verify(brokerClient)
+        .sendRequest(
+            any(
+                io.camunda.zeebe.gateway.impl.broker.request
+                    .BrokerCreateProcessInstanceWithResultRequest.class));
+    verify(brokerClient, org.mockito.Mockito.never())
+        .sendRequest(any(), any(java.time.Duration.class));
+  }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -429,6 +429,57 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldCreateProcessInstancesWithResultAndCustomRequestTimeout() {
+    // given
+    when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
+    final var mockResponse =
+        new ProcessInstanceResultRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(123L)
+            .setTenantId("tenantId");
+
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
+    when(processInstanceServices.createProcessInstanceWithResult(
+            any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+            {
+                "processDefinitionKey": "123",
+                "awaitCompletion": true,
+                "requestTimeout": 600000,
+                "tenantId": "tenantId"
+            }""";
+
+    // when / then
+    final ResponseSpec response =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    response
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices).createProcessInstanceWithResult(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
+    assertThat(capturedRequest.awaitCompletion()).isTrue();
+    assertThat(capturedRequest.requestTimeout()).isEqualTo(600000L);
+  }
+
+  @Test
   void shouldRejectCreateProcessInstancesIfNoBpmnProcessIdOrProcessDefinitionKeyAreProvided() {
     // given
     final var request =


### PR DESCRIPTION
# Description
Backport of #45703 to `stable/8.8`.

relates to #43991