### PR TITLE
ci: re-enable failure notifications

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -429,42 +429,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-#  notify-failure:
-#    name: Notify on failure
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 5
-#    needs: [prepare-versions, run-compatibility-tests]
-#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-#    permissions: {}
-#    steps:
-#      - uses: actions/checkout@v6
-#      - name: Notify failure
-#        uses: slackapi/slack-github-action@v2.1.1
-#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-#        env:
-#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#        with:
-#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#           {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": ":alarm: *Camunda Client Compatibility Tests Failed*"
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-#                  }
-#                }
-#              ]
-#            }
+  notify-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [prepare-versions, run-compatibility-tests]
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v2.1.1
+        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        env:
+          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        with:
+          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+           {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Camunda Client Compatibility Tests Failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -553,42 +553,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-#  notify-failure:
-#    name: Notify on failure
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 5
-#    needs: [prepare-versions, run-cpt-tests]
-#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-#    permissions: {}
-#    steps:
-#      - uses: actions/checkout@v6
-#      - name: Notify failure
-#        uses: slackapi/slack-github-action@v2.1.1
-#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-#        env:
-#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#        with:
-#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#           {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-#                  }
-#                }
-#              ]
-#            }
+  notify-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [prepare-versions, run-cpt-tests]
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v2.1.1
+        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        env:
+          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        with:
+          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+           {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -426,42 +426,42 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-#  notify-failure:
-#    name: Notify on failure
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 5
-#    needs: [prepare-versions, run-compatibility-tests]
-#    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-#    permissions: {}
-#    steps:
-#      - uses: actions/checkout@v6
-#      - name: Notify failure
-#        uses: slackapi/slack-github-action@v2.1.1
-#        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-#        env:
-#          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#        with:
-#          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#           {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": ":alarm: *Camunda Spring Boot Starter Compatibility Tests Failed*"
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-#                  }
-#                }
-#              ]
-#            }
+  notify-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [prepare-versions, run-compatibility-tests]
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v2.1.1
+        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        env:
+          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        with:
+          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+           {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Camunda Spring Boot Starter Compatibility Tests Failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

re-enable failure notification of compatibility tests workflows
