### PR TITLE
fix: backups must not use snapshots where exporting is ahead of checkpoint

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import java.util.OptionalLong;
+import java.util.Set;
 
 interface InProgressBackup {
 
@@ -21,7 +23,7 @@ interface InProgressBackup {
 
   BackupIdentifier id();
 
-  ActorFuture<Void> findValidSnapshot();
+  ActorFuture<Set<PersistedSnapshot>> findValidSnapshot();
 
   ActorFuture<Void> reserveSnapshot();
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -25,11 +25,14 @@ import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -41,9 +44,6 @@ import org.slf4j.LoggerFactory;
 final class InProgressBackupImpl implements InProgressBackup {
 
   private static final Logger LOG = LoggerFactory.getLogger(InProgressBackupImpl.class);
-
-  private static final String ERROR_MSG_NO_VALID_SNAPSHOT =
-      "Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) have processedPosition or lastFollowupEventPosition > checkpointPosition %d";
 
   private final PersistedSnapshotStore snapshotStore;
   private final BackupIdentifier backupId;
@@ -292,40 +292,85 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   private Either<String, Set<PersistedSnapshot>> findValidSnapshot(
       final Set<PersistedSnapshot> snapshots) {
+    final var validationResults =
+        snapshots.stream().collect(Collectors.toMap(Function.identity(), this::validateSnapshot));
+
     final var validSnapshots =
-        snapshots.stream()
-            .filter(
-                s ->
-                    s.getMetadata().processedPosition()
-                        < backupDescriptor().checkpointPosition()) // &&
-            .filter(
-                s ->
-                    s.getMetadata().lastFollowupEventPosition()
-                        < backupDescriptor().checkpointPosition())
-            .filter(
-                s ->
-                    s.getMetadata().maxExportedPosition() < backupDescriptor().checkpointPosition())
+        validationResults.entrySet().stream()
+            .filter(entry -> entry.getValue().isEmpty())
+            .map(Entry::getKey)
             .collect(Collectors.toSet());
 
     if (validSnapshots.isEmpty()) {
-      LOG.atError()
-          .addKeyValue("invalidSnapshots", snapshots::size)
-          .setMessage("No valid snapshots found for backup")
-          .log();
-      return Either.left(
-          String.format(
-              ERROR_MSG_NO_VALID_SNAPSHOT,
-              id().checkpointId(),
-              snapshots,
-              backupDescriptor().checkpointPosition()));
+      final var errorMessage =
+          "No valid snapshots found for backup:\n"
+              + snapshotValidationErrorMessage(validationResults);
+      LOG.atError().addKeyValue("backup", backupId).log(errorMessage);
+      return Either.left(errorMessage);
     } else {
-      LOG.atTrace()
-          .addKeyValue("backup", backupId)
-          .addKeyValue("validSnapshots", validSnapshots::size)
-          .setMessage("Found valid snapshots for backup")
-          .log();
+      final var validSnapshotCount = validSnapshots.size();
+      final var invalidSnapshotCount = snapshots.size() - validSnapshotCount;
+      if (invalidSnapshotCount > 0) {
+        LOG.atDebug()
+            .addKeyValue("backup", backupId)
+            .addArgument(validSnapshotCount)
+            .addArgument(invalidSnapshotCount)
+            .addArgument(() -> snapshotValidationErrorMessage(validationResults))
+            .log("Found {} valid and {} invalid snapshots for backup\n:{}");
+      } else {
+        LOG.atTrace()
+            .addKeyValue("backup", backupId)
+            .addKeyValue("validSnapshots", validSnapshots::size)
+            .log("Found {} valid snapshots for backup", validSnapshotCount);
+      }
       return Either.right(validSnapshots);
     }
+  }
+
+  private String snapshotValidationErrorMessage(
+      final Map<PersistedSnapshot, Collection<SnapshotValidation>> validationResults) {
+    return validationResults.entrySet().stream()
+        .sorted(Comparator.comparing(entry -> entry.getKey().getId()))
+        .filter(entry -> !entry.getValue().isEmpty())
+        .map(
+            entry ->
+                String.format(
+                    "Snapshot %s is not valid:\n%s",
+                    entry.getKey().getId(),
+                    entry.getValue().stream()
+                        .map(SnapshotValidation::errorMessage)
+                        .collect(Collectors.joining("\n"))
+                        .indent(4)))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private Collection<SnapshotValidation> validateSnapshot(final PersistedSnapshot snapshot) {
+    final var checkpointPosition = backupDescriptor().checkpointPosition();
+    final var metadata = snapshot.getMetadata();
+
+    final var rejections = new ArrayList<SnapshotValidation>();
+
+    final var processedPositionOk = metadata.processedPosition() < checkpointPosition;
+    final var lastFollowupEventPositionOk =
+        metadata.lastFollowupEventPosition() < checkpointPosition;
+    final var maxExportedPositionOk = metadata.maxExportedPosition() < checkpointPosition;
+    if (!processedPositionOk) {
+      rejections.add(
+          new SnapshotValidation.ProcessedPositionPastCheckpoint(
+              checkpointPosition, metadata.processedPosition()));
+    }
+    if (!lastFollowupEventPositionOk) {
+      rejections.add(
+          new SnapshotValidation.FollowUpEventPositionPastCheckpoint(
+              checkpointPosition, metadata.lastFollowupEventPosition()));
+    }
+    if (!maxExportedPositionOk) {
+      rejections.add(
+          new SnapshotValidation.MaxExportedPositionPastCheckpoint(
+              checkpointPosition, metadata.maxExportedPosition()));
+    }
+
+    return rejections;
   }
 
   private void tryReserveAnySnapshot(
@@ -375,5 +420,39 @@ final class InProgressBackupImpl implements InProgressBackup {
             future.complete(null);
           }
         });
+  }
+
+  private sealed interface SnapshotValidation {
+    String errorMessage();
+
+    record ProcessedPositionPastCheckpoint(long checkpointPosition, long processedPosition)
+        implements SnapshotValidation {
+
+      @Override
+      public String errorMessage() {
+        return "processedPosition (%d) >= checkpointPosition (%d)"
+            .formatted(processedPosition, checkpointPosition);
+      }
+    }
+
+    record FollowUpEventPositionPastCheckpoint(long checkpointPosition, long followUpEventPosition)
+        implements SnapshotValidation {
+
+      @Override
+      public String errorMessage() {
+        return "lastFollowupEventPosition (%d) >= checkpointPosition (%d)"
+            .formatted(followUpEventPosition, checkpointPosition);
+      }
+    }
+
+    record MaxExportedPositionPastCheckpoint(long checkpointPosition, long maxExportedPosition)
+        implements SnapshotValidation {
+
+      @Override
+      public String errorMessage() {
+        return "maxExportedPosition (%d) >= checkpointPosition (%d)"
+            .formatted(maxExportedPosition, checkpointPosition);
+      }
+    }
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -46,12 +46,14 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -638,7 +640,7 @@ class BackupServiceImplTest {
     verify(backupStore, never()).storeRangeMarker(partitionId, new End(checkpointId));
   }
 
-  private ActorFuture<Void> failedFuture() {
+  private <T> ActorFuture<T> failedFuture() {
     return concurrencyControl.failedFuture(new RuntimeException("Expected"));
   }
 
@@ -656,7 +658,8 @@ class BackupServiceImplTest {
 
     private final BackupIdentifier id;
     private final BackupDescriptor checkpointDescriptor;
-    private ActorFuture<Void> findValidSnapshotFuture = TestActorFuture.completedFuture(null);
+    private ActorFuture<Set<PersistedSnapshot>> findValidSnapshotFuture =
+        TestActorFuture.completedFuture(null);
     private ActorFuture<Void> reserveSnapshotFuture = TestActorFuture.completedFuture(null);
     private ActorFuture<Void> findSnapshotFilesFuture = TestActorFuture.completedFuture(null);
     private ActorFuture<Void> findSegmentFilesFuture = TestActorFuture.completedFuture(null);
@@ -684,7 +687,7 @@ class BackupServiceImplTest {
     }
 
     @Override
-    public ActorFuture<Void> findValidSnapshot() {
+    public ActorFuture<Set<PersistedSnapshot>> findValidSnapshot() {
       return findValidSnapshotFuture;
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.LongArrayList;
+import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ExportersState {
@@ -101,6 +102,20 @@ public final class ExportersState {
     visitExporterState(
         (exporterId, exporterStateEntry) -> positions.addLong(exporterStateEntry.getPosition()));
     return positions.longStream().min().orElse(-1L);
+  }
+
+  /**
+   * Return highest position of all exporters or {@link Long#MIN_VALUE} if no exporters are present.
+   */
+  public long getHighestPosition() {
+    final var max = new MutableLong(Long.MIN_VALUE);
+    visitExporterState(
+        (exporterId, exporterStateEntry) -> {
+          if (max.longValue() < exporterStateEntry.getPosition()) {
+            max.set(exporterStateEntry.getPosition());
+          }
+        });
+    return max.get();
   }
 
   public void removeExporterState(final String exporterId) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/DbPositionSupplier.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/DbPositionSupplier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.logstreams.state;
+
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
+import io.camunda.zeebe.broker.exporter.stream.ExportersState;
+import io.camunda.zeebe.db.ZeebeDb;
+
+public final class DbPositionSupplier implements StatePositionSupplier {
+
+  private final boolean continuousBackup;
+  private final ExportersState exporterState;
+  private final DbCheckpointState checkpointState;
+
+  public DbPositionSupplier(final ZeebeDb zeebeDb, final boolean continuousBackup) {
+    this.continuousBackup = continuousBackup;
+    final var context = zeebeDb.createContext();
+    exporterState = new ExportersState(zeebeDb, context);
+    checkpointState = new DbCheckpointState(zeebeDb, context);
+  }
+
+  @Override
+  public long getLowestExportedPosition() {
+    if (exporterState.hasExporters()) {
+      return exporterState.getLowestPosition();
+    } else {
+      return Long.MAX_VALUE;
+    }
+  }
+
+  @Override
+  public long getHighestExportedPosition() {
+    return exporterState.getHighestPosition();
+  }
+
+  @Override
+  public long getHighestBackupPosition() {
+    if (continuousBackup) {
+      return checkpointState.getLatestBackupPosition();
+    } else {
+      // When continuous backups are disabled, act as if everything is backed up. Ensures
+      // that backups do not control compaction.
+      return Long.MAX_VALUE;
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -14,13 +14,17 @@ import io.camunda.zeebe.db.ZeebeDb;
 public final class StatePositionSupplier {
   private StatePositionSupplier() {}
 
-  public static long getHighestExportedPosition(final ZeebeDb zeebeDb) {
+  public static long getLowestExportedPosition(final ZeebeDb zeebeDb) {
     final var exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
     if (exporterState.hasExporters()) {
       return exporterState.getLowestPosition();
     } else {
       return Long.MAX_VALUE;
     }
+  }
+
+  public static long getHighestExportedPosition(final ZeebeDb zeebeDb) {
+    return new ExportersState(zeebeDb, zeebeDb.createContext()).getHighestPosition();
   }
 
   public static long getHighestBackupPosition(final ZeebeDb zeebeDb) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -7,28 +7,15 @@
  */
 package io.camunda.zeebe.broker.logstreams.state;
 
-import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
-import io.camunda.zeebe.broker.exporter.stream.ExportersState;
-import io.camunda.zeebe.db.ZeebeDb;
+/** Supplies various positions from the persisted state. */
+public interface StatePositionSupplier {
 
-public final class StatePositionSupplier {
-  private StatePositionSupplier() {}
+  /** Returns the lowest position across all exporters. */
+  long getLowestExportedPosition();
 
-  public static long getLowestExportedPosition(final ZeebeDb zeebeDb) {
-    final var exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
-    if (exporterState.hasExporters()) {
-      return exporterState.getLowestPosition();
-    } else {
-      return Long.MAX_VALUE;
-    }
-  }
+  /** Returns the highest position across all exporters. */
+  long getHighestExportedPosition();
 
-  public static long getHighestExportedPosition(final ZeebeDb zeebeDb) {
-    return new ExportersState(zeebeDb, zeebeDb.createContext()).getHighestPosition();
-  }
-
-  public static long getHighestBackupPosition(final ZeebeDb zeebeDb) {
-    final var checkpointState = new DbCheckpointState(zeebeDb, zeebeDb.createContext());
-    return checkpointState.getLatestBackupPosition();
-  }
+  /** Returns the highest backup position. */
+  long getHighestBackupPosition();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -249,7 +249,7 @@ public final class ZeebePartitionFactory {
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),
-        StatePositionSupplier::getHighestExportedPosition,
+        StatePositionSupplier::getLowestExportedPosition,
         getBackupPositionSupplier(),
         concurrencyControl);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -28,7 +28,7 @@ import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.function.ToLongFunction;
+import java.util.function.Function;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 
@@ -41,13 +41,13 @@ public class StateControllerImpl implements StateController {
 
   private final Path runtimeDirectory;
   private final ZeebeDbFactory zeebeDbFactory;
-  private final ToLongFunction<ZeebeDb> exporterPositionSupplier;
-  private final ToLongFunction<ZeebeDb> backupPositionSupplier;
+  private final Function<ZeebeDb, StatePositionSupplier> positionSupplierFactory;
   private final AtomixRecordEntrySupplier entrySupplier;
   private final ConstructableSnapshotStore constructableSnapshotStore;
   private final ConcurrencyControl concurrencyControl;
 
   private ZeebeDb db;
+  private StatePositionSupplier positionSupplier;
   private ScheduledTimer metricsExportTimer;
 
   public StateControllerImpl(
@@ -55,15 +55,13 @@ public class StateControllerImpl implements StateController {
       final ConstructableSnapshotStore constructableSnapshotStore,
       final Path runtimeDirectory,
       final AtomixRecordEntrySupplier entrySupplier,
-      final ToLongFunction<ZeebeDb> exporterPositionSupplier,
-      final ToLongFunction<ZeebeDb> backupPositionSupplier,
+      final Function<ZeebeDb, StatePositionSupplier> positionSupplierFactory,
       final ConcurrencyControl concurrencyControl) {
     this.constructableSnapshotStore = requireNonNull(constructableSnapshotStore);
     this.runtimeDirectory = requireNonNull(runtimeDirectory);
     this.zeebeDbFactory = requireNonNull(zeebeDbFactory);
     this.entrySupplier = requireNonNull(entrySupplier);
-    this.exporterPositionSupplier = requireNonNull(exporterPositionSupplier);
-    this.backupPositionSupplier = backupPositionSupplier;
+    this.positionSupplierFactory = requireNonNull(positionSupplierFactory);
     this.concurrencyControl = requireNonNull(concurrencyControl);
 
     concurrencyControl.execute(this::scheduleDbMetricsExport);
@@ -196,8 +194,8 @@ public class StateControllerImpl implements StateController {
 
   private NextSnapshotId tryFindNextSnapshotId(final long lastProcessedPosition)
       throws NoEntryAtSnapshotPosition {
-    final var exportedPosition = exporterPositionSupplier.applyAsLong(db);
-    final var backupPosition = backupPositionSupplier.applyAsLong(db);
+    final var exportedPosition = positionSupplier.getLowestExportedPosition();
+    final var backupPosition = positionSupplier.getHighestBackupPosition();
     if (exportedPosition == -1 || backupPosition == -1 || lastProcessedPosition == 0) {
       final var latestSnapshot = constructableSnapshotStore.getLatestSnapshot();
       if (latestSnapshot.isPresent()) {
@@ -245,6 +243,7 @@ public class StateControllerImpl implements StateController {
     try {
       if (db == null) {
         db = zeebeDbFactory.createDb(runtimeDirectory.toFile());
+        positionSupplier = positionSupplierFactory.apply(db);
         LOG.debug("Opened database from '{}'.", runtimeDirectory);
         future.complete(db);
       }
@@ -285,16 +284,14 @@ public class StateControllerImpl implements StateController {
               db.createSnapshot(snapshotDir.toFile());
             });
 
-    snapshotTaken
-        .thenApply(
-            ignored -> {
-              // After taking the snapshot, determine the highest exported position again so that we
-              // can include it in the snapshot metadata.
-              return snapshot.withMaxExportedPosition(
-                  StatePositionSupplier.getHighestExportedPosition(db));
-            },
-            concurrencyControl)
-        .onComplete(transientSnapshotFuture, concurrencyControl);
+    snapshotTaken.onComplete(
+        (ok, error) -> {
+          if (error != null) {
+            transientSnapshotFuture.completeExceptionally(error);
+          } else {
+            transientSnapshotFuture.complete(snapshot);
+          }
+        });
   }
 
   private record NextSnapshotId(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -219,6 +219,10 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
           }
         });
 
-    return transientSnapshot.withLastFollowupEventPosition(lastWrittenPosition).persist().join();
+    return transientSnapshot
+        .withMaxExportedPosition(lastWrittenPosition)
+        .withLastFollowupEventPosition(lastWrittenPosition)
+        .persist()
+        .join();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -259,4 +259,21 @@ public final class ExportersStateTest {
     assertThat(state.hasExporters()).isFalse();
     assertThat(state.getLowestPosition()).isEqualTo(-1L);
   }
+
+  @Test
+  public void shouldGetHighestPosition() {
+    // given
+    state.setPosition("e1", 1L);
+    state.setPosition("e2", 100L);
+    state.setPosition("e3", 50L);
+
+    // when/then
+    assertThat(state.getHighestPosition()).isEqualTo(100L);
+  }
+
+  @Test
+  public void shouldReturnMinValueForHighestPositionWhenNoExporters() {
+    // when/then
+    assertThat(state.getHighestPosition()).isEqualTo(Long.MIN_VALUE);
+  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions.impl.perf;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.broker.logstreams.state.DbPositionSupplier;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.test.util.jmh.JMHTestCase;
 import io.camunda.zeebe.test.util.junit.JMHTest;
@@ -87,8 +88,7 @@ public class LargeStateControllerPerformanceTest {
             context.snapshotStore(),
             context.temporaryFolder().resolve("runtime"),
             ignored -> Optional.empty(),
-            ignored -> 0L,
-            ignored -> 0L,
+            zeebeDb -> new DbPositionSupplier(zeebeDb, false),
             context.snapshotStore());
 
     // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStepTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldInstallService;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -56,6 +57,7 @@ class SnapshotDirectorPartitionTransitionStepTest {
   void setup() {
     transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
     transitionContext.setStreamProcessor(mock(StreamProcessor.class));
+    transitionContext.setZeebeDb(mock(ZeebeDb.class));
     transitionContext.setBrokerCfg(new BrokerCfg());
     transitionContext.setLogStream(logStream);
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -283,6 +283,10 @@ class PartitionRestoreServiceTest {
           }
         });
 
-    return transientSnapshot.withLastFollowupEventPosition(lastWrittenPosition).persist().join();
+    return transientSnapshot
+        .withLastFollowupEventPosition(lastWrittenPosition)
+        .withMaxExportedPosition(lastWrittenPosition)
+        .persist()
+        .join();
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotMetadata.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotMetadata.java
@@ -20,9 +20,15 @@ public interface SnapshotMetadata {
   long processedPosition();
 
   /**
-   * @return exported position in the snapshot (same as in SnapshotId)
+   * Smallest exported position in the snapshot, as determined before taking the snapshot. Same as
+   * in SnapshotId.
    */
-  long exportedPosition();
+  long minExportedPosition();
+
+  /**
+   * Returns the maximum exported position in the snapshot, as determined after taking the snapshot.
+   */
+  long maxExportedPosition();
 
   /**
    * A snapshot is only valid if the logstream consists of the events from the processedPosition up

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotMetadata.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotMetadata.java
@@ -15,18 +15,20 @@ public interface SnapshotMetadata {
   int version();
 
   /**
-   * @return processed position in the snapshot (same as in SnapshotId)
+   * @return upper bound processed position in the snapshot, as determined after taking the
+   *     snapshot. Same as in SnapshotId.
    */
   long processedPosition();
 
   /**
    * Smallest exported position in the snapshot, as determined before taking the snapshot. Same as
-   * in SnapshotId.
+   * in SnapshotId. The true exported position is somewhere between the min and max.
    */
   long minExportedPosition();
 
   /**
    * Returns the maximum exported position in the snapshot, as determined after taking the snapshot.
+   * The true exported position is somewhere between the min and max.
    */
   long maxExportedPosition();
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
@@ -35,4 +35,7 @@ public interface TransientSnapshot extends PersistableSnapshot {
    * @return transient snapshot.
    */
   TransientSnapshot withLastFollowupEventPosition(long followupEventPosition);
+
+  /** Sets the highest exported position that could be reflected in this snapshot. */
+  TransientSnapshot withMaxExportedPosition(long maxExportedPosition);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -273,6 +273,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
                 snapshotId.getProcessedPosition(),
                 snapshotId.getExportedPosition(),
                 Long.MAX_VALUE,
+                Long.MAX_VALUE,
                 false);
       }
       final PersistedSnapshot value =

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -210,7 +210,9 @@ public final class FileBasedSnapshotStoreImpl {
           VERSION,
           snapshotId.getProcessedPosition(),
           snapshotId.getExportedPosition(),
-          Long.MAX_VALUE);
+          Long.MAX_VALUE,
+          Long.MAX_VALUE,
+          false);
     }
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -48,6 +48,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private MutableChecksumsSFV checksum;
   private final CRC32CChecksumProvider checksumProvider;
   private long lastFollowupEventPosition = Long.MAX_VALUE;
+  private long maxExportedPosition = Long.MAX_VALUE;
   private final boolean isBootstrap;
 
   FileBasedTransientSnapshot(
@@ -74,6 +75,12 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   @Override
   public TransientSnapshot withLastFollowupEventPosition(final long lastFollowupEventPosition) {
     actor.run(() -> this.lastFollowupEventPosition = lastFollowupEventPosition);
+    return this;
+  }
+
+  @Override
+  public TransientSnapshot withMaxExportedPosition(final long maxExportedPosition) {
+    actor.run(() -> this.maxExportedPosition = maxExportedPosition);
     return this;
   }
 
@@ -171,7 +178,9 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
                   FileBasedSnapshotStoreImpl.VERSION,
                   snapshotId.getProcessedPosition(),
                   snapshotId.getExportedPosition(),
-                  lastFollowupEventPosition);
+                  maxExportedPosition,
+                  lastFollowupEventPosition,
+                  false);
 
       writeMetadataAndUpdateChecksum(metadata);
       // snapshot id and director were first provided without the checksum because we could only

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadataTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadataTest.java
@@ -18,20 +18,27 @@ public class FileBasedSnapshotMetadataTest {
   @Test
   public void shouldDeserializeMetadataFromPreviousVersion() throws IOException {
     final var previousMetadata =
-"""
-{"version":1,"processedPosition":71662471,"exportedPosition":74709149,"lastFollowupEventPosition":74708149}
-""";
+        // language=JSON
+        """
+        {
+          "version": 1,
+          "processedPosition": 71662471,
+          "exportedPosition": 74709149,
+          "lastFollowupEventPosition": 74708149,
+          "bootstrap": false
+        }""";
     final var deserialized = FileBasedSnapshotMetadata.decode(previousMetadata.getBytes());
     assertThat(deserialized.isBootstrap()).isFalse();
     assertThat(deserialized.version()).isOne();
-    assertThat(deserialized.exportedPosition()).isEqualTo(74709149L);
+    assertThat(deserialized.minExportedPosition()).isEqualTo(74709149L);
     assertThat(deserialized.processedPosition()).isEqualTo(71662471L);
     assertThat(deserialized.lastFollowupEventPosition()).isEqualTo(74708149L);
+    assertThat(deserialized.maxExportedPosition()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   void shouldSerializeDeserialize() throws IOException {
-    final var metadata = new FileBasedSnapshotMetadata(1, 100L, 200L, 300L, true);
+    final var metadata = new FileBasedSnapshotMetadata(1, 100L, 200L, 300L, 350L, true);
     final var bos = new ByteArrayOutputStream(1024);
     metadata.encode(bos);
     final var deserialized = FileBasedSnapshotMetadata.decode(bos.toByteArray());

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -110,10 +110,14 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
-  public void shouldLoadExistingSnapshotWithMetadata() throws IOException {
+  public void shouldLoadExistingSnapshotWithMetadata() {
     // given
     final var persistedSnapshot =
-        takeTransientSnapshot().withLastFollowupEventPosition(100L).persist().join();
+        takeTransientSnapshot()
+            .withLastFollowupEventPosition(100L)
+            .withMaxExportedPosition(90L)
+            .persist()
+            .join();
 
     // when
     snapshotStore.close();

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -110,9 +110,9 @@ public final class FileBasedSnapshotTest {
   }
 
   @Test
-  public void shoulNotdMarkAsReservedBootstrappedSnapshots() throws IOException {
+  public void shouldNotMarkAsReservedBootstrappedSnapshots() throws IOException {
     // given
-    final var metadata = new FileBasedSnapshotMetadata(1, 1L, 1L, 0, true);
+    final var metadata = new FileBasedSnapshotMetadata(1, 1L, 1L, 1L, 0, true);
     final var snapshotPath = snapshotDir.resolve("snapshot");
     final Path checksumPath = snapshotDir.resolve("checksum");
 


### PR DESCRIPTION
Ensures that we don't use snapshots where the exporter position has already moved past the checkpoint position.
Using such snapshots would lead to failures after restore where the exporter would expect to have exported records that were not actually restored.
This could not happen before continuous backups because exporting had to be paused before creating the checkpoint.
Now that we have continuous and scheduled backups, we need to prevent this.

For correctness, we are now excluding snapshots that _may_ contain an exporter position > checkpoint position. After taking the snapshot, we will check the exporter position again and attach it to the snapshot metadata as `maxExportedPosition`. This complements the already existing `exportedPosition`, now renamed to `minExportedPosition`, which records the smallest exported position _before_ taking a snapshot.