### PR TITLE
ci: reintroduce Not Sure component to task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -10,6 +10,7 @@ body:
       description: In which component shall the task be carried out?
       # The components should be kept in alphabetical order, with "Not sure" at the top
       options:
+        - <!-- Not sure- -->
         - <!-- C8-API- -->
         - <!-- C8Run- -->
         - <!-- Camunda Process Test- -->

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -26,6 +26,8 @@ component/tasklist:
   '(Tasklist-)'
 component/zeebe:
   '(Zeebe-)'
+needs component label:
+  '(Not sure-)'
 severity/critical:
   '(Critical-)'
 severity/high:


### PR DESCRIPTION
## Description

We have seen a couple of tasks being falsely tagged with C8-API, while they were not api relevant, the cause is that it's the default option. (e.g. https://github.com/camunda/camunda/issues/45791 )

As tasks are not to be triaged, I'd like to bring the "Not sure" option back, to reduce noise on triage of c8-api bugs and feature requests.

This partially reverts https://github.com/camunda/camunda/pull/39624

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
