### PR TITLE
fix: skipping test for version <= 8.8.11 and single quotes removal

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -478,9 +478,9 @@ jobs:
             # For CPT versions <= 8.8.7, skip CamundaSpringProcessMultiTenancyTestListenerIT
             if (( MAJOR < 8 )) || \
                (( MAJOR == 8 && MINOR < 8 )) || \
-               (( MAJOR == 8 && MINOR == 8 && PATCH <= 7 )); then
-              EXTRA_PROPS+=" -Dit.test='!CamundaSpringProcessMultiTenancyTestListenerIT'"
-              echo "CPT version $CLIENT_VERSION <= 8.8.7 - excluding CamundaSpringProcessMultiTenancyTestListenerIT"
+               (( MAJOR == 8 && MINOR == 8 && PATCH <= 11 )); then
+              EXTRA_PROPS+=" -Dit.test=!CamundaSpringProcessMultiTenancyTestListenerIT -Dfailsafe.failIfNoSpecifiedTests=false"
+              echo "CPT version $CLIENT_VERSION <= 8.8.11 - excluding CamundaSpringProcessMultiTenancyTestListenerIT"
             fi
           fi
           echo "extra-props=${EXTRA_PROPS}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We need to skip the test for all the versions <= 8.8.11 

related to https://github.com/camunda/camunda/actions/runs/22124805185
