### PR TITLE
Expand processInstanceFilter.spec.ts

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -37,6 +37,7 @@ import {IdentityMappingRulesPage} from '@pages/IdentityMappingRulesPage';
 import {IdentityRolesPage} from '@pages/IdentityRolesPage';
 import {IdentityTenantsPage} from '@pages/IdentityTenantsPage';
 import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
+import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 
 import {sleep} from 'utils/sleep';
 
@@ -59,6 +60,7 @@ type PlaywrightFixtures = {
   operateProcessMigrationModePage: OperateProcessMigrationModePage;
   operateProcessModificationModePage: OperateProcessModificationModePage;
   operateProcessInstanceViewModificationModePage: OperateProcessInstanceViewModificationModePage;
+  operateOperationsDetailsPage: OperateOperationsDetailsPage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
   tasklistProcessesPage: TasklistProcessesPage;
@@ -125,6 +127,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateProcessInstanceViewModificationModePage: async ({page}, use) => {
     await use(new OperateProcessInstanceViewModificationModePage(page));
+  },
+  operateOperationsDetailsPage: async ({page}, use) => {
+    await use(new OperateOperationsDetailsPage(page));
   },
   taskDetailsPage: async ({page}, use) => {
     await use(new TaskDetailsPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -31,7 +31,7 @@ export class OperateFiltersPanelPage {
   readonly processNameClearButton: Locator;
   readonly processInstanceKeysFilter: Locator;
   readonly processInstanceKeysFilterOption: Locator;
-  readonly parentProcessInstanceKey: Locator;
+  readonly parentProcessInstanceKeyFilter: Locator;
   readonly processInstanceKey: Locator;
   readonly flowNodeFilter: Locator;
   readonly operationIdFilter: Locator;
@@ -56,24 +56,24 @@ export class OperateFiltersPanelPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.runningInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Running',
-    });
-    this.activeInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Active',
-    });
-    this.incidentsInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Incidents',
-    });
-    this.completedInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Completed',
-    });
-    this.canceledInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Canceled',
-    });
-    this.finishedInstancesCheckbox = this.page.getByRole('checkbox', {
-      name: 'Finished',
-    });
+    this.activeInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Active'});
+    this.completedInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Completed'});
+    this.canceledInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Canceled'});
+    this.runningInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Running Instances'});
+    this.incidentsInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Incidents'});
+    this.finishedInstancesCheckbox = page
+      .locator('label')
+      .filter({hasText: 'Finished Instances'});
     this.processNameFilter = this.page.getByRole('combobox', {
       name: 'Name',
     });
@@ -91,7 +91,7 @@ export class OperateFiltersPanelPage {
     this.processInstanceKeysFilter = page.getByRole('textbox', {
       name: 'process instance key',
     });
-    this.parentProcessInstanceKey = page.getByRole('textbox', {
+    this.parentProcessInstanceKeyFilter = page.getByRole('textbox', {
       name: 'parent process instance key',
     });
     this.processInstanceKey = page.getByRole('textbox', {
@@ -204,17 +204,20 @@ export class OperateFiltersPanelPage {
 
   async fillVariableNameFilter(name: string) {
     await expect(this.variableNameFilter).toBeVisible();
+    await expect(this.variableNameFilter).toBeEnabled();
     await this.variableNameFilter.fill(name);
   }
 
   async fillVariableValueFilter(value: string) {
     await expect(this.variableValueFilter).toBeVisible();
+    await expect(this.variableValueFilter).toBeEnabled();
     await this.variableValueFilter.fill(value);
     await expect(this.variableValueFilter).toHaveValue(value);
   }
 
   async fillProcessInstanceKeyFilter(processInstanceKey: string) {
     await expect(this.processInstanceKeysFilter).toBeVisible();
+    await expect(this.processInstanceKeysFilter).toBeEnabled();
     await this.processInstanceKeysFilter.fill(processInstanceKey);
     await expect(this.processInstanceKeysFilter).toHaveValue(
       processInstanceKey,
@@ -222,7 +225,12 @@ export class OperateFiltersPanelPage {
   }
 
   async fillParentProcessInstanceKeyFilter(parentProcessInstanceKey: string) {
-    await this.parentProcessInstanceKey.fill(parentProcessInstanceKey);
+    await expect(this.parentProcessInstanceKeyFilter).toBeVisible();
+    await expect(this.parentProcessInstanceKeyFilter).toBeEnabled();
+    await this.parentProcessInstanceKeyFilter.fill(parentProcessInstanceKey);
+    await expect(this.parentProcessInstanceKeyFilter).toHaveValue(
+      parentProcessInstanceKey,
+    );
   }
 
   async fillFromTimeInput(fromTime: string) {
@@ -274,7 +282,10 @@ export class OperateFiltersPanelPage {
   }
 
   async fillErrorMessageFilter(errorMessage: string) {
+    await expect(this.errorMessageFilter).toBeVisible();
+    await expect(this.errorMessageFilter).toBeEnabled();
     await this.errorMessageFilter.fill(errorMessage);
+    await expect(this.errorMessageFilter).toHaveValue(errorMessage);
   }
 
   async fillOperationIdFilter(operationId: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Locator, Page} from '@playwright/test';
+
+export class OperateOperationsDetailsPage {
+  private page: Page;
+  private tileElement: Locator;
+  readonly state: Locator;
+  readonly summaryOfItems: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.tileElement = this.page.locator('.cds--tile');
+    this.state = this.tileElement
+      .filter({hasText: 'State'})
+      .getByRole('status', {name: /Batch operation status:/});
+    this.summaryOfItems = this.tileElement
+      .filter({hasText: 'Summary of items'})
+      .getByRole('status');
+  }
+
+  async getBatchOperationStatus(): Promise<string> {
+    return await this.state.innerText();
+  }
+
+  async getBatchOperationId(): Promise<string> {
+    const url = this.page.url();
+
+    const match = url.match(/\/batch-operations\/([^/?]+)/);
+    if (match && match[1]) {
+      const batchOperationId = match[1];
+      return batchOperationId;
+    }
+
+    throw new Error(`Could not extract batch operation ID from URL: ${url}`);
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -678,13 +678,11 @@ export class OperateProcessInstanceViewModificationModePage {
     nameText: string;
     scopeText?: string;
   }) {
-    let targetRow:
-      | ReturnType<
-          OperateProcessInstanceViewModificationModePage['applyModificationDialogVariableModificationRowByIndex']
-        >
-      | null = null;
+    let targetRow: ReturnType<
+      OperateProcessInstanceViewModificationModePage['applyModificationDialogVariableModificationRowByIndex']
+    > | null = null;
 
-    await this.iterateVariableModificationDialogRows(async row => {
+    await this.iterateVariableModificationDialogRows(async (row) => {
       const variableNameValue = await row.nameValue.innerText();
       if (variableNameValue !== nameText) {
         return true;
@@ -701,7 +699,10 @@ export class OperateProcessInstanceViewModificationModePage {
       return false;
     });
 
-    expect(targetRow, `Variable modification ${nameText} not found`).toBeTruthy();
+    expect(
+      targetRow,
+      `Variable modification ${nameText} not found`,
+    ).toBeTruthy();
 
     await expect(targetRow!.nameValue).toHaveText(nameText);
     if (scopeText) {
@@ -711,7 +712,7 @@ export class OperateProcessInstanceViewModificationModePage {
   }
 
   async expectVariableNotPresentInDialog(forbiddenText: string) {
-    await this.iterateVariableModificationDialogRows(async row => {
+    await this.iterateVariableModificationDialogRows(async (row) => {
       const variableName = await row.nameValue.innerText();
       expect(variableName).not.toContain(forbiddenText);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -69,6 +69,7 @@ class OperateProcessesPage {
       | 'Cancel Process Instance',
   ) => Locator;
   readonly processCouldNotBeFoundMessage: Locator;
+  readonly goToOperationDetailsButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -151,8 +152,8 @@ class OperateProcessesPage {
       .locator('label')
       .filter({hasText: 'Incidents'});
     this.processFinishedInstancesCheckbox = page
-      .getByTestId('filter-finished-instances')
-      .getByRole('checkbox');
+      .locator('label')
+      .filter({hasText: 'Finished Instances'});
     this.dataList = page.getByTestId('data-list');
     this.continueButton = page.getByRole('button', {name: 'continue'});
     this.processInstancesPanel = page.getByRole('region', {
@@ -200,6 +201,9 @@ class OperateProcessesPage {
     this.processCouldNotBeFoundMessage = this.page
       .getByRole('status')
       .getByText('Process could not be found');
+    this.goToOperationDetailsButton = this.page.getByText(
+      'Go to operation details',
+    );
   }
 
   async filterByProcessName(name: string): Promise<void> {
@@ -418,30 +422,6 @@ class OperateProcessesPage {
     ).toBeVisible();
   }
 
-  async clickProcessActiveCheckbox(): Promise<void> {
-    await this.processActiveCheckbox.click();
-  }
-
-  async clickProcessCompletedCheckbox(): Promise<void> {
-    await this.processCompletedCheckbox.click({timeout: 120000});
-  }
-
-  async clickProcessCanceledCheckbox(): Promise<void> {
-    await this.processCanceledCheckbox.click({timeout: 120000});
-  }
-
-  async clickProcessIncidentsCheckbox(): Promise<void> {
-    await this.processIncidentsCheckbox.click({timeout: 90000});
-  }
-
-  async clickRunningProcessInstancesCheckbox(): Promise<void> {
-    await this.processRunningInstancesCheckbox.click({timeout: 90000});
-  }
-
-  async clickFinishedProcessInstancesCheckbox(): Promise<void> {
-    await this.processFinishedInstancesCheckbox.click({timeout: 90000});
-  }
-
   async clickMigrateButton(): Promise<void> {
     await this.migrateButton.click();
   }
@@ -470,6 +450,10 @@ class OperateProcessesPage {
     while (!(await locator.isVisible())) {
       await this.page.mouse.wheel(0, 600);
     }
+  }
+
+  async clickGoToOperationDetailsButton(): Promise<void> {
+    await this.goToOperationDetailsButton.click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/NamedEventsProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/NamedEventsProcess.bpmn
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="eb92200" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1ynf09m" name="NamedEventsProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_OrderReceived" name="Order received">
+      <bpmn:outgoing>Flow_18wuolb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_SendOrderConfirmation" name="Send order confirmation">
+      <bpmn:incoming>Flow_18wuolb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fudmr8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_18wuolb" sourceRef="StartEvent_OrderReceived" targetRef="Activity_SendOrderConfirmation" />
+    <bpmn:intermediateThrowEvent id="Event_OrderConfirmed" name="Order Confirmed">
+      <bpmn:incoming>Flow_1fudmr8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pwra77</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_1fudmr8" sourceRef="Activity_SendOrderConfirmation" targetRef="Event_OrderConfirmed" />
+    <bpmn:task id="Activity_PackItems" name="Pack Items">
+      <bpmn:incoming>Flow_0pwra77</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mrasjb</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0pwra77" sourceRef="Event_OrderConfirmed" targetRef="Activity_PackItems" />
+    <bpmn:task id="Activity_SendItems" name="Send items">
+      <bpmn:incoming>Flow_1mrasjb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jqiolh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1mrasjb" sourceRef="Activity_PackItems" targetRef="Activity_SendItems" />
+    <bpmn:endEvent id="Event_OrderFulfilled" name="Order fulfilled">
+      <bpmn:incoming>Flow_1jqiolh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1jqiolh" sourceRef="Activity_SendItems" targetRef="Event_OrderFulfilled" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1ynf09m">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_OrderReceived">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="143" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lamzw9_di" bpmnElement="Activity_SendOrderConfirmation">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hpaa0w_di" bpmnElement="Event_OrderConfirmed">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="143" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dgrk0t_di" bpmnElement="Activity_PackItems">
+        <dc:Bounds x="500" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dh6toz_di" bpmnElement="Activity_SendItems">
+        <dc:Bounds x="670" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dy1clr_di" bpmnElement="Event_OrderFulfilled">
+        <dc:Bounds x="842" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="828" y="143" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_18wuolb_di" bpmnElement="Flow_18wuolb">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fudmr8_di" bpmnElement="Flow_1fudmr8">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pwra77_di" bpmnElement="Flow_0pwra77">
+        <di:waypoint x="438" y="118" />
+        <di:waypoint x="500" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mrasjb_di" bpmnElement="Flow_1mrasjb">
+        <di:waypoint x="600" y="118" />
+        <di:waypoint x="670" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jqiolh_di" bpmnElement="Flow_1jqiolh">
+        <di:waypoint x="770" y="118" />
+        <di:waypoint x="842" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/ProcessToCancel.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/ProcessToCancel.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="d4cbe29" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="ProcessToCancel" name="ProcessToCancel" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_10hbqcc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_10hbqcc" sourceRef="StartEvent_1" targetRef="Activity_07qbjge" />
+    <bpmn:userTask id="Activity_07qbjge">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_10hbqcc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dt7hcd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1h5a8dc">
+      <bpmn:incoming>Flow_0dt7hcd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0dt7hcd" sourceRef="Activity_07qbjge" targetRef="Event_1h5a8dc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1im3r0c">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0efuhuw_di" bpmnElement="Activity_07qbjge">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h5a8dc_di" bpmnElement="Event_1h5a8dc">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10hbqcc_di" bpmnElement="Flow_10hbqcc">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dt7hcd_di" bpmnElement="Flow_0dt7hcd">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -118,6 +118,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     page,
     loginPage,
   }) => {
@@ -142,8 +143,8 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
-      await operateProcessesPage.clickProcessActiveCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.clickActiveInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Form_User_Task');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -155,6 +156,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     loginPage,
     page,
   }) => {
@@ -163,7 +165,7 @@ test.describe('HTO User Flow Tests', () => {
       await loginPage.login('demo', 'demo');
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 180000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Start_Form_Process');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -176,6 +178,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPage,
     taskPanelPage,
     loginPage,
@@ -221,7 +224,7 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName(
         'Zeebe_Priority_User_Task_Process',
@@ -237,6 +240,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPage,
     taskPanelPage,
   }) => {
@@ -262,7 +266,7 @@ test.describe('HTO User Flow Tests', () => {
       await loginPage.login('demo', 'demo');
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 120000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Zeebe_User_Task_Process');
       await operateProcessesPage.clickProcessInstanceLink();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/hto-user-flows.spec.ts
@@ -59,6 +59,7 @@ test.describe('HTO User Flow Tests', () => {
     taskDetailsPageV1,
     taskPanelPageV1,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     page,
     loginPage,
   }) => {
@@ -87,7 +88,7 @@ test.describe('HTO User Flow Tests', () => {
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 120000});
       await operateHomePage.clickProcessesTab();
       await operateProcessesPage.filterByProcessName('Job_Worker_Process');
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(10000);
       await operateProcessesPage.clickProcessInstanceLink();
       await operateProcessInstancePage.completedIconAssertion();
@@ -99,6 +100,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskPanelPageV1,
     taskDetailsPageV1,
     loginPage,
@@ -159,6 +161,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     page,
     loginPage,
   }) => {
@@ -183,8 +186,8 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
-      await operateProcessesPage.clickProcessActiveCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.clickActiveInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Form_User_Task');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -196,6 +199,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     loginPage,
     page,
   }) => {
@@ -204,7 +208,7 @@ test.describe('HTO User Flow Tests', () => {
       await loginPage.login('demo', 'demo');
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 180000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Start_Form_Process');
       await operateProcessesPage.clickProcessInstanceLink();
@@ -217,6 +221,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPageV1,
     taskPanelPageV1,
     loginPage,
@@ -262,7 +267,7 @@ test.describe('HTO User Flow Tests', () => {
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName(
         'Zeebe_Priority_User_Task_Process',
@@ -278,6 +283,7 @@ test.describe('HTO User Flow Tests', () => {
     operateHomePage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateFiltersPanelPage,
     taskDetailsPageV1,
     taskPanelPageV1,
   }) => {
@@ -303,7 +309,7 @@ test.describe('HTO User Flow Tests', () => {
       await loginPage.login('demo', 'demo');
       await expect(operateHomePage.processesTab).toBeVisible({timeout: 120000});
       await operateHomePage.clickProcessesTab();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(1000);
       await operateProcessesPage.filterByProcessName('Zeebe_User_Task_Process');
       await operateProcessesPage.clickProcessInstanceLink();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -161,8 +161,8 @@ test.describe('Operations', () => {
       await operateProcessesPage.cancelButton.click();
       await operateProcessesPage.applyButton.click();
 
-      await operateProcessesPage.clickProcessIncidentsCheckbox();
-      await operateProcessesPage.clickProcessCanceledCheckbox();
+      await operateFiltersPanelPage.clickIncidentsInstancesCheckbox();
+      await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
 
       await expect(
         operateProcessesPage.batchOperationStartedMessage(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -211,11 +211,7 @@ test.describe('Process Instance Listeners', () => {
         'Service Task B',
       );
 
-      userTaskKey = await findUserTask(
-        request,
-        processInstanceKey,
-        'CREATED',
-      );
+      userTaskKey = await findUserTask(request, processInstanceKey, 'CREATED');
 
       expect(userTaskKey).toMatch(userTaskKeyRegex);
       await expect(operateProcessInstancePage.stateOverlayActive).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -472,7 +472,7 @@ test.describe('Process Instance Modifications', () => {
         1,
         JSON.stringify(validJSONValue1),
       );
-      
+
       await waitForAssertion({
         assertion: async () => {
           await expect(
@@ -565,7 +565,6 @@ test.describe('Process Instance Modifications', () => {
     await test.step('Apply modifications and verify variable values in the instance', async () => {
       await operateProcessInstanceViewModificationModePage.clickApplyModificationsButton();
       await operateProcessInstanceViewModificationModePage.clickApplyButtonModificationsDialog();
-
     });
 
     await test.step('Check that the added variables are visible on element level and have correct values', async () => {
@@ -602,9 +601,8 @@ test.describe('Process Instance Modifications', () => {
         operateProcessInstanceViewModificationModePage.modificationModeText,
       ).toBeHidden();
       await expect(
-        operateProcessInstancePage.existingVariableByName(
-          'testNewMeowVariable',
-        ).name,
+        operateProcessInstancePage.existingVariableByName('testNewMeowVariable')
+          .name,
       ).toBeVisible();
       expect(
         await operateProcessInstancePage

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -528,7 +528,6 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.displayOptionalFilter('End Date Range');
 
       const todayDate = new Date();
-      console.log('Today date:', todayDate.getDate());
 
       await operateFiltersPanelPage.pickDateTimeRange({
         fromDay: todayDate.getDate().toString(),
@@ -679,7 +678,7 @@ test.describe('Process Instances Filters', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('1 results')).toBeVisible();
+          await expect(page.getByText('1 result')).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -18,6 +18,7 @@ type ProcessInstance = {processInstanceKey: number};
 
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
+let variableProcessInstance: ProcessInstance;
 
 test.beforeAll(async () => {
   await deploy([
@@ -53,6 +54,17 @@ test.beforeAll(async () => {
         .processInstanceKey,
     ),
   };
+
+  await deploy(['./resources/Variable_Process.bpmn']);
+  variableProcessInstance = {
+    processInstanceKey: Number(
+      (await createSingleInstance('Variable_Process', 1, {filtersTest: 604}))
+        .processInstanceKey,
+    ),
+  };
+
+  await deploy(['./resources/ProcessToCancel.bpmn']);
+  await deploy(['./resources/NamedEventsProcess.bpmn']);
 });
 
 test.describe('Process Instances Filters', () => {
@@ -151,7 +163,7 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
         `${orderProcessInstanceKey}, ${callActivityProcessInstanceKey}`,
       );
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await sleep(200);
     });
 
@@ -248,6 +260,7 @@ test.describe('Process Instances Filters', () => {
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
+    operateOperationsDetailsPage,
   }) => {
     await test.step('Filter by Parent Process Instance Key and assert results', async () => {
       const callActivityProcessInstanceKey =
@@ -257,12 +270,12 @@ test.describe('Process Instances Filters', () => {
         'Parent Process Instance Key',
       );
       await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
-        callActivityProcessInstanceKey,
+        `${callActivityProcessInstanceKey}`,
       );
       await expect(
         operateProcessesPage.noMatchingInstancesMessage,
       ).toBeVisible();
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
       await waitForAssertion({
         assertion: async () => {
           await expect(page.getByText('1 result')).toBeVisible();
@@ -272,7 +285,7 @@ test.describe('Process Instances Filters', () => {
         },
       });
       await expect(operateProcessesPage.parentInstanceIdCell).toHaveText(
-        callActivityProcessInstanceKey,
+        `${callActivityProcessInstanceKey}`,
       );
       expect(await operateProcessesPage.processInstancesTable.count()).toBe(1);
     });
@@ -280,7 +293,7 @@ test.describe('Process Instances Filters', () => {
     await test.step('Reset filter', async () => {
       await operateFiltersPanelPage.clickResetFilters();
       await expect(
-        operateFiltersPanelPage.parentProcessInstanceKey,
+        operateFiltersPanelPage.parentProcessInstanceKeyFilter,
       ).toBeHidden();
       await expect
         .poll(() => operateProcessesPage.processInstancesTable.count())
@@ -288,7 +301,7 @@ test.describe('Process Instances Filters', () => {
     });
 
     await test.step('Filter by End Date Range and assert results', async () => {
-      await operateProcessesPage.clickProcessCompletedCheckbox();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
 
       let currentRowCount =
         await operateProcessesPage.processInstancesTable.count();
@@ -346,6 +359,460 @@ test.describe('Process Instances Filters', () => {
 
       await expect(operateFiltersPanelPage.errorMessageFilter).toBeHidden();
       await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
+    });
+
+    await test.step('Filter by Parent Instance Key and by Error Message and assert results', async () => {
+      const callActivityProcessInstanceKey =
+        callActivityProcessInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Parent Process Instance Key',
+      );
+      await operateFiltersPanelPage.fillParentProcessInstanceKeyFilter(
+        `${callActivityProcessInstanceKey}`,
+      );
+      await expect(
+        operateProcessesPage.noMatchingInstancesMessage,
+      ).toBeVisible();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      const errorMessage =
+        "Failed to extract the correlation key for 'nonExistingClientId'";
+      await operateFiltersPanelPage.displayOptionalFilter('Error Message');
+      await operateFiltersPanelPage.fillErrorMessageFilter(`${errorMessage}`);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Reset filter', async () => {
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect(
+        operateFiltersPanelPage.parentProcessInstanceKeyFilter,
+      ).toBeHidden();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThan(1);
+    });
+
+    await test.step('Filter by variable and assert results', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
+      await operateFiltersPanelPage.fillVariableValueFilter('604');
+
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+
+      await sleep(1_000);
+
+      await waitForAssertion({
+        assertion: async () => {
+          const variableProcessInstanceKeys = new Set<string>();
+          for (const element of await operateProcessesPage.processInstancesTable
+            .getByTestId('cell-processInstanceKey')
+            .elementHandles()) {
+            variableProcessInstanceKeys.add(await element.innerText());
+          }
+          expect(
+            variableProcessInstanceKeys.has(variableProcessInstanceKey),
+          ).toBeTruthy();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Filter by process instance key with one key and assert results', async () => {
+      await operateFiltersPanelPage.clickResetFilters();
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        `${variableProcessInstanceKey}`,
+      );
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.processInstanceKeyCell).toHaveText(
+            variableProcessInstanceKey,
+          );
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Filter by process instance key with multiple keys and assert results', async () => {
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+      const callActivityProcessInstanceKey =
+        callActivityProcessInstance.processInstanceKey.toString();
+      await operateFiltersPanelPage.resetFiltersButton.click();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+
+      await expect(
+        operateProcessesPage.processFinishedInstancesCheckbox,
+      ).toBeVisible();
+      await expect(
+        operateProcessesPage.processFinishedInstancesCheckbox,
+      ).toBeEnabled();
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
+
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        `${variableProcessInstanceKey}, ${callActivityProcessInstanceKey}`,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Reset filter', async () => {
+      await operateFiltersPanelPage.clickResetFilters();
+      await expect(
+        operateFiltersPanelPage.processInstanceKeysFilter,
+      ).toBeHidden();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThan(1);
+    });
+
+    await test.step('Filter by end and start date range', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: '1',
+        toDay: '1',
+        fromTime: '00:00:00',
+        toTime: '00:00:00',
+      });
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('End Date Range');
+
+      const todayDate = new Date();
+      console.log('Today date:', todayDate.getDate());
+
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: todayDate.getDate().toString(),
+        toDay: todayDate.getDate().toString(),
+        fromTime: '00:00:00',
+        toTime: '23:59:59',
+      });
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.removeOptionalFilter('Start Date Range');
+
+      await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
+      await operateFiltersPanelPage.displayOptionalFilter('Start Date Range');
+      await expect(operateFiltersPanelPage.startDateFilter).toBeVisible();
+
+      await operateFiltersPanelPage.pickDateTimeRange({
+        fromDay: todayDate.getDate().toString(),
+        toDay: todayDate.getDate().toString(),
+        fromTime: '00:00:00',
+        toTime: '23:59:59',
+      });
+
+      await operateFiltersPanelPage.clickApply();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
+      await expect
+        .poll(() => operateProcessesPage.processInstancesTable.count())
+        .toBeGreaterThanOrEqual(2);
+      await operateFiltersPanelPage.clickResetFilters();
+    });
+
+    await test.step('Filter by variable and operation id and assert results', async () => {
+      const processToCancelMeowInstance = {
+        processInstanceKey: Number(
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))
+            .processInstanceKey,
+        ),
+      };
+
+      const processToCancelGawInstance = {
+        processInstanceKey: Number(
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'gaw'}))
+            .processInstanceKey,
+        ),
+      };
+
+      const processToCancelInstanceMeowIK =
+        processToCancelMeowInstance.processInstanceKey.toString();
+      const processToCancelInstanceGawIK =
+        processToCancelGawInstance.processInstanceKey.toString();
+
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        `${processToCancelInstanceMeowIK}, ${processToCancelInstanceGawIK}`,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateProcessesPage.selectProcessCheckboxByPIK(
+        processToCancelInstanceMeowIK,
+        processToCancelInstanceGawIK,
+      );
+
+      await operateProcessesPage.clickCancelBatchOperationButton();
+
+      await operateProcessesPage.clickCancelProcessInstanceDialogButton();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateProcessesPage.clickGoToOperationDetailsButton();
+
+      await sleep(1_000);
+      await expect(operateOperationsDetailsPage.state).toBeVisible();
+
+      const operationId =
+        await operateOperationsDetailsPage.getBatchOperationId();
+
+      await page.goto(`operate/processes`);
+
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.processInstancesTable.first(),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('Operation Id');
+      await operateFiltersPanelPage.fillOperationIdFilter(operationId);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('2 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('sound');
+      await operateFiltersPanelPage.fillVariableValueFilter('"meow"');
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 results')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+  });
+
+  test('Verify flow node selection reflects in filters and assert results', async ({
+    operateFiltersPanelPage,
+    operateDiagramPage,
+    page,
+  }) => {
+    await test.step('Select process from dropdown and assert results', async () => {
+      await operateFiltersPanelPage.selectProcess('NamedEventsProcess');
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateFiltersPanelPage.processNameFilter).toHaveValue(
+            'NamedEventsProcess',
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await expect(operateDiagramPage.diagram).toBeVisible();
+    });
+
+    await test.step('Click start flow node and assert filter value and results', async () => {
+      await operateDiagramPage.clickFlowNode('StartEvent_OrderReceived');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order received',
+      );
+    });
+
+    await test.step('Click task flow nodes and assert filter value and results', async () => {
+      await operateDiagramPage.clickFlowNode('Activity_SendOrderConfirmation');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Send order confirmation',
+      );
+
+      await operateDiagramPage.clickFlowNode('Activity_PackItems');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Pack Items',
+      );
+
+      await operateDiagramPage.clickFlowNode('Activity_SendItems');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Send items',
+      );
+    });
+
+    await test.step('Click end event flow node and assert filter value and results', async () => {
+      await operateDiagramPage.clickFlowNode('Event_OrderFulfilled');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order fulfilled',
+      );
+    });
+
+    await test.step('Click intermediate throw event flow node and assert results', async () => {
+      await operateDiagramPage.clickFlowNode('Event_OrderConfirmed');
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue(
+        'Order Confirmed',
+      );
+    });
+
+    await test.step('Click same flow node again and see filter is removed', async () => {
+      await operateDiagramPage.clickFlowNode('Event_OrderConfirmed');
+
+      await expect(operateFiltersPanelPage.flowNodeFilter).toHaveValue('');
+    });
+  });
+
+  test('Reset filters when navigating away and assert results', async ({
+    page,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+    operateHomePage,
+  }) => {
+    await test.step('Apply Process Instance Key and variable filter and assert results', async () => {
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      const variableProcessInstanceKey =
+        variableProcessInstance.processInstanceKey.toString();
+      await operateFiltersPanelPage.fillProcessInstanceKeyFilter(
+        variableProcessInstanceKey,
+      );
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.processInstanceKeyCell).toHaveText(
+            variableProcessInstanceKey,
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await operateFiltersPanelPage.displayOptionalFilter('Variable');
+      await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
+      await operateFiltersPanelPage.fillVariableValueFilter('604');
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(page.getByText('1 result')).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Click on the "Process" link button in the header and assert the results', async () => {
+      await operateHomePage.clickProcessesTab();
+      await expect(
+        operateFiltersPanelPage.processInstanceKeysFilter,
+      ).toBeHidden();
+      await expect(operateFiltersPanelPage.variableNameFilter).toBeHidden();
+      await operateFiltersPanelPage.validateCheckedState(
+        [
+          operateFiltersPanelPage.activeInstancesCheckbox,
+          operateFiltersPanelPage.incidentsInstancesCheckbox,
+          operateFiltersPanelPage.runningInstancesCheckbox,
+        ],
+
+        [
+          operateFiltersPanelPage.finishedInstancesCheckbox,
+          operateFiltersPanelPage.completedInstancesCheckbox,
+          operateFiltersPanelPage.canceledInstancesCheckbox,
+        ],
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

This PR introduces [Verify Filter Functionality in Process View](https://github.com/camunda/camunda/issues/33949) for main.
That required new Page Object for OperateOperationDetails. For now this page has only properties required for current test.
Also this PR updates checkboxes locators in `OperateFiltersPanelPage.ts` and removes filtering functionality from `OperateProcessesPage.ts`, updates used functions accordingly.

## Related issues

related #33949 
closes #46093 

## On demand workflow
[Was green](https://github.com/camunda/camunda/actions/runs/22135005833)