### PR TITLE
fix: prevent modifications with orphaned variables

### DIFF
--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/OrphanedVariablesError.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/OrphanedVariablesError.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Text, InlineNotification} from './styled';
+
+const OrphanedVariablesError: React.FC = () => {
+  return (
+    <InlineNotification
+      kind="error"
+      hideCloseButton
+      lowContrast
+      title="Invalid modification plan"
+      children={
+        <Text>
+          Some planned variable modifications cannot be applied. They must be
+          scoped to elements with a pending ADD or MOVE token modification. For
+          global variable modifications (scoped to the process instance), at
+          least one ADD or MOVE modification must be planned.
+        </Text>
+      }
+    />
+  );
+};
+
+export {OrphanedVariablesError};

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/OrphanedVariablesError.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/OrphanedVariablesError.tsx
@@ -20,7 +20,7 @@ const OrphanedVariablesError: React.FC = () => {
           Some planned variable modifications cannot be applied. They must be
           scoped to elements with a pending ADD or MOVE token modification. For
           global variable modifications (scoped to the process instance), at
-          least one ADD or MOVE modification must be planned.
+          least one ADD or MOVE token modification must be planned.
         </Text>
       }
     />


### PR DESCRIPTION
## Description

This PR adds an error message and prevents users from applying a modification when it contains variable modifications that cannot be scoped to a token modification. These variable modifications are "considered" orphaned as they cannot be mapped into the payload for the C8 API. 

## Checklist

- [X] The solution of showing an error message is up for discussion and [awaits a decision from product and design](https://github.com/camunda/camunda/issues/45268#issuecomment-3915560038).

## Related issues

closes #45268
