### PR TITLE
Enforce short-circuiting of the `RecordingExporter`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
@@ -114,7 +114,7 @@ public class ResourceEventsClaimsTest {
             .withIntent(DecisionRequirementsIntent.CREATED)
             .findFirst();
     final var decisionRecords =
-        RecordingExporter.decisionRecords().withIntent(DecisionIntent.CREATED).limit(3L);
+        RecordingExporter.decisionRecords().withIntent(DecisionIntent.CREATED).limit(2);
     assertAuthorizationClaims(record);
     decisionRecords.forEach(decisionRecord -> assertAuthorizationClaims(decisionRecord));
   }
@@ -143,7 +143,7 @@ public class ResourceEventsClaimsTest {
             .withDecisionRequirementsKey(drgKey)
             .findFirst();
     final var decisionRecords =
-        RecordingExporter.decisionRecords().withIntent(DecisionIntent.DELETED).limit(3L);
+        RecordingExporter.decisionRecords().withIntent(DecisionIntent.DELETED).limit(2);
     assertAuthorizationClaims(record);
     decisionRecords.forEach(decisionRecord -> assertAuthorizationClaims(decisionRecord));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -54,6 +54,7 @@ public final class CallActivityTest {
 
   private static final String PROCESS_ID_PARENT = "wf-parent";
   private static final String PROCESS_ID_CHILD = "wf-child";
+  private static final String CHILD_TASK = "child-task";
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
@@ -75,7 +76,7 @@ public final class CallActivityTest {
     final var builder =
         Bpmn.createExecutableProcess(PROCESS_ID_CHILD)
             .startEvent()
-            .serviceTask("child-task", t -> t.zeebeJobType(jobType));
+            .serviceTask(CHILD_TASK, t -> t.zeebeJobType(jobType));
 
     consumer.accept(builder);
 
@@ -1290,12 +1291,30 @@ public final class CallActivityTest {
     // when
     final long rootInstanceKey = ENGINE.processInstance().ofBpmnProcessId(rootProcessId).create();
 
-    final var rootInstanceRecords = getInstancesOf(rootInstanceKey);
+    final var processInstanceRecords =
+        RecordingExporter.processInstanceRecords()
+            .limit(
+                r ->
+                    r.getValue().getElementId().equals(CHILD_TASK)
+                        && r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .map(Record::getValue)
+            .toList();
+
+    final var rootInstanceRecords =
+        processInstanceRecords.stream()
+            .filter(r -> r.getProcessInstanceKey() == rootInstanceKey)
+            .toList();
     final var parentInstanceKey = getChildInstanceOf(rootInstanceKey).getProcessInstanceKey();
-    final var parentInstanceRecords = getInstancesOf(parentInstanceKey);
+    final var parentInstanceRecords =
+        processInstanceRecords.stream()
+            .filter(r -> r.getProcessInstanceKey() == parentInstanceKey)
+            .toList();
     final var childProcessInstanceKey =
         getChildInstanceOf(parentInstanceKey).getProcessInstanceKey();
-    final var childInstanceRecords = getInstancesOf(childProcessInstanceKey);
+    final var childInstanceRecords =
+        processInstanceRecords.stream()
+            .filter(r -> r.getProcessInstanceKey() == childProcessInstanceKey)
+            .toList();
 
     // then
     assertThat(rootInstanceRecords)
@@ -1354,13 +1373,6 @@ public final class CallActivityTest {
         .withParentProcessInstanceKey(processInstanceKey)
         .getFirst()
         .getValue();
-  }
-
-  private List<ProcessInstanceRecordValue> getInstancesOf(final long processInstanceKey) {
-    return RecordingExporter.processInstanceRecords()
-        .withProcessInstanceKey(processInstanceKey)
-        .map(Record::getValue)
-        .toList();
   }
 
   private long getCallActivityInstanceKey(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableMultiPartitionTest.java
@@ -62,7 +62,7 @@ public final class UpdateClusterVariableMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.CLUSTER_VARIABLE
@@ -130,7 +130,7 @@ public final class UpdateClusterVariableMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.CLUSTER_VARIABLE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
@@ -246,7 +246,7 @@ public class MultiPartitionDeploymentLifecycleTest {
 
     // first one is skipped
     engine.getClock().addTime(EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL);
-    Awaitility.await()
+    RecordingExporter.await()
         .untilAsserted(
             () -> {
               // continue to add time to the clock until the deployment is re-distributed

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -388,6 +388,7 @@ public class GroupTest {
         RecordingExporter.groupRecords()
             .withIntents(GroupIntent.ENTITY_REMOVED, GroupIntent.DELETED)
             .withGroupId(groupId)
+            .limit(2)
             .asList();
     assertThat(deletedGroup).hasGroupId(groupId);
     assertThat(groupRecords).hasSize(2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -2950,7 +2950,8 @@ public class ModifyProcessInstanceTest {
             RecordingExporter.processInstanceRecords()
                 .onlyEvents()
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementId("A"))
+                .withElementId("A")
+                .limit(4))
         .extracting(Record::getIntent)
         .containsSequence(
             ProcessInstanceIntent.ELEMENT_TERMINATING, ProcessInstanceIntent.ELEMENT_TERMINATED);
@@ -3000,7 +3001,8 @@ public class ModifyProcessInstanceTest {
             RecordingExporter.processInstanceRecords()
                 .onlyEvents()
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementId("A"))
+                .withElementId("A")
+                .limit(4))
         .extracting(Record::getIntent)
         .containsSequence(
             ProcessInstanceIntent.ELEMENT_TERMINATING, ProcessInstanceIntent.ELEMENT_TERMINATED);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ModifyProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/ModifyProcessInstanceTest.java
@@ -228,24 +228,24 @@ public class ModifyProcessInstanceTest {
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
-            .toList();
+            .getFirst();
     final var activatedTasksB =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("B")
-            .toList();
+            .getFirst();
 
     Assertions.assertThat(terminatedTasksA)
         .describedAs("Expect that tasks A are terminated")
-        .hasSize(1);
+        .isNotNull();
     Assertions.assertThat(activatedTasksB)
         .describedAs("Expect that task B is activated")
-        .hasSize(1);
+        .isNotNull();
 
     Assertions.assertThat(
             RecordingExporter.variableRecords(VariableIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withScopeKey(activatedTasksB.getFirst().getKey())
+                .withScopeKey(activatedTasksB.getKey())
                 .withName("foo")
                 .getFirst())
         .describedAs("Expect that variable 'foo' is created in task B's scope")
@@ -289,24 +289,24 @@ public class ModifyProcessInstanceTest {
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("A")
-            .toList();
+            .getFirst();
     final var activatedTasksB =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("B")
-            .toList();
+            .getFirst();
 
     Assertions.assertThat(terminatedTasksA)
         .describedAs("Expect that tasks A are terminated")
-        .hasSize(1);
+        .isNotNull();
     Assertions.assertThat(activatedTasksB)
         .describedAs("Expect that task B is activated")
-        .hasSize(1);
+        .isNotNull();
 
     Assertions.assertThat(
             RecordingExporter.variableRecords(VariableIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withScopeKey(activatedTasksB.getFirst().getKey())
+                .withScopeKey(activatedTasksB.getKey())
                 .withName("foo")
                 .getFirst())
         .describedAs("Expect that variable 'foo' is created in task B's scope")

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -136,6 +136,7 @@ import org.awaitility.core.ThrowingRunnable;
 public final class RecordingExporter implements Exporter {
   public static final long DEFAULT_MAX_WAIT_TIME = Duration.ofSeconds(5).toMillis();
   public static final long DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME = Duration.ofMillis(200).toMillis();
+  public static final long DEFAULT_AWAITILITY_MAX_WAIT_TIME = Duration.ofMillis(100).toMillis();
 
   private static final ConcurrentSkipListMap<Integer, Record<?>> RECORDS =
       new ConcurrentSkipListMap<Integer, Record<?>>();
@@ -143,7 +144,7 @@ public final class RecordingExporter implements Exporter {
   private static final Condition IS_EMPTY = LOCK.newCondition();
   private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
   private static volatile boolean autoAcknowledge = true;
-  private static boolean overrideMaximumWaitTime = false;
+  private static boolean overrideShortCircuitingCheck = false;
   private Controller controller;
 
   static long getMaximumWaitTime() {
@@ -205,7 +206,7 @@ public final class RecordingExporter implements Exporter {
       maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
       RECORDS.clear();
       autoAcknowledge = true;
-      overrideMaximumWaitTime = false;
+      overrideShortCircuitingCheck = false;
     } finally {
       LOCK.unlock();
     }
@@ -765,10 +766,36 @@ public final class RecordingExporter implements Exporter {
   public static <T> T expectNoMatchingRecords(final Function<RecordStream, T> consumer) {
     final var previousMaximumWaitTime = maximumWaitTime;
     maximumWaitTime = DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME;
+    overrideShortCircuitingCheck = true;
     try {
       return consumer.apply(records());
     } finally {
       maximumWaitTime = previousMaximumWaitTime;
+      overrideShortCircuitingCheck = false;
+    }
+  }
+
+  public record AwaitilityWrapper(ConditionFactory conditionFactory) {
+
+    public void untilAsserted(final ThrowingRunnable throwingRunnable) {
+      final var previousMaximumWaitTime = maximumWaitTime;
+      try {
+        maximumWaitTime = DEFAULT_AWAITILITY_MAX_WAIT_TIME;
+        overrideShortCircuitingCheck = true;
+        conditionFactory.untilAsserted(throwingRunnable);
+      } finally {
+        maximumWaitTime = previousMaximumWaitTime;
+        overrideShortCircuitingCheck = false;
+      }
+    }
+
+    public void until(final Callable<Boolean> callable) {
+      try {
+        overrideShortCircuitingCheck = true;
+        conditionFactory.until(callable);
+      } finally {
+        overrideShortCircuitingCheck = false;
+      }
     }
   }
 
@@ -784,16 +811,33 @@ public final class RecordingExporter implements Exporter {
     public boolean hasNext() {
       LOCK.lock();
       try {
-        if (overrideMaximumWaitTime) {
-          return !isEmpty();
-        }
-
         long now = System.currentTimeMillis();
         final long endTime = now + maximumWaitTime;
         while (isEmpty() && endTime > now) {
           final long waitTime = endTime - now;
           try {
-            IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
+            final var isConditionMetInTime = IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
+            if (!isConditionMetInTime && !overrideShortCircuitingCheck) {
+              throw new IllegalStateException(
+                  """
+                  Timed out waiting for records to be exported. Please ensure your test is short-circuiting properly.
+
+                  To do this you must use a short-circuiting method call in your stream. Examples are:
+                  - limit() to short-circuit on a specific exported record.
+                  - between() to short-circuit between two exported positions.
+                  - exists() this will short-circuit as long as there is a record matching your filters.
+                  - getFirst() this will short-circuit as long as there is a record matching your filters.
+
+                  If you need to wait for an assertion in an Awaitility type fashion you can use the RecordingExporter.await() method.
+
+                  If you need to assert that a specific record is not exported please consider:
+                  - Is there really no record you can limit on? Limiting always has preference.
+                  - If you do, you can use the RecordingExporter.expectNoMatchingRecords() method to
+                    temporarily reduce the wait time of the exporter and prevent the short-circuiting failure.
+                    Please be aware that doing this will set the maximum wait time to 200ms. It cannot guarantee
+                    the record won't be exported after this.
+                  """);
+            }
           } catch (final InterruptedException ignored) {
             // ignored
           }
@@ -808,27 +852,6 @@ public final class RecordingExporter implements Exporter {
     @Override
     public Record<?> next() {
       return RECORDS.get(nextIndex++);
-    }
-  }
-
-  public record AwaitilityWrapper(ConditionFactory conditionFactory) {
-
-    public void untilAsserted(final ThrowingRunnable throwingRunnable) {
-      try {
-        overrideMaximumWaitTime = true;
-        conditionFactory.untilAsserted(throwingRunnable);
-      } finally {
-        overrideMaximumWaitTime = false;
-      }
-    }
-
-    public void until(final Callable<Boolean> callable) {
-      try {
-        overrideMaximumWaitTime = true;
-        conditionFactory.until(callable);
-      } finally {
-        overrideMaximumWaitTime = false;
-      }
     }
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -144,7 +144,7 @@ public final class RecordingExporter implements Exporter {
   private static final Condition IS_EMPTY = LOCK.newCondition();
   private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
   private static volatile boolean autoAcknowledge = true;
-  private static boolean overrideShortCircuitingCheck = false;
+  private static boolean disableShortCircuitingCheck = false;
   private Controller controller;
 
   static long getMaximumWaitTime() {
@@ -206,7 +206,7 @@ public final class RecordingExporter implements Exporter {
       maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
       RECORDS.clear();
       autoAcknowledge = true;
-      overrideShortCircuitingCheck = false;
+      disableShortCircuitingCheck = false;
     } finally {
       LOCK.unlock();
     }
@@ -766,12 +766,12 @@ public final class RecordingExporter implements Exporter {
   public static <T> T expectNoMatchingRecords(final Function<RecordStream, T> consumer) {
     final var previousMaximumWaitTime = maximumWaitTime;
     maximumWaitTime = DEFAULT_NON_EXISTENCE_MAX_WAIT_TIME;
-    overrideShortCircuitingCheck = true;
+    disableShortCircuitingCheck = true;
     try {
       return consumer.apply(records());
     } finally {
       maximumWaitTime = previousMaximumWaitTime;
-      overrideShortCircuitingCheck = false;
+      disableShortCircuitingCheck = false;
     }
   }
 
@@ -781,20 +781,20 @@ public final class RecordingExporter implements Exporter {
       final var previousMaximumWaitTime = maximumWaitTime;
       try {
         maximumWaitTime = DEFAULT_AWAITILITY_MAX_WAIT_TIME;
-        overrideShortCircuitingCheck = true;
+        disableShortCircuitingCheck = true;
         conditionFactory.untilAsserted(throwingRunnable);
       } finally {
         maximumWaitTime = previousMaximumWaitTime;
-        overrideShortCircuitingCheck = false;
+        disableShortCircuitingCheck = false;
       }
     }
 
     public void until(final Callable<Boolean> callable) {
       try {
-        overrideShortCircuitingCheck = true;
+        disableShortCircuitingCheck = true;
         conditionFactory.until(callable);
       } finally {
-        overrideShortCircuitingCheck = false;
+        disableShortCircuitingCheck = false;
       }
     }
   }
@@ -817,7 +817,7 @@ public final class RecordingExporter implements Exporter {
           final long waitTime = endTime - now;
           try {
             final var isConditionMetInTime = IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
-            if (!isConditionMetInTime && !overrideShortCircuitingCheck) {
+            if (!isConditionMetInTime && !disableShortCircuitingCheck) {
               throw new IllegalStateException(
                   """
                   Timed out waiting for records to be exported. Please ensure your test is short-circuiting properly.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This changes the iterator of the RecordingExporter so that it throws if it did not find a matching record within the configured amount of time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #39897 
