### PR TITLE
build: improvements in the configuration of maven-build-cache-extension

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -11,12 +11,30 @@
     <hashAlgorithm>XX</hashAlgorithm>
     <validateXml>true</validateXml>
     <local>
-      <maxBuildsCached>5</maxBuildsCached>
+      <maxBuildsCached>10</maxBuildsCached>
     </local>
+    <!-- Save generated sources alongside the JAR so they are restored on cache hits.
+         This covers protobuf, openapi, and SBE generated Java files. -->
+    <attachedOutputs>
+      <dirNames>
+        <dirName>generated-sources</dirName>
+      </dirNames>
+    </attachedOutputs>
   </configuration>
   <input>
     <global>
-      <glob>{*.java,*.xml,*.properties, *.proto, resources/api/*.xml, rest-api*.yml }</glob>
+      <!-- Match all common source/config file types recursively across modules.
+           XML and YAML are restricted to src/main to avoid IDE (.idea/), tool configs (spotbugs/),
+           CI workflows (.github/), and Docker Compose files from invalidating the cache.
+           pom.xml is matched separately at the module root. -->
+      <glob>{*.java,pom.xml,src/main/**/*.xml,src/main/**/*.yaml,src/main/**/*.yml
+            ,*.properties,*.proto,*.factories,*.imports,*.json}</glob>
+      <includes>
+        <!-- Explicit include for the parent POM directory: changes to shared build config
+             affect all modules but may not be detected via effective-POM checksumming alone. -->
+        <include recursive="false" glob="pom.xml">parent</include>
+      </includes>
     </global>
   </input>
+
 </cache>

--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -311,10 +311,12 @@
           <generateModelTests>false</generateModelTests>
           <!-- no need to validate the spec here - this happens in zeebe-gateway-rest already -->
           <skipValidateSpec>true</skipValidateSpec>
+          <minimalUpdate>true</minimalUpdate>
           <configOptions>
             <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
             <documentationProvider>none</documentationProvider>
             <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
+            <hideGenerationTimestamp>true</hideGenerationTimestamp>
             <library>google-api-client</library>
             <java8>true</java8>
             <openApiNullable>false</openApiNullable>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -342,10 +342,12 @@
           <templateDirectory>${project.basedir}/src/main/resources/templates</templateDirectory>
           <!-- no need to validate the spec here - this happens in zeebe-gateway-rest already -->
           <skipValidateSpec>true</skipValidateSpec>
+          <minimalUpdate>true</minimalUpdate>
           <configOptions>
             <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
             <documentationProvider>none</documentationProvider>
             <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
+            <hideGenerationTimestamp>true</hideGenerationTimestamp>
             <library>google-api-client</library>
             <java8>true</java8>
             <openApiNullable>false</openApiNullable>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1109,6 +1109,10 @@
             <configuration>
               <inputSpec>${project.basedir}/src/main/resources/api/backup-management-api.yaml</inputSpec>
               <modelPackage>io.camunda.management.backups</modelPackage>
+              <minimalUpdate>true</minimalUpdate>
+              <configOptions>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+              </configOptions>
             </configuration>
           </execution>
           <execution>
@@ -1119,6 +1123,10 @@
             <configuration>
               <inputSpec>${project.basedir}/src/main/resources/api/cluster/cluster-api.yaml</inputSpec>
               <modelPackage>io.camunda.zeebe.management.cluster</modelPackage>
+              <minimalUpdate>true</minimalUpdate>
+              <configOptions>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+              </configOptions>
             </configuration>
           </execution>
           <execution>
@@ -1129,6 +1137,10 @@
             <configuration>
               <inputSpec>${project.basedir}/src/main/resources/api/cluster/exporter-api.yaml</inputSpec>
               <modelPackage>io.camunda.zeebe.management.cluster</modelPackage>
+              <minimalUpdate>true</minimalUpdate>
+              <configOptions>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+              </configOptions>
             </configuration>
           </execution>
         </executions>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -117,6 +117,8 @@
               <generateModelTests>false</generateModelTests>
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
+              <!-- only write files whose content changed to avoid spurious recompilation -->
+              <minimalUpdate>true</minimalUpdate>
               <openapiNormalizer>REF_AS_PARENT_IN_ALLOF=true</openapiNormalizer>
               <configOptions>
                 <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS)</additionalModelTypeAnnotations>
@@ -125,6 +127,7 @@
                 <jdk8>true</jdk8>
                 <openApiNullable>false</openApiNullable>
                 <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
               </configOptions>
             </configuration>
           </execution>
@@ -228,6 +231,8 @@
               <generateModelTests>false</generateModelTests>
               <!-- no validation needed, done in the advanced execution already -->
               <skipValidateSpec>true</skipValidateSpec>
+              <!-- only write files whose content changed to avoid spurious recompilation -->
+              <minimalUpdate>true</minimalUpdate>
               <configOptions>
                 <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS)</additionalModelTypeAnnotations>
                 <serializationLibrary>jackson</serializationLibrary>
@@ -236,6 +241,7 @@
                 <openApiNullable>false</openApiNullable>
                 <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
                 <useOneOfInterfaces>false</useOneOfInterfaces>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
               </configOptions>
             </configuration>
           </execution>


### PR DESCRIPTION
## Description
This PR aims at improving the caching by adding missing file extensions, copying generated-resources (so they don't need to be regenerated) and not regenerating openapi files if not necessary.

The cache is disabled by default as before. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
