### PR TITLE
fix(ci): improve CPT compatibility test reliability for older versions

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -343,25 +343,6 @@ jobs:
           # Inject an explicit <version> on camunda-client-java to override the parent-managed version
           sed -i '/<artifactId>camunda-client-java<\/artifactId>/a\      <version>${{ matrix.client }}<\/version>' qa/acceptance-tests/pom.xml
 
-      - name: Determine tests to exclude
-        id: test-exclusions
-        run: |
-          CLIENT_VERSION="${{ matrix.client }}"
-          EXCLUDES=""
-
-          # Skip CompatibilityJobWorkerAnnotationSettingsIT for client versions < 8.8.3
-          # Before 8.8.3, worker defaults always override @JobWorker annotation values
-          # (fixed in https://github.com/camunda/camunda/pull/40317)
-          if [[ ! "$CLIENT_VERSION" =~ SNAPSHOT ]]; then
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CLIENT_VERSION"
-            if (( MAJOR < 8 )) || (( MAJOR == 8 && MINOR < 8 )) || (( MAJOR == 8 && MINOR == 8 && PATCH < 3 )); then
-              EXCLUDES="${EXCLUDES} -Dit.test=!CompatibilityJobWorkerAnnotationSettingsIT"
-              echo "Excluding CompatibilityJobWorkerAnnotationSettingsIT (client $CLIENT_VERSION < 8.8.3)"
-            fi
-          fi
-
-          echo "excludes=$EXCLUDES" >> "$GITHUB_OUTPUT"
-
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
@@ -371,7 +352,6 @@ jobs:
             -pl qa/acceptance-tests
             -Dcamunda.compatibility.test.version=${{ matrix.server }}
             -DfailIfNoTests=false
-            ${{ steps.test-exclusions.outputs.excludes }}
 
       - name: Record tested combination
         if: success()

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -442,6 +442,23 @@ jobs:
             -DskipUTs
             -DskipChecks
 
+      - name: Override connectors version in properties file
+        # Older CPT versions (< 8.8.x) use ${project.version} for connectorsDockerImageVersion
+        # in the properties file, which ignores the Maven -D flag. This step patches the
+        # source properties file so resource filtering produces the correct version.
+        run: |
+          PROPS_FILE="testing/camunda-process-test-java/src/main/resources/camunda-container-runtime-version.properties"
+          CONNECTORS_VERSION="${{ steps.connectors-version.outputs.version }}"
+          if [[ -f "$PROPS_FILE" ]]; then
+            echo "Before override:"
+            cat "$PROPS_FILE"
+            sed -i "s|^connectorsDockerImageVersion=.*|connectorsDockerImageVersion=${CONNECTORS_VERSION}|" "$PROPS_FILE"
+            echo "After override:"
+            cat "$PROPS_FILE"
+          else
+            echo "::warning::Properties file not found at $PROPS_FILE"
+          fi
+
       - name: Determine Docker API version override
         id: api-version
         run: |

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -443,7 +443,7 @@ jobs:
             -DskipChecks
 
       - name: Override connectors version in properties file
-        # Older CPT versions (< 8.8.x) use ${project.version} for connectorsDockerImageVersion
+        # nicpuppa/fix-cpt-workflow for connectorsDockerImageVersion
         # in the properties file, which ignores the Maven -D flag. This step patches the
         # source properties file so resource filtering produces the correct version.
         run: |
@@ -459,24 +459,31 @@ jobs:
             echo "::warning::Properties file not found at $PROPS_FILE"
           fi
 
-      - name: Determine Docker API version override
+      - name: Determine version-specific overrides
         id: api-version
         run: |
           CLIENT_VERSION="${{ matrix.client }}"
           EXTRA_PROPS=""
-          # For CPT versions < 8.8.5, we need to pin the API version
           if [[ "$CLIENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
             PATCH="${BASH_REMATCH[3]}"
+            # For CPT versions < 8.8.5, we need to pin the API version
             if (( MAJOR < 8 )) || \
                (( MAJOR == 8 && MINOR < 8 )) || \
                (( MAJOR == 8 && MINOR == 8 && PATCH < 5 )); then
-              EXTRA_PROPS="-Dapi.version=1.44"
-              echo "CPT version $CLIENT_VERSION < 8.8.5 - adding $EXTRA_PROPS"
+              EXTRA_PROPS+=" -Dapi.version=1.44"
+              echo "CPT version $CLIENT_VERSION < 8.8.5 - adding Docker API version override"
+            fi
+            # For CPT versions <= 8.8.7, skip CamundaSpringProcessMultiTenancyTestListenerIT
+            if (( MAJOR < 8 )) || \
+               (( MAJOR == 8 && MINOR < 8 )) || \
+               (( MAJOR == 8 && MINOR == 8 && PATCH <= 7 )); then
+              EXTRA_PROPS+=" -Dit.test='!CamundaSpringProcessMultiTenancyTestListenerIT'"
+              echo "CPT version $CLIENT_VERSION <= 8.8.7 - excluding CamundaSpringProcessMultiTenancyTestListenerIT"
             fi
           fi
-          echo "extra-props=$EXTRA_PROPS" >> "$GITHUB_OUTPUT"
+          echo "extra-props=${EXTRA_PROPS}" >> "$GITHUB_OUTPUT"
 
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -341,6 +341,25 @@ jobs:
           # Inject an explicit <version> on camunda-spring-boot-starter to override the parent-managed version
           sed -i '/<artifactId>camunda-spring-boot-starter<\/artifactId>/a\      <version>${{ matrix.client }}<\/version>' qa/compatibility-test/pom.xml
 
+      - name: Determine tests to exclude
+        id: test-exclusions
+        run: |
+          CLIENT_VERSION="${{ matrix.client }}"
+          EXCLUDES=""
+
+          # Skip CompatibilityJobWorkerAnnotationSettingsIT for client versions < 8.8.3
+          # Before 8.8.3, worker defaults always override @JobWorker annotation values
+          # (fixed in https://github.com/camunda/camunda/pull/40317)
+          if [[ ! "$CLIENT_VERSION" =~ SNAPSHOT ]]; then
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CLIENT_VERSION"
+            if (( MAJOR < 8 )) || (( MAJOR == 8 && MINOR < 8 )) || (( MAJOR == 8 && MINOR == 8 && PATCH < 3 )); then
+              EXCLUDES="${EXCLUDES} -Dit.test=!CompatibilityJobWorkerAnnotationSettingsIT"
+              echo "Excluding CompatibilityJobWorkerAnnotationSettingsIT (client $CLIENT_VERSION < 8.8.3)"
+            fi
+          fi
+
+          echo "excludes=$EXCLUDES" >> "$GITHUB_OUTPUT"
+
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven
         with:
@@ -349,6 +368,7 @@ jobs:
             -pl qa/compatibility-test
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
             -DfailIfNoTests=false
+            ${{ steps.test-exclusions.outputs.excludes }}
 
       - name: Record tested combination
         if: success()


### PR DESCRIPTION
## Description

This PR fixes several issues with the Camunda Process Test (CPT) compatibility workflow when testing older client versions against newer runtimes.

### Problem

When the workflow runs from `stable/8.8`, it checks out older tags (e.g., `8.8.0`) and runs their test code. Two issues arise:

1. **Connectors Docker image version not overridable on older tags**: CPT versions prior to the current code use `connectorsDockerImageVersion=${project.version}` in the properties file, which is resolved at build time and ignores the Maven `-D` flag. This causes tests to pull the wrong connectors-bundle Docker image.

2. **`CamundaSpringProcessMultiTenancyTestListenerIT` fails on CPT ≤ 8.8.7**: This test is not supported on older versions and needs to be excluded.

## Changes

- **Override connectors version in properties file**: Added a step that patches `camunda-container-runtime-version.properties` with the resolved connectors-bundle version before Maven resource filtering, ensuring the correct Docker image is used regardless of the CPT version.
- **Skip unsupported test on older versions**: For CPT versions ≤ 8.8.7, `CamundaSpringProcessMultiTenancyTestListenerIT` is excluded via `-Dit.test` to prevent spurious failures.
- **Renamed step**: "Determine Docker API version override" → "Determine version-specific overrides" to reflect its expanded scope.

related to https://camunda.slack.com/archives/C089T36Q7H8/p1771316510685569