### PR TITLE
fix: io mapping banner moves focus on render

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/IOMappingInfoBanner.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/IOMappingInfoBanner.tsx
@@ -22,6 +22,7 @@ const IOMappingInfoBanner: React.FC<Props> = ({type, text, onClose}) => {
       inline
       lowContrast
       subtitle={text}
+      hasFocus={false}
       actionButtonLabel="Learn more"
       onActionButtonClick={() => {
         window.open(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.test.tsx
@@ -107,4 +107,12 @@ describe('Input Mappings', () => {
       expect(screen.queryByText(message)).not.toBeInTheDocument();
     },
   );
+
+  it('should not move focus to the info banner on render', () => {
+    render(<InputOutputMappings type="Input" elementId="Activity_0qtp1k6" />, {
+      wrapper: Wrapper,
+    });
+
+    expect(document.activeElement).toBe(document.body);
+  });
 });


### PR DESCRIPTION
## Description

This is a minimal solution that no longer moves the focus to the banner when rendered. The problem is that `hasFocus` is **marked deprecated** and will be removed with Carbon v12.

I briefly explored the suggested approach of using [`Callout`](https://react.carbondesignsystem.com/?path=/docs/components-notifications-callout--overview) instead, and looked at [`InlineNotification`](https://react.carbondesignsystem.com/?path=/docs/components-notifications-inline--overview). `Callout` seems to be closed to a workable solution but **requires concerning style hacks** to get the layout to look as before.

I believe a proper solution for Carbon v12 is to rather align with design on a solution that does not require styling hacks... For this bugfix, it feels a bit out of scope before Camunda 8.9.

## Related issues

closes #45994
