### PR TITLE
ci: escape message text properly to avoid accidental yaml parsing

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/statistics-daily.yml'
-      - '.ci/scripts/setup-medic-lookup.sh'
+      - '.ci/scripts/ci/setup-medic-lookup.sh'
   workflow_dispatch: {}
 
 env:
@@ -126,7 +126,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "${{ steps.message.outputs.MESSAGE }}"
+                  text: ${{ toJSON(steps.message.outputs.MESSAGE) }}
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

Fix for failing https://github.com/camunda/camunda/actions/runs/22129286010/job/63965802558

Demo that it works again (enabled the real notification for one run on PRs): https://camunda.slack.com/archives/C071KP5BTHB/p1771412362045249

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed, only on main

## Related issues

None
