### PR TITLE
New node ids can be acquired during scaling

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
@@ -64,6 +65,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
+  private final NodeIdProvider nodeIdProvider;
 
   private Broker broker;
 
@@ -82,7 +84,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
-      @Autowired(required = false) final SearchClientsProxy searchClientsProxy) {
+      @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
+      final NodeIdProvider nodeIdProvider) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -96,6 +99,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
+    this.nodeIdProvider = nodeIdProvider;
   }
 
   @Bean
@@ -125,7 +129,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             passwordEncoder,
             jwtDecoder,
             searchClientsProxy,
-            new BrokerRequestAuthorizationConverter(securityConfiguration));
+            new BrokerRequestAuthorizationConverter(securityConfiguration),
+            nodeIdProvider);
     springBrokerBridge.registerShutdownHelper(
         errorCode -> shutdownHelper.initiateShutdown(errorCode));
     broker =

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -433,6 +433,10 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>dynamic-node-id-provider</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -91,7 +91,8 @@ public final class Broker implements AutoCloseable {
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoder(),
             systemContext.getSearchClientsProxy(),
-            systemContext.getBrokerRequestAuthorizationConverter());
+            systemContext.getBrokerRequestAuthorizationConverter(),
+            systemContext.getNodeIdProvider());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -148,4 +149,6 @@ public interface BrokerStartupContext {
   CheckpointSchedulingService getCheckpointSchedulingService();
 
   void setCheckpointSchedulingService(CheckpointSchedulingService checkpointSchedulingService);
+
+  NodeIdProvider getNodeIdProvider();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -69,6 +70,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
+  private final NodeIdProvider nodeIdProvider;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
   private ConcurrencyControl concurrencyControl;
@@ -104,7 +106,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final NodeIdProvider nodeIdProvider) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
@@ -122,6 +125,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
+    this.nodeIdProvider = nodeIdProvider;
     partitionListeners.addAll(additionalPartitionListeners);
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
   }
@@ -163,7 +167,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         passwordEncoder,
         jwtDecoder,
         searchClientsProxy,
-        brokerRequestAuthorizationConverter);
+        brokerRequestAuthorizationConverter,
+        null);
   }
 
   @Override
@@ -426,5 +431,10 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   public void setCheckpointSchedulingService(
       final CheckpointSchedulingService checkpointSchedulingService) {
     this.checkpointSchedulingService = checkpointSchedulingService;
+  }
+
+  @Override
+  public NodeIdProvider getNodeIdProvider() {
+    return nodeIdProvider;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -34,6 +34,7 @@ public class ClusterConfigurationManagerStep
         new ClusterChangeExecutorImpl(
             brokerStartupContext.getConcurrencyControl(),
             brokerStartupContext.getExporterRepository(),
+            brokerStartupContext.getNodeIdProvider(),
             brokerStartupContext.getMeterRegistry());
     final ClusterConfigurationService clusterConfigurationService =
         new DynamicClusterConfigurationService(clusterChangeExecutor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Objects;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,7 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
       final MeterRegistry meterRegistry) {
     this.concurrencyControl = concurrencyControl;
     this.exporterRepository = exporterRepository;
-    this.nodeIdProvider = nodeIdProvider;
+    this.nodeIdProvider = Objects.requireNonNull(nodeIdProvider);
     this.meterRegistry = meterRegistry;
   }
 
@@ -70,11 +71,6 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
       return result;
     }
 
-    if (nodeIdProvider == null) {
-      result.completeExceptionally(
-          new IllegalStateException("NodeIdProvider is required for scaling operations"));
-      return result;
-    }
     concurrencyControl.run(
         () -> {
           try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -49,6 +49,7 @@ import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.processing.globallistener.GlobalListenerValidator;
 import io.camunda.zeebe.engine.processing.identity.initialize.AuthorizationConfigurer;
 import io.camunda.zeebe.engine.processing.identity.initialize.GroupConfigurer;
@@ -137,6 +138,7 @@ public final class SystemContext {
   private final JwtDecoder jwtDecoder;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
+  private final NodeIdProvider nodeIdProvider;
   private final GlobalListenerValidator globalListenerValidator;
 
   public SystemContext(
@@ -152,7 +154,8 @@ public final class SystemContext {
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final NodeIdProvider nodeIdProvider) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
@@ -166,6 +169,7 @@ public final class SystemContext {
     this.jwtDecoder = jwtDecoder;
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+    this.nodeIdProvider = nodeIdProvider;
     globalListenerValidator = new GlobalListenerValidator();
     initSystemContext();
   }
@@ -195,7 +199,8 @@ public final class SystemContext {
         passwordEncoder,
         jwtDecoder,
         searchClientsProxy,
-        brokerRequestAuthorizationConverter);
+        brokerRequestAuthorizationConverter,
+        null);
   }
 
   private void initSystemContext() {
@@ -747,5 +752,9 @@ public final class SystemContext {
 
   public BrokerRequestAuthorizationConverter getBrokerRequestAuthorizationConverter() {
     return brokerRequestAuthorizationConverter;
+  }
+
+  public NodeIdProvider getNodeIdProvider() {
+    return nodeIdProvider;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -185,7 +185,8 @@ public final class SystemContext {
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final NodeIdProvider nodeIdProvider) {
     this(
         DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
@@ -200,7 +201,7 @@ public final class SystemContext {
         jwtDecoder,
         searchClientsProxy,
         brokerRequestAuthorizationConverter,
-        null);
+        nodeIdProvider);
   }
 
   private void initSystemContext() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
 import io.camunda.zeebe.broker.test.TestClusterFactory;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -77,7 +78,8 @@ public final class SimpleBrokerStartTest {
                       mock(PasswordEncoder.class),
                       mock(JwtDecoder.class),
                       mock(SearchClientsProxy.class),
-                      mock(BrokerRequestAuthorizationConverter.class));
+                      mock(BrokerRequestAuthorizationConverter.class),
+                      mock(NodeIdProvider.class));
               new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
             });
 
@@ -108,7 +110,8 @@ public final class SimpleBrokerStartTest {
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
             mock(SearchClientsProxy.class),
-            mock(BrokerRequestAuthorizationConverter.class));
+            mock(BrokerRequestAuthorizationConverter.class),
+            mock(NodeIdProvider.class));
 
     final var leaderLatch = new CountDownLatch(1);
     final var listener =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -10,36 +10,23 @@ package io.camunda.zeebe.broker.bootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
-import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.UserServices;
-import io.camunda.zeebe.broker.SpringBrokerBridge;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 class ApiMessagingServiceStepTest {
 
@@ -56,7 +43,7 @@ class ApiMessagingServiceStepTest {
   }
 
   private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
-  private BrokerStartupContextImpl testBrokerStartupContext;
+  private MockBrokerStartupContext testBrokerStartupContext;
   private final ApiMessagingServiceStep sut = new ApiMessagingServiceStep();
 
   @BeforeEach
@@ -64,24 +51,11 @@ class ApiMessagingServiceStepTest {
     when(mockActorSchedulingService.submitActor(any()))
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
-    testBrokerStartupContext =
-        new BrokerStartupContextImpl(
-            TEST_BROKER_INFO,
-            TEST_BROKER_CONFIG,
-            mock(SpringBrokerBridge.class),
-            mockActorSchedulingService,
-            mock(BrokerHealthCheckService.class),
-            mock(ExporterRepository.class),
-            mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
-            mock(BrokerClient.class),
-            Collections.emptyList(),
-            TEST_SHUTDOWN_TIMEOUT,
-            new SecurityConfiguration(),
-            mock(UserServices.class),
-            mock(PasswordEncoder.class),
-            mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class),
-            mock(BrokerRequestAuthorizationConverter.class));
+    testBrokerStartupContext = new MockBrokerStartupContext();
+    testBrokerStartupContext.setBrokerInfo(TEST_BROKER_INFO);
+    testBrokerStartupContext.setBrokerConfiguration(TEST_BROKER_CONFIG);
+    testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);
+    testBrokerStartupContext.setActorSchedulingService(mockActorSchedulingService);
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -10,34 +10,21 @@ package io.camunda.zeebe.broker.bootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.UserServices;
-import io.camunda.zeebe.broker.SpringBrokerBridge;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 class GatewayBrokerTransportStepTest {
   private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
@@ -47,7 +34,7 @@ class GatewayBrokerTransportStepTest {
 
   private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
 
-  private BrokerStartupContextImpl testBrokerStartupContext;
+  private MockBrokerStartupContext testBrokerStartupContext;
   private final BrokerInfo mockBrokerInfo = mock(BrokerInfo.class);
 
   private final GatewayBrokerTransportStep sut = new GatewayBrokerTransportStep();
@@ -57,24 +44,11 @@ class GatewayBrokerTransportStepTest {
     when(mockActorSchedulingService.submitActor(any()))
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
-    testBrokerStartupContext =
-        new BrokerStartupContextImpl(
-            mockBrokerInfo,
-            TEST_BROKER_CONFIG,
-            mock(SpringBrokerBridge.class),
-            mockActorSchedulingService,
-            mock(BrokerHealthCheckService.class),
-            mock(ExporterRepository.class),
-            mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
-            mock(BrokerClient.class),
-            Collections.emptyList(),
-            TEST_SHUTDOWN_TIMEOUT,
-            new SecurityConfiguration(),
-            mock(UserServices.class),
-            mock(PasswordEncoder.class),
-            mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class),
-            mock(BrokerRequestAuthorizationConverter.class));
+    testBrokerStartupContext = new MockBrokerStartupContext();
+    testBrokerStartupContext.setBrokerInfo(mockBrokerInfo);
+    testBrokerStartupContext.setBrokerConfiguration(TEST_BROKER_CONFIG);
+    testBrokerStartupContext.setActorSchedulingService(mockActorSchedulingService);
+    testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -9,40 +9,26 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.UserServices;
-import io.camunda.zeebe.broker.SpringBrokerBridge;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Random;
 import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 class RequestIdGeneratorStepTest {
   private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
-  private BrokerStartupContextImpl testBrokerStartupContext;
+  private MockBrokerStartupContext testBrokerStartupContext;
   private final BrokerInfo mockBrokerInfo = mock(BrokerInfo.class);
   private final TestConcurrencyControl spyConcurrencyControl = spy(new TestConcurrencyControl());
 
@@ -51,24 +37,10 @@ class RequestIdGeneratorStepTest {
   @BeforeEach
   void setUp() {
 
-    testBrokerStartupContext =
-        new BrokerStartupContextImpl(
-            mockBrokerInfo,
-            TEST_BROKER_CONFIG,
-            mock(SpringBrokerBridge.class),
-            mock(ActorScheduler.class),
-            mock(BrokerHealthCheckService.class),
-            mock(ExporterRepository.class),
-            mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
-            mock(BrokerClient.class),
-            Collections.emptyList(),
-            TEST_SHUTDOWN_TIMEOUT,
-            new SecurityConfiguration(),
-            mock(UserServices.class),
-            mock(PasswordEncoder.class),
-            mock(JwtDecoder.class),
-            mock(SearchClientsProxy.class),
-            mock(BrokerRequestAuthorizationConverter.class));
+    testBrokerStartupContext = new MockBrokerStartupContext();
+    testBrokerStartupContext.setBrokerInfo(mockBrokerInfo);
+    testBrokerStartupContext.setBrokerConfiguration(TEST_BROKER_CONFIG);
+    testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);
     testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
 import io.camunda.zeebe.broker.test.TestClusterFactory;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
@@ -119,7 +120,8 @@ final class PartitionJoinTest {
             null,
             null,
             null,
-            null);
+            null,
+            NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.test.TestActorSchedulerFactory;
 import io.camunda.zeebe.broker.test.TestBrokerClientFactory;
 import io.camunda.zeebe.broker.test.TestClusterFactory;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -235,7 +236,8 @@ final class PartitionLeaveTest {
             null,
             null,
             null,
-            null);
+            null,
+            NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -48,7 +48,10 @@ public class ClusterChangeExecutorImplTest {
 
     final var executor =
         new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(), repository, null, new SimpleMeterRegistry());
+            new TestConcurrencyControl(),
+            repository,
+            mock(NodeIdProvider.class),
+            new SimpleMeterRegistry());
 
     // when
     final Future<Void> result = executor.deleteHistory();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -7,8 +7,16 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.Record;
@@ -18,6 +26,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,7 +48,7 @@ public class ClusterChangeExecutorImplTest {
 
     final var executor =
         new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(), repository, new SimpleMeterRegistry());
+            new TestConcurrencyControl(), repository, null, new SimpleMeterRegistry());
 
     // when
     final Future<Void> result = executor.deleteHistory();
@@ -45,12 +56,67 @@ public class ClusterChangeExecutorImplTest {
     // then
     Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
     Assertions.assertThat(AuditExporter.AUDITS)
-        .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1");
-    Assertions.assertThat(AuditExporter.AUDITS)
-        .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2");
-    Assertions.assertThat(AuditExporter.AUDITS)
+        .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1")
+        .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
         .doesNotContainAnyElementsOf(
             Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
+  }
+
+  @Test
+  void shouldCallNodeIdProviderScale() {
+    // given
+    final var nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
+    final var executor =
+        new ClusterChangeExecutorImpl(
+            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+    // when
+    final var result =
+        executor.preScaling(1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+    // then
+    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdProvider, times(1)).scale(3);
+  }
+
+  @Test
+  void shouldOnlyCallNodeIdProviderScaleWhenScalingUp() {
+    // given
+    final var nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
+    final var executor =
+        new ClusterChangeExecutorImpl(
+            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+    // when
+    final var result = executor.preScaling(3, Set.of(MemberId.from("0"), MemberId.from("1")));
+
+    // then
+    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    verify(nodeIdProvider, times(0)).scale(anyInt());
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenNodeIdProviderScaleFails() {
+    // given
+    final var nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.scale(anyInt()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
+    final var executor =
+        new ClusterChangeExecutorImpl(
+            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+    // when
+    final var result =
+        executor.preScaling(1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+    // then
+    Assertions.assertThat(result)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("scale failed");
+    verify(nodeIdProvider, times(1)).scale(3);
   }
 
   public static class AuditExporter implements Exporter {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionC
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -383,7 +384,8 @@ final class SystemContextTest {
         mock(PasswordEncoder.class),
         mock(JwtDecoder.class),
         mock(SearchClientsProxy.class),
-        mock(BrokerRequestAuthorizationConverter.class));
+        mock(BrokerRequestAuthorizationConverter.class),
+        mock(NodeIdProvider.class));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
@@ -255,7 +256,8 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             null,
-            null);
+            null,
+            NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
@@ -33,10 +33,11 @@ public interface ClusterChangeExecutor {
    *
    * <p>This operation should be idempotent, as it may be retried multiple times until successful.
    *
+   * @param currentClusterSize the size of the cluster before scaling
    * @param clusterMembers the set of member ids that will be part of the cluster after scaling
    * @return future when the operation is completed
    */
-  ActorFuture<Void> preScaling(Set<MemberId> clusterMembers);
+  ActorFuture<Void> preScaling(final int currentClusterSize, Set<MemberId> clusterMembers);
 
   final class NoopClusterChangeExecutor implements ClusterChangeExecutor {
     @Override
@@ -45,7 +46,8 @@ public interface ClusterChangeExecutor {
     }
 
     @Override
-    public ActorFuture<Void> preScaling(final Set<MemberId> clusterMembers) {
+    public ActorFuture<Void> preScaling(
+        final int currentClusterSize, final Set<MemberId> clusterMembers) {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplier.java
@@ -23,6 +23,7 @@ final class PreScalingApplier implements ClusterOperationApplier {
   private final MemberId memberId;
   private final Set<MemberId> clusterMembers;
   private final ClusterChangeExecutor clusterChangeExecutor;
+  private int currentClusterSize;
 
   public PreScalingApplier(
       final MemberId memberId,
@@ -44,13 +45,14 @@ final class PreScalingApplier implements ClusterOperationApplier {
                   + memberId
                   + " is not part of the current cluster configuration."));
     }
+    currentClusterSize = currentClusterConfiguration.clusterSize();
     return Either.right(UnaryOperator.identity());
   }
 
   @Override
   public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
     return clusterChangeExecutor
-        .preScaling(clusterMembers)
+        .preScaling(currentClusterSize, clusterMembers)
         .thenApply(ignore -> UnaryOperator.identity());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PreScalingApplierTest.java
@@ -103,7 +103,8 @@ final class PreScalingApplierTest {
           }
 
           @Override
-          public ActorFuture<Void> preScaling(final Set<MemberId> clusterMembers) {
+          public ActorFuture<Void> preScaling(
+              final int currentClusterSize, final Set<MemberId> clusterMembers) {
             return CompletableActorFuture.completedExceptionally(
                 new RuntimeException("Failed to execute operation"));
           }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -82,6 +82,15 @@ public interface NodeIdRepository extends AutoCloseable {
   StoredRestoreStatus getRestoreStatus(final String restoreId);
 
   /**
+   * Get the count of available leases in the repository. This can be used to refresh the available
+   * lease count during lease acquisition, especially when a concurrent scale operation might have
+   * added new leases.
+   *
+   * @return the number of available leases
+   */
+  int getAvailableLeaseCount();
+
+  /**
    * A StoredLease represents the Lease stored in a Repository such as S3. It can be
    *
    * <ul>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -311,6 +311,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-core</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -383,6 +383,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             null);
 
     final Broker broker =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -384,7 +384,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
-            null);
+            NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     final Broker broker =
         new Broker(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.dynamicnodeid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.NodeIdProvider.S3;
+import io.camunda.configuration.NodeIdProvider.Type;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
+import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
+import io.camunda.zeebe.management.cluster.BrokerState;
+import io.camunda.zeebe.management.cluster.BrokerStateCode;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@Testcontainers
+@ZeebeIntegration
+@Timeout(120)
+public class DynamicNodeIdScalingIT {
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices("s3")
+          .withEnv("LS_LOG", "info");
+
+  @AutoClose private static S3Client s3Client;
+  private static final String BUCKET_NAME = UUID.randomUUID().toString();
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(10);
+  private static final int INITIAL_CLUSTER_SIZE = 1;
+  private static final int PARTITIONS_COUNT = 3;
+  private static final int TARGET_CLUSTER_SIZE = 3;
+
+  private static final String CLUSTER_NAME = "dynamic-node-id-scaling-test";
+
+  private final List<AutoCloseable> resourcesToClose = new java.util.ArrayList<>();
+
+  @TestZeebe(autoStart = false)
+  private final TestCluster testCluster =
+      TestCluster.builder()
+          .withName(CLUSTER_NAME)
+          .withBrokersCount(INITIAL_CLUSTER_SIZE)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(1)
+          .withoutNodeId()
+          .withNodeConfig(
+              app ->
+                  app.withProperty(
+                          "camunda.data.secondary-storage.type", SecondaryStorageType.none.name())
+                      .withUnifiedConfig(DynamicNodeIdScalingIT::configureBroker))
+          .build();
+
+  @AfterEach
+  void cleanup() throws Exception {
+    final var objects = s3Client.listObjects(b -> b.bucket(BUCKET_NAME));
+    objects.contents().parallelStream()
+        .forEach(obj -> s3Client.deleteObject(b -> b.bucket(BUCKET_NAME).key(obj.key())));
+
+    for (final var autoCloseable : resourcesToClose) {
+      autoCloseable.close();
+    }
+  }
+
+  @BeforeAll
+  static void setupAll() {
+    s3Client =
+        S3NodeIdRepository.buildClient(
+            new S3ClientConfig(
+                Optional.of(new S3ClientConfig.Credentials(S3.getAccessKey(), S3.getSecretKey())),
+                Optional.of(Region.of(S3.getRegion())),
+                Optional.of(S3.getEndpoint())));
+
+    s3Client.createBucket(b -> b.bucket(BUCKET_NAME));
+  }
+
+  @Test
+  public void shouldScaleClusterWithDynamicNodeIdProvider() {
+    // given - start cluster with one broker
+    testCluster.start();
+    testCluster.awaitHealthyTopology();
+
+    final var firstBroker = testCluster.brokers().values().iterator().next();
+    final var initialContactPoint = firstBroker.address(TestZeebePort.CLUSTER);
+
+    // verify initial state - one lease object
+    Awaitility.await("Until initial broker has a valid lease")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> assertThat(getLeasesCount()).isEqualTo(1));
+
+    // when - start two new brokers with contact point to first broker
+    final var secondBroker = getAdditionalBroker(initialContactPoint);
+    final var thirdBroker = getAdditionalBroker(initialContactPoint);
+
+    // Start in a separate thread as start() is blocking because node-id-provider cannot acquire a
+    // lease until scale api is called.
+    final var thread1 = Thread.ofVirtual().start(secondBroker::start);
+    final var thread2 = Thread.ofVirtual().start(thirdBroker::start);
+
+    // send scale request using ClusterActuator
+    final var clusterActuator = ClusterActuator.of(firstBroker);
+    final var scaleRequest =
+        new ClusterConfigPatchRequest()
+            .brokers(new ClusterConfigPatchRequestBrokers().count(TARGET_CLUSTER_SIZE));
+
+    clusterActuator.patchCluster(scaleRequest, false, false);
+
+    // verify second broker has acquired a lease
+    Awaitility.await("Until new brokers has a valid lease")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(getLeasesCount()).isEqualTo(TARGET_CLUSTER_SIZE));
+
+    // then - verify scale operation completes
+    Awaitility.await("Until scale operation completes")
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              final var topology = clusterActuator.getTopology();
+              assertThat(topology.getBrokers()).hasSize(TARGET_CLUSTER_SIZE);
+
+              // verify no pending changes
+              assertThat(topology.getPendingChange()).isNull();
+
+              // verify all brokers are active
+              final var activeBrokers =
+                  topology.getBrokers().stream()
+                      .filter(b -> b.getState() == BrokerStateCode.ACTIVE)
+                      .collect(Collectors.toList());
+              assertThat(activeBrokers).hasSize(TARGET_CLUSTER_SIZE);
+
+              // verify partitions are distributed
+              for (final BrokerState broker : topology.getBrokers()) {
+                assertThat(broker.getPartitions()).isNotEmpty();
+              }
+            });
+
+    assertThat(thread1.isAlive()).describedAs("Startup of secondBroker completes").isFalse();
+    assertThat(thread2.isAlive()).describedAs("Startup of thirdBroker completes").isFalse();
+  }
+
+  private TestStandaloneBroker getAdditionalBroker(final String initialContactPoint) {
+    final var broker =
+        new TestStandaloneBroker()
+            .withProperty("camunda.data.secondary-storage.type", SecondaryStorageType.none.name())
+            .withUnifiedConfig(
+                cfg -> {
+                  cfg.getCluster().setName(CLUSTER_NAME);
+                  cfg.getCluster().setInitialContactPoints(List.of(initialContactPoint));
+                  configureBroker(cfg);
+                });
+    resourcesToClose.add(broker);
+    return broker;
+  }
+
+  private static void configureBroker(final Camunda cfg) {
+    cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+
+    cfg.getCluster().setSize(INITIAL_CLUSTER_SIZE);
+    cfg.getCluster().getNodeIdProvider().setType(Type.S3);
+    final S3 s3 = cfg.getCluster().getNodeIdProvider().s3();
+    s3.setTaskId(UUID.randomUUID().toString());
+    s3.setBucketName(BUCKET_NAME);
+    s3.setLeaseDuration(LEASE_DURATION);
+    s3.setEndpoint(S3.getEndpoint().toString());
+    s3.setRegion(S3.getRegion());
+    s3.setAccessKey(S3.getAccessKey());
+    s3.setSecretKey(S3.getSecretKey());
+  }
+
+  private int getLeasesCount() throws IOException {
+    return (int)
+        s3Client.listObjects(b -> b.bucket(BUCKET_NAME)).contents().stream()
+            .map(S3Object::key)
+            .filter(key -> key.matches("\\d+\\.json"))
+            .count();
+  }
+}


### PR DESCRIPTION
## Description

This PR add support for scaling up number of brokers using the patch api, by incrementing broker count when dynamic node id is configured. `PreScalingOperation` calls back to `NodeIdProvider` with the new clusterSize, which then scales the available number of leases.

## Related issues

related #45812 
