### PR TITLE
test: add MCP connector integration tests for orchestration suite

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -35,7 +35,7 @@ jobs:
           else
             echo "Using standalone camunda container"
             echo "Starting Camunda with NON_STANDALONE:$NON_STANDALONE, database:$DATABASE"
-            DATABASE=elasticsearch docker compose up -d camunda
+            DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -227,12 +227,12 @@ jobs:
             echo "Using standalone camunda container"
             if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
               echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             else
               echo "Starting with default Tasklist V2 mode"
               export DATABASE=elasticsearch
             echo "Starting Camunda with NON_STANDALONE:$NON_STANDALONE, database:$DATABASE"
-            DATABASE=elasticsearch docker compose up -d camunda
+            DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             fi
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -83,7 +83,7 @@ jobs:
             DATABASE=elasticsearch docker compose up -d operate tasklist
           else
             echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
+            DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -273,10 +273,10 @@ jobs:
             echo "Using standalone camunda container"
             if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
               echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             else
               echo "Starting with default Tasklist V2 mode"
-              DATABASE=elasticsearch docker compose up -d camunda
+              DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             fi
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -138,7 +138,7 @@ jobs:
             DATABASE=elasticsearch docker compose up -d operate tasklist
           else
             echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
+            DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -363,10 +363,10 @@ jobs:
             echo "Using standalone camunda container"
             if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
               echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             else
               echo "Starting with default Tasklist V2 mode"
-              DATABASE=elasticsearch docker compose up -d camunda
+              DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
             fi
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Start Camunda
         run: |
           echo "Starting Camunda with unified architecture"
-          DATABASE=elasticsearch docker compose up -d camunda
+          DATABASE=elasticsearch docker compose up -d camunda mcp-test-server connectors
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     container_name: postgres
     image: postgres:18.2-alpine
     ports:
-      - '5432:5432'
+      - "5432:5432"
     environment:
       POSTGRES_DB: identity
       POSTGRES_USER: identity
-      POSTGRES_PASSWORD: 't2L@!AqSMg8%I%NmHM'
+      POSTGRES_PASSWORD: "t2L@!AqSMg8%I%NmHM"
     networks:
       - zeebe_network
 
@@ -95,11 +95,63 @@ services:
     networks:
       - zeebe_network
 
+  mcp-test-server:
+    container_name: mcp-test-server
+    image: registry.camunda.cloud/mcp/mcp-test-server:latest
+    ports:
+      - 12001:12001
+    networks:
+      - zeebe_network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:12001/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  connectors:
+    container_name: connectors
+    image: camunda/connectors-bundle:SNAPSHOT
+    environment:
+      - CAMUNDA_CLIENT_ZEEBE_GRPC_ADDRESS=grpc://camunda:26500
+      - CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS=http://camunda:8080
+      - CAMUNDA_CLIENT_AUTH_METHOD=BASIC
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+      - management.endpoints.web.exposure.include=health
+      - management.endpoint.health.probes.enabled=true
+      - CAMUNDA_CONNECTOR_LOG_APPENDER=stdout
+      - LOGGING_LEVEL_IO_CAMUNDA_CONNECTOR=DEBUG
+      - CAMUNDA_CLIENT_WORKER_DEFAULTNAME=connectors-bundle
+      - CAMUNDA_CLIENT_WORKER_THREADS=10
+    ports:
+      - 8081:8080
+    depends_on:
+      camunda:
+        condition: service_started
+      mcp-test-server:
+        condition: service_healthy
+    networks:
+      - zeebe_network
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "--spider",
+          "http://localhost:8080/actuator/health/readiness",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
   camunda:
     container_name: camunda
     image: camunda/camunda:SNAPSHOT
     environment:
-      - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
+      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g"
       - ZEEBE_BROKER_NETWORK_HOST=camunda
       - SPRING_PROFILES_ACTIVE=e2e-test,consolidated-auth,tasklist,broker,operate,admin
       - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_server_list_tools.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_server_list_tools.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+    xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1"
+    targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+    exporterVersion="dd3b335" modeler:executionPlatform="Camunda Cloud"
+    modeler:executionPlatformVersion="8.9.0">
+    <bpmn:process id="mcp_remote_client" name="mcp_remote_client" isExecutable="true">
+        <bpmn:startEvent id="StartEvent_1">
+            <bpmn:outgoing>Flow_1jxr5k6</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1jxr5k6" sourceRef="StartEvent_1" targetRef="Activity_1jtuozy" />
+        <bpmn:endEvent id="Event_0ap30yg">
+            <bpmn:incoming>Flow_04vys7c</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_04vys7c" sourceRef="Activity_1jtuozy" targetRef="Event_0ap30yg" />
+        <bpmn:serviceTask id="Activity_1jtuozy"
+            zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0"
+            zeebe:modelerTemplateVersion="2"
+            zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+            <bpmn:extensionElements>
+                <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:1" retries="3" />
+                <zeebe:ioMapping>
+                    <zeebe:input source="http" target="data.transport.type" />
+                    <zeebe:input source="http://mcp-test-server:12001/mcp"
+                        target="data.transport.http.url" />
+                    <zeebe:input source="noAuth" target="data.transport.http.authentication.type" />
+                    <zeebe:input source="=false" target="data.options.clientCache" />
+                    <zeebe:input source="standalone" target="data.connectorMode.type" />
+                    <zeebe:input source="tools/list" target="data.connectorMode.operation.type" />
+                </zeebe:ioMapping>
+                <zeebe:taskHeaders>
+                    <zeebe:header key="elementTemplateVersion" value="2" />
+                    <zeebe:header key="elementTemplateId"
+                        value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+                    <zeebe:header key="resultExpression"
+                        value="={toolCallResult:toolDefinitions.name}" />
+                    <zeebe:header key="retryBackoff" value="PT0S" />
+                </zeebe:taskHeaders>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_1jxr5k6</bpmn:incoming>
+            <bpmn:outgoing>Flow_04vys7c</bpmn:outgoing>
+        </bpmn:serviceTask>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcp_remote_client">
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                <dc:Bounds x="372" y="192" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0ap30yg_di" bpmnElement="Event_0ap30yg">
+                <dc:Bounds x="612" y="192" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0igv5yz_di" bpmnElement="Activity_1jtuozy">
+                <dc:Bounds x="460" y="170" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1jxr5k6_di" bpmnElement="Flow_1jxr5k6">
+                <di:waypoint x="408" y="210" />
+                <di:waypoint x="460" y="210" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_04vys7c_di" bpmnElement="Flow_04vys7c">
+                <di:waypoint x="560" y="210" />
+                <di:waypoint x="612" y="210" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/agentic_orchestration/mcp-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/agentic_orchestration/mcp-user-flows.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {validateMcpServerHealth} from 'utils/mcpServerHelpers';
+import {validateConnectorsHealth} from 'utils/connectorsRuntimeHelpers';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeAll(async () => {
+  await validateMcpServerHealth();
+  await validateConnectorsHealth();
+  await deploy([
+    './resources/agentic_orchestration/mcp_server_list_tools.bpmn',
+  ]);
+  await createInstances('mcp_remote_client', 1, 1);
+  await sleep(2000);
+});
+
+test.describe('MCP Server Integration', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Verify MCP server returns list of tools', async ({
+    operateHomePage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to completed process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.selectProcess('mcp_remote_client');
+      await sleep(100);
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.completedIcon).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify toolCallResult variable contains expected tools', async () => {
+      const toolCallResult =
+        operateProcessInstancePage.existingVariableByName('toolCallResult');
+      await expect(toolCallResult.value).toContainText('add');
+      await expect(toolCallResult.value).toContainText('greet');
+      await expect(toolCallResult.value).toContainText('echo');
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/connectorsRuntimeHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/connectorsRuntimeHelpers.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const CONNECTORS_HEALTH_URL =
+  process.env.CONNECTORS_URL || 'http://localhost:8081';
+
+export async function waitForConnectorsRuntime(
+  maxRetries = 30,
+  retryDelay = 2000
+): Promise<void> {
+  let lastError: string | undefined;
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(
+        `${CONNECTORS_HEALTH_URL}/actuator/health/readiness`
+      );
+
+      if (response.ok) {
+        const health = await response.json();
+        if (health.status === 'UP') {
+          console.log('✓ Connectors runtime is ready');
+          return;
+        }
+        lastError = `Health status is '${health.status}', expected 'UP'`;
+      } else {
+        const errorBody = await response.text();
+        lastError = `Health check failed with status ${response.status}. Response: ${errorBody}`;
+      }
+    } catch (error) {
+      lastError =
+        error instanceof Error ? error.message : 'Unknown error occurred';
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, retryDelay));
+  }
+
+  throw new Error(
+    `Connectors runtime failed to become ready after ${maxRetries} attempts. ` +
+      (lastError ? `Last error: ${lastError}. ` : '') +
+      `Health endpoint: ${CONNECTORS_HEALTH_URL}/actuator/health/readiness. ` +
+      'Please ensure connector service is running:\n' +
+      'docker compose up -d connectors'
+  );
+}
+
+export async function validateConnectorsHealth(): Promise<void> {
+  console.log(
+    `Verifying connectors runtime is healthy at ${CONNECTORS_HEALTH_URL}...`
+  );
+  await waitForConnectorsRuntime();
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/mcpServerHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/mcpServerHelpers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIResponse, request} from '@playwright/test';
+
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL || 'http://localhost:12001';
+
+/*
+ * Validate that the MCP test server is healthy and ready to accept requests.
+ *
+ * Optionally allows overriding the MCP server URL.
+ */
+
+export async function validateMcpServerHealth(
+  serverUrl?: string,
+): Promise<APIResponse> {
+  const mcpServerUrl = serverUrl || MCP_SERVER_URL;
+  const healthEndpoint = `${mcpServerUrl}/actuator/health`;
+
+  const apiRequestContext = await request.newContext();
+
+  try {
+    const response = await apiRequestContext.get(healthEndpoint);
+
+    if (response.status() !== 200) {
+      const errorBody = await response.text();
+      throw new Error(
+        `MCP server health check failed with status ${response.status()}. Response: ${errorBody}`,
+      );
+    }
+
+    return response;
+  } catch (error: unknown) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(
+      `MCP server is not available at ${healthEndpoint}. ` +
+        `Error: ${errorMessage}. ` +
+        'Please ensure the MCP docker container is running with: ' +
+        'docker run -d --name mcp-test-server --network host registry.camunda.cloud/mcp/mcp-test-server:latest',
+    );
+  } finally {
+    await apiRequestContext.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
Adds end-to-end tests validating MCP (Model Context Protocol) Remote Client connector integration with Camunda 8 orchestration platform.

## Changes
- Add MCP test server service to docker-compose (`registry.camunda.cloud/mcp/mcp-test-server:latest`)
- Add connectors runtime service with MCP Remote Client connector (`camunda/connectors-bundle:SNAPSHOT`)
- Create test suite in `tests/agentic_orchestration/` validating MCP server tool listing
- Add BPMN process definition for MCP Remote Client connector usage
- Add connector runtime health check utilities

## Test Plan
- [x] MCP test server starts successfully
- [x] Connectors runtime starts and connects to Camunda
- [x] Process instance completes successfully calling MCP server
- [x] Tool list results are correctly validated (add, greet, echo tools)

🤖 Created with [Claude Code](https://claude.com/claude-code)

GHA for on demand run: https://github.com/camunda/camunda/actions/runs/22176438084/job/64126369573