### PR TITLE
fix: prevent NPE when BoundaryEvent attachedTo is null

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ActivityImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/ActivityImpl.java
@@ -197,7 +197,7 @@ public abstract class ActivityImpl extends FlowNodeImpl implements Activity {
   public Query<BoundaryEvent> getBoundaryEvents() {
     final Collection<BoundaryEvent> queryElements =
         getParentElement().getChildElementsByType(BoundaryEvent.class).stream()
-            .filter(event -> event.getAttachedTo().equals(this))
+            .filter(event -> event.getAttachedTo() != null && event.getAttachedTo().equals(this))
             .collect(Collectors.toSet());
 
     return new QueryImpl<>(queryElements);

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -15,11 +15,14 @@
  */
 package io.camunda.zeebe.model.bpmn.validation;
 
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_ATTACHED_TO_REF;
 import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTest {
@@ -89,7 +92,27 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .endEvent("end")
             .done(),
         singletonList(expect("boundary", "Cannot have incoming sequence flows"))
+      },
+      {
+        createBoundaryEventWithNonExistingAttachedTo(),
+        singletonList(expect("boundary", "Must be attached to an activity"))
       }
     };
+  }
+
+  private static BpmnModelInstance createBoundaryEventWithNonExistingAttachedTo() {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .boundaryEvent("boundary")
+            .timerWithDuration("PT1S")
+            .endEvent("end")
+            .done();
+
+    final BoundaryEvent boundary = model.getModelElementById("boundary");
+    boundary.setAttributeValue(BPMN_ATTRIBUTE_ATTACHED_TO_REF, "no_such_activity", false);
+
+    return model;
   }
 }


### PR DESCRIPTION
Add a null check in ActivityImpl#getBoundaryEvents to prevent a NullPointerException when a BPMN BoundaryEvent has a missing, empty, or invalid attachedTo reference. Adds testing to verify no Exceptions are thrown in ActivityImplBoundaryEventTest.

This change prevents NullPointerExceptions from occurring.

closes #42907

