### PR TITLE
Tombstone manifests before deletion

### DIFF
--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -364,6 +364,7 @@ components:
         - FAILED
         - INCOMPLETE
         - INCOMPATIBLE
+        - DELETED
       example: IN_PROGRESS
 
     HistoryStateCode:

--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -122,11 +122,5 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -116,5 +116,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Objects;
@@ -173,10 +174,18 @@ public final class AzureBackupStore implements BackupStore {
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.markAsDeleted(id);
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest == null) {
+            return;
+          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+            throw new UnexpectedManifestState(
+                "Cannot delete Backup with id '%s' while saving is in progress."
+                    .formatted(id.toString()));
+          }
+          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
-          manifestManager.deleteManifest(id);
+          manifestManager.deleteManifest(manifest);
         },
         executor);
   }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -189,7 +189,7 @@ public final class AzureBackupStore implements BackupStore {
             throw new UnexpectedManifestState(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
           }
           return switch (manifest.statusCode()) {
-            case FAILED, IN_PROGRESS ->
+            case FAILED, IN_PROGRESS, DELETED ->
                 throw new UnexpectedManifestState(
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -173,9 +173,10 @@ public final class AzureBackupStore implements BackupStore {
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.deleteManifest(id);
+          manifestManager.markAsDeleted(id);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
+          manifestManager.deleteManifest(id);
         },
         executor);
   }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -177,12 +177,11 @@ public final class AzureBackupStore implements BackupStore {
           final var manifest = manifestManager.getManifest(id);
           if (manifest == null) {
             return;
-          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+          } else if (manifest.statusCode() != StatusCode.DELETED) {
             throw new UnexpectedManifestState(
-                "Cannot delete Backup with id '%s' while saving is in progress."
+                "Cannot delete Backup with id '%s', must be marked as deleted."
                     .formatted(id.toString()));
           }
-          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
           manifestManager.deleteManifest(manifest);
@@ -224,6 +223,17 @@ public final class AzureBackupStore implements BackupStore {
         () -> {
           manifestManager.markAsFailed(id, failureReason);
           return BackupStatusCode.FAILED;
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var manifest = manifestManager.getManifest(id);
+          manifestManager.markAsDeleted(manifest);
+          return BackupStatusCode.DELETED;
         },
         executor);
   }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -170,6 +170,32 @@ public final class ManifestManager {
     }
   }
 
+  void markAsDeleted(final BackupIdentifier manifestId) {
+    assureContainerCreated();
+
+    final Manifest manifest = getManifest(manifestId);
+    if (manifest == null) {
+      return;
+    }
+
+    final var deletedManifest =
+        switch (manifest.statusCode()) {
+          case DELETED -> manifest;
+          case COMPLETED -> manifest.asCompleted().delete();
+          case IN_PROGRESS -> manifest.asInProgress().delete();
+          case FAILED -> manifest.asFailed().delete();
+        };
+
+    if (manifest != deletedManifest) {
+      try {
+        final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(manifestId));
+        blobClient.upload(BinaryData.fromBytes(MAPPER.writeValueAsBytes(deletedManifest)), true);
+      } catch (final JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
   public void deleteManifest(final BackupIdentifier id) {
     final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(id));
     final Manifest manifest = getManifest(id);

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -21,7 +21,7 @@ import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.BlockBlobItem;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
-import com.azure.storage.common.implementation.Constants;
+import com.azure.storage.common.implementation.Constants.HeaderConstants;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -157,6 +157,8 @@ public final class ManifestManager {
           case FAILED -> manifest.asFailed();
           case COMPLETED -> manifest.asCompleted().fail(failureReason);
           case IN_PROGRESS -> manifest.asInProgress().fail(failureReason);
+          case DELETED ->
+              throw new UnexpectedManifestState("Cannot fail a deleted manifest" + manifestId);
         };
 
     if (manifest != updatedManifest) {
@@ -261,7 +263,7 @@ public final class ManifestManager {
   public static void disableOverwrite(final BlobRequestConditions blobRequestConditions) {
     // Optionally limit requests to resources that do not match the passed ETag.
     // None will match therefore it will not overwrite.
-    blobRequestConditions.setIfNoneMatch(Constants.HeaderConstants.ETAG_WILDCARD);
+    blobRequestConditions.setIfNoneMatch(HeaderConstants.ETAG_WILDCARD);
   }
 
   record PersistedManifest(String eTag, InProgressManifest manifest) {}

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -106,7 +106,6 @@ public final class ManifestManager {
   void completeManifest(final PersistedManifest inProgressManifest) {
     final byte[] serializedManifest;
     final var completed = inProgressManifest.manifest().complete();
-    assureContainerCreated();
     try {
       serializedManifest = MAPPER.writeValueAsBytes(completed);
     } catch (final JsonProcessingException e) {
@@ -144,7 +143,6 @@ public final class ManifestManager {
   }
 
   void markAsFailed(final BackupIdentifier manifestId, final String failureReason) {
-    assureContainerCreated();
 
     final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(manifestId));
     Manifest manifest = getManifest(manifestId);
@@ -170,13 +168,7 @@ public final class ManifestManager {
     }
   }
 
-  void markAsDeleted(final BackupIdentifier manifestId) {
-    assureContainerCreated();
-
-    final Manifest manifest = getManifest(manifestId);
-    if (manifest == null) {
-      return;
-    }
+  void markAsDeleted(final Manifest manifest) {
 
     final var deletedManifest =
         switch (manifest.statusCode()) {
@@ -188,7 +180,8 @@ public final class ManifestManager {
 
     if (manifest != deletedManifest) {
       try {
-        final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(manifestId));
+        final BlobClient blobClient =
+            blobContainerClient.getBlobClient(manifestIdPath(manifest.id()));
         blobClient.upload(BinaryData.fromBytes(MAPPER.writeValueAsBytes(deletedManifest)), true);
       } catch (final JsonProcessingException e) {
         throw new RuntimeException(e);
@@ -196,21 +189,13 @@ public final class ManifestManager {
     }
   }
 
-  public void deleteManifest(final BackupIdentifier id) {
-    final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(id));
-    final Manifest manifest = getManifest(id);
-    if (manifest == null) {
-      return;
-    } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
-      throw new UnexpectedManifestState(
-          "Cannot delete Backup with id '%s' while saving is in progress."
-              .formatted(id.toString()));
-    }
-
+  public void deleteManifest(final Manifest manifest) {
+    final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(manifest.id()));
     blobClient.delete();
   }
 
   Manifest getManifest(final BackupIdentifier id) {
+    assureContainerCreated();
     return getManifestWithPath(
         MANIFEST_PATH_FORMAT.formatted(id.partitionId(), id.checkpointId(), id.nodeId()));
   }

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -109,8 +109,8 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Cannot delete Backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}' \
-                while saving is in progress.""");
+                'BackupId{node=1, partition=2, checkpoint=3}'\
+                , must be marked as deleted.""");
   }
 
   @ParameterizedTest

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.camunda.zeebe.util.VersionUtil;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+final class ManifestManagerTest {
+
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+
+  private ManifestManager manifestManager;
+  private BackupIdentifierImpl backupIdentifier;
+  private BackupImpl backup;
+
+  @BeforeEach
+  void setUp() {
+    final String containerName = UUID.randomUUID().toString();
+    final BlobServiceClient blobServiceClient =
+        new BlobServiceClientBuilder()
+            .connectionString(AZURITE_CONTAINER.getConnectString())
+            .buildClient();
+    final BlobContainerClient blobContainerClient =
+        blobServiceClient.getBlobContainerClient(containerName);
+    manifestManager = new ManifestManager(blobContainerClient, true);
+    backupIdentifier = new BackupIdentifierImpl(1337, 0, 42L);
+    backup = createBackup(backupIdentifier);
+  }
+
+  private static BackupImpl createBackup(final BackupIdentifierImpl backupIdentifier) {
+    return new BackupImpl(
+        backupIdentifier,
+        new BackupDescriptorImpl(
+            backupIdentifier.checkpointId(),
+            1,
+            VersionUtil.getVersion(),
+            Instant.now(),
+            CheckpointType.MANUAL_BACKUP),
+        new NamedFileSetImpl(Map.of()),
+        new NamedFileSetImpl(Map.of()));
+  }
+
+  @Nested
+  class ManifestDeleteTransitionTest {
+    @Test
+    void shouldMarkInProgressManifestAsDeleted() {
+      // given
+      final var persisted = manifestManager.createInitialManifest(backup);
+      final var inProgressManifest = persisted.manifest();
+
+      // when
+      manifestManager.markAsDeleted(inProgressManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(inProgressManifest.id());
+    }
+
+    @Test
+    void shouldMarkCompletedManifestAsDeleted() {
+      // given
+      final var persisted = manifestManager.createInitialManifest(backup);
+      manifestManager.completeManifest(persisted);
+      final var completedManifest = manifestManager.getManifest(backupIdentifier);
+
+      // when
+      manifestManager.markAsDeleted(completedManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(backupIdentifier);
+    }
+
+    @Test
+    void shouldMarkFailedManifestAsDeleted() {
+      // given
+      manifestManager.createInitialManifest(backup);
+      manifestManager.markAsFailed(backupIdentifier, "failure reason");
+      final var failedManifest = manifestManager.getManifest(backupIdentifier);
+
+      // when
+      manifestManager.markAsDeleted(failedManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(backupIdentifier);
+    }
+
+    @Test
+    void shouldNotUpdateAlreadyDeletedManifest() {
+      // given
+      final var persisted = manifestManager.createInitialManifest(backup);
+      manifestManager.completeManifest(persisted);
+      final var completedManifest = manifestManager.getManifest(backupIdentifier);
+      manifestManager.markAsDeleted(completedManifest);
+      final var deletedManifest = manifestManager.getManifest(backupIdentifier);
+      final var modifiedAt = deletedManifest.asDeleted().modifiedAt();
+
+      // when
+      manifestManager.markAsDeleted(deletedManifest);
+
+      // then - manifest should remain deleted and unchanged
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.asDeleted().modifiedAt()).isEqualTo(modifiedAt);
+    }
+  }
+}

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
-import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -58,7 +57,7 @@ final class ManifestManagerTest {
         new BackupDescriptorImpl(
             backupIdentifier.checkpointId(),
             1,
-            VersionUtil.getVersion(),
+            "8.9.0",
             Instant.now(),
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/Manifest.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/Manifest.java
@@ -60,6 +60,8 @@ public sealed interface Manifest {
 
   FailedManifest asFailed();
 
+  DeletedManifest asDeleted();
+
   static BackupStatus toStatus(final Manifest manifest) {
     return switch (manifest.statusCode()) {
       case IN_PROGRESS ->
@@ -86,6 +88,14 @@ public sealed interface Manifest {
               Optional.ofNullable(manifest.asFailed().failureReason()),
               Optional.ofNullable(manifest.createdAt()),
               Optional.ofNullable(manifest.modifiedAt()));
+      case DELETED ->
+          new BackupStatusImpl(
+              manifest.id(),
+              Optional.ofNullable(manifest.descriptor()),
+              BackupStatusCode.DELETED,
+              Optional.empty(),
+              Optional.ofNullable(manifest.createdAt()),
+              Optional.ofNullable(manifest.modifiedAt()));
     };
   }
 
@@ -94,11 +104,15 @@ public sealed interface Manifest {
     CompletedManifest complete();
 
     FailedManifest fail(final String failureReason);
+
+    DeletedManifest delete();
   }
 
   sealed interface CompletedManifest extends Manifest permits ManifestImpl {
 
     FailedManifest fail(final String failureReason);
+
+    DeletedManifest delete();
 
     FileSet snapshot();
 
@@ -108,11 +122,16 @@ public sealed interface Manifest {
   sealed interface FailedManifest extends Manifest permits ManifestImpl {
 
     String failureReason();
+
+    DeletedManifest delete();
   }
+
+  sealed interface DeletedManifest extends Manifest permits ManifestImpl {}
 
   enum StatusCode {
     IN_PROGRESS,
     COMPLETED,
-    FAILED
+    FAILED,
+    DELETED
   }
 }

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/ManifestImpl.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/ManifestImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.common;
 
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.COMPLETED;
+import static io.camunda.zeebe.backup.common.Manifest.StatusCode.DELETED;
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.FAILED;
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.IN_PROGRESS;
 
@@ -24,7 +25,10 @@ public record ManifestImpl(
     Instant createdAt,
     Instant modifiedAt,
     String failureReason)
-    implements Manifest.InProgressManifest, Manifest.CompletedManifest, Manifest.FailedManifest {
+    implements Manifest.InProgressManifest,
+        Manifest.CompletedManifest,
+        Manifest.FailedManifest,
+        Manifest.DeletedManifest {
 
   public static final String ERROR_MSG_WRONG_STATE =
       "Expected a failed Manifest to set failureReason '%s', but was in state '%s'.";
@@ -60,6 +64,12 @@ public record ManifestImpl(
   }
 
   @Override
+  public DeletedManifest delete() {
+    return new ManifestImpl(
+        id, descriptor, DELETED, snapshot, segments, createdAt, Instant.now(), null);
+  }
+
+  @Override
   public InProgressManifest asInProgress() {
     if (statusCode != IN_PROGRESS) {
       throw new UnexpectedManifestState(IN_PROGRESS, statusCode);
@@ -81,6 +91,15 @@ public record ManifestImpl(
   public FailedManifest asFailed() {
     if (statusCode != FAILED) {
       throw new UnexpectedManifestState(FAILED, statusCode);
+    }
+
+    return this;
+  }
+
+  @Override
+  public DeletedManifest asDeleted() {
+    if (statusCode != DELETED) {
+      throw new UnexpectedManifestState(DELETED, statusCode);
     }
 
     return this;

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateCastingTest.java
@@ -76,4 +76,122 @@ final class ManifestStateCastingTest {
         .isInstanceOf(UnexpectedManifestState.class)
         .hasMessageContaining("but was in 'IN_PROGRESS'");
   }
+
+  @Test
+  void shouldFailOnAsDeletedWhenInProgress() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    // when expect thrown
+    assertThatThrownBy(manifest::asDeleted)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'IN_PROGRESS'");
+  }
+
+  @Test
+  void shouldFailOnAsDeletedWhenCompleted() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var completed = manifest.complete();
+
+    // when expect thrown
+    assertThatThrownBy(completed::asDeleted)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'COMPLETED'");
+  }
+
+  @Test
+  void shouldFailOnAsDeletedWhenFailed() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var failed = manifest.fail("failure reason");
+
+    // when expect thrown
+    assertThatThrownBy(failed::asDeleted)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'FAILED'");
+  }
+
+  @Test
+  void shouldFailOnAsInProgressWhenDeleted() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var deleted = manifest.delete();
+
+    // when expect thrown
+    assertThatThrownBy(deleted::asInProgress)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'DELETED'");
+  }
+
+  @Test
+  void shouldFailOnAsCompletedWhenDeleted() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var deleted = manifest.delete();
+
+    // when expect thrown
+    assertThatThrownBy(deleted::asCompleted)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'DELETED'");
+  }
+
+  @Test
+  void shouldFailOnAsFailedWhenDeleted() {
+    // given
+    final var manifest =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var deleted = manifest.delete();
+
+    // when expect thrown
+    assertThatThrownBy(deleted::asFailed)
+        .isInstanceOf(UnexpectedManifestState.class)
+        .hasMessageContaining("but was in 'DELETED'");
+  }
 }

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/manifest/ManifestStateTransitionTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.common.manifest;
 
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.COMPLETED;
+import static io.camunda.zeebe.backup.common.Manifest.StatusCode.DELETED;
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.FAILED;
 import static io.camunda.zeebe.backup.common.Manifest.StatusCode.IN_PROGRESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,8 +62,9 @@ final class ManifestStateTransitionTest {
     assertThat(completed.statusCode()).isEqualTo(COMPLETED);
     assertThat(completed.createdAt().getEpochSecond()).isPositive();
     assertThat(completed.modifiedAt().getEpochSecond()).isPositive();
-    assertThat(completed.createdAt()).isBefore(completed.modifiedAt());
-    assertThat(completed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(completed.createdAt())
+        .isBefore(completed.modifiedAt())
+        .isEqualTo(created.modifiedAt());
     assertThat(completed.modifiedAt()).isNotEqualTo(created.modifiedAt());
   }
 
@@ -85,8 +87,7 @@ final class ManifestStateTransitionTest {
     assertThat(failed.statusCode()).isEqualTo(FAILED);
     assertThat(failed.createdAt().getEpochSecond()).isPositive();
     assertThat(failed.modifiedAt().getEpochSecond()).isPositive();
-    assertThat(failed.createdAt()).isBefore(failed.modifiedAt());
-    assertThat(failed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(failed.createdAt()).isBefore(failed.modifiedAt()).isEqualTo(created.modifiedAt());
     assertThat(failed.modifiedAt()).isNotEqualTo(created.modifiedAt());
     assertThat(failed.failureReason()).isEqualTo("expected failure reason");
   }
@@ -112,9 +113,81 @@ final class ManifestStateTransitionTest {
     assertThat(failed.statusCode()).isEqualTo(FAILED);
     assertThat(failed.createdAt().getEpochSecond()).isPositive();
     assertThat(failed.modifiedAt().getEpochSecond()).isPositive();
-    assertThat(failed.createdAt()).isBefore(failed.modifiedAt());
-    assertThat(failed.createdAt()).isEqualTo(created.modifiedAt());
+    assertThat(failed.createdAt()).isBefore(failed.modifiedAt()).isEqualTo(created.modifiedAt());
     assertThat(failed.modifiedAt()).isNotEqualTo(created.modifiedAt());
     assertThat(failed.failureReason()).isEqualTo("expected failure reason");
+  }
+
+  @Test
+  void shouldUpdateManifestFromInProgressToDeleted() {
+    // given
+    final var created =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    // when
+    final var deleted = created.delete();
+
+    // then
+    assertThat(deleted.statusCode()).isEqualTo(DELETED);
+    assertThat(deleted.createdAt().getEpochSecond()).isPositive();
+    assertThat(deleted.modifiedAt().getEpochSecond()).isPositive();
+    assertThat(deleted.createdAt()).isBefore(deleted.modifiedAt()).isEqualTo(created.modifiedAt());
+    assertThat(deleted.modifiedAt()).isNotEqualTo(created.modifiedAt());
+  }
+
+  @Test
+  void shouldUpdateManifestFromCompletedToDeleted() {
+    // given
+    final var created =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var completed = created.complete();
+
+    // when
+    final var deleted = completed.delete();
+
+    // then
+    assertThat(deleted.statusCode()).isEqualTo(DELETED);
+    assertThat(deleted.createdAt().getEpochSecond()).isPositive();
+    assertThat(deleted.modifiedAt().getEpochSecond()).isPositive();
+    assertThat(deleted.createdAt()).isBefore(deleted.modifiedAt()).isEqualTo(created.modifiedAt());
+    assertThat(deleted.modifiedAt()).isNotEqualTo(completed.modifiedAt());
+  }
+
+  @Test
+  void shouldUpdateManifestFromFailedToDeleted() {
+    // given
+    final var created =
+        Manifest.createInProgress(
+            new BackupImpl(
+                new BackupIdentifierImpl(1, 2, 43),
+                new BackupDescriptorImpl(
+                    2345234L, 3, "1.2.0-SNAPSHOT", Instant.now(), CheckpointType.MANUAL_BACKUP),
+                null,
+                null));
+
+    final var failed = created.fail("expected failure reason");
+
+    // when
+    final var deleted = failed.delete();
+
+    // then
+    assertThat(deleted.statusCode()).isEqualTo(DELETED);
+    assertThat(deleted.createdAt().getEpochSecond()).isPositive();
+    assertThat(deleted.modifiedAt().getEpochSecond()).isPositive();
+    assertThat(deleted.createdAt()).isBefore(deleted.modifiedAt()).isEqualTo(created.modifiedAt());
+    assertThat(deleted.modifiedAt()).isNotEqualTo(failed.modifiedAt());
   }
 }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -148,7 +148,7 @@ public final class FilesystemBackupStore implements BackupStore {
             throw new UnexpectedManifestState(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
           }
           return switch (manifest.statusCode()) {
-            case FAILED, IN_PROGRESS ->
+            case FAILED, IN_PROGRESS, DELETED ->
                 throw new UnexpectedManifestState(
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -136,12 +136,11 @@ public final class FilesystemBackupStore implements BackupStore {
           final var manifest = manifestManager.getManifest(id);
           if (manifest == null) {
             return;
-          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+          } else if (manifest.statusCode() != StatusCode.DELETED) {
             throw new UnexpectedManifestState(
-                "Cannot delete Backup with id '%s' while saving is in progress."
+                "Cannot delete Backup with id '%s', must be marked as deleted."
                     .formatted(id.toString()));
           }
-          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
           manifestManager.deleteManifest(manifest);
@@ -183,6 +182,17 @@ public final class FilesystemBackupStore implements BackupStore {
         () -> {
           manifestManager.markAsFailed(id, failureReason);
           return BackupStatusCode.FAILED;
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var manifest = manifestManager.getManifest(id);
+          manifestManager.markAsDeleted(manifest);
+          return BackupStatusCode.DELETED;
         },
         executor);
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -132,9 +132,10 @@ public final class FilesystemBackupStore implements BackupStore {
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.deleteManifest(id);
+          manifestManager.markAsDeleted(id);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
+          manifestManager.deleteManifest(id);
         },
         executor);
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -132,10 +133,18 @@ public final class FilesystemBackupStore implements BackupStore {
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.markAsDeleted(id);
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest == null) {
+            return;
+          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+            throw new UnexpectedManifestState(
+                "Cannot delete Backup with id '%s' while saving is in progress."
+                    .formatted(id.toString()));
+          }
+          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
-          manifestManager.deleteManifest(id);
+          manifestManager.deleteManifest(manifest);
         },
         executor);
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -133,12 +133,7 @@ public final class ManifestManager {
     updateManifestFile(manifest, updatedManifest);
   }
 
-  void markAsDeleted(final BackupIdentifier manifestId) {
-    final Manifest manifest = getManifest(manifestId);
-    if (manifest == null) {
-      return;
-    }
-
+  void markAsDeleted(final Manifest manifest) {
     final var deletedManifest =
         switch (manifest.statusCode()) {
           case DELETED -> manifest;
@@ -162,23 +157,14 @@ public final class ManifestManager {
     }
   }
 
-  void deleteManifest(final BackupIdentifier id) {
-    final Manifest manifest = getManifest(id);
-    if (manifest == null) {
-      return;
-    } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
-      throw new UnexpectedManifestState(
-          "Cannot delete Backup with id '%s' while saving is in progress."
-              .formatted(id.toString()));
-    }
-
+  void deleteManifest(final Manifest manifest) {
     try {
       final var path = manifestPath(manifest);
       Files.delete(path);
-      final var dirLimit = manifestsPath.resolve(String.valueOf(id.partitionId()));
+      final var dirLimit = manifestsPath.resolve(String.valueOf(manifest.id().partitionId()));
       FilesystemBackupStore.backtrackDeleteEmptyParents(path.getParent(), dirLimit);
     } catch (final NoSuchFileException e) {
-      LOGGER.warn("Try to remove unknown manifest with id {}", id);
+      LOGGER.warn("Try to remove unknown manifest with id {}", manifest.id());
     } catch (final IOException e) {
       throw new UncheckedIOException("Unable to delete manifest", e);
     }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -126,6 +126,8 @@ public final class ManifestManager {
           case FAILED -> manifest.asFailed();
           case COMPLETED -> manifest.asCompleted().fail(failureReason);
           case IN_PROGRESS -> manifest.asInProgress().fail(failureReason);
+          case DELETED ->
+              throw new UnexpectedManifestState("Cannot fail a deleted manifest" + manifestId);
         };
 
     if (manifest != updatedManifest) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -130,10 +130,31 @@ public final class ManifestManager {
               throw new UnexpectedManifestState("Cannot fail a deleted manifest" + manifestId);
         };
 
-    if (manifest != updatedManifest) {
+    updateManifestFile(manifest, updatedManifest);
+  }
+
+  void markAsDeleted(final BackupIdentifier manifestId) {
+    final Manifest manifest = getManifest(manifestId);
+    if (manifest == null) {
+      return;
+    }
+
+    final var deletedManifest =
+        switch (manifest.statusCode()) {
+          case DELETED -> manifest;
+          case COMPLETED -> manifest.asCompleted().delete();
+          case IN_PROGRESS -> manifest.asInProgress().delete();
+          case FAILED -> manifest.asFailed().delete();
+        };
+
+    updateManifestFile(manifest, deletedManifest);
+  }
+
+  private void updateManifestFile(final Manifest originManifest, final Manifest updatedManifest) {
+    if (originManifest != updatedManifest) {
       try {
         final var serializedManifest = MAPPER.writeValueAsBytes(updatedManifest);
-        final var path = manifestPath(manifest);
+        final var path = manifestPath(originManifest);
         Files.write(path, serializedManifest, StandardOpenOption.SYNC);
       } catch (final IOException e) {
         throw new UncheckedIOException("Unable to write updated manifest", e);

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -103,8 +103,8 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Cannot delete Backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}' \
-                while saving is in progress.""");
+                'BackupId{node=1, partition=2, checkpoint=3}'\
+                , must be marked as deleted.""");
   }
 
   @ParameterizedTest
@@ -130,6 +130,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
   void parentDirectoriesAreDeletedAfterDeletion(final Backup backup) {
     // given
     getStore().save(backup).join();
+    getStore().markDeleted(backup.id()).join();
 
     // when
     getStore().delete(backup.id()).join();
@@ -152,6 +153,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
     final var node2Backup = TestBackupProvider.simpleBackupWithId(node2BackupId);
 
     getStore().save(node1Backup).join();
+    getStore().markDeleted(node1Backup.id()).join();
     getStore().save(node2Backup).join();
 
     // when

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestSta
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.FailedManifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -176,5 +178,73 @@ class ManifestManagerTest {
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of()));
+  }
+
+  @Nested
+  class ManifestDeleteTransitionTest {
+    @Test
+    void shouldMarkInProgressManifestAsDeleted() throws IOException {
+      // given
+      final var inProgressManifest = createInitialManifest();
+
+      // when
+      manifestManager.markAsDeleted(inProgressManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(inProgressManifest.id());
+    }
+
+    @Test
+    void shouldMarkCompletedManifestAsDeleted() throws IOException {
+      // given
+      final var inProgressManifest = createInitialManifest();
+      manifestManager.completeManifest(inProgressManifest);
+      final var completedManifest = manifestManager.getManifest(backupIdentifier);
+
+      // when
+      manifestManager.markAsDeleted(completedManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(inProgressManifest.id());
+    }
+
+    @Test
+    void shouldMarkFailedManifestAsDeleted() throws IOException {
+      // given
+      final var inProgressManifest = createInitialManifest();
+      manifestManager.markAsFailed(backupIdentifier, "failure reason");
+      final var failedManifest = manifestManager.getManifest(backupIdentifier);
+
+      // when
+      manifestManager.markAsDeleted(failedManifest);
+
+      // then
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.id()).isEqualTo(inProgressManifest.id());
+    }
+
+    @Test
+    void shouldNotUpdateAlreadyDeletedManifest() throws IOException {
+      // given
+      final var inProgressManifest = createInitialManifest();
+      manifestManager.completeManifest(inProgressManifest);
+      final var completedManifest = manifestManager.getManifest(backupIdentifier);
+      manifestManager.markAsDeleted(completedManifest);
+      final var deletedManifest = manifestManager.getManifest(backupIdentifier);
+      final var modifiedAt = deletedManifest.asDeleted().modifiedAt();
+
+      // when
+      manifestManager.markAsDeleted(deletedManifest);
+
+      // then - manifest should remain deleted and unchanged
+      final var manifest = manifestManager.getManifest(backupIdentifier);
+      assertThat(manifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      assertThat(manifest.asDeleted().modifiedAt()).isEqualTo(modifiedAt);
+    }
   }
 }

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -116,7 +116,7 @@ class ManifestManagerTest {
     final var inProgressManifest = createInitialManifest();
     manifestManager.completeManifest(inProgressManifest);
 
-    manifestManager.deleteManifest(backupIdentifier);
+    manifestManager.deleteManifest(inProgressManifest);
 
     final var manifestPath = tempDir.resolve("0/42/1337/manifest.json");
     assertThat(Files.exists(manifestPath)).isFalse();

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -139,11 +139,13 @@ public final class GcsBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
+
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.deleteManifest(id);
+          manifestManager.markAsDeleted(id);
           fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
+          manifestManager.deleteManifest(id);
         },
         executor);
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -157,7 +157,7 @@ public final class GcsBackupStore implements BackupStore {
             throw new RuntimeException(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
           }
           return switch (manifest.statusCode()) {
-            case FAILED, IN_PROGRESS ->
+            case FAILED, DELETED, IN_PROGRESS ->
                 throw new RuntimeException(
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -21,7 +21,9 @@ import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 import java.nio.file.Path;
@@ -142,10 +144,18 @@ public final class GcsBackupStore implements BackupStore {
 
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.markAsDeleted(id);
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest == null) {
+            return;
+          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+            throw new UnexpectedManifestState(
+                "Cannot delete Backup with id '%s' while saving is in progress."
+                    .formatted(id.toString()));
+          }
+          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
-          manifestManager.deleteManifest(id);
+          manifestManager.deleteManifest(manifest);
         },
         executor);
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -147,12 +147,11 @@ public final class GcsBackupStore implements BackupStore {
           final var manifest = manifestManager.getManifest(id);
           if (manifest == null) {
             return;
-          } else if (manifest.statusCode() == StatusCode.IN_PROGRESS) {
+          } else if (manifest.statusCode() != StatusCode.DELETED) {
             throw new UnexpectedManifestState(
-                "Cannot delete Backup with id '%s' while saving is in progress."
+                "Cannot delete Backup with id '%s', must be marked as deleted."
                     .formatted(id.toString()));
           }
-          manifestManager.markAsDeleted(manifest);
           fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
           manifestManager.deleteManifest(manifest);
@@ -211,6 +210,20 @@ public final class GcsBackupStore implements BackupStore {
         () -> {
           manifestManager.markAsFailed(id, failureReason);
           return BackupStatusCode.FAILED;
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest == null) {
+            throw new RuntimeException(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
+          }
+          manifestManager.markAsDeleted(manifest);
+          return BackupStatusCode.DELETED;
         },
         executor);
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -161,6 +161,9 @@ public final class ManifestManager {
           case FAILED -> existingManifest.asFailed();
           case COMPLETED -> existingManifest.asCompleted().fail(failureReason);
           case IN_PROGRESS -> existingManifest.asInProgress().fail(failureReason);
+          case DELETED ->
+              throw new UnexpectedManifestState(
+                  "Cannot fail a deleted manifest" + existingManifest.id());
         };
 
     if (existingManifest != updatedManifest) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -204,6 +204,30 @@ public final class ManifestManager {
     client.delete(manifestBlobInfo(id).getBlobId());
   }
 
+  public void markAsDeleted(final BackupIdentifier id) {
+    final var blobInfo = manifestBlobInfo(id);
+    final var blob = client.get(blobInfo.getBlobId());
+    if (blob != null) {
+      try {
+        final var existingManifest = MAPPER.readValue(blob.getContent(), Manifest.class);
+        final var deletedManifest =
+            switch (existingManifest.statusCode()) {
+              case DELETED -> existingManifest;
+              case COMPLETED -> existingManifest.asCompleted().delete();
+              case IN_PROGRESS -> existingManifest.asInProgress().delete();
+              case FAILED -> existingManifest.asFailed().delete();
+            };
+        if (existingManifest != deletedManifest) {
+          client.create(blobInfo, MAPPER.writeValueAsBytes(deletedManifest));
+        }
+      } catch (final JsonProcessingException e) {
+        throw new RuntimeException(e);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+
   private BlobInfo manifestBlobInfo(final BackupIdentifier id) {
     final var blobName =
         MANIFEST_PATH_FORMAT.formatted(

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -200,30 +200,25 @@ public final class ManifestManager {
         .toList();
   }
 
-  public void deleteManifest(final BackupIdentifier id) {
-    client.delete(manifestBlobInfo(id).getBlobId());
+  public void deleteManifest(final Manifest manifest) {
+    final var blobInfo = manifestBlobInfo(manifest.id());
+    client.delete(blobInfo.getBlobId());
   }
 
-  public void markAsDeleted(final BackupIdentifier id) {
-    final var blobInfo = manifestBlobInfo(id);
-    final var blob = client.get(blobInfo.getBlobId());
-    if (blob != null) {
+  public void markAsDeleted(final Manifest manifest) {
+    final var deletedManifest =
+        switch (manifest.statusCode()) {
+          case DELETED -> manifest;
+          case COMPLETED -> manifest.asCompleted().delete();
+          case IN_PROGRESS -> manifest.asInProgress().delete();
+          case FAILED -> manifest.asFailed().delete();
+        };
+    if (manifest != deletedManifest) {
+      final var blobInfo = manifestBlobInfo(manifest.id());
       try {
-        final var existingManifest = MAPPER.readValue(blob.getContent(), Manifest.class);
-        final var deletedManifest =
-            switch (existingManifest.statusCode()) {
-              case DELETED -> existingManifest;
-              case COMPLETED -> existingManifest.asCompleted().delete();
-              case IN_PROGRESS -> existingManifest.asInProgress().delete();
-              case FAILED -> existingManifest.asFailed().delete();
-            };
-        if (existingManifest != deletedManifest) {
-          client.create(blobInfo, MAPPER.writeValueAsBytes(deletedManifest));
-        }
+        client.create(blobInfo, MAPPER.writeValueAsBytes(deletedManifest));
       } catch (final JsonProcessingException e) {
         throw new RuntimeException(e);
-      } catch (final IOException e) {
-        throw new UncheckedIOException(e);
       }
     }
   }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -209,5 +212,146 @@ final class ManifestManagerTest {
     Assertions.assertThatThrownBy(() -> manager.completeManifest(persisted))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected but unhandled");
+  }
+
+  @Nested
+  class ManifestDeleteTransitionTest {
+    @Test
+    void shouldMarkInProgressManifestAsDeleted() throws IOException {
+      // given
+      final var client = Mockito.mock(Storage.class);
+      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, 2, 3),
+              new BackupDescriptorImpl(
+                  1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of()),
+              new NamedFileSetImpl(Map.of()));
+      final var inProgressManifest = Manifest.createInProgress(backup);
+
+      final var blob = Mockito.mock(Blob.class);
+      Mockito.when(blob.getContent())
+          .thenReturn(ManifestManager.MAPPER.writeValueAsBytes(inProgressManifest));
+      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
+
+      // when
+      manager.markAsDeleted(backup.id());
+
+      // then
+      final var captor = ArgumentCaptor.forClass(byte[].class);
+      Mockito.verify(client).create(Mockito.any(BlobInfo.class), captor.capture());
+
+      final var actualManifest =
+          ManifestManager.MAPPER.readValue(captor.getValue(), Manifest.class);
+      Assertions.assertThat(actualManifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      Assertions.assertThat(actualManifest.id()).isEqualTo(inProgressManifest.id());
+    }
+
+    @Test
+    void shouldMarkCompletedManifestAsDeleted() throws IOException {
+      // given
+      final var client = Mockito.mock(Storage.class);
+      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, 2, 3),
+              new BackupDescriptorImpl(
+                  1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of()),
+              new NamedFileSetImpl(Map.of()));
+      final var completedManifest = Manifest.createInProgress(backup).complete();
+
+      final var blob = Mockito.mock(Blob.class);
+      Mockito.when(blob.getContent())
+          .thenReturn(ManifestManager.MAPPER.writeValueAsBytes(completedManifest));
+      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
+
+      // when
+      manager.markAsDeleted(backup.id());
+
+      // then
+      final var captor = ArgumentCaptor.forClass(byte[].class);
+      Mockito.verify(client).create(Mockito.any(BlobInfo.class), captor.capture());
+
+      final var actualManifest =
+          ManifestManager.MAPPER.readValue(captor.getValue(), Manifest.class);
+      Assertions.assertThat(actualManifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      Assertions.assertThat(actualManifest.id()).isEqualTo(completedManifest.id());
+    }
+
+    @Test
+    void shouldMarkFailedManifestAsDeleted() throws IOException {
+      // given
+      final var client = Mockito.mock(Storage.class);
+      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, 2, 3),
+              new BackupDescriptorImpl(
+                  1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of()),
+              new NamedFileSetImpl(Map.of()));
+      final var failedManifest = Manifest.createInProgress(backup).fail("failure reason");
+
+      final var blob = Mockito.mock(Blob.class);
+      Mockito.when(blob.getContent())
+          .thenReturn(ManifestManager.MAPPER.writeValueAsBytes(failedManifest));
+      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
+
+      // when
+      manager.markAsDeleted(backup.id());
+
+      // then
+      final var captor = ArgumentCaptor.forClass(byte[].class);
+      Mockito.verify(client).create(Mockito.any(BlobInfo.class), captor.capture());
+
+      final var actualManifest =
+          ManifestManager.MAPPER.readValue(captor.getValue(), Manifest.class);
+      Assertions.assertThat(actualManifest.statusCode()).isEqualTo(StatusCode.DELETED);
+      Assertions.assertThat(actualManifest.id()).isEqualTo(failedManifest.id());
+    }
+
+    @Test
+    void shouldNotUpdateAlreadyDeletedManifest() throws IOException {
+      // given
+      final var client = Mockito.mock(Storage.class);
+      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, 2, 3),
+              new BackupDescriptorImpl(
+                  1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of()),
+              new NamedFileSetImpl(Map.of()));
+      final var deletedManifest = Manifest.createInProgress(backup).complete().delete();
+
+      final var blob = Mockito.mock(Blob.class);
+      Mockito.when(blob.getContent())
+          .thenReturn(ManifestManager.MAPPER.writeValueAsBytes(deletedManifest));
+      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
+
+      // when
+      manager.markAsDeleted(backup.id());
+
+      // then - should not call create since manifest is already deleted
+      Mockito.verify(client, Mockito.never()).create(Mockito.any(BlobInfo.class), Mockito.any());
+    }
+
+    @Test
+    void shouldDoNothingWhenMarkingNonExistentManifestAsDeleted() {
+      // given
+      final var client = Mockito.mock(Storage.class);
+      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+      final var backupId = new BackupIdentifierImpl(1, 2, 3);
+
+      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(null);
+
+      // when
+      manager.markAsDeleted(backupId);
+
+      // then - should not call create since manifest does not exist
+      Mockito.verify(client, Mockito.never()).create(Mockito.any(BlobInfo.class), Mockito.any());
+    }
   }
 }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -236,7 +236,7 @@ final class ManifestManagerTest {
       Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
 
       // when
-      manager.markAsDeleted(backup.id());
+      manager.markAsDeleted(inProgressManifest);
 
       // then
       final var captor = ArgumentCaptor.forClass(byte[].class);
@@ -268,7 +268,7 @@ final class ManifestManagerTest {
       Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
 
       // when
-      manager.markAsDeleted(backup.id());
+      manager.markAsDeleted(completedManifest);
 
       // then
       final var captor = ArgumentCaptor.forClass(byte[].class);
@@ -300,7 +300,7 @@ final class ManifestManagerTest {
       Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
 
       // when
-      manager.markAsDeleted(backup.id());
+      manager.markAsDeleted(failedManifest);
 
       // then
       final var captor = ArgumentCaptor.forClass(byte[].class);
@@ -332,25 +332,9 @@ final class ManifestManagerTest {
       Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(blob);
 
       // when
-      manager.markAsDeleted(backup.id());
+      manager.markAsDeleted(deletedManifest);
 
       // then - should not call create since manifest is already deleted
-      Mockito.verify(client, Mockito.never()).create(Mockito.any(BlobInfo.class), Mockito.any());
-    }
-
-    @Test
-    void shouldDoNothingWhenMarkingNonExistentManifestAsDeleted() {
-      // given
-      final var client = Mockito.mock(Storage.class);
-      final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
-      final var backupId = new BackupIdentifierImpl(1, 2, 3);
-
-      Mockito.when(client.get(Mockito.any(BlobId.class))).thenReturn(null);
-
-      // when
-      manager.markAsDeleted(backupId);
-
-      // then - should not call create since manifest does not exist
       Mockito.verify(client, Mockito.never()).create(Mockito.any(BlobInfo.class), Mockito.any());
     }
   }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -265,6 +266,7 @@ public final class S3BackupStore implements BackupStore {
                 return manifest;
               }
             })
+        .thenCompose(manifest -> markAsDeleted(id, manifest))
         .thenComposeAsync(
             manifest ->
                 listObjects(manifest, Directory.MANIFESTS)
@@ -315,7 +317,7 @@ public final class S3BackupStore implements BackupStore {
                     .map(S3Object::key)
                     .map(key -> key.substring(prefix.length()))
                     .map(BackupRangeMarker::fromName)
-                    .filter(marker -> marker != null)
+                    .filter(Objects::nonNull)
                     .toList());
   }
 
@@ -366,6 +368,15 @@ public final class S3BackupStore implements BackupStore {
   public CompletableFuture<Void> closeAsync() {
     client.close();
     return CompletableFuture.completedFuture(null);
+  }
+
+  private CompletableFuture<Manifest> markAsDeleted(
+      final BackupIdentifier id, final Manifest manifest) {
+    if (manifest instanceof final ValidBackupManifest validManifest) {
+      return updateManifestObject(id, m -> validManifest.asDeleted())
+          .thenApply(Manifest.class::cast);
+    }
+    return CompletableFuture.completedFuture(manifest);
   }
 
   private String rangeMarkersPrefix(final int partitionId) {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -258,15 +258,15 @@ public final class S3BackupStore implements BackupStore {
     return readManifestObject(id)
         .thenApply(
             manifest -> {
-              if (manifest.statusCode() == BackupStatusCode.IN_PROGRESS) {
+              if (manifest.statusCode() != BackupStatusCode.DELETED
+                  && manifest.statusCode() != BackupStatusCode.DOES_NOT_EXIST) {
                 throw new BackupInInvalidStateException(
-                    "Can't delete in-progress backup %s, must be marked as failed first"
-                        .formatted(manifest.id()));
+                    "Cannot delete Backup with id '%s', must be marked as deleted."
+                        .formatted(id.toString()));
               } else {
                 return manifest;
               }
             })
-        .thenCompose(manifest -> markAsDeleted(id, manifest))
         .thenComposeAsync(
             manifest ->
                 listObjects(manifest, Directory.MANIFESTS)
@@ -304,6 +304,19 @@ public final class S3BackupStore implements BackupStore {
       final BackupIdentifier id, final String failureReason) {
     return updateManifestObject(id, manifest -> manifest.asFailed(failureReason))
         .thenApply(Manifest::statusCode);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    return readManifestObject(id)
+        .thenCompose(
+            manifest -> {
+              if (manifest instanceof final ValidBackupManifest validManifest) {
+                return updateManifestObject(id, m -> validManifest.asDeleted())
+                    .thenApply(Manifest::statusCode);
+              }
+              return CompletableFuture.completedFuture(manifest.statusCode());
+            });
   }
 
   @Override
@@ -368,15 +381,6 @@ public final class S3BackupStore implements BackupStore {
   public CompletableFuture<Void> closeAsync() {
     client.close();
     return CompletableFuture.completedFuture(null);
-  }
-
-  private CompletableFuture<Manifest> markAsDeleted(
-      final BackupIdentifier id, final Manifest manifest) {
-    if (manifest instanceof final ValidBackupManifest validManifest) {
-      return updateManifestObject(id, m -> validManifest.asDeleted())
-          .thenApply(Manifest.class::cast);
-    }
-    return CompletableFuture.completedFuture(manifest);
   }
 
   private String rangeMarkersPrefix(final int partitionId) {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/DeletedBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/DeletedBackupManifest.java
@@ -16,10 +16,11 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.function.Function;
 
-public record CompletedBackupManifest(
+public record DeletedBackupManifest(
     BackupIdentifierImpl id,
-    BackupDescriptorImpl descriptor,
+    Optional<BackupDescriptorImpl> descriptor,
     @JsonAlias("snapshotFileNames") FileSet snapshotFiles,
     @JsonAlias("segmentFileNames") FileSet segmentFiles,
     Instant createdAt,
@@ -28,14 +29,14 @@ public record CompletedBackupManifest(
 
   @Override
   public BackupStatusCode statusCode() {
-    return BackupStatusCode.COMPLETED;
+    return BackupStatusCode.DELETED;
   }
 
   @Override
   public BackupStatus toStatus() {
     return new BackupStatusImpl(
         id,
-        Optional.of(descriptor),
+        descriptor.map(Function.identity()),
         statusCode(),
         Optional.empty(),
         Optional.of(createdAt),
@@ -45,23 +46,16 @@ public record CompletedBackupManifest(
   @Override
   public FailedBackupManifest asFailed(final String failureReason) {
     return new FailedBackupManifest(
-        id,
-        Optional.of(descriptor),
-        failureReason,
-        snapshotFiles,
-        segmentFiles,
-        createdAt,
-        Instant.now());
+        id, descriptor, failureReason, snapshotFiles, segmentFiles, createdAt, Instant.now());
   }
 
   @Override
   public Optional<BackupDescriptor> backupDescriptor() {
-    return Optional.of(descriptor);
+    return descriptor.map(Function.identity());
   }
 
   @Override
   public DeletedBackupManifest asDeleted() {
-    return new DeletedBackupManifest(
-        id, Optional.of(descriptor), snapshotFiles, segmentFiles, createdAt, Instant.now());
+    return this;
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
@@ -53,4 +53,10 @@ public record FailedBackupManifest(
   public Optional<BackupDescriptor> backupDescriptor() {
     return descriptor.map(Function.identity());
   }
+
+  @Override
+  public DeletedBackupManifest asDeleted() {
+    return new DeletedBackupManifest(
+        id, descriptor, snapshotFiles, segmentFiles, createdAt, Instant.now());
+  }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
@@ -59,6 +59,12 @@ public record InProgressBackupManifest(
     return Optional.of(descriptor);
   }
 
+  @Override
+  public DeletedBackupManifest asDeleted() {
+    return new DeletedBackupManifest(
+        id, Optional.of(descriptor), snapshotFiles, segmentFiles, createdAt, Instant.now());
+  }
+
   public CompletedBackupManifest asCompleted(final FileSet snapshot, final FileSet segments) {
     return new CompletedBackupManifest(
         id, descriptor, snapshot, segments, createdAt, Instant.now());

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/ValidBackupManifest.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/ValidBackupManifest.java
@@ -22,10 +22,14 @@ import java.util.Optional;
 @JsonSubTypes({
   @Type(value = CompletedBackupManifest.class, name = "completed"),
   @Type(value = InProgressBackupManifest.class, name = "in_progress"),
-  @Type(value = FailedBackupManifest.class, name = "failed")
+  @Type(value = FailedBackupManifest.class, name = "failed"),
+  @Type(value = DeletedBackupManifest.class, name = "deleted")
 })
 public sealed interface ValidBackupManifest extends Manifest
-    permits InProgressBackupManifest, CompletedBackupManifest, FailedBackupManifest {
+    permits InProgressBackupManifest,
+        CompletedBackupManifest,
+        FailedBackupManifest,
+        DeletedBackupManifest {
 
   @Override
   BackupIdentifier id();
@@ -35,4 +39,6 @@ public sealed interface ValidBackupManifest extends Manifest
   Instant createdAt();
 
   Instant modifiedAt();
+
+  DeletedBackupManifest asDeleted();
 }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestDeleteTransitionTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestDeleteTransitionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.s3.manifest.CompletedBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.DeletedBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.FailedBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.FileSet;
+import io.camunda.zeebe.backup.s3.manifest.InProgressBackupManifest;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class ManifestDeleteTransitionTest {
+
+  private static final BackupIdentifierImpl BACKUP_ID = new BackupIdentifierImpl(1, 2, 3);
+  private static final BackupDescriptorImpl DESCRIPTOR =
+      new BackupDescriptorImpl(3L, 1, "8.7.0", Instant.now(), CheckpointType.MANUAL_BACKUP);
+  private static final FileSet EMPTY_FILE_SET = FileSet.empty();
+
+  @Nested
+  class ManifestTransitions {
+
+    @Test
+    void shouldTransitionCompletedManifestToDeleted() {
+      // given
+      final var completedManifest =
+          new CompletedBackupManifest(
+              BACKUP_ID, DESCRIPTOR, EMPTY_FILE_SET, EMPTY_FILE_SET, Instant.now(), Instant.now());
+
+      // when
+      final var deletedManifest = completedManifest.asDeleted();
+
+      // then
+      assertThat(deletedManifest.statusCode()).isEqualTo(BackupStatusCode.DELETED);
+      assertThat(deletedManifest.id()).isEqualTo(BACKUP_ID);
+      assertThat(deletedManifest.descriptor()).contains(DESCRIPTOR);
+      assertThat(deletedManifest.createdAt()).isEqualTo(completedManifest.createdAt());
+      assertThat(deletedManifest.modifiedAt()).isAfterOrEqualTo(completedManifest.modifiedAt());
+    }
+
+    @Test
+    void shouldTransitionFailedManifestToDeleted() {
+      // given
+      final var failedManifest =
+          new FailedBackupManifest(
+              BACKUP_ID,
+              Optional.of(DESCRIPTOR),
+              "failure reason",
+              EMPTY_FILE_SET,
+              EMPTY_FILE_SET,
+              Instant.now(),
+              Instant.now());
+
+      // when
+      final var deletedManifest = failedManifest.asDeleted();
+
+      // then
+      assertThat(deletedManifest.statusCode()).isEqualTo(BackupStatusCode.DELETED);
+      assertThat(deletedManifest.id()).isEqualTo(BACKUP_ID);
+      assertThat(deletedManifest.descriptor()).contains(DESCRIPTOR);
+      assertThat(deletedManifest.createdAt()).isEqualTo(failedManifest.createdAt());
+      assertThat(deletedManifest.modifiedAt()).isAfterOrEqualTo(failedManifest.modifiedAt());
+    }
+
+    @Test
+    void shouldTransitionInProgressManifestToDeleted() {
+      // given
+      final var inProgressManifest =
+          new InProgressBackupManifest(
+              BACKUP_ID, DESCRIPTOR, EMPTY_FILE_SET, EMPTY_FILE_SET, Instant.now(), Instant.now());
+
+      // when
+      final var deletedManifest = inProgressManifest.asDeleted();
+
+      // then
+      assertThat(deletedManifest.statusCode()).isEqualTo(BackupStatusCode.DELETED);
+      assertThat(deletedManifest.id()).isEqualTo(BACKUP_ID);
+      assertThat(deletedManifest.descriptor()).contains(DESCRIPTOR);
+      assertThat(deletedManifest.createdAt()).isEqualTo(inProgressManifest.createdAt());
+      assertThat(deletedManifest.modifiedAt()).isAfterOrEqualTo(inProgressManifest.modifiedAt());
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenAlreadyDeleted() {
+      // given
+      final var deletedManifest =
+          new DeletedBackupManifest(
+              BACKUP_ID,
+              Optional.of(DESCRIPTOR),
+              EMPTY_FILE_SET,
+              EMPTY_FILE_SET,
+              Instant.now(),
+              Instant.now());
+
+      // when
+      final var result = deletedManifest.asDeleted();
+
+      // then
+      assertThat(result).isSameAs(deletedManifest);
+    }
+  }
+}

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -196,6 +196,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   default void allBackupObjectsAreDeleted(final Backup backup) {
     // given
     getStore().save(backup).join();
+    getStore().markDeleted(backup.id()).join();
 
     // when
     getStore().delete(backup.id()).join();
@@ -249,6 +250,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   default void deletingPartialBackupSucceeds(final Backup backup) {
     // given
     getStore().save(backup).join();
+    getStore().markDeleted(backup.id()).join();
 
     // when
     getClient()

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/DeletingBackup.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/DeletingBackup.java
@@ -35,6 +35,7 @@ public interface DeletingBackup {
   default void backupDoesNotExistAfterDeleting(final Backup backup) {
     // given
     getStore().save(backup).join();
+    getStore().markDeleted(backup.id()).join();
 
     // when
     getStore().delete(backup.id()).join();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 public enum BackupStatusCode {
   // WARNING! Must be ordered from "worst" to "best" for comparator below!
   DOES_NOT_EXIST,
+  DELETED,
   FAILED,
 
   IN_PROGRESS,

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -40,6 +40,8 @@ public interface BackupStore {
    */
   CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id, final String failureReason);
 
+  CompletableFuture<BackupStatusCode> markDeleted(BackupIdentifier id);
+
   /** Returns all range markers stored for this partition. */
   CompletableFuture<Collection<BackupRangeMarker>> rangeMarkers(int partitionId);
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -358,24 +358,15 @@ final class BackupServiceImpl {
                 CompletableFuture.allOf(
                     backups.stream()
                         .map(
-                            backup -> {
-                              final CompletableFuture<Void> preparationStep;
-                              if (backup.statusCode() == BackupStatusCode.IN_PROGRESS) {
-                                preparationStep =
-                                    backupStore
-                                        .markFailed(backup.id(), "The backup is being deleted.")
-                                        .thenApply(ignored -> null);
-                              } else {
-                                preparationStep = CompletableFuture.completedFuture(null);
-                              }
-                              return preparationStep
-                                  .thenCompose(
-                                      ignored ->
-                                          backupStore.storeRangeMarker(
-                                              backup.id().partitionId(),
-                                              new Deletion(checkpointId)))
-                                  .thenCompose(ignored -> backupStore.delete(backup.id()));
-                            })
+                            backup ->
+                                backupStore
+                                    .markDeleted(backup.id())
+                                    .thenCompose(
+                                        ignored ->
+                                            backupStore.storeRangeMarker(
+                                                backup.id().partitionId(),
+                                                new Deletion(checkpointId)))
+                                    .thenCompose(ignored -> backupStore.delete(backup.id())))
                         .toArray(CompletableFuture[]::new)))
         .exceptionally(
             error -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -365,6 +365,7 @@ public final class BackupApiRequestHandler
       case IN_PROGRESS -> BackupStatusCode.IN_PROGRESS;
       case COMPLETED -> BackupStatusCode.COMPLETED;
       case FAILED -> BackupStatusCode.FAILED;
+      case DELETED -> BackupStatusCode.DELETED;
     };
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
@@ -78,6 +78,11 @@ public class InMemoryMockBackupStore implements BackupStore, AutoCloseable {
   }
 
   @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    throw new UnsupportedOperationException("Not yet implemented; implemented it when required");
+  }
+
+  @Override
   public CompletableFuture<Collection<BackupRangeMarker>> rangeMarkers(final int partitionId) {
     throw new UnsupportedOperationException("Range markers are not yet supported");
   }

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -31,6 +31,7 @@
       <validValue name="IN_PROGRESS">1</validValue>
       <validValue name="COMPLETED">2</validValue>
       <validValue name="FAILED">3</validValue>
+      <validValue name="DELETED">4</validValue>
     </enum>
 
     <composite name="largeGroupSizeEncoding">

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -603,6 +603,11 @@ final class BackupRangeResolverTest {
     }
 
     @Override
+    public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+      return CompletableFuture.completedFuture(BackupStatusCode.DELETED);
+    }
+
+    @Override
     public CompletableFuture<Collection<BackupRangeMarker>> rangeMarkers(final int partitionId) {
       return CompletableFuture.completedFuture(
           rangeMarkersByPartition.getOrDefault(partitionId, List.of()));

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -147,6 +147,11 @@ final class TestRestorableBackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<BackupStatusCode> markDeleted(final BackupIdentifier id) {
+    return CompletableFuture.completedFuture(BackupStatusCode.DELETED);
+  }
+
+  @Override
   public CompletableFuture<Collection<BackupRangeMarker>> rangeMarkers(final int partitionId) {
     return CompletableFuture.completedFuture(
         rangeMarkersByPartition.getOrDefault(partitionId, List.of()));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Before proceeding with the contents and manifest deletion, first update it's status to `DELETED` effectively tombstoning it. That way we can guarantee that no partially deleted backups will be left over since we maintain the manifest until all contents are deleted. Also, that makes sure that potentially partially deleted backups cannot be used during restore as they're not marked as `COMPLETED` anymore.

Deletion of a backup is prohibited if it's not first successfully transitioned in the `DELETED` status.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #https://github.com/camunda/camunda/issues/45258
