### PR TITLE
feat: Log a warning when using HTTP in Camunda Client

### DIFF
--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -51,6 +51,8 @@ import org.slf4j.LoggerFactory;
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
   private static final AtomicBoolean DEPRECATION_WARNING_LOGGED = new AtomicBoolean(false);
+  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED =
+      new AtomicBoolean(false);
 
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
@@ -80,7 +82,23 @@ public final class HttpClient implements AutoCloseable {
   }
 
   public void start() {
+    if (INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)
+        && isPlaintextConnection(address)) {
+      LOGGER.warn(
+          "The REST API is configured to use HTTP without TLS ({}). "
+              + "This is not recommended for production environments as communication will not be encrypted. "
+              + "Consider using HTTPS to secure the connection.",
+          address);
+    }
     client.start();
+  }
+
+  private static boolean isPlaintextConnection(final URI address) {
+    if (address == null) {
+      return true;
+    }
+    final String scheme = address.getScheme();
+    return "http".equals(scheme) || "grpc".equals(scheme);
   }
 
   @Override

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -51,8 +51,7 @@ import org.slf4j.LoggerFactory;
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
   private static final AtomicBoolean DEPRECATION_WARNING_LOGGED = new AtomicBoolean(false);
-  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED =
-      new AtomicBoolean(false);
+  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED = new AtomicBoolean(false);
 
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
@@ -82,8 +81,8 @@ public final class HttpClient implements AutoCloseable {
   }
 
   public void start() {
-    if (INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)
-        && isPlaintextConnection(address)) {
+    if (isPlaintextConnection(address)
+        && INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)) {
       LOGGER.warn(
           "The REST API is configured to use HTTP without TLS ({}). "
               + "This is not recommended for production environments as communication will not be encrypted. "

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -1015,4 +1015,32 @@ public final class ZeebeClientTest extends ClientTest {
     // then
     assertThat(builder.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofMillis(100));
   }
+
+  @Test
+  public void shouldBuildClientWithInsecureHttpRestAddress() throws URISyntaxException {
+    // given - using HTTP (not HTTPS) should trigger a warning
+    final URI httpRestAddress = new URI("http://localhost:8080");
+
+    // when - client is built with insecure REST address
+    try (final ZeebeClient client =
+        ZeebeClient.newClientBuilder().restAddress(httpRestAddress).build()) {
+
+      // then - client should be successfully created (warning is logged)
+      assertThat(client.getConfiguration().getRestAddress()).isEqualTo(httpRestAddress);
+    }
+  }
+
+  @Test
+  public void shouldBuildClientWithSecureHttpsRestAddress() throws URISyntaxException {
+    // given - using HTTPS should NOT trigger a warning
+    final URI httpsRestAddress = new URI("https://localhost:8443");
+
+    // when - client is built with secure REST address
+    try (final ZeebeClient client =
+        ZeebeClient.newClientBuilder().restAddress(httpsRestAddress).build()) {
+
+      // then - client should be successfully created (no warning logged)
+      assertThat(client.getConfiguration().getRestAddress()).isEqualTo(httpsRestAddress);
+    }
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.command.ClientException;
+import io.camunda.client.impl.util.AddressUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
@@ -50,6 +52,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
+  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED =
+      new AtomicBoolean(false);
 
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
@@ -79,6 +83,14 @@ public final class HttpClient implements AutoCloseable {
   }
 
   public void start() {
+    if (INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)
+        && AddressUtil.isPlaintextConnection(address)) {
+      LOGGER.warn(
+          "The REST API is configured to use HTTP without TLS ({}). "
+              + "This is not recommended for production environments as communication will not be encrypted. "
+              + "Consider using HTTPS to secure the connection.",
+          address);
+    }
     client.start();
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClient.java
@@ -52,8 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class HttpClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
-  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED =
-      new AtomicBoolean(false);
+  private static final AtomicBoolean INSECURE_CONNECTION_WARNING_LOGGED = new AtomicBoolean(false);
 
   private static final int MAX_RETRY_ATTEMPTS = 2;
 
@@ -83,8 +82,8 @@ public final class HttpClient implements AutoCloseable {
   }
 
   public void start() {
-    if (INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)
-        && AddressUtil.isPlaintextConnection(address)) {
+    if (AddressUtil.isPlaintextConnection(address)
+        && INSECURE_CONNECTION_WARNING_LOGGED.compareAndSet(false, true)) {
       LOGGER.warn(
           "The REST API is configured to use HTTP without TLS ({}). "
               + "This is not recommended for production environments as communication will not be encrypted. "

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -1291,4 +1291,32 @@ public final class CamundaClientTest {
     // then
     assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
   }
+
+  @Test
+  public void shouldBuildClientWithInsecureHttpRestAddress() throws URISyntaxException {
+    // given - using HTTP (not HTTPS) should trigger a warning
+    final URI httpRestAddress = new URI("http://localhost:8080");
+
+    // when - client is built with insecure REST address
+    try (final CamundaClient client =
+        CamundaClient.newClientBuilder().restAddress(httpRestAddress).build()) {
+
+      // then - client should be successfully created (warning is logged)
+      assertThat(client.getConfiguration().getRestAddress()).isEqualTo(httpRestAddress);
+    }
+  }
+
+  @Test
+  public void shouldBuildClientWithSecureHttpsRestAddress() throws URISyntaxException {
+    // given - using HTTPS should NOT trigger a warning
+    final URI httpsRestAddress = new URI("https://localhost:8443");
+
+    // when - client is built with secure REST address
+    try (final CamundaClient client =
+        CamundaClient.newClientBuilder().restAddress(httpsRestAddress).build()) {
+
+      // then - client should be successfully created (no warning logged)
+      assertThat(client.getConfiguration().getRestAddress()).isEqualTo(httpsRestAddress);
+    }
+  }
 }


### PR DESCRIPTION
## Description

Implement a security warning that logs when the Camunda Client's REST API is configured to use HTTP without TLS, similar to the existing gRPC implementation. The warning is displayed once at client creation to inform users about potential security risks in production environments.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #36658

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**
