### PR TITLE
feat: add member assign reminder to the Add Tenant flow

### DIFF
--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -8,21 +8,22 @@
 
 import { FC, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import {
-  Button, InlineNotification,
+  Button,
+  ContainedList,
+  ContainedListItem,
+  IconButton,
   Link,
   Stack,
-  StructuredListBody,
-  StructuredListCell,
-  StructuredListRow,
-  StructuredListWrapper,
 } from "@carbon/react";
-import { spacing06 } from "@carbon/elements";
+import { ArrowRight, InformationFilled } from "@carbon/icons-react";
+import { spacing03, spacing06 } from "@carbon/elements";
 import styled from "styled-components";
 import { documentationHref } from "src/components/documentation";
 import TextField from "src/components/form/TextField";
 import Modal, { FormModal, UseModalProps } from "src/components/modal";
-import { docsUrl } from "src/configuration";
+import { docsUrl, isOIDC } from "src/configuration";
 import { useApiCall } from "src/utility/api";
 import { createTenant } from "src/utility/api/tenants";
 import useTranslate from "src/utility/localization";
@@ -34,10 +35,6 @@ type FormData = {
   description: string;
 };
 
-const StyledStructuredListWrapper = styled(StructuredListWrapper)`
-  margin-bottom: 0;
-`;
-
 const RightAlignedButtonSet = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -45,19 +42,46 @@ const RightAlignedButtonSet = styled.div`
   gap: ${spacing06};
 `;
 
-const ASSIGN_ENTITY_ITEMS = [
+const InfoHint = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: ${spacing03};
+  margin-top: ${spacing03};
+  color: var(--cds-text-primary);
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  line-height: var(--cds-helper-text-01-line-height, 1.34);
+`;
+
+const ITEM_TO_TAB: Record<string, string> = {
+  assignUsers: "users",
+  assignGroups: "groups",
+  assignRoles: "roles",
+  assignMappingRules: "mapping-rules",
+  assignClients: "clients",
+};
+
+const BASE_ASSIGN_ENTITY_ITEMS = [
   "assignUsers",
   "assignGroups",
   "assignRoles",
+] as const;
+
+const OIDC_ASSIGN_ENTITY_ITEMS = [
   "assignMappingRules",
   "assignClients",
 ] as const;
 
+const ASSIGN_ENTITY_ITEMS = isOIDC
+  ? ([...BASE_ASSIGN_ENTITY_ITEMS, ...OIDC_ASSIGN_ENTITY_ITEMS] as const)
+  : BASE_ASSIGN_ENTITY_ITEMS;
+
 const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   const { t, Translate } = useTranslate("tenants");
-  const [createdTenantName, setCreatedTenantName] = useState<string | null>(
-    null,
-  );
+  const navigate = useNavigate();
+  const [createdTenant, setCreatedTenant] = useState<{
+    name: string;
+    tenantId: string;
+  } | null>(null);
   const [callAddTenant, { loading, error }] = useApiCall(createTenant, {
     suppressErrorNotification: true,
   });
@@ -79,65 +103,75 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     });
 
     if (success) {
-      setCreatedTenantName(data.name);
+      setCreatedTenant({ name: data.name, tenantId: data.tenantId });
     }
   };
 
-  if (createdTenantName) {
+  if (createdTenant) {
     return (
       <Modal
         open={open}
-        headline={t("tenantCreatedSuccessfully", { name: createdTenantName })}
+        headline={t("tenantCreatedSuccessfully", { name: createdTenant.name })}
         confirmLabel={t("close")}
         onClose={onSuccess}
         buttons={[
           <RightAlignedButtonSet key="close">
-            <Button kind="secondary" onClick={onSuccess}>
-              {t("close")}
+            <Button kind="primary" onClick={onSuccess} data-modal-primary-focus>
+              {t("gotIt")}
             </Button>
           </RightAlignedButtonSet>,
         ]}
       >
-        <Stack gap={spacing06}>
-          <strong>{t("nextStepAssignEntities")}</strong>
-          <StyledStructuredListWrapper>
-            <StructuredListBody>
-              {ASSIGN_ENTITY_ITEMS.map((item) => (
-                <StructuredListRow key={item}>
-                  <StructuredListCell>
-                    {t(item)}
-                    {item === "assignClients" && (
-                      <InlineNotification
-                        kind="info"
-                        lowContrast
-                        hideCloseButton
-                        style={{ marginTop: spacing06 }}
-                      >
-                        t("assignConnectorRoleInfo", {link: "blah"})
-                        <Translate i18nKey="assignConnectorRoleInfo">
-                          Assign the &ldquo;connector&rdquo; role to
-                          automatically assign all clients to this tenant. Your
-                          clients can be configured to
-                          <Link
-                            href={documentationHref(
-                              docsUrl,
-                              "/docs/components/identity/tenant/",
-                            )}
-                            target="_blank"
-                            inline
-                          >
-                            dynamically access assigned tenants
-                          </Link>
-                          .
-                        </Translate>
-                      </InlineNotification>
-                    )}
-                  </StructuredListCell>
-                </StructuredListRow>
-              ))}
-            </StructuredListBody>
-          </StyledStructuredListWrapper>
-        </Stack>
+        <ContainedList label={t("nextStepAssignEntities")}>
+          {ASSIGN_ENTITY_ITEMS.map((item) => (
+            <ContainedListItem
+              key={item}
+              action={
+                <IconButton
+                  label={t(item)}
+                  kind="ghost"
+                  onClick={() =>
+                    navigate(
+                      `/tenants/${createdTenant.tenantId}/${ITEM_TO_TAB[item]}`,
+                    )
+                  }
+                >
+                  <ArrowRight />
+                </IconButton>
+              }
+            >
+              {t(item)}
+              {item === "assignClients" && (
+                <InfoHint>
+                  <InformationFilled
+                    size={16}
+                    style={{ color: "var(--cds-support-info)", flexShrink: 0 }}
+                  />
+                  <div>
+                    <div>{t("assignConnectorRoleInfo")}</div>
+                    <div>
+                      <Translate i18nKey="dynamicAccessToAssignedTenantsInfoLink">
+                        Your clients can be configured to
+                        <Link
+                          href={documentationHref(
+                            docsUrl,
+                            "/docs/components/identity/tenant/",
+                          )}
+                          target="_blank"
+                          inline
+                          size="sm"
+                        >
+                          dynamically access assigned tenants
+                        </Link>
+                        .
+                      </Translate>
+                    </div>
+                  </div>
+                </InfoHint>
+              )}
+            </ContainedListItem>
+          ))}
+        </ContainedList>
       </Modal>
     );
   }

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -113,6 +113,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                 <IconButton
                   label={t(item)}
                   kind="ghost"
+                  align="left"
                   onClick={() => {
                     onClose?.();
                     void navigate(

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -17,7 +17,7 @@ import {
   Link,
   Stack,
 } from "@carbon/react";
-import { ArrowRight, InformationFilled } from "@carbon/icons-react";
+import { ArrowRight, InformationFilled } from "@carbon/react/icons";
 import { spacing03, spacing06 } from "@carbon/elements";
 import styled from "styled-components";
 import { documentationHref } from "src/components/documentation";
@@ -112,7 +112,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
       <Modal
         open={open}
         headline={t("tenantCreatedSuccessfully", { name: createdTenant.name })}
-        confirmLabel={t("close")}
+        passiveModal
         onClose={onSuccess}
         buttons={[
           <RightAlignedButtonSet key="close">
@@ -130,11 +130,12 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                 <IconButton
                   label={t(item)}
                   kind="ghost"
-                  onClick={() =>
+                  onClick={() => {
+                    onClose?.();
                     navigate(
                       `/tenants/${createdTenant.tenantId}/${ITEM_TO_TAB[item]}`,
-                    )
-                  }
+                    );
+                  }}
                 >
                   <ArrowRight />
                 </IconButton>

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -132,7 +132,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
                   kind="ghost"
                   onClick={() => {
                     onClose?.();
-                    navigate(
+                    void navigate(
                       `/tenants/${createdTenant.tenantId}/${ITEM_TO_TAB[item]}`,
                     );
                   }}

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -6,16 +6,26 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Stack } from "@carbon/react";
+import {
+  Button, InlineNotification,
+  Link,
+  Stack,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListRow,
+  StructuredListWrapper,
+} from "@carbon/react";
 import { spacing06 } from "@carbon/elements";
+import styled from "styled-components";
+import { documentationHref } from "src/components/documentation";
 import TextField from "src/components/form/TextField";
+import Modal, { FormModal, UseModalProps } from "src/components/modal";
+import { docsUrl } from "src/configuration";
 import { useApiCall } from "src/utility/api";
-import useTranslate from "src/utility/localization";
-import { FormModal, UseModalProps } from "src/components/modal";
 import { createTenant } from "src/utility/api/tenants";
-import { useNotifications } from "src/components/notifications";
+import useTranslate from "src/utility/localization";
 import { isValidTenantId } from "src/utility/validate";
 
 type FormData = {
@@ -24,9 +34,30 @@ type FormData = {
   description: string;
 };
 
+const StyledStructuredListWrapper = styled(StructuredListWrapper)`
+  margin-bottom: 0;
+`;
+
+const RightAlignedButtonSet = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: ${spacing06};
+`;
+
+const ASSIGN_ENTITY_ITEMS = [
+  "assignUsers",
+  "assignGroups",
+  "assignRoles",
+  "assignMappingRules",
+  "assignClients",
+] as const;
+
 const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
-  const { t } = useTranslate("tenants");
-  const { enqueueNotification } = useNotifications();
+  const { t, Translate } = useTranslate("tenants");
+  const [createdTenantName, setCreatedTenantName] = useState<string | null>(
+    null,
+  );
   const [callAddTenant, { loading, error }] = useApiCall(createTenant, {
     suppressErrorNotification: true,
   });
@@ -48,16 +79,68 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     });
 
     if (success) {
-      enqueueNotification({
-        kind: "success",
-        title: t("tenantCreated"),
-        subtitle: t("createTenantSuccess", {
-          name: data.name,
-        }),
-      });
-      onSuccess();
+      setCreatedTenantName(data.name);
     }
   };
+
+  if (createdTenantName) {
+    return (
+      <Modal
+        open={open}
+        headline={t("tenantCreatedSuccessfully", { name: createdTenantName })}
+        confirmLabel={t("close")}
+        onClose={onSuccess}
+        buttons={[
+          <RightAlignedButtonSet key="close">
+            <Button kind="secondary" onClick={onSuccess}>
+              {t("close")}
+            </Button>
+          </RightAlignedButtonSet>,
+        ]}
+      >
+        <Stack gap={spacing06}>
+          <strong>{t("nextStepAssignEntities")}</strong>
+          <StyledStructuredListWrapper>
+            <StructuredListBody>
+              {ASSIGN_ENTITY_ITEMS.map((item) => (
+                <StructuredListRow key={item}>
+                  <StructuredListCell>
+                    {t(item)}
+                    {item === "assignClients" && (
+                      <InlineNotification
+                        kind="info"
+                        lowContrast
+                        hideCloseButton
+                        style={{ marginTop: spacing06 }}
+                      >
+                        t("assignConnectorRoleInfo", {link: "blah"})
+                        <Translate i18nKey="assignConnectorRoleInfo">
+                          Assign the &ldquo;connector&rdquo; role to
+                          automatically assign all clients to this tenant. Your
+                          clients can be configured to
+                          <Link
+                            href={documentationHref(
+                              docsUrl,
+                              "/docs/components/identity/tenant/",
+                            )}
+                            target="_blank"
+                            inline
+                          >
+                            dynamically access assigned tenants
+                          </Link>
+                          .
+                        </Translate>
+                      </InlineNotification>
+                    )}
+                  </StructuredListCell>
+                </StructuredListRow>
+              ))}
+            </StructuredListBody>
+          </StyledStructuredListWrapper>
+        </Stack>
+      </Modal>
+    );
+  }
 
   return (
     <FormModal

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -18,8 +18,7 @@ import {
   Stack,
 } from "@carbon/react";
 import { ArrowRight, InformationFilled } from "@carbon/react/icons";
-import { spacing03, spacing06 } from "@carbon/elements";
-import styled from "styled-components";
+import { spacing06 } from "@carbon/elements";
 import { documentationHref } from "src/components/documentation";
 import TextField from "src/components/form/TextField";
 import Modal, { FormModal, UseModalProps } from "src/components/modal";
@@ -28,29 +27,13 @@ import { useApiCall } from "src/utility/api";
 import { createTenant } from "src/utility/api/tenants";
 import useTranslate from "src/utility/localization";
 import { isValidTenantId } from "src/utility/validate";
+import { InfoHint, RightAlignedButtonSet } from "src/pages/tenants/styled.ts";
 
 type FormData = {
   name: string;
   tenantId: string;
   description: string;
 };
-
-const RightAlignedButtonSet = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  gap: ${spacing06};
-`;
-
-const InfoHint = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: ${spacing03};
-  margin-top: ${spacing03};
-  color: var(--cds-text-primary);
-  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
-  line-height: var(--cds-helper-text-01-line-height, 1.34);
-`;
 
 const ITEM_TO_TAB: Record<string, string> = {
   assignUsers: "users",

--- a/identity/client/src/pages/tenants/styled.ts
+++ b/identity/client/src/pages/tenants/styled.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+import { spacing03, spacing06 } from "@carbon/elements";
+
+export const RightAlignedButtonSet = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: ${spacing06};
+`;
+
+export const InfoHint = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: ${spacing03};
+  margin-top: ${spacing03};
+  color: var(--cds-text-primary);
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  line-height: var(--cds-helper-text-01-line-height, 1.34);
+`;

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -83,6 +83,5 @@
   "pleaseEnterValidTenantId": "Please enter a valid Tenant ID (only characters, numbers and . _ - and max 31 characters)",
   "tenantNameRequired": "Tenant name is required",
   "searchByTenantId": "Search by tenant ID",
-  "close": "Close",
   "gotIt": "Got it"
 }

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -21,6 +21,14 @@
   "tenantMemberRemoved": "Tenant member has been removed.",
   "assignUsersToTenant": "Assign users to this Tenant",
   "tenantCreated": "Tenant created",
+  "tenantCreatedSuccessfully": "\u201c{{ name }}\u201d created successfully",
+  "nextStepAssignEntities": "Next step: assign entities to your new tenant",
+  "assignUsers": "Assign users",
+  "assignGroups": "Assign groups",
+  "assignRoles": "Assign roles",
+  "assignMappingRules": "Assign mapping rules",
+  "assignClients": "Assign clients",
+  "assignConnectorRoleInfo": "Assign the \u201cconnector\u201d role to automatically assign all clients to this tenant. Your clients can be configured to <1>dynamically access assigned tenants</1>.",
   "createTenantSuccess": "You have successfully created tenant {{ name }}",
   "deleteTenantSuccess": "You have successfully deleted tenant {{ name }}",
   "tenantIdPlaceholder": "Enter tenant ID",
@@ -72,5 +80,6 @@
   "removeClientFromTenant": "Are you sure you want to remove <strong>{{clientId}}</strong> from this tenant?",
   "pleaseEnterValidTenantId": "Please enter a valid Tenant ID (only characters, numbers and . _ - and max 31 characters)",
   "tenantNameRequired": "Tenant name is required",
-  "searchByTenantId": "Search by tenant ID"
+  "searchByTenantId": "Search by tenant ID",
+  "close": "Close"
 }

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -7,6 +7,7 @@
   "openTenantContextMenu": "Open tenant context menu",
   "tenantDetails": "Tenant details",
   "createTenant": "Create tenant",
+  "creatingTenant": "Creating tenant...",
   "createNewTenant": "Create new tenant",
   "learnMoreAboutTenants": "Learn more about tenants",
   "tenantsListCouldNotLoad": "The list of tenants could not be loaded.",
@@ -21,14 +22,15 @@
   "tenantMemberRemoved": "Tenant member has been removed.",
   "assignUsersToTenant": "Assign users to this Tenant",
   "tenantCreated": "Tenant created",
-  "tenantCreatedSuccessfully": "\u201c{{ name }}\u201d created successfully",
+  "tenantCreatedSuccessfully": "\u201c{{ name }}\u201d successfully created",
   "nextStepAssignEntities": "Next step: assign entities to your new tenant",
   "assignUsers": "Assign users",
   "assignGroups": "Assign groups",
   "assignRoles": "Assign roles",
   "assignMappingRules": "Assign mapping rules",
   "assignClients": "Assign clients",
-  "assignConnectorRoleInfo": "Assign the \u201cconnector\u201d role to automatically assign all clients to this tenant. Your clients can be configured to <1>dynamically access assigned tenants</1>.",
+  "assignConnectorRoleInfo": "Assign the \u201cconnector\u201d role to this tenant to automatically assign all clients with the same role.",
+  "dynamicAccessToAssignedTenantsInfoLink": "Your clients can be configured to <1>dynamically access assigned tenants</1>.",
   "createTenantSuccess": "You have successfully created tenant {{ name }}",
   "deleteTenantSuccess": "You have successfully deleted tenant {{ name }}",
   "tenantIdPlaceholder": "Enter tenant ID",
@@ -81,5 +83,6 @@
   "pleaseEnterValidTenantId": "Please enter a valid Tenant ID (only characters, numbers and . _ - and max 31 characters)",
   "tenantNameRequired": "Tenant name is required",
   "searchByTenantId": "Search by tenant ID",
-  "close": "Close"
+  "close": "Close",
+  "gotIt": "Got it"
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds in a new modal to the Add Tenant flow in the Identity UI, this mdal prompts users to consider assigning members to the newly created tenant with specific reference to the new Dynamic Access to Tenants feature.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45328
