### PR TITLE
Implement global listeners search in secondary storage

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -18,6 +18,7 @@ import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.read.service.FormDbReader;
+import io.camunda.db.rdbms.read.service.GlobalListenerDbReader;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
@@ -94,6 +95,7 @@ public class RdbmsService {
       incidentProcessInstanceStatisticsByErrorDbReader;
   private final IncidentProcessInstanceStatisticsByDefinitionDbReader
       incidentProcessInstanceStatisticsByDefinitionDbReader;
+  private final GlobalListenerDbReader globalListenerDbReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -136,7 +138,8 @@ public class RdbmsService {
       final IncidentProcessInstanceStatisticsByErrorDbReader
           incidentProcessInstanceStatisticsByErrorDbReader,
       final IncidentProcessInstanceStatisticsByDefinitionDbReader
-          incidentProcessInstanceStatisticsByDefinitionDbReader) {
+          incidentProcessInstanceStatisticsByDefinitionDbReader,
+      final GlobalListenerDbReader globalListenerDbReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
@@ -178,6 +181,7 @@ public class RdbmsService {
         incidentProcessInstanceStatisticsByErrorDbReader;
     this.incidentProcessInstanceStatisticsByDefinitionDbReader =
         incidentProcessInstanceStatisticsByDefinitionDbReader;
+    this.globalListenerDbReader = globalListenerDbReader;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -331,6 +335,10 @@ public class RdbmsService {
   public IncidentProcessInstanceStatisticsByDefinitionDbReader
       getIncidentProcessInstanceStatisticsByDefinitionReader() {
     return incidentProcessInstanceStatisticsByDefinitionDbReader;
+  }
+
+  public GlobalListenerDbReader getGlobalListenerDbReader() {
+    return globalListenerDbReader;
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/GlobalListenerDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/GlobalListenerDbQuery.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record GlobalListenerDbQuery(
+    GlobalListenerFilter filter, DbQuerySorting<GlobalListenerEntity> sort, DbQueryPage page) {
+
+  public static GlobalListenerDbQuery of(
+      final Function<GlobalListenerDbQuery.Builder, ObjectBuilder<GlobalListenerDbQuery>> fn) {
+    return fn.apply(new GlobalListenerDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<GlobalListenerDbQuery> {
+
+    private static final GlobalListenerFilter EMPTY_FILTER =
+        FilterBuilders.globalListener().build();
+
+    private GlobalListenerFilter filter;
+    private DbQuerySorting<GlobalListenerEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final GlobalListenerFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<GlobalListenerEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<GlobalListenerFilter.Builder, ObjectBuilder<GlobalListenerFilter>> fn) {
+      return filter(FilterBuilders.globalListener(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<GlobalListenerEntity>,
+                ObjectBuilder<DbQuerySorting<GlobalListenerEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public GlobalListenerDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(Collections.emptyList()));
+      return new GlobalListenerDbQuery(filter, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.search.entities.GlobalListenerEntity;
+
+public class GlobalListenerEntityMapper {
+  public static GlobalListenerEntity toEntity(final GlobalListenerDbModel dbModel) {
+    if (dbModel == null) {
+      return null;
+    }
+    return new GlobalListenerEntity(
+        dbModel.id(),
+        dbModel.listenerId(),
+        dbModel.type(),
+        dbModel.eventTypes(),
+        dbModel.retries(),
+        dbModel.afterNonGlobal(),
+        dbModel.priority(),
+        dbModel.source(),
+        dbModel.listenerType());
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.GlobalListenerDbQuery;
+import io.camunda.db.rdbms.read.mapper.GlobalListenerEntityMapper;
+import io.camunda.db.rdbms.sql.GlobalListenerMapper;
+import io.camunda.db.rdbms.sql.columns.GlobalListenerSearchColumn;
+import io.camunda.search.clients.reader.GlobalListenerReader;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.GlobalListenerUtil;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GlobalListenerDbReader extends AbstractEntityReader<GlobalListenerEntity>
+    implements GlobalListenerReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GlobalListenerDbReader.class);
+
+  private final GlobalListenerMapper globalListenerMapper;
+
+  public GlobalListenerDbReader(final GlobalListenerMapper globalListenerMapper) {
+    super(GlobalListenerSearchColumn.values());
+    this.globalListenerMapper = globalListenerMapper;
+  }
+
+  @Override
+  public GlobalListenerEntity getGlobalListener(
+      final String listenerId,
+      final GlobalListenerType listenerType,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return GlobalListenerEntityMapper.toEntity(
+        globalListenerMapper.get(GlobalListenerUtil.generateId(listenerId, listenerType)));
+  }
+
+  @Override
+  public SearchQueryResult<GlobalListenerEntity> search(
+      final GlobalListenerQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    final var dbSort = convertSort(query.sort(), GlobalListenerSearchColumn.ID);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+    final var dbPage = convertPaging(dbSort, query.page());
+    final var dbQuery =
+        GlobalListenerDbQuery.of(b -> b.filter(query.filter()).sort(dbSort).page(dbPage));
+
+    LOG.trace("[RDBMS DB] Search for global listeners with filter {}", dbQuery);
+    final var totalHits = globalListenerMapper.count(dbQuery);
+
+    if (shouldReturnEmptyPage(dbPage, totalHits)) {
+      return buildSearchQueryResult(totalHits, List.of(), dbSort);
+    }
+
+    final var hits =
+        globalListenerMapper.search(dbQuery).stream()
+            .map(GlobalListenerEntityMapper::toEntity)
+            .toList();
+    return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GlobalListenerMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GlobalListenerMapper.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.GlobalListenerDbQuery;
 import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import java.util.List;
 
 public interface GlobalListenerMapper {
 
@@ -20,4 +22,10 @@ public interface GlobalListenerMapper {
   void delete(GlobalListenerDbModel listener);
 
   void deleteEventTypes(GlobalListenerDbModel listener);
+
+  Long count(GlobalListenerDbQuery filter);
+
+  GlobalListenerDbModel get(String id);
+
+  List<GlobalListenerDbModel> search(GlobalListenerDbQuery filter);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/GlobalListenerSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/GlobalListenerSearchColumn.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.GlobalListenerEntity;
+
+public enum GlobalListenerSearchColumn implements SearchColumn<GlobalListenerEntity> {
+  ID("id"),
+  LISTENER_ID("listenerId"),
+  TYPE("type"),
+  RETRIES("retries"),
+  AFTER_NON_GLOBAL("afterNonGlobal"),
+  PRIORITY("priority"),
+  SOURCE("source"),
+  LISTENER_TYPE("listenerType");
+  private final String property;
+
+  GlobalListenerSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<GlobalListenerEntity> getEntityClass() {
+    return GlobalListenerEntity.class;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
@@ -13,16 +13,115 @@ import io.camunda.util.GlobalListenerUtil;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
-public record GlobalListenerDbModel(
-    String id,
-    String listenerId,
-    String type,
-    Integer retries,
-    List<String> eventTypes,
-    boolean afterNonGlobal,
-    Integer priority,
-    GlobalListenerSource source,
-    GlobalListenerType listenerType) {
+// Note: this is not a record in order to be able to use <collection> to aggregate event types in
+// the MyBatis mapping file
+public class GlobalListenerDbModel {
+  private String id;
+  private String listenerId;
+  private String type;
+  private Integer retries;
+  private List<String> eventTypes;
+  private boolean afterNonGlobal;
+  private Integer priority;
+  private GlobalListenerSource source;
+  private GlobalListenerType listenerType;
+
+  public GlobalListenerDbModel(final String id) {
+    this.id = id;
+  }
+
+  public GlobalListenerDbModel(
+      final String id,
+      final String listenerId,
+      final String type,
+      final Integer retries,
+      final List<String> eventTypes,
+      final boolean afterNonGlobal,
+      final Integer priority,
+      final GlobalListenerSource source,
+      final GlobalListenerType listenerType) {
+    this.id = id;
+    this.listenerId = listenerId;
+    this.type = type;
+    this.retries = retries;
+    this.eventTypes = eventTypes;
+    this.afterNonGlobal = afterNonGlobal;
+    this.priority = priority;
+    this.source = source;
+    this.listenerType = listenerType;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public void id(final String id) {
+    this.id = id;
+  }
+
+  public String listenerId() {
+    return listenerId;
+  }
+
+  public void listenerId(final String listenerId) {
+    this.listenerId = listenerId;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public void type(final String type) {
+    this.type = type;
+  }
+
+  public Integer retries() {
+    return retries;
+  }
+
+  public void retries(final Integer retries) {
+    this.retries = retries;
+  }
+
+  public List<String> eventTypes() {
+    return eventTypes;
+  }
+
+  public void eventTypes(final List<String> eventTypes) {
+    this.eventTypes = eventTypes;
+  }
+
+  public boolean afterNonGlobal() {
+    return afterNonGlobal;
+  }
+
+  public void afterNonGlobal(final boolean afterNonGlobal) {
+    this.afterNonGlobal = afterNonGlobal;
+  }
+
+  public Integer priority() {
+    return priority;
+  }
+
+  public void priority(final Integer priority) {
+    this.priority = priority;
+  }
+
+  public GlobalListenerSource source() {
+    return source;
+  }
+
+  public void source(final GlobalListenerSource source) {
+    this.source = source;
+  }
+
+  public GlobalListenerType listenerType() {
+    return listenerType;
+  }
+
+  public void listenerType(final GlobalListenerType listenerType) {
+    this.listenerType = listenerType;
+  }
 
   public static class GlobalListenerDbModelBuilder implements ObjectBuilder<GlobalListenerDbModel> {
     private String listenerId;

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -93,7 +93,7 @@
       FROM ${prefix}GLOBAL_LISTENER gl
       WHERE ID = #{id}
     ) gl
-    LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.ID = gl.ID)
+    LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.GLOBAL_LISTENER_ID = gl.ID)
   </select>
 
   <select id="search"
@@ -121,7 +121,7 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
         <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
       ) gl
-      LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.ID = gl.ID)
+      LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.GLOBAL_LISTENER_ID = gl.ID)
     ) sorted
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
@@ -178,7 +178,7 @@
       <!-- event types -->
       <if
         test="filter.eventTypeOperations != null and !filter.eventTypeOperations.isEmpty()">
-        AND EXISTS (Select * from ${prefix}GLOBAL_LISTENER_EVENT_TYPE et where et.ID = gl.ID
+        AND EXISTS (Select * from ${prefix}GLOBAL_LISTENER_EVENT_TYPE et where et.GLOBAL_LISTENER_ID = gl.ID
         <foreach collection="filter.eventTypeOperations" item="operation">
           AND et.EVENT_TYPE
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -61,5 +61,130 @@
     WHERE GLOBAL_LISTENER_ID = #{id}
   </delete>
 
+  <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
+    <constructor>
+      <idArg column="ID" javaType="java.lang.String"/>
+      <arg column="LISTENER_ID" javaType="java.lang.String"/>
+      <arg column="TYPE" javaType="java.lang.String"/>
+      <arg column="RETRIES" javaType="java.lang.Integer"/>
+      <arg column="AFTER_NON_GLOBAL" javaType="java.lang.Boolean"/>
+      <arg column="PRIORITY" javaType="java.lang.Integer"/>
+      <arg column="SOURCE" javaType="io.camunda.search.entities.GlobalListenerSource"/>
+      <arg column="LISTENER_TYPE" javaType="io.camunda.search.entities.GlobalListenerType"/>
+      <arg column="EVENT_TYPE" javaType="java.util.List"/>
+    </constructor>
+  </resultMap>
+
+  <select id="get" parameterType="java.lang.String"
+    resultMap="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchResultMap">
+    SELECT gl.*, et.EVENT_TYPE
+    FROM (
+      SELECT
+        gl.ID,
+        gl.LISTENER_ID,
+        gl.TYPE,
+        gl.RETRIES,
+        gl.AFTER_NON_GLOBAL,
+        gl.PRIORITY,
+        gl.SOURCE,
+        gl.LISTENER_TYPE
+      FROM ${prefix}GLOBAL_LISTENER gl
+      WHERE ID = #{id}
+    ) gl
+    LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.ID = gl.ID)
+  </select>
+
+  <select id="search"
+    parameterType="io.camunda.db.rdbms.read.domain.GlobalListenerDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchResultMap">
+    SELECT * FROM (
+      SELECT
+        gl.*,
+        et.EVENT_TYPE
+      FROM (
+        SELECT * FROM (
+          SELECT
+            gl.ID,
+            gl.LISTENER_ID,
+            gl.TYPE,
+            gl.RETRIES,
+            gl.AFTER_NON_GLOBAL,
+            gl.PRIORITY,
+            gl.SOURCE,
+            gl.LISTENER_TYPE
+          FROM ${prefix}GLOBAL_LISTENER gl
+          <include refid="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchFilter"/>
+        ) filtered
+        <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+        <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+        <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+      ) gl
+      LEFT JOIN ${prefix}GLOBAL_LISTENER_EVENT_TYPE et ON (et.ID = gl.ID)
+    ) sorted
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+  </select>
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*)
+    FROM ${prefix}GLOBAL_LISTENER gl
+    <include refid="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchFilter"/>
+  </select>
+
+  <sql id="searchFilter">
+    <where>
+      <!-- basic filters -->
+      <if test="filter.listenerIdOperations != null and !filter.listenerIdOperations.isEmpty()">
+        <foreach collection="filter.listenerIdOperations" item="operation">
+          AND gl.LISTENER_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.typeOperations != null and !filter.typeOperations.isEmpty()">
+        <foreach collection="filter.typeOperations" item="operation">
+          AND gl.TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.retriesOperations != null and !filter.retriesOperations.isEmpty()">
+        <foreach collection="filter.retriesOperations" item="operation">
+          AND gl.RETRIES
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.afterNonGlobal != null">
+        AND gl.AFTER_NON_GLOBAL = #{filter.afterNonGlobal}
+      </if>
+      <if test="filter.priorityOperations != null and !filter.priorityOperations.isEmpty()">
+        <foreach collection="filter.priorityOperations" item="operation">
+          AND gl.PRIORITY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.sourceOperations != null and !filter.sourceOperations.isEmpty()">
+        <foreach collection="filter.sourceOperations" item="operation">
+          AND gl.SOURCE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.listenerTypeOperations != null and !filter.listenerTypeOperations.isEmpty()">
+        <foreach collection="filter.listenerTypeOperations" item="operation">
+          AND gl.LISTENER_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <!-- event types -->
+      <if
+        test="filter.eventTypeOperations != null and !filter.eventTypeOperations.isEmpty()">
+        AND EXISTS (Select * from ${prefix}GLOBAL_LISTENER_EVENT_TYPE et where et.ID = gl.ID
+        <foreach collection="filter.eventTypeOperations" item="operation">
+          AND et.EVENT_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+        )
+      </if>
+    </where>
+  </sql>
+
 </mapper>
 

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -64,15 +64,17 @@
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
     <constructor>
       <idArg column="ID" javaType="java.lang.String"/>
-      <arg column="LISTENER_ID" javaType="java.lang.String"/>
-      <arg column="TYPE" javaType="java.lang.String"/>
-      <arg column="RETRIES" javaType="java.lang.Integer"/>
-      <arg column="AFTER_NON_GLOBAL" javaType="java.lang.Boolean"/>
-      <arg column="PRIORITY" javaType="java.lang.Integer"/>
-      <arg column="SOURCE" javaType="io.camunda.search.entities.GlobalListenerSource"/>
-      <arg column="LISTENER_TYPE" javaType="io.camunda.search.entities.GlobalListenerType"/>
-      <arg column="EVENT_TYPE" javaType="java.util.List"/>
     </constructor>
+    <result property="listenerId" column="LISTENER_ID" javaType="java.lang.String"/>
+    <result property="type" column="TYPE" javaType="java.lang.String"/>
+    <result property="retries" column="RETRIES" javaType="java.lang.Integer"/>
+    <result property="afterNonGlobal" column="AFTER_NON_GLOBAL" javaType="java.lang.Boolean"/>
+    <result property="priority" column="PRIORITY" javaType="java.lang.Integer"/>
+    <result property="source" column="SOURCE" javaType="io.camunda.search.entities.GlobalListenerSource"/>
+    <result property="listenerType" column="LISTENER_TYPE" javaType="io.camunda.search.entities.GlobalListenerType"/>
+    <collection property="eventTypes" ofType="java.lang.String" javaType="java.util.List">
+      <id column="EVENT_TYPE"/>
+    </collection>
   </resultMap>
 
   <select id="get" parameterType="java.lang.String"

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReaderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.sql.GlobalListenerMapper;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GlobalListenerDbReaderTest {
+  private final GlobalListenerMapper globalListenerMapper = mock(GlobalListenerMapper.class);
+  private final GlobalListenerDbReader globalListenerDbReader =
+      new GlobalListenerDbReader(globalListenerMapper);
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {
+    final GlobalListenerQuery query = GlobalListenerQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                Authorization.of(
+                    a -> a.globalListener().permissionType(PermissionType.READ_TASK_LISTENER))),
+            TenantCheck.disabled());
+
+    final var items = globalListenerDbReader.search(query, resourceAccessChecks).items();
+    assertThat(items).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedTenantIdsIsNull() {
+    final GlobalListenerQuery query = GlobalListenerQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    final var items = globalListenerDbReader.search(query, resourceAccessChecks).items();
+    assertThat(items).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyPageWhenPageSizeIsZero() {
+    when(globalListenerMapper.count(any())).thenReturn(21L);
+
+    final GlobalListenerQuery query = GlobalListenerQuery.of(b -> b.page(p -> p.size(0)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    final var result = globalListenerDbReader.search(query, resourceAccessChecks);
+
+    assertThat(result.total()).isEqualTo(21L);
+    assertThat(result.items()).isEmpty();
+    verify(globalListenerMapper, times(0)).search(any());
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -24,6 +24,8 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.JobEntity.JobKind;
@@ -169,7 +171,17 @@ public class SearchColumnTest {
               AuditLogTenantScope.class,
               List.of(
                   Tuple.of(AuditLogTenantScope.TENANT, AuditLogTenantScope.TENANT),
-                  Tuple.of(AuditLogTenantScope.TENANT, "TENANT"))));
+                  Tuple.of(AuditLogTenantScope.TENANT, "TENANT"))),
+          Map.entry(
+              GlobalListenerSource.class,
+              List.of(
+                  Tuple.of(GlobalListenerSource.API, GlobalListenerSource.API),
+                  Tuple.of(GlobalListenerSource.API, "API"))),
+          Map.entry(
+              GlobalListenerType.class,
+              List.of(
+                  Tuple.of(GlobalListenerType.USER_TASK, GlobalListenerType.USER_TASK),
+                  Tuple.of(GlobalListenerType.USER_TASK, "USER_TASK"))));
 
   private static List<Object[]> provideSearchColumns() {
     return SearchColumnUtils.findAll().stream()

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.read.service.FormDbReader;
+import io.camunda.db.rdbms.read.service.GlobalListenerDbReader;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
@@ -63,6 +64,7 @@ import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
+import io.camunda.db.rdbms.sql.GlobalListenerMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -347,6 +349,12 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public GlobalListenerDbReader globalListenerRdbmsReader(
+      final GlobalListenerMapper globalListenerMapper) {
+    return new GlobalListenerDbReader(globalListenerMapper);
+  }
+
+  @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
       final ExporterPositionMapper exporterPositionMapper,
@@ -445,7 +453,8 @@ public class RdbmsConfiguration {
       final IncidentProcessInstanceStatisticsByErrorDbReader
           incidentProcessInstanceStatisticsByErrorReader,
       final IncidentProcessInstanceStatisticsByDefinitionDbReader
-          incidentProcessInstanceStatisticsByDefinitionReader) {
+          incidentProcessInstanceStatisticsByDefinitionReader,
+      final GlobalListenerDbReader globalListenerDbReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         auditLogReader,
@@ -483,7 +492,8 @@ public class RdbmsConfiguration {
         processDefinitionInstanceVersionStatisticsReader,
         historyDeletionDbReader,
         incidentProcessInstanceStatisticsByErrorReader,
-        incidentProcessInstanceStatisticsByDefinitionReader);
+        incidentProcessInstanceStatisticsByDefinitionReader,
+        globalListenerDbReader);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -24,6 +24,7 @@ import io.camunda.search.clients.reader.DecisionInstanceReader;
 import io.camunda.search.clients.reader.DecisionRequirementsReader;
 import io.camunda.search.clients.reader.FlowNodeInstanceReader;
 import io.camunda.search.clients.reader.FormReader;
+import io.camunda.search.clients.reader.GlobalListenerReader;
 import io.camunda.search.clients.reader.GroupMemberReader;
 import io.camunda.search.clients.reader.GroupReader;
 import io.camunda.search.clients.reader.IncidentProcessInstanceStatisticsByDefinitionReader;
@@ -144,7 +145,8 @@ public class SearchClientConfiguration {
       final IncidentProcessInstanceStatisticsByErrorReader
           incidentProcessInstanceStatisticsByErrorReader,
       final IncidentProcessInstanceStatisticsByDefinitionReader
-          incidentProcessInstanceStatisticsByDefinitionReader) {
+          incidentProcessInstanceStatisticsByDefinitionReader,
+      final GlobalListenerReader globalListenerReader) {
     return new SearchClientReaders(
         authorizationReader,
         batchOperationReader,
@@ -182,6 +184,7 @@ public class SearchClientConfiguration {
         clusterVariableReader,
         auditLogReader,
         incidentProcessInstanceStatisticsByErrorReader,
-        incidentProcessInstanceStatisticsByDefinitionReader);
+        incidentProcessInstanceStatisticsByDefinitionReader,
+        globalListenerReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReaderConfiguration.java
@@ -34,6 +34,8 @@ import io.camunda.search.clients.reader.FlowNodeInstanceDocumentReader;
 import io.camunda.search.clients.reader.FlowNodeInstanceReader;
 import io.camunda.search.clients.reader.FormDocumentReader;
 import io.camunda.search.clients.reader.FormReader;
+import io.camunda.search.clients.reader.GlobalListenerDocumentReader;
+import io.camunda.search.clients.reader.GlobalListenerReader;
 import io.camunda.search.clients.reader.GroupDocumentReader;
 import io.camunda.search.clients.reader.GroupMemberDocumentReader;
 import io.camunda.search.clients.reader.GroupMemberReader;
@@ -95,6 +97,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
@@ -423,6 +426,12 @@ public class SearchClientReaderConfiguration {
           final ProcessCache processCache) {
     return new IncidentProcessInstanceStatisticsByDefinitionDocumentReader(
         executor, descriptors.get(IncidentTemplate.class), processCache);
+  }
+
+  @Bean
+  public GlobalListenerReader globalListenerReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptors descriptors) {
+    return new GlobalListenerDocumentReader(executor, descriptors.get(GlobalListenerIndex.class));
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -20,6 +20,7 @@ import io.camunda.search.clients.DecisionInstanceSearchClient;
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.clients.FormSearchClient;
+import io.camunda.search.clients.GlobalListenerSearchClient;
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.clients.JobSearchClient;
@@ -608,11 +609,13 @@ public class CamundaServicesConfiguration {
   public GlobalListenerServices globalListenerServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
+      final GlobalListenerSearchClient globalListenerSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new GlobalListenerServices(
         brokerClient,
         securityContextProvider,
+        globalListenerSearchClient,
         null,
         executorProvider,
         brokerRequestAuthorizationConverter);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GlobalListenerFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GlobalListenerFixtures.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel.GlobalListenerDbModelBuilder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class GlobalListenerFixtures extends CommonFixtures {
+
+  private GlobalListenerFixtures() {}
+
+  public static GlobalListenerDbModel createRandomGlobalListener(
+      final Function<GlobalListenerDbModelBuilder, GlobalListenerDbModelBuilder> builderFunction) {
+    final var key = CommonFixtures.nextStringKey();
+    final var builder =
+        new GlobalListenerDbModelBuilder()
+            .listenerId("listener-" + key)
+            .type("job-" + key)
+            .retries(RANDOM.nextInt(1, 5))
+            .eventTypes(List.of("creating", "assigning"))
+            .afterNonGlobal(false)
+            .priority(RANDOM.nextInt(0, 100))
+            .source(GlobalListenerSource.CONFIGURATION)
+            .listenerType(GlobalListenerType.USER_TASK);
+    return builderFunction.apply(builder).build();
+  }
+
+  public static List<GlobalListenerDbModel> createAndSaveRandomGlobalListeners(
+      final CamundaRdbmsTestApplication testApplication,
+      final int numberOfListeners,
+      final Function<GlobalListenerDbModelBuilder, GlobalListenerDbModelBuilder> builderFunction) {
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    final List<GlobalListenerDbModel> models = new ArrayList<>();
+    for (int i = 0; i < numberOfListeners; i++) {
+      final GlobalListenerDbModel randomized = createRandomGlobalListener(builderFunction);
+      models.add(randomized);
+      rdbmsWriters.getGlobalListenerWriter().create(randomized);
+    }
+    rdbmsWriters.flush();
+    return models;
+  }
+
+  public static GlobalListenerDbModel createAndSaveRandomGlobalListener(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<GlobalListenerDbModelBuilder, GlobalListenerDbModelBuilder> builderFunction) {
+    return createAndSaveRandomGlobalListeners(testApplication, 1, builderFunction).getFirst();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
@@ -1,0 +1,674 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.globallistener;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.GlobalListenerFixtures.createAndSaveRandomGlobalListener;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.GlobalListenerSort;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class GlobalListenerFilterIT {
+  @TestTemplate
+  public void shouldFindGlobalListenerWithEqListenerIdFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only one with "expectedEq" listenerId
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    final var expectedListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.listenerId("expectedEq"));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+
+    // when searching by equal listenerId
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .listenerIdOperations(Operation.eq("expectedEq"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listener is found
+    assertExpectedResult(searchResult, expectedListener);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLikeListenerIdFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only two with listenerId matching "expectedLike*"
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.listenerId("expectedLike1"));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.listenerId("expectedLike2"));
+
+    // when searching by listenerId matching pattern
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .listenerIdOperations(Operation.like("expectedLike*"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithInListenerIdFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only two with listenerId either "expectedIn1" or "expectedIn2"
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.listenerId("expectedIn1"));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.listenerId("different" + nextStringId()));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.listenerId("expectedIn2"));
+
+    // when searching by listenerId in provided set
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .listenerIdOperations(Operation.in("expectedIn1", "expectedIn2"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithEqTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only one with "expectedEq" type
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    final var expectedListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("expectedEq"));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+
+    // when searching by equal type
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .typeOperations(Operation.eq("expectedEq"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listener is found
+    assertExpectedResult(searchResult, expectedListener);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLikeTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only two with type matching "expectedLike*"
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("expectedLike1"));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("expectedLike2"));
+
+    // when searching by type matching pattern
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .typeOperations(Operation.like("expectedLike*"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithInTypeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only two with type either "expectedIn1" or "expectedIn2"
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("expectedIn1"));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.type("different" + nextStringId()));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("expectedIn2"));
+
+    // when searching by type in provided set
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .typeOperations(Operation.in("expectedIn1", "expectedIn2"))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithEqRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only one with retries=2
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+
+    // when searching by equal retries
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.eq(2))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listener is found
+    assertExpectedResult(searchResult, expectedListener);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithGtRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with retries > 3
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(5).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+
+    // when searching by greater retries
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.gt(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithGteRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with retries >= 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+
+    // when searching by greater or equal retries
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.gte(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLtRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with retries < 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(5).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(2).type(testIdentifier));
+
+    // when searching by smaller retries
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.lt(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLteRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with retries <= 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(5).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(6).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(2).type(testIdentifier));
+
+    // when searching by smaller or equal retries
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.lte(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithInRetriesFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with retries either 2 or 5
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.retries(5).type(testIdentifier));
+
+    // when searching by retries in provided set
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .retriesOperations(Operation.in(2, 5))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithAfterNonGlobalFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given multiple listeners but only one with afterNonGlobal=true
+    createAndSaveRandomGlobalListener(testApplication, b -> b.afterNonGlobal(false));
+    final var expectedListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.afterNonGlobal(true));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.afterNonGlobal(false));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.afterNonGlobal(false));
+
+    // when searching by true afterNonGlobal
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder().afterNonGlobal(true).build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listener is found
+    assertExpectedResult(searchResult, expectedListener);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithEqPriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only one with priority=2
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+
+    // when searching by equal priority
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.eq(2))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listener is found
+    assertExpectedResult(searchResult, expectedListener);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithGtPriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with priority > 3
+    createAndSaveRandomGlobalListener(
+        testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(5).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+
+    // when searching by greater priority
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.gt(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithGtePriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with priority >= 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+
+    // when searching by greater or equal priority
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.gte(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLtPriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with priority < 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(5).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(2).type(testIdentifier));
+
+    // when searching by smaller priority
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.lt(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithLtePriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with priority <= 3
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(5).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(6).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(2).type(testIdentifier));
+
+    // when searching by smaller or equal priority
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.lte(3))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  @TestTemplate
+  public void shouldFindGlobalListenerWithInPriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple listeners but only two with priority either 2 or 5
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
+    final var expectedListener1 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(2).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(4).type(testIdentifier));
+    final var expectedListener2 =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.priority(5).type(testIdentifier));
+
+    // when searching by priority in provided set
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        .types(testIdentifier)
+                        .priorityOperations(Operation.in(2, 5))
+                        .build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled());
+
+    // then only the expected listeners are found
+    assertExpectedResult(searchResult, expectedListener1, expectedListener2);
+  }
+
+  private void assertExpectedResult(
+      final SearchQueryResult<GlobalListenerEntity> searchResult,
+      final GlobalListenerDbModel... expected) {
+    assertThat(searchResult.total()).isEqualTo(expected.length);
+    assertThat(searchResult.items()).hasSize(expected.length);
+    final var actualIds =
+        searchResult.items().stream().map(GlobalListenerEntity::id).collect(Collectors.toSet());
+    final var expectedIds =
+        Arrays.stream(expected).map(GlobalListenerDbModel::id).collect(Collectors.toSet());
+    assertThat(actualIds).isEqualTo(expectedIds);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerFilterIT.java
@@ -257,8 +257,7 @@ public class GlobalListenerFilterIT {
     final String testIdentifier = nextStringId();
 
     // given multiple listeners but only two with retries > 3
-    createAndSaveRandomGlobalListener(
-        testApplication, b -> b.retries(1).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.retries(1).type(testIdentifier));
     final var expectedListener1 =
         createAndSaveRandomGlobalListener(testApplication, b -> b.retries(5).type(testIdentifier));
     createAndSaveRandomGlobalListener(testApplication, b -> b.retries(3).type(testIdentifier));
@@ -492,8 +491,7 @@ public class GlobalListenerFilterIT {
     final String testIdentifier = nextStringId();
 
     // given multiple listeners but only two with priority > 3
-    createAndSaveRandomGlobalListener(
-        testApplication, b -> b.priority(1).type(testIdentifier));
+    createAndSaveRandomGlobalListener(testApplication, b -> b.priority(1).type(testIdentifier));
     final var expectedListener1 =
         createAndSaveRandomGlobalListener(testApplication, b -> b.priority(5).type(testIdentifier));
     createAndSaveRandomGlobalListener(testApplication, b -> b.priority(3).type(testIdentifier));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.globallistener;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.GlobalListenerFixtures.createAndSaveRandomGlobalListener;
+import static io.camunda.it.rdbms.db.fixtures.GlobalListenerFixtures.createAndSaveRandomGlobalListeners;
+import static io.camunda.it.rdbms.db.fixtures.GlobalListenerFixtures.createRandomGlobalListener;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.sort.GlobalListenerSort;
+import io.camunda.security.reader.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class GlobalListenerIT {
+
+  @TestTemplate
+  public void shouldCreateAndGetGlobalListenerByListenerIdAndListenerType(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given a randomized listener
+    final GlobalListenerDbModel globalListener = createRandomGlobalListener(b -> b);
+
+    // when creating it and retrieving it using the global listener writer and reader
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    rdbmsWriters.getGlobalListenerWriter().create(globalListener);
+    rdbmsWriters.flush();
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .getGlobalListener(
+                globalListener.listenerId(),
+                globalListener.listenerType(),
+                ResourceAccessChecks.disabled());
+
+    // then the listener is correctly retrieved
+    assertThat(entity).isNotNull();
+    assertDbModelEqualToEntity(globalListener, entity);
+  }
+
+  @TestTemplate
+  public void shouldFindAllGlobalListenersPaged(final CamundaRdbmsTestApplication testApplication) {
+    // This value is set in the "type" of all listeners and used in the search query in order to
+    // ensure that only the listeners created in this specific test are returned
+    final String testIdentifier = nextStringId();
+
+    // given multiple global listeners
+    createAndSaveRandomGlobalListeners(testApplication, 20, b -> b.type(testIdentifier));
+
+    // when searching with no filter and paging
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder().types(testIdentifier).build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))),
+                ResourceAccessChecks.disabled());
+
+    // then all listeners are found and the paged ones are returned
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldUpdateGlobalListener(final CamundaRdbmsTestApplication testApplication) {
+    // given an existing global listener
+    final GlobalListenerDbModel globalListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("old-job-type"));
+
+    // when it is updated with a new version with the same listener id and listener type
+    final GlobalListenerDbModel updatedGlobalListener =
+        createRandomGlobalListener(
+            b ->
+                b.listenerId(globalListener.listenerId())
+                    .listenerType(globalListener.listenerType())
+                    .type("new-job-type"));
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    rdbmsWriters.getGlobalListenerWriter().update(updatedGlobalListener);
+    rdbmsWriters.flush();
+
+    // then the update version can be retrieved
+    final var instance =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .getGlobalListener(
+                globalListener.listenerId(),
+                globalListener.listenerType(),
+                ResourceAccessChecks.disabled());
+    assertThat(instance).isNotNull();
+    assertDbModelEqualToEntity(updatedGlobalListener, instance);
+  }
+
+  @TestTemplate
+  public void shouldDeleteGlobalListener(final CamundaRdbmsTestApplication testApplication) {
+    // given an existing global listener
+    final GlobalListenerDbModel globalListener =
+        createAndSaveRandomGlobalListener(testApplication, b -> b.type("old-job-type"));
+
+    // when deleting it (with the same listener id and listener type, regardless of changes in other
+    // fields)
+    final GlobalListenerDbModel deletedGlobalListener =
+        createRandomGlobalListener(
+            b ->
+                b.listenerId(globalListener.listenerId())
+                    .listenerType(globalListener.listenerType()));
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    rdbmsWriters.getGlobalListenerWriter().delete(deletedGlobalListener);
+    rdbmsWriters.flush();
+
+    // then the listener is not available anymore
+    final var instance =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .getGlobalListener(
+                globalListener.listenerId(),
+                globalListener.listenerType(),
+                ResourceAccessChecks.disabled());
+    assertThat(instance).isNull();
+  }
+
+  private void assertDbModelEqualToEntity(
+      final GlobalListenerDbModel dbModel, final GlobalListenerEntity entity) {
+    assertThat(entity).usingRecursiveComparison().isEqualTo(dbModel);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.globallistener;
+
+import static io.camunda.it.rdbms.db.fixtures.GlobalListenerFixtures.createAndSaveRandomGlobalListeners;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.GlobalListenerDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.sort.GlobalListenerSort;
+import io.camunda.search.sort.GlobalListenerSort.Builder;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class GlobalListenerSortIT {
+
+  @BeforeAll
+  public static void a() {
+    final int i = 0;
+  }
+
+  @TestTemplate
+  public void shouldSortByIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(testApplication, b -> b.id().asc(), Comparator.comparing(GlobalListenerEntity::id));
+  }
+
+  @TestTemplate
+  public void shouldSortByIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.id().desc(),
+        Comparator.comparing(GlobalListenerEntity::id).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByListenerIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.listenerId().asc(),
+        Comparator.comparing(GlobalListenerEntity::listenerId));
+  }
+
+  @TestTemplate
+  public void shouldSortByListenerIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.listenerId().desc(),
+        Comparator.comparing(GlobalListenerEntity::listenerId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTypeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication, b -> b.type().asc(), Comparator.comparing(GlobalListenerEntity::type));
+  }
+
+  @TestTemplate
+  public void shouldSortByTypeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.type().desc(),
+        Comparator.comparing(GlobalListenerEntity::type).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByAfterNonGlobalAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.afterNonGlobal().asc(),
+        Comparator.comparing(GlobalListenerEntity::afterNonGlobal));
+  }
+
+  @TestTemplate
+  public void shouldSortByAfterNonGlobalDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.afterNonGlobal().desc(),
+        Comparator.comparing(GlobalListenerEntity::afterNonGlobal).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByPriorityAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.priority().asc(),
+        Comparator.comparing(GlobalListenerEntity::priority));
+  }
+
+  @TestTemplate
+  public void shouldSortByPriorityDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.priority().desc(),
+        Comparator.comparing(GlobalListenerEntity::priority).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortBySourceAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication, b -> b.source().asc(), Comparator.comparing(GlobalListenerEntity::source));
+  }
+
+  @TestTemplate
+  public void shouldSortBySourceDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.source().desc(),
+        Comparator.comparing(GlobalListenerEntity::source).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByListenerTypeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.listenerType().asc(),
+        Comparator.comparing(GlobalListenerEntity::listenerType));
+  }
+
+  @TestTemplate
+  public void shouldSortByListenerTypeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.listenerType().desc(),
+        Comparator.comparing(GlobalListenerEntity::listenerType).reversed());
+  }
+
+  private void testSorting(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<GlobalListenerSort>> sortBuilder,
+      final Comparator<GlobalListenerEntity> comparator) {
+    final var listenersInThisTest = createAndSaveRandomGlobalListeners(testApplication, 20, b -> b);
+
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder()
+                        // only consider entities specifically created for this test
+                        .listenerIdOperations(
+                            Operation.in(
+                                listenersInThisTest.stream()
+                                    .map(GlobalListenerDbModel::listenerId)
+                                    .toList()))
+                        .build(),
+                    GlobalListenerSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)),
+                ResourceAccessChecks.disabled())
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GlobalListenerDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GlobalListenerDocumentReader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.GlobalListenerUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class GlobalListenerDocumentReader extends DocumentBasedReader
+    implements GlobalListenerReader {
+
+  public GlobalListenerDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<GlobalListenerEntity> search(
+      final GlobalListenerQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity.class,
+            resourceAccessChecks);
+  }
+
+  @Override
+  public GlobalListenerEntity getGlobalListener(
+      final String listenerId,
+      final GlobalListenerType listenerType,
+      final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .getById(
+            GlobalListenerUtil.generateId(listenerId, listenerType),
+            io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity.class,
+            indexDescriptor.getFullQualifiedName());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -78,6 +78,7 @@ import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTrans
 import io.camunda.search.clients.transformers.entity.DecisionRequirementsEntityTransformer;
 import io.camunda.search.clients.transformers.entity.FlowNodeInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.FormEntityTransformer;
+import io.camunda.search.clients.transformers.entity.GlobalListenerEntityTransformer;
 import io.camunda.search.clients.transformers.entity.GroupEntityTransformer;
 import io.camunda.search.clients.transformers.entity.GroupMemberEntityTransformer;
 import io.camunda.search.clients.transformers.entity.IncidentEntityTransformer;
@@ -108,6 +109,7 @@ import io.camunda.search.clients.transformers.filter.FilterTransformer;
 import io.camunda.search.clients.transformers.filter.FlownodeInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.FormFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GlobalJobStatisticsFilterTransformer;
+import io.camunda.search.clients.transformers.filter.GlobalListenerFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupMemberFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
@@ -147,6 +149,7 @@ import io.camunda.search.clients.transformers.sort.DecisionRequirementsFieldSort
 import io.camunda.search.clients.transformers.sort.FieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.FlowNodeInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.FormFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.GlobalListenerFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.GroupFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.GroupMemberFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.IncidentFieldSortingTransformer;
@@ -177,6 +180,7 @@ import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.FormFilter;
 import io.camunda.search.filter.GlobalJobStatisticsFilter;
+import io.camunda.search.filter.GlobalListenerFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.filter.IncidentFilter;
@@ -212,6 +216,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -253,6 +258,7 @@ import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.FormSort;
+import io.camunda.search.sort.GlobalListenerSort;
 import io.camunda.search.sort.GroupMemberSort;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.search.sort.IncidentProcessInstanceStatisticsByDefinitionSort;
@@ -277,6 +283,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
@@ -311,6 +318,7 @@ import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntit
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.form.FormEntity;
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -429,7 +437,8 @@ public final class ServiceTransformers {
             IncidentProcessInstanceStatisticsByErrorQuery.class,
             IncidentProcessInstanceStatisticsByDefinitionQuery.class,
             GlobalJobStatisticsQuery.class,
-            JobTypeStatisticsQuery.class)
+            JobTypeStatisticsQuery.class,
+            GlobalListenerQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -462,6 +471,7 @@ public final class ServiceTransformers {
     mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
     mappers.put(AuditLogEntity.class, new AuditLogEntityTransformer());
+    mappers.put(GlobalListenerEntity.class, new GlobalListenerEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
@@ -497,6 +507,7 @@ public final class ServiceTransformers {
     mappers.put(
         IncidentProcessInstanceStatisticsByDefinitionSort.class,
         new IncidentFieldSortingTransformer());
+    mappers.put(GlobalListenerSort.class, new GlobalListenerFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -610,6 +621,9 @@ public final class ServiceTransformers {
         ProcessDefinitionInstanceVersionStatisticsFilter.class,
         new ProcessDefinitionInstanceVersionStatisticsFilterTransformer(
             indexDescriptors.get(ListViewTemplate.class)));
+    mappers.put(
+        GlobalListenerFilter.class,
+        new GlobalListenerFilterTransformer(indexDescriptors.get(GlobalListenerIndex.class)));
     // result config -> source config
     mappers.put(
         DecisionInstanceQueryResultConfig.class, new DecisionInstanceResultConfigTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GlobalListenerEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GlobalListenerEntityTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerSource;
+import io.camunda.search.entities.GlobalListenerType;
+
+public class GlobalListenerEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity,
+        GlobalListenerEntity> {
+
+  @Override
+  public GlobalListenerEntity apply(
+      final io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity value) {
+    return new GlobalListenerEntity(
+        value.getId(),
+        value.getListenerId(),
+        value.getType(),
+        value.getEventTypes(),
+        value.getRetries(),
+        value.isAfterNonGlobal(),
+        value.getPriority(),
+        GlobalListenerSource.valueOf(value.getSource().name()),
+        GlobalListenerType.valueOf(value.getListenerType().name()));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GlobalListenerFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GlobalListenerFilterTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
+import java.util.ArrayList;
+
+public final class GlobalListenerFilterTransformer
+    extends IndexFilterTransformer<GlobalListenerFilter> {
+
+  public GlobalListenerFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final GlobalListenerFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(
+        stringOperations(GlobalListenerIndex.LISTENER_ID, filter.listenerIdOperations()));
+    queries.addAll(stringOperations(GlobalListenerIndex.TYPE, filter.typeOperations()));
+    queries.addAll(intOperations(GlobalListenerIndex.RETRIES, filter.retriesOperations()));
+    queries.addAll(stringOperations(GlobalListenerIndex.EVENT_TYPES, filter.eventTypeOperations()));
+    if (filter.afterNonGlobal() != null) {
+      queries.add(term(GlobalListenerIndex.AFTER_NON_GLOBAL, filter.afterNonGlobal()));
+    }
+    queries.addAll(intOperations(GlobalListenerIndex.PRIORITY, filter.priorityOperations()));
+    queries.addAll(stringOperations(GlobalListenerIndex.SOURCE, filter.sourceOperations()));
+    queries.addAll(
+        stringOperations(GlobalListenerIndex.LISTENER_TYPE, filter.listenerTypeOperations()));
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GlobalListenerFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GlobalListenerFieldSortingTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.AFTER_NON_GLOBAL;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.ID;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.LISTENER_ID;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.LISTENER_TYPE;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.PRIORITY;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.SOURCE;
+import static io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex.TYPE;
+
+public class GlobalListenerFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "id" -> ID;
+      case "listenerId" -> LISTENER_ID;
+      case "type" -> TYPE;
+      case "afterNonGlobal" -> AFTER_NON_GLOBAL;
+      case "priority" -> PRIORITY;
+      case "source" -> SOURCE;
+      case "listenerType" -> LISTENER_TYPE;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return ID;
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/GlobalListenerEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/GlobalListenerEntityTransformerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerSource;
+import io.camunda.webapps.schema.entities.globallistener.GlobalListenerType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GlobalListenerEntityTransformerTest {
+
+  private final GlobalListenerEntityTransformer transformer = new GlobalListenerEntityTransformer();
+
+  @Test
+  void shouldTransformEntityToSearchEntity() {
+    // given
+    final GlobalListenerEntity entity = new GlobalListenerEntity();
+    entity.setId("USER_TASK-my-listener");
+    entity.setListenerId("my-listener");
+    entity.setType("my-job");
+    entity.setRetries(3);
+    entity.setEventTypes(List.of("all"));
+    entity.setAfterNonGlobal(true);
+    entity.setPriority(50);
+    entity.setSource(GlobalListenerSource.API);
+    entity.setListenerType(GlobalListenerType.USER_TASK);
+
+    // when
+    final var searchEntity = transformer.apply(entity);
+    assertThat(searchEntity).isNotNull();
+    assertThat(searchEntity.id()).isEqualTo("USER_TASK-my-listener");
+    assertThat(searchEntity.listenerId()).isEqualTo("my-listener");
+    assertThat(searchEntity.type()).isEqualTo("my-job");
+    assertThat(searchEntity.retries()).isEqualTo(3);
+    assertThat(searchEntity.eventTypes()).isEqualTo(List.of("all"));
+    assertThat(searchEntity.afterNonGlobal()).isTrue();
+    assertThat(searchEntity.priority()).isEqualTo(50);
+    assertThat(searchEntity.source())
+        .isEqualTo(io.camunda.search.entities.GlobalListenerSource.API);
+    assertThat(searchEntity.listenerType())
+        .isEqualTo(io.camunda.search.entities.GlobalListenerType.USER_TASK);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GlobalListenerFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GlobalListenerFilterTransformerTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import org.junit.jupiter.api.Test;
+
+class GlobalListenerFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByListenerId() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.listenerIds("listener-123"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("listenerId");
+              assertThat(t.value().stringValue()).isEqualTo("listener-123");
+            });
+  }
+
+  @Test
+  void shouldQueryByType() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.types("my-job"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue()).isEqualTo("my-job");
+            });
+  }
+
+  @Test
+  void shouldQueryByRetries() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.retries(3));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("retries");
+              assertThat(t.value().intValue()).isEqualTo(3);
+            });
+  }
+
+  @Test
+  void shouldQueryByEventTypes() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.eventTypes("creating"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("eventTypes");
+              assertThat(t.value().stringValue()).isEqualTo("creating");
+            });
+  }
+
+  @Test
+  void shouldQueryByAfterNonGlobal() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.afterNonGlobal(true));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("afterNonGlobal");
+              assertThat(t.value().booleanValue()).isTrue();
+            });
+  }
+
+  @Test
+  void shouldQueryByPriority() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.priorities(10));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("priority");
+              assertThat(t.value().intValue()).isEqualTo(10);
+            });
+  }
+
+  @Test
+  void shouldQueryBySource() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.sources("CONFIGURATION"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("source");
+              assertThat(t.value().stringValue()).isEqualTo("CONFIGURATION");
+            });
+  }
+
+  @Test
+  void shouldQueryByListenerType() {
+    // given
+    final var filter = FilterBuilders.globalListener(f -> f.listenerTypes("USER_TASK"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("listenerType");
+              assertThat(t.value().stringValue()).isEqualTo("USER_TASK");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    // given
+    final var filter =
+        FilterBuilders.globalListener(
+            f ->
+                f.listenerIds("listener-123")
+                    .types("my-job")
+                    .retries(3)
+                    .eventTypes("created")
+                    .afterNonGlobal(true)
+                    .priorities(10)
+                    .sources("API")
+                    .listenerTypes("USER_TASK"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(8);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("listenerId");
+              assertThat(t.value().stringValue()).isEqualTo("listener-123");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue()).isEqualTo("my-job");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(2).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("retries");
+              assertThat(t.value().intValue()).isEqualTo(3);
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(3).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("eventTypes");
+              assertThat(t.value().stringValue()).isEqualTo("created");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(4).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("afterNonGlobal");
+              assertThat(t.value().booleanValue()).isTrue();
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(5).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("priority");
+              assertThat(t.value().intValue()).isEqualTo(10);
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(6).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("source");
+              assertThat(t.value().stringValue()).isEqualTo("API");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(7).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("listenerType");
+              assertThat(t.value().stringValue()).isEqualTo("USER_TASK");
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/GlobalListenerFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/GlobalListenerFieldSortingTransformerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.GlobalListenerSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class GlobalListenerFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("id", SortOrder.ASC, s -> s.id().asc()),
+        new TestArguments("listenerId", SortOrder.DESC, s -> s.listenerId().desc()),
+        new TestArguments("type", SortOrder.ASC, s -> s.type().asc()),
+        new TestArguments("afterNonGlobal", SortOrder.DESC, s -> s.afterNonGlobal().desc()),
+        new TestArguments("priority", SortOrder.ASC, s -> s.priority().asc()),
+        new TestArguments("source", SortOrder.DESC, s -> s.source().desc()),
+        new TestArguments("listenerType", SortOrder.ASC, s -> s.listenerType().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<GlobalListenerSort.Builder, ObjectBuilder<GlobalListenerSort>> fn) {
+    // when
+    final var request = SearchQueryBuilders.globalListenerSearchQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(field);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("id");
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<GlobalListenerSort.Builder, ObjectBuilder<GlobalListenerSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/GlobalListenerReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/GlobalListenerReader.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+public interface GlobalListenerReader
+    extends SearchEntityReader<GlobalListenerEntity, GlobalListenerQuery> {
+
+  GlobalListenerEntity getGlobalListener(
+      String listenerId,
+      GlobalListenerType listenerType,
+      ResourceAccessChecks resourceAccessChecks);
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -47,4 +47,5 @@ public record SearchClientReaders(
     AuditLogReader auditLogReader,
     IncidentProcessInstanceStatisticsByErrorReader incidentProcessInstanceStatisticsByErrorReader,
     IncidentProcessInstanceStatisticsByDefinitionReader
-        incidentProcessInstanceStatisticsByDefinitionReader) {}
+        incidentProcessInstanceStatisticsByDefinitionReader,
+    GlobalListenerReader globalListenerReader) {}

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -30,6 +30,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients;
 
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_ID_NOT_FOUND;
 import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_KEY_NOT_FOUND;
+import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND;
 
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
@@ -25,6 +26,8 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -69,6 +72,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -102,10 +106,12 @@ import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.TenantCheck;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -500,6 +506,29 @@ public class CamundaSearchClients implements SearchClientsProxy {
     return doSearchWithReader(readers.batchOperationItemReader(), query);
   }
 
+  @Override
+  public GlobalListenerEntity getGlobalListener(
+      final String listenerId, final GlobalListenerType listenerType) {
+    return doGet(
+            resourceAccessChecks ->
+                readers
+                    .globalListenerReader()
+                    .getGlobalListener(listenerId, listenerType, resourceAccessChecks))
+        .orElseThrow(
+            () ->
+                entityByMultipleIdsNotFoundException(
+                    "Global Listener",
+                    List.of(
+                        Tuple.of("listenerId", listenerId),
+                        Tuple.of("listenerType", listenerType.name()))));
+  }
+
+  @Override
+  public SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(
+      final GlobalListenerQuery query) {
+    return doSearchWithReader(readers.globalListenerReader(), query);
+  }
+
   protected <T, Q extends TypedSearchQuery<?, ?>> Optional<T> doGetWithReader(
       final SearchEntityReader<T, Q> reader, final long key) {
     return doGet(a -> reader.getByKey(key, a));
@@ -617,5 +646,16 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final String entityType, final String idType, final String id) {
     return new CamundaSearchException(
         ERROR_ENTITY_BY_ID_NOT_FOUND.formatted(entityType, idType, id), Reason.NOT_FOUND);
+  }
+
+  private CamundaSearchException entityByMultipleIdsNotFoundException(
+      final String entityType, final List<Tuple<String, String>> idTypesAndValues) {
+    final String formattedIds =
+        idTypesAndValues.stream()
+            .map(e -> "%s '%s'".formatted(e.getLeft(), e.getRight()))
+            .collect(Collectors.joining(", "));
+    return new CamundaSearchException(
+        ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND.formatted(entityType, formattedIds),
+        Reason.NOT_FOUND);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/GlobalListenerSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GlobalListenerSearchClient.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
+import io.camunda.search.query.GlobalListenerQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface GlobalListenerSearchClient {
+
+  GlobalListenerEntity getGlobalListener(
+      final String listenerId, final GlobalListenerType listenerType);
+
+  SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(GlobalListenerQuery query);
+
+  GlobalListenerSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -33,7 +33,8 @@ public interface SearchClientsProxy
         UserTaskSearchClient,
         UserSearchClient,
         VariableSearchClient,
-        ClusterVariableSearchClient {
+        ClusterVariableSearchClient,
+        GlobalListenerSearchClient {
 
   @Override
   SearchClientsProxy withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -20,6 +20,8 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -59,6 +61,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -407,6 +410,18 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public GlobalListenerEntity getGlobalListener(
+      final String listenerId, final GlobalListenerType listenerType) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(
+      final GlobalListenerQuery query) {
     throw new NoSecondaryStorageException();
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -22,6 +22,8 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.GlobalListenerEntity;
+import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -60,6 +62,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -409,6 +412,18 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public GlobalListenerEntity getGlobalListener(
+      final String listenerId, final GlobalListenerType listenerType) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(
+      final GlobalListenerQuery query) {
     return SearchQueryResult.empty();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerEntity.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GlobalListenerEntity(
+    String id,
+    String listenerId,
+    String type,
+    List<String> eventTypes,
+    Integer retries,
+    Boolean afterNonGlobal,
+    Integer priority,
+    GlobalListenerSource source,
+    GlobalListenerType listenerType) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GlobalListenerEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -20,4 +21,11 @@ public record GlobalListenerEntity(
     Boolean afterNonGlobal,
     Integer priority,
     GlobalListenerSource source,
-    GlobalListenerType listenerType) {}
+    GlobalListenerType listenerType) {
+  public GlobalListenerEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    eventTypes = eventTypes != null ? eventTypes : new ArrayList<>();
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -11,6 +11,7 @@ public class ErrorMessages {
 
   public static final String ERROR_ENTITY_BY_KEY_NOT_FOUND = "%s with key '%d' not found";
   public static final String ERROR_ENTITY_BY_ID_NOT_FOUND = "%s with %s '%s' not found";
+  public static final String ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND = "%s with %s not found";
   public static final String ERROR_FAILED_DELETE_REQUEST = "Failed to execute delete request";
   public static final String ERROR_FAILED_FIND_ALL_QUERY = "Failed to execute findAll query";
   public static final String ERROR_FAILED_GET_ALIAS_REQUEST = "Failed to execute getAlias request";

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -356,4 +356,13 @@ public final class FilterBuilders {
       final Function<JobTypeStatisticsFilter.Builder, ObjectBuilder<JobTypeStatisticsFilter>> fn) {
     return fn.apply(jobTypeStatistics()).build();
   }
+
+  public static GlobalListenerFilter.Builder globalListener() {
+    return new GlobalListenerFilter.Builder();
+  }
+
+  public static GlobalListenerFilter globalListener(
+      final Function<GlobalListenerFilter.Builder, ObjectBuilder<GlobalListenerFilter>> fn) {
+    return fn.apply(globalListener()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GlobalListenerFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GlobalListenerFilter.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record GlobalListenerFilter(
+    List<Operation<String>> listenerIdOperations,
+    List<Operation<String>> typeOperations,
+    List<Operation<Integer>> retriesOperations,
+    List<Operation<String>> eventTypeOperations,
+    Boolean afterNonGlobal,
+    List<Operation<Integer>> priorityOperations,
+    List<Operation<String>> sourceOperations,
+    List<Operation<String>> listenerTypeOperations)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<GlobalListenerFilter> {
+    List<Operation<String>> listenerIdOperations;
+    List<Operation<String>> typeOperations;
+    List<Operation<Integer>> retriesOperations;
+    List<Operation<String>> eventTypeOperations;
+    Boolean afterNonGlobal;
+    List<Operation<Integer>> priorityOperations;
+    List<Operation<String>> sourceOperations;
+    List<Operation<String>> listenerTypeOperations;
+
+    @SafeVarargs
+    public final Builder listenerIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return listenerIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder listenerIdOperations(final List<Operation<String>> operations) {
+      listenerIdOperations = addValuesToList(listenerIdOperations, operations);
+      return this;
+    }
+
+    public Builder listenerIds(final String value, final String... values) {
+      return listenerIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder typeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return typeOperations(collectValues(operation, operations));
+    }
+
+    public Builder typeOperations(final List<Operation<String>> operations) {
+      typeOperations = addValuesToList(typeOperations, operations);
+      return this;
+    }
+
+    public Builder types(final String value, final String... values) {
+      return typeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder retriesOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return retriesOperations(collectValues(operation, operations));
+    }
+
+    public Builder retriesOperations(final List<Operation<Integer>> operations) {
+      retriesOperations = addValuesToList(retriesOperations, operations);
+      return this;
+    }
+
+    public Builder retries(final Integer value, final Integer... values) {
+      return retriesOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder eventTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return eventTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder eventTypeOperations(final List<Operation<String>> operations) {
+      eventTypeOperations = addValuesToList(eventTypeOperations, operations);
+      return this;
+    }
+
+    public Builder eventTypes(final String value, final String... values) {
+      return eventTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder afterNonGlobal(final Boolean value) {
+      afterNonGlobal = value;
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder priorityOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return priorityOperations(collectValues(operation, operations));
+    }
+
+    public Builder priorityOperations(final List<Operation<Integer>> operations) {
+      priorityOperations = addValuesToList(priorityOperations, operations);
+      return this;
+    }
+
+    public Builder priorities(final Integer value, final Integer... values) {
+      return priorityOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder sourceOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return sourceOperations(collectValues(operation, operations));
+    }
+
+    public Builder sourceOperations(final List<Operation<String>> operations) {
+      sourceOperations = addValuesToList(sourceOperations, operations);
+      return this;
+    }
+
+    public Builder sources(final String value, final String... values) {
+      return sourceOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder listenerTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return listenerTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder listenerTypeOperations(final List<Operation<String>> operations) {
+      listenerTypeOperations = addValuesToList(listenerTypeOperations, operations);
+      return this;
+    }
+
+    public Builder listenerTypes(final String value, final String... values) {
+      return listenerTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @Override
+    public GlobalListenerFilter build() {
+      return new GlobalListenerFilter(
+          Objects.requireNonNullElse(listenerIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(typeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(retriesOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(eventTypeOperations, Collections.emptyList()),
+          afterNonGlobal,
+          Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(sourceOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(listenerTypeOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/GlobalListenerQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/GlobalListenerQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.search.query;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.GlobalListenerFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.GlobalListenerSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record GlobalListenerQuery(
+    GlobalListenerFilter filter, GlobalListenerSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<GlobalListenerFilter, GlobalListenerSort> {
+
+  public static GlobalListenerQuery of(
+      final Function<Builder, ObjectBuilder<GlobalListenerQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          GlobalListenerQuery, Builder, GlobalListenerFilter, GlobalListenerSort> {
+
+    private static final GlobalListenerFilter EMPTY_FILTER =
+        FilterBuilders.globalListener().build();
+    private static final GlobalListenerSort EMPTY_SORT =
+        SortOptionBuilders.globalListener().build();
+
+    private GlobalListenerFilter filter;
+    private GlobalListenerSort sort;
+
+    @Override
+    public Builder filter(final GlobalListenerFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final GlobalListenerSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<GlobalListenerFilter.Builder, ObjectBuilder<GlobalListenerFilter>> fn) {
+      return filter(FilterBuilders.globalListener(fn));
+    }
+
+    public Builder sort(
+        final Function<GlobalListenerSort.Builder, ObjectBuilder<GlobalListenerSort>> fn) {
+      return sort(SortOptionBuilders.globalListener(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public GlobalListenerQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new GlobalListenerQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -298,4 +298,13 @@ public final class SearchQueryBuilders {
       incidentProcessInstanceStatisticsByDefinitionQuery() {
     return new IncidentProcessInstanceStatisticsByDefinitionQuery.Builder();
   }
+
+  public static GlobalListenerQuery.Builder globalListenerSearchQuery() {
+    return new GlobalListenerQuery.Builder();
+  }
+
+  public static GlobalListenerQuery globalListenerSearchQuery(
+      final Function<GlobalListenerQuery.Builder, ObjectBuilder<GlobalListenerQuery>> fn) {
+    return fn.apply(globalListenerSearchQuery()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/GlobalListenerSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/GlobalListenerSort.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final record GlobalListenerSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static GlobalListenerSort of(
+      final Function<Builder, ObjectBuilder<GlobalListenerSort>> fn) {
+    return SortOptionBuilders.globalListener(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<GlobalListenerSort> {
+
+    public Builder id() {
+      currentOrdering = new FieldSorting("id", null);
+      return this;
+    }
+
+    public Builder listenerId() {
+      currentOrdering = new FieldSorting("listenerId", null);
+      return this;
+    }
+
+    public Builder type() {
+      currentOrdering = new FieldSorting("type", null);
+      return this;
+    }
+
+    public Builder afterNonGlobal() {
+      currentOrdering = new FieldSorting("afterNonGlobal", null);
+      return this;
+    }
+
+    public Builder priority() {
+      currentOrdering = new FieldSorting("priority", null);
+      return this;
+    }
+
+    public Builder source() {
+      currentOrdering = new FieldSorting("source", null);
+      return this;
+    }
+
+    public Builder listenerType() {
+      currentOrdering = new FieldSorting("listenerType", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public GlobalListenerSort build() {
+      return new GlobalListenerSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -324,4 +324,13 @@ public final class SortOptionBuilders {
               fn) {
     return fn.apply(new IncidentProcessInstanceStatisticsByDefinitionSort.Builder()).build();
   }
+
+  public static GlobalListenerSort.Builder globalListener() {
+    return new GlobalListenerSort.Builder();
+  }
+
+  public static GlobalListenerSort globalListener(
+      final Function<GlobalListenerSort.Builder, ObjectBuilder<GlobalListenerSort>> fn) {
+    return fn.apply(globalListener()).build();
+  }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.C
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DOCUMENT;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.GLOBAL_LISTENER;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
@@ -286,6 +287,10 @@ public record Authorization<T>(
 
     public Builder<T> clusterVariable() {
       return resourceType(CLUSTER_VARIABLE);
+    }
+
+    public Builder<T> globalListener() {
+      return resourceType(GLOBAL_LISTENER);
     }
 
     public Builder<T> resourceId(final String resourceId) {

--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.camunda.search.clients.GlobalListenerSearchClient;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.service.security.SecurityContextProvider;
@@ -19,9 +20,12 @@ import java.util.concurrent.CompletableFuture;
 
 public final class GlobalListenerServices extends ApiServices<GlobalListenerServices> {
 
+  private final GlobalListenerSearchClient globalListenerSearchClient;
+
   public GlobalListenerServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
+      final GlobalListenerSearchClient globalListenerSearchClient,
       final CamundaAuthentication authentication,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
@@ -31,6 +35,7 @@ public final class GlobalListenerServices extends ApiServices<GlobalListenerServ
         authentication,
         executorProvider,
         brokerRequestAuthorizationConverter);
+    this.globalListenerSearchClient = globalListenerSearchClient;
   }
 
   @Override
@@ -38,6 +43,7 @@ public final class GlobalListenerServices extends ApiServices<GlobalListenerServ
     return new GlobalListenerServices(
         brokerClient,
         securityContextProvider,
+        globalListenerSearchClient,
         authentication,
         executorProvider,
         brokerRequestAuthorizationConverter);

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -9,6 +9,7 @@ package io.camunda.service.authorization;
 
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.COMPONENT;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.ACCESS;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_TASK_LISTENER;
 
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
@@ -18,6 +19,7 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.GlobalListenerEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.JobEntity;
@@ -123,6 +125,9 @@ public abstract class Authorizations {
 
   public static final Authorization<ClusterVariableEntity> CLUSTER_VARIABLE_READ_AUTHORIZATION =
       Authorization.of(a -> a.clusterVariable().read());
+
+  public static final Authorization<GlobalListenerEntity> GLOBAL_TASK_LISTENER_READ_AUTHORIZATION =
+      Authorization.of(a -> a.globalListener().permissionType(READ_TASK_LISTENER));
 
   public static final Authorization<ProcessInstanceEntity>
       PROCESS_DEFINITION_DELETE_PROCESS_INSTANCE_AUTHORIZATION =


### PR DESCRIPTION
## Description
This pull request introduces support for reading and searching global listeners from secondary storage. It adds new query, mapping, and service classes for global listeners, updates the RDBMS service to expose these capabilities, and integrates the necessary SQL mapping and search column definitions. Additionally, the search client transformer infrastructure is updated to recognize and handle global listener entities, filters, and sorting.

**RDBMS support for global listeners:**

* Added a new `GlobalListenerDbReader` service to read and search global listeners, including implementation of the `GlobalListenerReader` interface. (`db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java`)
* Introduced `GlobalListenerDbQuery` for building and representing global listener queries, and `GlobalListenerEntityMapper` for mapping DB models to entities. (`db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/GlobalListenerDbQuery.java`, `db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/GlobalListenerEntityMapper.java`)
* Added `GlobalListenerSearchColumn` enum to define searchable/sortable columns for global listeners. (`db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/GlobalListenerSearchColumn.java`)
* Updated `GlobalListenerMapper` interface and MyBatis XML mapping to support count, get, and search operations for global listeners, including new SQL queries and result maps. (`db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GlobalListenerMapper.java`, `db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml`)

**Integration with RdbmsService:**

* Registered `GlobalListenerDbReader` in `RdbmsService`, updated constructor and added a getter method. (`db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java`)

**Search client and transformer updates:**

* Added a `GlobalListenerDocumentReader` for document-based global listener reads. (`search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/GlobalListenerDocumentReader.java`)
* Registered new transformers and sorters for global listener entities, filters, and sorting in the `ServiceTransformers` class. (`search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java`)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #43189
