### PR TITLE
Significantly reduce the maximum deletion delay

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
+++ b/configuration/src/main/java/io/camunda/configuration/HistoryDeletion.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 public class HistoryDeletion {
 
   private static final Duration DEFAULT_DELAY_BETWEEN_RUNS = Duration.ofSeconds(1);
-  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofMinutes(5);
+  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofSeconds(15);
   private static final int DEFAULT_QUEUE_BATCH_SIZE = 100;
   private static final int DEFAULT_DEPENDENT_ROW_LIMIT = 10000;
 

--- a/configuration/src/test/java/io/camunda/configuration/HistoryDeletionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/HistoryDeletionTest.java
@@ -32,7 +32,7 @@ class HistoryDeletionTest {
         .isEqualTo(Duration.ofSeconds(1));
     assertThat(historyDeletion.getMaxDelayBetweenRuns())
         .as("Default maxDelayBetweenRuns should be 5 minutes")
-        .isEqualTo(Duration.ofMinutes(5));
+        .isEqualTo(Duration.ofSeconds(15));
     assertThat(historyDeletion.getQueueBatchSize())
         .as("Default queueBatchSize should be 100")
         .isEqualTo(100);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfiguration.java
@@ -12,7 +12,7 @@ import java.time.Duration;
 public final class HistoryDeletionConfiguration {
 
   private static final Duration DEFAULT_DELAY_BETWEEN_RUNS = Duration.ofSeconds(1);
-  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofMinutes(5);
+  private static final Duration DEFAULT_MAX_DELAY_BETWEEN_RUNS = Duration.ofSeconds(15);
   private static final int DEFAULT_QUEUE_BATCH_SIZE = 100;
   private static final int DEFAULT_DEPENDENT_ROW_LIMIT = 10000;
 

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/historydeletion/HistoryDeletionConfigurationTest.java
@@ -33,7 +33,7 @@ class HistoryDeletionConfigurationTest {
   void shouldHaveDefaultMaxDelayBetweenRuns() {
     final var config = new HistoryDeletionConfiguration();
 
-    assertThat(config.getMaxDelayBetweenRuns()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(config.getMaxDelayBetweenRuns()).isEqualTo(Duration.ofSeconds(15));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

If a user deletes history one way or the other, it is very likely we have reached our maximum wait time. As a result it would take 5 minutes before a user sees anything getting deleted. This is just poor UX. We should significantly lower this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Didn't create an issue as it's such a small change. Discussed in slack [here](https://camunda.slack.com/archives/C08HB8KJFG8/p1770653265658819).
