### PR TITLE
[Backport stable/8.8] fix: exclude BPMN XML from search results in Elasticsearch and Opensearch

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -528,31 +528,18 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
 
     // when
     final ProcessEntity retrievedProcess = processStore.getProcessByKey(storedProcess.getKey());
+    final String diagram = processStore.getDiagramByKey(storedProcess.getKey());
 
     // then - verify the process is retrieved (BPMN_XML exclusion doesn't affect structure)
     assertThat(retrievedProcess).isNotNull();
     assertThat(retrievedProcess.getKey()).isEqualTo(storedProcess.getKey());
     assertThat(retrievedProcess.getName()).isEqualTo(storedProcess.getName());
     assertThat(retrievedProcess.getBpmnProcessId()).isEqualTo(storedProcess.getBpmnProcessId());
-    // Note: BPMN_XML may be null due to exclusion from search, but xmlByKey() method can be used
-    // to explicitly fetch the XML when needed
-  }
+    assertThat(retrievedProcess.getBpmnXml()).isNull();
 
-  @Test
-  public void testGetProcessByKeyAndGetDiagramByKeyUseDifferentMethods() {
-    // given - a stored process with BPMN XML
-    final ProcessEntity storedProcess = firstProcessDefinition;
-
-    // when - get process by key (excludes BPMN_XML)
-    final ProcessEntity process = processStore.getProcessByKey(storedProcess.getKey());
-    // and get diagram by key (explicitly includes XML)
-    final String diagram = processStore.getDiagramByKey(storedProcess.getKey());
-
-    // then
-    assertThat(process).isNotNull();
+    // The diagram can be fetched even though getProcessByKey excludes BPMN_XML
     assertThat(diagram).isNotNull();
     assertThat(diagram).isEqualTo(storedProcess.getBpmnXml());
-    // The diagram can be fetched even though getProcessByKey excludes BPMN_XML
   }
 
   private String getFullIndexNameForDependant(final String indexName) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/store/ProcessStoreIT.java
@@ -521,6 +521,40 @@ public class ProcessStoreIT extends OperateSearchAbstractIT {
                 firstProcessDefinition.getBpmnProcessId(), TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
+  @Test
+  public void testGetProcessByKeyReturnsBpmnXmlExcluded() {
+    // given - fetch a process by key
+    final ProcessEntity storedProcess = firstProcessDefinition;
+
+    // when
+    final ProcessEntity retrievedProcess = processStore.getProcessByKey(storedProcess.getKey());
+
+    // then - verify the process is retrieved (BPMN_XML exclusion doesn't affect structure)
+    assertThat(retrievedProcess).isNotNull();
+    assertThat(retrievedProcess.getKey()).isEqualTo(storedProcess.getKey());
+    assertThat(retrievedProcess.getName()).isEqualTo(storedProcess.getName());
+    assertThat(retrievedProcess.getBpmnProcessId()).isEqualTo(storedProcess.getBpmnProcessId());
+    // Note: BPMN_XML may be null due to exclusion from search, but xmlByKey() method can be used
+    // to explicitly fetch the XML when needed
+  }
+
+  @Test
+  public void testGetProcessByKeyAndGetDiagramByKeyUseDifferentMethods() {
+    // given - a stored process with BPMN XML
+    final ProcessEntity storedProcess = firstProcessDefinition;
+
+    // when - get process by key (excludes BPMN_XML)
+    final ProcessEntity process = processStore.getProcessByKey(storedProcess.getKey());
+    // and get diagram by key (explicitly includes XML)
+    final String diagram = processStore.getDiagramByKey(storedProcess.getKey());
+
+    // then
+    assertThat(process).isNotNull();
+    assertThat(diagram).isNotNull();
+    assertThat(diagram).isEqualTo(storedProcess.getBpmnXml());
+    // The diagram can be fetched even though getProcessByKey excludes BPMN_XML
+  }
+
   private String getFullIndexNameForDependant(final String indexName) {
     final ProcessInstanceDependant dependant =
         processInstanceDependantTemplates.stream()

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -179,7 +179,9 @@ public class ElasticsearchProcessStore implements ProcessStore {
         new SearchRequest(processIndex.getAlias())
             .source(
                 new SearchSourceBuilder()
-                    .query(QueryBuilders.termQuery(ProcessIndex.KEY, processDefinitionKey)));
+                    .query(QueryBuilders.termQuery(ProcessIndex.KEY, processDefinitionKey))
+                    // Exclude BPMN_XML for performance - use getDiagramByKey() to retrieve XML
+                    .fetchSource(null, new String[] {BPMN_XML}));
 
     try {
       final SearchResponse response = tenantAwareClient.search(searchRequest);

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -14,6 +14,7 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.withTenantCheck;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_XML;
 import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.TREE_PATH;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.*;
 import static java.util.function.UnaryOperator.identity;
@@ -99,7 +100,8 @@ public class OpensearchProcessStore implements ProcessStore {
   public ProcessEntity getProcessByKey(final Long processDefinitionKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
-            .query(withTenantCheck(term(ProcessIndex.KEY, processDefinitionKey)));
+            .query(withTenantCheck(term(ProcessIndex.KEY, processDefinitionKey)))
+            .source(sourceExclude(BPMN_XML));
 
     return richOpenSearchClient
         .doc()

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.store.elasticsearch;
 
-import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_XML;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,13 +29,16 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -180,7 +183,7 @@ public class ElasticsearchProcessStoreTest {
     when(tenantAwareClient.search(any())).thenThrow(new IOException());
 
     assertThatExceptionOfType(OperateRuntimeException.class)
-        .isThrownBy(() -> underTest.getProcessesGrouped(DEFAULT_TENANT_ID, Set.of("demoProcess")));
+        .isThrownBy(() -> underTest.getProcessesGrouped("<default>", Set.of("demoProcess")));
   }
 
   @Test
@@ -417,5 +420,104 @@ public class ElasticsearchProcessStoreTest {
             .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Refresh indices needs at least one index to refresh.");
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesBpmnXml() throws IOException {
+    // Given - mock search response
+    final SearchResponse mockResponse = Mockito.mock(SearchResponse.class);
+    final SearchHits mockHits = Mockito.mock(SearchHits.class);
+    final TotalHits mockTotalHits = new TotalHits(1L, Mockito.mock(TotalHits.Relation.class));
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(tenantAwareClient.search(any())).thenReturn(mockResponse);
+    when(processIndex.getAlias()).thenReturn("process-index");
+
+    // When - getProcessByKey is called
+    try {
+      underTest.getProcessByKey(123L);
+    } catch (final Exception e) {
+      // Expected - mock doesn't return proper entity
+    }
+
+    // Then - capture the SearchRequest and verify BPMN_XML is excluded
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest).isNotNull();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().fetchSource()).isNotNull();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void testGetDiagramByKeyIncludesBpmnXml() throws IOException {
+    // Given - mock search response
+    final SearchResponse mockResponse = Mockito.mock(SearchResponse.class);
+    final SearchHits mockHits = Mockito.mock(SearchHits.class);
+    final TotalHits mockTotalHits = new TotalHits(1L, Mockito.mock(TotalHits.Relation.class));
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(tenantAwareClient.search(any())).thenReturn(mockResponse);
+    when(processIndex.getAlias()).thenReturn("process-index");
+
+    // When - getDiagramByKey is called
+    try {
+      underTest.getDiagramByKey(123L);
+    } catch (final Exception e) {
+      // Expected - mock doesn't return proper entity
+    }
+
+    // Then - capture the SearchRequest and verify BPMN_XML is NOT excluded (should be included)
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest).isNotNull();
+    assertThat(capturedRequest.source()).isNotNull();
+    // getDiagramByKey should include BPMN_XML, not exclude it
+    final var fetchSource = capturedRequest.source().fetchSource();
+    if (fetchSource != null && fetchSource.excludes() != null) {
+      assertThat(fetchSource.excludes()).doesNotContain(BPMN_XML);
+    }
+    // Verify that BPMN_XML is in the includes (the method fetches BPMN_XML explicitly)
+    if (fetchSource != null && fetchSource.includes() != null) {
+      assertThat(fetchSource.includes()).contains(BPMN_XML);
+    }
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesOnlyBpmnXml() throws IOException {
+    // Given - mock search response
+    final SearchResponse mockResponse = Mockito.mock(SearchResponse.class);
+    final SearchHits mockHits = Mockito.mock(SearchHits.class);
+    final TotalHits mockTotalHits = new TotalHits(1L, Mockito.mock(TotalHits.Relation.class));
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(tenantAwareClient.search(any())).thenReturn(mockResponse);
+    when(processIndex.getAlias()).thenReturn("process-index");
+
+    // When - getProcessByKey is called
+    try {
+      underTest.getProcessByKey(456L);
+    } catch (final Exception e) {
+      // Expected - mock doesn't return proper entity
+    }
+
+    // Then - verify ONLY bpmnXml is in the excludes list
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    final String[] excludes = capturedRequest.source().fetchSource().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(BPMN_XML);
+
+    // Verify no includes are set (all other fields should be returned)
+    assertThat(capturedRequest.source().fetchSource().includes()).isNullOrEmpty();
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchProcessStoreTest {
+
+  @Mock private ProcessIndex processIndex;
+
+  @Mock private RichOpenSearchClient richOpenSearchClient;
+
+  @Mock private OpenSearchDocumentOperations documentOperations;
+
+  @InjectMocks private OpensearchProcessStore underTest;
+
+  @BeforeEach
+  public void setup() {
+
+    when(richOpenSearchClient.doc()).thenReturn(documentOperations);
+    when(processIndex.getAlias()).thenReturn("process-index");
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesBpmnXml() {
+    // Given - mock document operations
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(123L);
+    mockProcess.setBpmnProcessId("test-process");
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When - getProcessByKey is called
+    final ProcessEntity result = underTest.getProcessByKey(123L);
+
+    // Then - verify the result is returned
+    assertThat(result).isNotNull();
+    assertThat(result.getKey()).isEqualTo(123L);
+
+    // Verify that searchUnique was called with a SearchRequest.Builder
+    final ArgumentCaptor<SearchRequest.Builder> captor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    verify(documentOperations).searchUnique(captor.capture(), eq(ProcessEntity.class), eq("123"));
+
+    // Verify the search request builder was configured
+    final SearchRequest.Builder requestBuilder = captor.getValue();
+    assertThat(requestBuilder).isNotNull();
+
+    // Build the request to inspect it
+    final SearchRequest builtRequest = requestBuilder.build();
+
+    // Verify source filtering is applied (excludes bpmnXml)
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void testGetDiagramByKeyIncludesBpmnXml() {
+    // Given - mock document operations
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(123L);
+    mockProcess.setBpmnXml("<?xml version=\"1.0\"?><process></process>");
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When - getDiagramByKey is called
+    final String result = underTest.getDiagramByKey(123L);
+
+    // Then - verify BPMN XML is returned
+    assertThat(result).isNotNull();
+    assertThat(result).contains("<?xml");
+
+    // Verify searchUnique was called
+    verify(documentOperations)
+        .searchUnique(any(SearchRequest.Builder.class), eq(ProcessEntity.class), eq("123"));
+  }
+
+  @Test
+  public void testGetProcessByKeyExcludesOnlyBpmnXmlNotOtherFields() {
+    // Given
+    final ProcessEntity mockProcess = new ProcessEntity();
+    mockProcess.setKey(456L);
+    mockProcess.setBpmnProcessId("another-process");
+    mockProcess.setName("Another Process");
+    mockProcess.setVersion(2);
+
+    when(documentOperations.searchUnique(
+            any(SearchRequest.Builder.class), eq(ProcessEntity.class), any(String.class)))
+        .thenReturn(mockProcess);
+
+    // When
+    final ProcessEntity result = underTest.getProcessByKey(456L);
+
+    // Then - verify all other fields are present except bpmnXml
+    assertThat(result).isNotNull();
+    assertThat(result.getKey()).isEqualTo(456L);
+    assertThat(result.getBpmnProcessId()).isEqualTo("another-process");
+    assertThat(result.getName()).isEqualTo("Another Process");
+    assertThat(result.getVersion()).isEqualTo(2);
+
+    // Verify the request excludes ONLY bpmnXml
+    final ArgumentCaptor<SearchRequest.Builder> captor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    verify(documentOperations).searchUnique(captor.capture(), eq(ProcessEntity.class), eq("456"));
+
+    final SearchRequest builtRequest = captor.getValue().build();
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+
+    final List<String> excludes = builtRequest.source().filter().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(ProcessIndex.BPMN_XML);
+
+    // Verify no includes are set (all other fields should be returned)
+    assertThat(builtRequest.source().filter().includes()).isNullOrEmpty();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
@@ -50,6 +50,8 @@ public class ElasticsearchProcessDefinitionDao extends ElasticsearchDao<ProcessD
     logger.debug("search {}", query);
     final SearchSourceBuilder searchSourceBuilder =
         buildQueryOn(query, ProcessDefinition.KEY, new SearchSourceBuilder());
+    // Exclude BPMN XML from search results for performance
+    searchSourceBuilder.fetchSource(null, new String[] {BPMN_XML});
     try {
       final SearchRequest searchRequest =
           new SearchRequest().indices(processIndex.getAlias()).source(searchSourceBuilder);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -18,10 +18,13 @@ import io.camunda.operate.webapp.api.v1.exceptions.ServerException;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -82,6 +85,15 @@ public class OpensearchProcessDefinitionDao
     }
     throw new ResourceNotFoundException(
         String.format("Process definition for key %s not found.", key));
+  }
+
+  @Override
+  protected SearchRequest.Builder buildSearchRequest(
+      final Query<ProcessDefinition> query,
+      final org.opensearch.client.opensearch._types.query_dsl.Query filtering,
+      final ArrayList<SortOptions> sortOptions) {
+    return super.buildSearchRequest(query, filtering, sortOptions)
+        .source(queryDSLWrapper.sourceExclude(ProcessIndex.BPMN_XML));
   }
 
   @Override

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
@@ -7,23 +7,53 @@
  */
 package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
 
+import static io.camunda.webapps.schema.descriptors.index.ProcessIndex.BPMN_XML;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.tenant.TenantAwareElasticsearchClient;
 import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
 import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.api.v1.exceptions.APIException;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.io.IOException;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ElasticsearchProcessDefinitionDaoTest {
 
-  @Spy
-  ElasticsearchProcessDefinitionDao processDefinitionDao = new ElasticsearchProcessDefinitionDao();
+  @Mock private TenantAwareElasticsearchClient tenantAwareClient;
+
+  @Mock private ObjectMapper objectMapper;
+
+  @Mock private ProcessIndex processIndex;
+
+  @Spy private ElasticsearchProcessDefinitionDao processDefinitionDao;
+
+  @BeforeEach
+  public void setup() {
+    ReflectionTestUtils.setField(processDefinitionDao, "tenantAwareClient", tenantAwareClient);
+    ReflectionTestUtils.setField(processDefinitionDao, "objectMapper", objectMapper);
+    ReflectionTestUtils.setField(processDefinitionDao, "processIndex", processIndex);
+    when(processIndex.getAlias()).thenReturn("process-index");
+  }
 
   @Test
   public void shouldApplyFilters() {
@@ -57,5 +87,150 @@ public class ElasticsearchProcessDefinitionDaoTest {
         .buildTermQuery(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
     verify(processDefinitionDao, times(1))
         .buildTermQuery(ProcessDefinition.KEY, processDefinition.getKey());
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearch() throws APIException, IOException {
+    // given
+    final Query<ProcessDefinition> query = new Query<>();
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - capture the SearchRequest and verify BPMN_XML is excluded
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest).isNotNull();
+    assertThat(capturedRequest.source()).isNotNull();
+    assertThat(capturedRequest.source().fetchSource()).isNotNull();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithFilters() throws APIException, IOException {
+    // given - query with filters applied
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setName("testProcess")
+            .setBpmnProcessId("process-123")
+            .setTenantId("<default>")
+            .setVersion(2);
+    final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN_XML is excluded even with filters
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithPagination() throws APIException, IOException {
+    // given - query with pagination parameters
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>().setSize(100).setSearchAfter(new Object[] {50L});
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN_XML is excluded
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldOnlyExcludeBpmnXmlAndNotOtherFields() throws APIException, IOException {
+    // given - ensure only BPMN XML is excluded, not other process definition fields
+    final Query<ProcessDefinition> query = new Query<>();
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify ONLY bpmnXml is in the excludes list
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    final String[] excludes = capturedRequest.source().fetchSource().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(BPMN_XML);
+
+    // Verify no includes are set (we want all other fields)
+    assertThat(capturedRequest.source().fetchSource().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlWithComplexQuery() throws APIException, IOException {
+    // given - complex query with all filter fields populated
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setKey(999L)
+            .setName("complexProcess")
+            .setBpmnProcessId("complex-process-id")
+            .setTenantId("complex-tenant")
+            .setVersion(10)
+            .setVersionTag("v2.0.0");
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setFilter(filter)
+            .setSize(25)
+            .setSort(Query.Sort.listOf(ProcessDefinition.VERSION, Query.Sort.Order.DESC));
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is excluded even with complex query
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithSorting() throws APIException, IOException {
+    // given - query with custom sorting
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setSort(Query.Sort.listOf(ProcessDefinition.NAME, Query.Sort.Order.ASC));
+    mockSearchResponse();
+
+    // when
+    processDefinitionDao.search(query);
+
+    // then - verify BPMN XML is excluded with sorting
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(tenantAwareClient).search(captor.capture());
+
+    final SearchRequest capturedRequest = captor.getValue();
+    assertThat(capturedRequest.source().fetchSource().excludes()).contains(BPMN_XML);
+  }
+
+  private void mockSearchResponse() throws IOException {
+    final SearchResponse mockResponse = org.mockito.Mockito.mock(SearchResponse.class);
+    final SearchHits mockHits = org.mockito.Mockito.mock(SearchHits.class);
+    final org.apache.lucene.search.TotalHits.Relation mockRelation =
+        org.mockito.Mockito.mock(org.apache.lucene.search.TotalHits.Relation.class);
+    final org.apache.lucene.search.TotalHits mockTotalHits =
+        new org.apache.lucene.search.TotalHits(0L, mockRelation);
+
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(mockTotalHits);
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(tenantAwareClient.search(any(SearchRequest.class))).thenReturn(mockResponse);
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.webapp.api.v1.dao.opensearch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -18,25 +19,28 @@ import io.camunda.operate.webapp.api.v1.entities.Query;
 import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
 import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.SortOptions;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchProcessDefinitionDaoTest {
 
   private OpensearchProcessDefinitionDao processDefinitionDao;
-
-  private OpensearchQueryDSLWrapper wrapper;
+  private OpensearchQueryDSLWrapper queryWrapper;
+  private OpensearchRequestDSLWrapper requestWrapper;
 
   @BeforeEach
   public void setup() {
-    wrapper = spy(new OpensearchQueryDSLWrapper());
+    queryWrapper = spy(new OpensearchQueryDSLWrapper());
+    requestWrapper = spy(new OpensearchRequestDSLWrapper());
     processDefinitionDao =
         new OpensearchProcessDefinitionDao(
-            wrapper,
-            mock(OpensearchRequestDSLWrapper.class),
+            queryWrapper,
+            requestWrapper,
             mock(RichOpenSearchClient.class),
             new ProcessIndex("test-index", false));
   }
@@ -59,13 +63,108 @@ public class OpensearchProcessDefinitionDaoTest {
     processDefinitionDao.buildFiltering(query);
 
     // then
-    verify(wrapper, times(1)).term(ProcessDefinition.NAME, processDefinition.getName());
-    verify(wrapper, times(1))
+    verify(queryWrapper, times(1)).term(ProcessDefinition.NAME, processDefinition.getName());
+    verify(queryWrapper, times(1))
         .term(ProcessDefinition.BPMN_PROCESS_ID, processDefinition.getBpmnProcessId());
-    verify(wrapper, times(1)).term(ProcessDefinition.TENANT_ID, processDefinition.getTenantId());
-    verify(wrapper, times(1)).term(ProcessDefinition.VERSION, processDefinition.getVersion());
-    verify(wrapper, times(1))
+    verify(queryWrapper, times(1))
+        .term(ProcessDefinition.TENANT_ID, processDefinition.getTenantId());
+    verify(queryWrapper, times(1)).term(ProcessDefinition.VERSION, processDefinition.getVersion());
+    verify(queryWrapper, times(1))
         .term(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
-    verify(wrapper, times(1)).term(ProcessDefinition.KEY, processDefinition.getKey());
+    verify(queryWrapper, times(1)).term(ProcessDefinition.KEY, processDefinition.getKey());
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearch() {
+    // given
+    final Query<ProcessDefinition> query = new Query<>();
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    // when
+    final var searchRequest =
+        processDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that source filter excludes bpmnXml
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlFromSearchWithFilter() {
+    // given - query with filters applied
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setName("testProcess")
+            .setBpmnProcessId("process-123")
+            .setTenantId("<default>")
+            .setVersion(2);
+    final Query<ProcessDefinition> query = new Query<ProcessDefinition>().setFilter(filter);
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    // when
+    final var searchRequest =
+        processDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that bpmnXml is still excluded even with filters
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
+  }
+
+  @Test
+  public void shouldOnlyExcludeBpmnXmlFieldAndNotOthers() {
+    // given - ensure only BPMN XML is excluded, not other process definition fields
+    final Query<ProcessDefinition> query = new Query<>();
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    // when
+    final var searchRequest =
+        processDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify ONLY bpmnXml is in the excludes list
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    final var excludes = builtRequest.source().filter().excludes();
+    assertThat(excludes).hasSize(1);
+    assertThat(excludes).containsExactly(ProcessIndex.BPMN_XML);
+    // Verify no includes are set (we want all other fields)
+    assertThat(builtRequest.source().filter().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldExcludeBpmnXmlWithComplexFilter() {
+    // given - complex query with all filter fields populated
+    final ProcessDefinition filter =
+        new ProcessDefinition()
+            .setKey(999L)
+            .setName("complexProcess")
+            .setBpmnProcessId("complex-process-id")
+            .setTenantId("complex-tenant")
+            .setVersion(10)
+            .setVersionTag("v2.0.0");
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>()
+            .setFilter(filter)
+            .setSize(25)
+            .setSort(Query.Sort.listOf(ProcessDefinition.VERSION, Query.Sort.Order.DESC));
+    final var filtering = processDefinitionDao.buildFiltering(query);
+    final var sortOptions = new ArrayList<SortOptions>();
+
+    // when
+    final var searchRequest =
+        processDefinitionDao.buildSearchRequest(query, filtering, sortOptions);
+    final var builtRequest = searchRequest.build();
+
+    // then - verify that bpmnXml is excluded even with complex filters
+    assertThat(builtRequest.source()).isNotNull();
+    assertThat(builtRequest.source().filter()).isNotNull();
+    assertThat(builtRequest.source().filter().excludes()).contains(ProcessIndex.BPMN_XML);
   }
 }


### PR DESCRIPTION
# Description
Backport of #45998 to `stable/8.8`.

relates to #30372