### PR TITLE
Allow deleting historic data of already deleted process definitions / DRGs

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -485,13 +485,17 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ApiServicesExecutorProvider executorProvider,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final ProcessDefinitionSearchClient processDefinitionSearchClient,
+      final DecisionRequirementSearchClient decisionRequirementSearchClient) {
     return new ResourceServices(
         brokerClient,
         securityContextProvider,
         null,
         executorProvider,
-        brokerRequestAuthorizationConverter);
+        brokerRequestAuthorizationConverter,
+        processDefinitionSearchClient,
+        decisionRequirementSearchClient);
   }
 
   @Bean

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.service;
 
+import static io.camunda.search.query.SearchQueryBuilders.decisionRequirementsSearchQuery;
+import static io.camunda.search.query.SearchQueryBuilders.processDefinitionSearchQuery;
+
+import io.camunda.search.clients.DecisionRequirementSearchClient;
+import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
@@ -17,23 +22,31 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerFetchResourceRequest;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public final class ResourceServices extends ApiServices<ResourceServices> {
+
+  private final ProcessDefinitionSearchClient processDefinitionSearchClient;
+  private final DecisionRequirementSearchClient decisionRequirementSearchClient;
 
   public ResourceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final CamundaAuthentication authentication,
       final ApiServicesExecutorProvider executorProvider,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final ProcessDefinitionSearchClient processDefinitionSearchClient,
+      final DecisionRequirementSearchClient decisionRequirementSearchClient) {
     super(
         brokerClient,
         securityContextProvider,
         authentication,
         executorProvider,
         brokerRequestAuthorizationConverter);
+    this.processDefinitionSearchClient = processDefinitionSearchClient;
+    this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
 
   @Override
@@ -43,7 +56,9 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
         securityContextProvider,
         authentication,
         executorProvider,
-        brokerRequestAuthorizationConverter);
+        brokerRequestAuthorizationConverter,
+        processDefinitionSearchClient,
+        decisionRequirementSearchClient);
   }
 
   public CompletableFuture<DeploymentRecord> deployResources(
@@ -60,6 +75,43 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
         new BrokerDeleteResourceRequest()
             .setResourceKey(request.resourceKey())
             .setDeleteHistory(request.deleteHistory());
+
+    // TODO extract to method and add javadoc explaining why we do this
+    if (request.deleteHistory()) {
+      final var processDefinition =
+          processDefinitionSearchClient
+              .withSecurityContext(
+                  securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()))
+              .searchProcessDefinitions(
+                  processDefinitionSearchQuery()
+                      .filter(f -> f.processDefinitionKeys(request.resourceKey()))
+                      .build())
+              .items();
+      if (!processDefinition.isEmpty()) {
+        brokerRequest
+            .setResourceType(ResourceType.PROCESS_DEFINITION)
+            .setResourceId(processDefinition.getFirst().processDefinitionId())
+            .setTenantId(processDefinition.getFirst().tenantId());
+      } else {
+        final var decisionRequirements =
+            decisionRequirementSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        CamundaAuthentication.anonymous()))
+                .searchDecisionRequirements(
+                    decisionRequirementsSearchQuery()
+                        .filter(f -> f.decisionRequirementsKeys(request.resourceKey))
+                        .build())
+                .items();
+        if (!decisionRequirements.isEmpty()) {
+          brokerRequest
+              .setResourceType(ResourceType.DECISION_REQUIREMENTS)
+              .setResourceId(decisionRequirements.getFirst().decisionRequirementsId())
+              .setTenantId(decisionRequirements.getFirst().tenantId());
+        }
+      }
+    }
+
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -432,7 +432,7 @@ public class ResourceDeletionDeleteProcessor
           deleteProcessInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
       case DECISION_REQUIREMENTS ->
           deleteDecisionInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
-      case FORM, UNKNOWN -> {
+      default -> {
         // No history to delete for forms and unknown resources
         // This should not be reached as SUPPORTED_HISTORY_DELETION_TYPES filters these out
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -213,6 +213,11 @@ public class ResourceDeletionDeleteProcessor
 
     final var process = processState.getProcessByKeyAndTenant(value.getResourceKey(), tenantId);
     if (process != null) {
+      command
+          .getValue()
+          .setResourceType(ResourceType.PROCESS_DEFINITION)
+          .setResourceId(process.getBpmnProcessId())
+          .setTenantId(process.getTenantId());
       return authorizeAndDelete(
           command,
           eventKey,
@@ -226,6 +231,11 @@ public class ResourceDeletionDeleteProcessor
         decisionState.findDecisionRequirementsByTenantAndKey(tenantId, value.getResourceKey());
     if (drgOptional.isPresent()) {
       final var drg = drgOptional.get();
+      command
+          .getValue()
+          .setResourceType(ResourceType.DECISION_REQUIREMENTS)
+          .setResourceId(drg.getDecisionRequirementsId())
+          .setTenantId(drg.getTenantId());
       return authorizeAndDelete(
           command,
           eventKey,
@@ -238,6 +248,11 @@ public class ResourceDeletionDeleteProcessor
     final var formOptional = formState.findFormByKey(value.getResourceKey(), tenantId);
     if (formOptional.isPresent()) {
       final var form = formOptional.get();
+      command
+          .getValue()
+          .setResourceType(ResourceType.FORM)
+          .setResourceId(form.getFormId())
+          .setTenantId(form.getTenantId());
       return authorizeAndDelete(
           command,
           eventKey,
@@ -250,6 +265,11 @@ public class ResourceDeletionDeleteProcessor
     final var resourceOptional = resourceState.findResourceByKey(value.getResourceKey(), tenantId);
     if (resourceOptional.isPresent()) {
       final var resource = resourceOptional.get();
+      command
+          .getValue()
+          .setResourceType(ResourceType.UNKNOWN)
+          .setResourceId(resource.getResourceId())
+          .setTenantId(resource.getTenantId());
       return authorizeAndDelete(
           command,
           eventKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -397,6 +397,11 @@ public class ResourceDeletionDeleteProcessor
 
   private void deleteHistory(
       final long eventKey, final TypedRecord<ResourceDeletionRecord> command) {
+    if (command.isCommandDistributed()) {
+      // We should not create batch operations for distributed commands. This gets handled by the
+      // batch operation creator itself.
+      return;
+    }
     final var commandValue = command.getValue();
     final var resourceType = commandValue.getResourceType();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -428,11 +428,13 @@ public class ResourceDeletionDeleteProcessor
     }
 
     switch (resourceType) {
-      case PROCESS_DEFINITION -> {
-        deleteProcessInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
-      }
-      case DECISION_REQUIREMENTS -> {
-        deleteDecisionInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+      case PROCESS_DEFINITION ->
+          deleteProcessInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+      case DECISION_REQUIREMENTS ->
+          deleteDecisionInstanceHistory(commandValue.getResourceKey(), eventKey, commandValue);
+      case FORM, UNKNOWN -> {
+        // No history to delete for forms and unknown resources
+        // This should not be reached as SUPPORTED_HISTORY_DELETION_TYPES filters these out
       }
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionReco
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
@@ -47,6 +48,21 @@ public class ResourceDeletionClient {
     return this;
   }
 
+  public ResourceDeletionClient withResourceType(final ResourceType resourceType) {
+    resourceDeletionRecord.setResourceType(resourceType);
+    return this;
+  }
+
+  public ResourceDeletionClient withResourceId(final String resourceId) {
+    resourceDeletionRecord.setResourceId(resourceId);
+    return this;
+  }
+
+  public ResourceDeletionClient withTenantId(final String tenantId) {
+    resourceDeletionRecord.setTenantId(tenantId);
+    return this;
+  }
+
   public ResourceDeletionClient withDeleteHistory(final boolean deleteHistory) {
     resourceDeletionRecord.setDeleteHistory(deleteHistory);
     return this;
@@ -74,7 +90,8 @@ public class ResourceDeletionClient {
 
   public Record<ResourceDeletionRecordValue> delete(final String username) {
     return delete(
-        AuthorizationUtil.getUsernameAuthInfo(username, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+        AuthorizationUtil.getUsernameAuthInfo(
+            username, authorizedTenantIds.toArray(new String[0])));
   }
 
   public ResourceDeletionClient expectRejection() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
@@ -33,6 +33,12 @@
             },
             "batchOperationType": {
               "type": "keyword"
+            },
+            "resourceType": {
+              "type": "keyword"
+            },
+            "resourceId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-resource-deletion-template.json
@@ -2,7 +2,9 @@
   "index_patterns": [
     "zeebe-record_resource-deletion_*"
   ],
-  "composed_of": ["zeebe-record"],
+  "composed_of": [
+    "zeebe-record"
+  ],
   "priority": 20,
   "version": 1,
   "template": {
@@ -32,6 +34,12 @@
               "type": "long"
             },
             "batchOperationType": {
+              "type": "keyword"
+            },
+            "resourceType": {
+              "type": "keyword"
+            },
+            "resourceId": {
               "type": "keyword"
             }
           }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteResourceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteResourceRequest.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import org.agrona.DirectBuffer;
 
 public final class BrokerDeleteResourceRequest
@@ -30,6 +31,21 @@ public final class BrokerDeleteResourceRequest
 
   public BrokerDeleteResourceRequest setDeleteHistory(final boolean deleteHistory) {
     requestDto.setDeleteHistory(deleteHistory);
+    return this;
+  }
+
+  public BrokerDeleteResourceRequest setResourceType(final ResourceType resourceType) {
+    requestDto.setResourceType(resourceType);
+    return this;
+  }
+
+  public BrokerDeleteResourceRequest setTenantId(final String tenantId) {
+    requestDto.setTenantId(tenantId);
+    return this;
+  }
+
+  public BrokerDeleteResourceRequest setResourceId(final String resourceId) {
+    requestDto.setResourceId(resourceId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
 
 public class ResourceDeletionRecord extends UnifiedRecordValue
     implements ResourceDeletionRecordValue {
@@ -26,6 +28,8 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
   private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
   private static final StringValue BATCH_OPERATION_TYPE = new StringValue("batchOperationType");
+  private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue RESOURCE_ID = new StringValue("resourceId");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY_KEY);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
@@ -36,14 +40,19 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
           BATCH_OPERATION_TYPE,
           BatchOperationType.class,
           BatchOperationType.DELETE_PROCESS_INSTANCE);
+  private final EnumProperty<ResourceType> resourceTypeProp =
+      new EnumProperty<>(RESOURCE_TYPE, ResourceType.class, ResourceType.UNKNOWN);
+  private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID, "");
 
   public ResourceDeletionRecord() {
-    super(5);
+    super(7);
     declareProperty(resourceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deleteHistoryProp)
         .declareProperty(batchOperationKeyProp)
-        .declareProperty(batchOperationTypeProp);
+        .declareProperty(batchOperationTypeProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(resourceIdProp);
   }
 
   @Override
@@ -67,6 +76,41 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationTypeProp.getValue();
+  }
+
+  public ResourceDeletionRecord setBatchOperationType(final BatchOperationType batchOperationType) {
+    batchOperationTypeProp.setValue(batchOperationType);
+    return this;
+  }
+
+  @Override
+  public ResourceType getResourceType() {
+    return resourceTypeProp.getValue();
+  }
+
+  public ResourceDeletionRecord setResourceType(final ResourceType resourceType) {
+    resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public String getResourceId() {
+    return BufferUtil.bufferAsString(resourceIdProp.getValue());
+  }
+
+  public ResourceDeletionRecord setResourceId(final String resourceId) {
+    resourceIdProp.setValue(resourceId);
+    return this;
+  }
+
+  public ResourceDeletionRecord setResourceId(final DirectBuffer resourceId) {
+    resourceIdProp.setValue(resourceId);
+    return this;
+  }
+
+  @Override
   public String getTenantId() {
     return BufferUtil.bufferAsString(tenantIdProp.getValue());
   }
@@ -83,16 +127,6 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setBatchOperationKey(final long batchOperationKey) {
     batchOperationKeyProp.setValue(batchOperationKey);
-    return this;
-  }
-
-  @Override
-  public BatchOperationType getBatchOperationType() {
-    return batchOperationTypeProp.getValue();
-  }
-
-  public ResourceDeletionRecord setBatchOperationType(final BatchOperationType batchOperationType) {
-    batchOperationTypeProp.setValue(batchOperationType);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -107,6 +107,7 @@ import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
@@ -2568,7 +2569,9 @@ final class JsonSerializableToJsonTest {
                   .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
                   .setDeleteHistory(true)
                   .setBatchOperationKey(batchOperationKey)
-                  .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
+                  .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
+                  .setResourceType(ResourceType.PROCESS_DEFINITION)
+                  .setResourceId("foo");
             },
         """
                 {
@@ -2576,7 +2579,9 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "deleteHistory": true,
                   "batchOperationKey": 2,
-                  "batchOperationType": "DELETE_PROCESS_INSTANCE"
+                  "batchOperationType": "DELETE_PROCESS_INSTANCE",
+                  "resourceType": "PROCESS_DEFINITION",
+                  "resourceId": "foo"
                 }
                 """
       },
@@ -2596,7 +2601,9 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "deleteHistory": false,
                   "batchOperationKey": -1,
-                  "batchOperationType": "DELETE_PROCESS_INSTANCE"
+                  "batchOperationType": "DELETE_PROCESS_INSTANCE",
+                  "resourceType": "UNKNOWN",
+                  "resourceId": ""
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
@@ -15,7 +15,9 @@ import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResourceType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
 
 public class ResourceDeletionRecord extends UnifiedRecordValue
     implements ResourceDeletionRecordValue {
@@ -26,6 +28,8 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
   private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
   private static final StringValue BATCH_OPERATION_TYPE = new StringValue("batchOperationType");
+  private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
+  private static final StringValue RESOURCE_ID = new StringValue("resourceId");
 
   private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY_KEY);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
@@ -36,14 +40,19 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
           BATCH_OPERATION_TYPE,
           BatchOperationType.class,
           BatchOperationType.DELETE_PROCESS_INSTANCE);
+  private final EnumProperty<ResourceType> resourceTypeProp =
+      new EnumProperty<>(RESOURCE_TYPE, ResourceType.class, ResourceType.UNKNOWN);
+  private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID, "");
 
   public ResourceDeletionRecord() {
-    super(5);
+    super(7);
     declareProperty(resourceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deleteHistoryProp)
         .declareProperty(batchOperationKeyProp)
-        .declareProperty(batchOperationTypeProp);
+        .declareProperty(batchOperationTypeProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(resourceIdProp);
   }
 
   @Override
@@ -67,6 +76,41 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationTypeProp.getValue();
+  }
+
+  public ResourceDeletionRecord setBatchOperationType(final BatchOperationType batchOperationType) {
+    batchOperationTypeProp.setValue(batchOperationType);
+    return this;
+  }
+
+  @Override
+  public ResourceType getResourceType() {
+    return resourceTypeProp.getValue();
+  }
+
+  public ResourceDeletionRecord setResourceType(final ResourceType resourceType) {
+    resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  @Override
+  public String getResourceId() {
+    return BufferUtil.bufferAsString(resourceIdProp.getValue());
+  }
+
+  public ResourceDeletionRecord setResourceId(final String resourceId) {
+    resourceIdProp.setValue(resourceId);
+    return this;
+  }
+
+  public ResourceDeletionRecord setResourceId(final DirectBuffer resourceId) {
+    resourceIdProp.setValue(resourceId);
+    return this;
+  }
+
+  @Override
   public String getTenantId() {
     return BufferUtil.bufferAsString(tenantIdProp.getValue());
   }
@@ -83,16 +127,6 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setBatchOperationKey(final long batchOperationKey) {
     batchOperationKeyProp.setValue(batchOperationKey);
-    return this;
-  }
-
-  @Override
-  public BatchOperationType getBatchOperationType() {
-    return batchOperationTypeProp.getValue();
-  }
-
-  public ResourceDeletionRecord setBatchOperationType(final BatchOperationType batchOperationType) {
-    batchOperationTypeProp.setValue(batchOperationType);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceDeletionRecordValue.java
@@ -44,4 +44,14 @@ public interface ResourceDeletionRecordValue
    * @return the batch operation type
    */
   BatchOperationType getBatchOperationType();
+
+  /**
+   * @return the type of the deleted resource
+   */
+  ResourceType getResourceType();
+
+  /**
+   * @return the id of the deleted resource
+   */
+  String getResourceId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ResourceType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/** Enumerates the resource types that can be deployed or deleted */
+public enum ResourceType {
+  PROCESS_DEFINITION,
+  DECISION_REQUIREMENTS,
+  FORM,
+  UNKNOWN
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allows us to use the resource deletion API to delete historic data process definitions or DRGs that are already deleted from primary storage. Essentially allowing users to first call the API with `deleteHistory` as `false`, and then with `deleteHistory` as `true`.

This turned out to be a bit more troublesome than I had anticipated. There were two challenges:
1. We don't know what resource we are deleting. We only know what the key is and we use this to find the resource in primary storage. Since the resource does not exist in primary storage, we cannot determine this in the engine.
2. To perform our authorization checks we rely on the data that we can retrieve using the resource key. Since the resource doesn't exist anymore in primary storage we cannot rely on this in these situations.

I solved both of these by enriching the `ResourceDeletionRecord` in the gateway, before sending the command to the broker. In the gateway we will retrieve the process definition or the DRG and pull the necessary information from it. We only have to do this if the `deleteHistory` flag is set to `true`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44627 
