### PR TITLE
refactor: removal of deprecated methods and obsolete Deprecations/ExperimentalAPI from camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -390,7 +390,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param processInstanceKey the key which refers to the process instance to migrate
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/14907")
   MigrateProcessInstanceCommandStep1 newMigrateProcessInstanceCommand(long processInstanceKey);
 
   /**
@@ -2152,7 +2151,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   CreateDocumentCommandStep1 newCreateDocumentCommand();
 
   /**
@@ -2201,7 +2199,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   CreateDocumentBatchCommandStep1 newCreateDocumentBatchCommand();
 
   /**
@@ -2222,7 +2219,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentId the id of the document
    * @return a builder for the request
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   DocumentContentGetRequest newDocumentContentGetRequest(String documentId);
 
   /**
@@ -2242,7 +2238,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentReferenceResponse the reference of the document
    * @return a builder for the request
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   DocumentContentGetRequest newDocumentContentGetRequest(
       DocumentReferenceResponse documentReferenceResponse);
 
@@ -2265,7 +2260,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentId the id of the document
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(String documentId);
 
   /**
@@ -2286,7 +2280,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentReferenceResponse the reference of the document
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   CreateDocumentLinkCommandStep1 newCreateDocumentLinkCommand(
       DocumentReferenceResponse documentReferenceResponse);
 
@@ -2308,7 +2301,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentId the id of the document
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   DeleteDocumentCommandStep1 newDeleteDocumentCommand(String documentId);
 
   /**
@@ -2328,7 +2320,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param documentReferenceResponse the reference of the document
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/issues/issues/841")
   DeleteDocumentCommandStep1 newDeleteDocumentCommand(
       DocumentReferenceResponse documentReferenceResponse);
 

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -281,6 +281,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @deprecated since 8 for removal with 8.1, replaced by {@link
    *     CamundaClient#newDeployResourceCommand()}
    */
+  @Deprecated
   DeployProcessCommandStep1 newDeployCommand();
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -31,10 +31,8 @@ public final class ClientProperties {
       "camunda.client.applyEnvironmentVariableOverrides";
 
   /**
-   * @deprecated since 8.5 for removal with 8.8, where toggling between both will not be possible
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)
    */
-  @Deprecated
   public static final String PREFER_REST_OVER_GRPC = "camunda.client.gateway.preferRestOverGrpc";
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/command/CommandWithCommunicationApiStep.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CommandWithCommunicationApiStep.java
@@ -16,49 +16,26 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.CamundaClientBuilder;
-import io.camunda.client.api.ExperimentalApi;
 
 public interface CommandWithCommunicationApiStep<T> {
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for a REST
-   * API in Camunda, and already wants to use this API during its development. As support for REST
-   * is added to Camunda, each of the commands that implement this method may start to take effect.
-   * Until this warning is removed, anything described below may not yet have taken effect, and the
-   * interface and its description are subject to change.</strong>
-   *
-   * <p>Sets REST as the communication API for this command. If this command doesn't support
+   * Sets REST as the communication API for this command. If this command doesn't support
    * communication over REST, it simply returns the command builder instance unchanged. The default
    * communication API can be configured using {@link
    * CamundaClientBuilder#preferRestOverGrpc(boolean)}.
    *
-   * @deprecated since 8.5, to be removed with 8.8
    * @return the configured command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
-  @Deprecated
   T useRest();
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for a REST
-   * API in Camunda, and already wants to use this API during its development. As support for REST
-   * is added to Zeebe, each of the commands that implement this method may start to take effect.
-   * Until this warning is removed, anything described below may not yet have taken effect, and the
-   * interface and its description are subject to change.</strong>
-   *
-   * <p>Sets gRPC as the communication API for this command. If this command doesn't support
+   * Sets gRPC as the communication API for this command. If this command doesn't support
    * communication over gRPC, it simply returns the command builder instance unchanged. The default
    * communication API can be configured using {@link
    * CamundaClientBuilder#preferRestOverGrpc(boolean)}.
    *
-   * @deprecated since 8.5, to be removed with 8.8
    * @return the configured command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
-  @Deprecated
   T useGrpc();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentCommandStep1.java
@@ -15,13 +15,11 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface CreateDocumentCommandStep1 extends DocumentBuilderStep1 {
 
   /**
@@ -103,20 +101,6 @@ public interface CreateDocumentCommandStep1 extends DocumentBuilderStep1 {
     CreateDocumentCommandStep2 timeToLive(Duration timeToLive);
 
     /**
-     * Sets the process definition that the document is associated with.
-     *
-     * @param processDefinitionId the process definition ID
-     */
-    CreateDocumentCommandStep2 processDefinitionId(String processDefinitionId);
-
-    /**
-     * Sets the process instance key that the document is associated with.
-     *
-     * @param processInstanceKey the process instance key
-     */
-    CreateDocumentCommandStep2 processInstanceKey(long processInstanceKey);
-
-    /**
      * Adds a custom key-value pair to the document metadata.
      *
      * @param key custom metadata key
@@ -132,5 +116,19 @@ public interface CreateDocumentCommandStep1 extends DocumentBuilderStep1 {
      */
     @Override
     CreateDocumentCommandStep2 customMetadata(Map<String, Object> customMetadata);
+
+    /**
+     * Sets the process definition that the document is associated with.
+     *
+     * @param processDefinitionId the process definition ID
+     */
+    CreateDocumentCommandStep2 processDefinitionId(String processDefinitionId);
+
+    /**
+     * Sets the process instance key that the document is associated with.
+     *
+     * @param processInstanceKey the process instance key
+     */
+    CreateDocumentCommandStep2 processInstanceKey(long processInstanceKey);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentLinkCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentLinkCommandStep1.java
@@ -15,12 +15,10 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.response.DocumentLinkResponse;
 import java.time.Duration;
 
 /** Command to create a document link in the document store. */
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface CreateDocumentLinkCommandStep1 extends FinalCommandStep<DocumentLinkResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteDocumentCommandStep1.java
@@ -15,11 +15,9 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.response.DeleteDocumentResponse;
 
 /** Command to delete a document from the document store. */
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface DeleteDocumentCommandStep1 extends FinalCommandStep<DeleteDocumentResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/command/MigrateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/MigrateProcessInstanceCommandStep1.java
@@ -15,10 +15,8 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.response.MigrateProcessInstanceResponse;
 
-@ExperimentalApi("https://github.com/camunda/camunda/issues/14907")
 public interface MigrateProcessInstanceCommandStep1
     extends CommandWithCommunicationApiStep<MigrateProcessInstanceCommandStep1> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/StreamJobsCommandStep1.java
@@ -15,14 +15,12 @@
  */
 package io.camunda.client.api.command;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.StreamJobsResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 
-@ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
 public interface StreamJobsCommandStep1 {
   /**
    * Set the type of jobs to work on; only jobs of this type will be activated and consumed by this

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/DocumentContentGetRequest.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.fetch;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.FinalCommandStep;
 import java.io.InputStream;
 
@@ -24,7 +23,6 @@ import java.io.InputStream;
  *
  * <p>The document content is returned as an {@link InputStream}.
  */
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface DocumentContentGetRequest extends FinalCommandStep<InputStream> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.search.enums.JobKind;
 import io.camunda.client.api.search.enums.ListenerEventType;
@@ -134,7 +133,6 @@ public interface ActivatedJob {
   /**
    * @return the identifier of the tenant that owns the job
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/13560")
   String getTenantId();
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentLinkResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentLinkResponse.java
@@ -15,10 +15,8 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
 import java.time.OffsetDateTime;
 
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface DocumentLinkResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentMetadata.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentMetadata.java
@@ -15,11 +15,9 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface DocumentMetadata {
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceResponse.java
@@ -16,9 +16,7 @@
 package io.camunda.client.api.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.camunda.client.api.ExperimentalApi;
 
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public interface DocumentReferenceResponse {
 
   @JsonProperty("camunda.document.type")

--- a/clients/java/src/main/java/io/camunda/client/api/response/MigrateProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/MigrateProcessInstanceResponse.java
@@ -15,7 +15,4 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
-
-@ExperimentalApi("https://github.com/camunda/camunda/issues/14907")
 public interface MigrateProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
 import java.util.Set;
 
 public interface ProcessInstanceEvent {
@@ -33,7 +32,6 @@ public interface ProcessInstanceEvent {
   long getProcessInstanceKey();
 
   /** Tenant identifier that owns this process instance */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/13321")
   String getTenantId();
 
   Set<String> getTags();

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ClientException;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +63,6 @@ public interface ProcessInstanceResult {
   Object getVariable(String name);
 
   /** Tenant identifier that owns this process instance */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/13321")
   String getTenantId();
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/response/StreamJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/StreamJobsResponse.java
@@ -15,7 +15,4 @@
  */
 package io.camunda.client.api.response;
 
-import io.camunda.client.api.ExperimentalApi;
-
-@ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
 public interface StreamJobsResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobClient.java
@@ -16,7 +16,6 @@
 package io.camunda.client.api.worker;
 
 import io.camunda.client.api.CamundaFuture;
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.FailJobCommandStep1;
@@ -211,9 +210,9 @@ public interface JobClient {
    *
    * <h2>Limitations</h2>
    *
-   * <p>This feature is still under development; as such, there is currently no way to rate limit
-   * how many jobs are streamed over a single call. This can be mitigated by opening more streams of
-   * the same type, which will ensure work is fairly load balanced.
+   * <p>There is currently no way to rate limit how many jobs are streamed over a single call. This
+   * can be mitigated by opening more streams of the same type, which will ensure work is fairly
+   * load balanced.
    *
    * <p>Additionally, only jobs which are created, retried, or timed out <em>after</em> the command
    * has been registered will be streamed out. For older jobs, you must still use the {@link
@@ -245,6 +244,5 @@ public interface JobClient {
    *
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
   StreamJobsCommandStep1 newStreamJobsCommand();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -16,7 +16,6 @@
 package io.camunda.client.api.worker;
 
 import io.camunda.client.CamundaClientConfiguration;
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.CommandWithOneOrMoreTenantsStep;
 import java.time.Duration;
 import java.util.List;
@@ -225,12 +224,8 @@ public interface JobWorkerBuilderStep1 {
      * <p>If the stream is closed, e.g. the server closed the connection, was restarted, etc., it
      * will be immediately recreated as long as the worker is opened.
      *
-     * <p>NOTE: Job streaming is still under active development, and should be disabled if you
-     * notice any issues.
-     *
      * @return the builder for this worker
      */
-    @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
     JobWorkerBuilderStep3 streamEnabled(boolean isStreamEnabled);
 
     /**
@@ -247,7 +242,6 @@ public interface JobWorkerBuilderStep1 {
      * @param timeout a timeout, after which the stream is recreated
      * @return the builder for this worker
      */
-    @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
     JobWorkerBuilderStep3 streamTimeout(final Duration timeout);
 
     /**

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
@@ -17,7 +17,6 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.CamundaFuture;
-import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CreateDocumentCommandStep1;
 import io.camunda.client.api.command.CreateDocumentCommandStep1.CreateDocumentCommandStep2;
@@ -40,7 +39,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ExperimentalApi("https://github.com/camunda/issues/issues/841")
 public class CreateDocumentCommandImpl extends DocumentBuilder
     implements CreateDocumentCommandStep1, CreateDocumentCommandStep2 {
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -23,7 +23,6 @@ import io.camunda.client.CredentialsProvider.StatusCode;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.ClientException;
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
@@ -87,36 +86,6 @@ public final class DeployResourceCommandImpl
     httpRequestConfig = httpClient.newRequestConfig();
     useRest = preferRestOverGrpc;
     this.jsonMapper = jsonMapper;
-    requestTimeout(requestTimeout);
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link
-   *     DeployResourceCommandImpl#DeployResourceCommandImpl(GatewayStub asyncStub,
-   *     CamundaClientConfiguration config, Predicate retryPredicate)}
-   */
-  @Deprecated
-  public DeployResourceCommandImpl(
-      final GatewayStub asyncStub,
-      final Duration requestTimeout,
-      final Predicate<StatusCode> retryPredicate,
-      final HttpClient httpClient,
-      final boolean preferRestOverGrpc,
-      final JsonMapper jsonMapper) {
-    this.asyncStub = asyncStub;
-    this.requestTimeout = requestTimeout;
-    this.retryPredicate = retryPredicate;
-    this.httpClient = httpClient;
-    httpRequestConfig = httpClient.newRequestConfig();
-    useRest = preferRestOverGrpc;
-    this.jsonMapper = jsonMapper;
-    tenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     requestTimeout(requestTimeout);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -19,7 +19,6 @@ import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider.StatusCode;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1.EvaluateDecisionCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
@@ -71,37 +70,6 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
     httpRequestObject = new DecisionEvaluationInstruction();
     useRest = config.preferRestOverGrpc();
     tenantId(config.getDefaultTenantId());
-    requestTimeout(requestTimeout);
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link
-   *     EvaluateDecisionCommandImpl#EvaluateDecisionCommandImpl(GatewayStub, JsonMapper,
-   *     CamundaClientConfiguration, Predicate, HttpClient)}
-   */
-  @Deprecated
-  public EvaluateDecisionCommandImpl(
-      final GatewayStub asyncStub,
-      final JsonMapper jsonMapper,
-      final Duration requestTimeout,
-      final Predicate<StatusCode> retryPredicate,
-      final HttpClient httpClient) {
-    super(jsonMapper);
-    this.asyncStub = asyncStub;
-    this.retryPredicate = retryPredicate;
-    this.jsonMapper = jsonMapper;
-    this.requestTimeout = requestTimeout;
-    grpcRequestObjectBuilder = EvaluateDecisionRequest.newBuilder();
-    this.httpClient = httpClient;
-    httpRequestConfig = httpClient.newRequestConfig();
-    httpRequestObject = new DecisionEvaluationInstruction();
-    tenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
     requestTimeout(requestTimeout);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -18,7 +18,6 @@ package io.camunda.client.impl.command;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1;
 import io.camunda.client.api.command.EvaluateExpressionCommandStep1.EvaluateExpressionCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
@@ -49,26 +48,6 @@ public class EvaluateExpressionCommandImpl
     httpRequestConfig = httpClient.newRequestConfig();
     request = new ExpressionEvaluationRequest();
     tenantId(config.getDefaultTenantId());
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.8.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.8.0, use {@link
-   *     EvaluateExpressionCommandImpl#EvaluateExpressionCommandImpl(CamundaClientConfiguration,
-   *     HttpClient, JsonMapper)}
-   */
-  @Deprecated
-  public EvaluateExpressionCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
-    this.jsonMapper = jsonMapper;
-    this.httpClient = httpClient;
-    httpRequestConfig = httpClient.newRequestConfig();
-    request = new ExpressionEvaluationRequest();
-    request.setTenantId(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DecisionImpl.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.response.Decision;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
 import java.util.Objects;
@@ -39,35 +38,6 @@ public final class DecisionImpl implements Decision {
         metadata.getDmnDecisionRequirementsId(),
         metadata.getDecisionRequirementsKey(),
         metadata.getTenantId());
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link DecisionImpl#DecisionImpl(String dmnDecisionId, String
-   *     dmnDecisionName, int version, long decisionKey, String dmnDecisionRequirementsId, long
-   *     decisionRequirementsKey, String tenantId)}
-   */
-  @Deprecated
-  public DecisionImpl(
-      final String dmnDecisionId,
-      final String dmnDecisionName,
-      final int version,
-      final long decisionKey,
-      final String dmnDecisionRequirementsId,
-      final long decisionRequirementsKey) {
-    this(
-        dmnDecisionId,
-        dmnDecisionName,
-        version,
-        decisionKey,
-        dmnDecisionRequirementsId,
-        decisionRequirementsKey,
-        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public DecisionImpl(

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DecisionRequirementsImpl.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.response.DecisionRequirements;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import java.util.Objects;
@@ -37,33 +36,6 @@ public final class DecisionRequirementsImpl implements DecisionRequirements {
         metadata.getDecisionRequirementsKey(),
         metadata.getResourceName(),
         metadata.getTenantId());
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link DecisionRequirementsImpl#DecisionRequirementsImpl(String
-   *     dmnDecisionRequirementsId, String dmnDecisionRequirementsName, int version, long
-   *     decisionRequirementsKey, String resourceName, String tenantId)}
-   */
-  @Deprecated
-  public DecisionRequirementsImpl(
-      final String dmnDecisionRequirementsId,
-      final String dmnDecisionRequirementsName,
-      final int version,
-      final long decisionRequirementsKey,
-      final String resourceName) {
-    this(
-        dmnDecisionRequirementsId,
-        dmnDecisionRequirementsName,
-        version,
-        decisionRequirementsKey,
-        resourceName,
-        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public DecisionRequirementsImpl(

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ProcessImpl.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.impl.response;
 
-import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.response.Process;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import java.util.Objects;
@@ -35,30 +34,6 @@ public final class ProcessImpl implements Process {
         process.getVersion(),
         process.getResourceName(),
         process.getTenantId());
-  }
-
-  /**
-   * A constructor that provides an instance with the <code><default></code> tenantId set.
-   *
-   * <p>From version 8.3.0, the java client supports multi-tenancy for this command, which requires
-   * the <code>tenantId</code> property to be defined. This constructor is only intended for
-   * backwards compatibility in tests.
-   *
-   * @deprecated since 8.3.0, use {@link ProcessImpl#ProcessImpl(long processDefinitionKey, String
-   *     bpmnProcessId, int version, String resourceName, String tenantId)}
-   */
-  @Deprecated
-  public ProcessImpl(
-      final long processDefinitionKey,
-      final String bpmnProcessId,
-      final int version,
-      final String resourceName) {
-    this(
-        processDefinitionKey,
-        bpmnProcessId,
-        version,
-        resourceName,
-        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   }
 
   public ProcessImpl(

--- a/clients/java/src/test/java/io/camunda/client/process/DeployProcessTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/DeployProcessTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.process;
 
+import static io.camunda.client.api.command.CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER;
 import static io.camunda.client.util.RecordingGatewayService.deployedProcess;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -236,8 +237,8 @@ public final class DeployProcessTest extends ClientTest {
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
         .containsExactly(
-            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1),
-            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2));
+            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, DEFAULT_TENANT_IDENTIFIER),
+            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, DEFAULT_TENANT_IDENTIFIER));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -462,14 +462,4 @@ public class RestGatewayPaths {
   public static String getResourceDeletionUrl(final long resourceKey) {
     return String.format(URL_RESOURCE_DELETION, resourceKey);
   }
-
-  @Deprecated
-  public static String getClusterVariablesUrl(final String variableName) {
-    return String.format(URL_CLUSTER_VARIABLES_GET_GLOBAL, variableName);
-  }
-
-  @Deprecated
-  public static String getClusterVariablesUrl(final String variableName, final String tenantId) {
-    return String.format(URL_CLUSTER_VARIABLES_GET_TENANT, tenantId, variableName);
-  }
 }


### PR DESCRIPTION
## Description

Noticed here https://github.com/camunda/camunda/pull/45703#discussion_r2816933621

This cleans up:
* long deprecated Ctors
* obsolete deprecations of rest/grpc switches - as we keep both and the feature makes sense to allow users to switch at will
* removal of obsolete @ExperimentalAPI annotations
* some unused getClusterVariableUrl methods that were flagged as deprecated

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

