### PR TITLE
fix: custom headers do not get preserved correctly for user task PIM

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/UserTaskProcessInstanceMigrationIT.java
@@ -150,7 +150,8 @@ public class UserTaskProcessInstanceMigrationIT {
                                   f.processDefinitionKey(pd2)
                                       .bpmnProcessId(TO_PROCESS_ID)
                                       .processInstanceKey(processInstanceKey)
-                                      .assignee(expectedTask.assignee))
+                                      .assignee(expectedTask.assignee)
+                                      .state(UserTaskState.CREATED))
                           // right task
                           .send()
                           .join()
@@ -178,6 +179,7 @@ public class UserTaskProcessInstanceMigrationIT {
     assertThat(migratedTask.getFormKey()).isEqualTo(expectedTask.formKey);
     assertThat(migratedTask.getExternalFormReference())
         .isEqualTo(expectedTask.externalFormReference);
+    assertThat(migratedTask.getCustomHeaders()).isEqualTo(expectedTask.headers);
 
     verifyFormOperationsWork(migratedTask.getUserTaskKey());
   }
@@ -190,7 +192,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 .zeebeCandidateUsers("u1,u2")
                 .zeebeDueDate(EXAMPLE_DUE_DATE)
                 .zeebeFollowUpDate(EXAMPLE_FOLLOW_UP_DATE)
-                .zeebeAssignee("original");
+                .zeebeAssignee("original")
+                .zeebeTaskHeader("key1", "value1");
     final Consumer<UserTaskBuilder> fromWithoutAssigneeAndPriority =
         t ->
             t.zeebeCandidateGroups("g1,g2")
@@ -210,7 +213,9 @@ public class UserTaskProcessInstanceMigrationIT {
             t.zeebeAssignee("original")
                 .zeebeFormId(FORM_1)
                 .zeebeDueDate(ALTERNATIVE_DUE_DATE)
-                .zeebeFollowUpDate(ALTERNATIVE_FOLLOW_UP_DATE);
+                .zeebeFollowUpDate(ALTERNATIVE_FOLLOW_UP_DATE)
+                .zeebeTaskHeader("key2", "value2")
+                .zeebeTaskHeader("key3", "value3");
     final Consumer<UserTaskBuilder> fromExternalForm =
         t ->
             t.zeebeAssigneeExpression("varAssignee")
@@ -241,6 +246,7 @@ public class UserTaskProcessInstanceMigrationIT {
                 .zeebeCandidateUsers("u3,u4")
                 .zeebeAssignee("targetAssignee")
                 .zeebeTaskPriority("10")
+                .zeebeTaskHeader("key3", "value3")
                 .zeebeFormId(FORM_2);
 
     return Stream.of(
@@ -255,7 +261,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of("key1", "value1"))),
         Arguments.of(
             fromWithoutAssigneeAndPriority,
             toWithoutAssigneeAndPriority,
@@ -267,7 +274,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromEmbeddedForm,
             toExternalForm,
@@ -279,7 +287,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromEmbeddedForm,
             toInternalForm,
@@ -291,7 +300,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of("g1", "g2"),
                 List.of("u1", "u2"),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)),
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())),
         Arguments.of(
             fromInternalForm,
             toExternalForm,
@@ -303,7 +313,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of(),
                 List.of(),
                 ALTERNATIVE_DUE_DATE,
-                ALTERNATIVE_FOLLOW_UP_DATE)),
+                ALTERNATIVE_FOLLOW_UP_DATE,
+                Map.of("key2", "value2", "key3", "value3"))),
         Arguments.of(
             fromExternalForm,
             toExternalForm,
@@ -315,7 +326,8 @@ public class UserTaskProcessInstanceMigrationIT {
                 List.of(),
                 List.of(),
                 EXAMPLE_DUE_DATE,
-                EXAMPLE_FOLLOW_UP_DATE)));
+                EXAMPLE_FOLLOW_UP_DATE,
+                Map.of())));
   }
 
   private static String getForm(final String formId) {
@@ -378,5 +390,6 @@ public class UserTaskProcessInstanceMigrationIT {
       List<String> candidateGroups,
       List<String> candidateUsers,
       String dueDate,
-      String followupDate) {}
+      String followupDate,
+      Map<String, String> headers) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -49,8 +49,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,10 +153,21 @@ public final class BpmnUserTaskBehavior {
       final BpmnElementContext context,
       final ExecutableUserTask element,
       final UserTaskProperties userTaskProperties) {
+    return createNewUserTask(
+        context,
+        element.getId(),
+        userTaskProperties,
+        element.getUserTaskProperties().getTaskHeaders());
+  }
+
+  public UserTaskRecord createNewUserTask(
+      final BpmnElementContext context,
+      final DirectBuffer id,
+      final UserTaskProperties userTaskProperties,
+      final Map<String, String> headers) {
     final var userTaskKey = keyGenerator.nextKey();
 
-    final var encodedHeaders =
-        headerEncoder.encode(element.getUserTaskProperties().getTaskHeaders());
+    final var encodedHeaders = headerEncoder.encode(headers);
 
     final var userTaskRecord =
         new UserTaskRecord()
@@ -172,7 +185,7 @@ public final class BpmnUserTaskBehavior {
             .setProcessDefinitionVersion(context.getProcessVersion())
             .setProcessDefinitionKey(context.getProcessDefinitionKey())
             .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setElementId(element.getId())
+            .setElementId(id)
             .setElementInstanceKey(context.getElementInstanceKey())
             .setTenantId(context.getTenantId())
             .setPriority(userTaskProperties.getPriority())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Preserve non-reserved headers from the user task job worker and map them to user task headers for the target task.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/46108
