### PR TITLE
46010 esos data layer

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbQuery.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobTypeStatisticsFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobTypeStatisticsDbQuery(
+    JobTypeStatisticsFilter filter, List<String> authorizedTenantIds, DbQueryPage page) {
+
+  public static JobTypeStatisticsDbQuery of(
+      final Function<JobTypeStatisticsDbQuery.Builder, ObjectBuilder<JobTypeStatisticsDbQuery>>
+          fn) {
+    return fn.apply(new JobTypeStatisticsDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobTypeStatisticsDbQuery> {
+    private JobTypeStatisticsFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQueryPage page;
+
+    public Builder filter(final JobTypeStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobTypeStatisticsFilter.Builder, ObjectBuilder<JobTypeStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobTypeStatistics(fn));
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    @Override
+    public JobTypeStatisticsDbQuery build() {
+      Objects.requireNonNull(filter, "filter must not be null");
+      authorizedTenantIds =
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList());
+      return new JobTypeStatisticsDbQuery(filter, authorizedTenantIds, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbResult.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import java.time.OffsetDateTime;
+
+public record JobTypeStatisticsDbResult(
+    String jobType,
+    Long createdCount,
+    OffsetDateTime lastCreatedAt,
+    Long completedCount,
+    OffsetDateTime lastCompletedAt,
+    Long failedCount,
+    OffsetDateTime lastFailedAt,
+    Integer workers) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -10,25 +10,38 @@ package io.camunda.db.rdbms.read.service;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.columns.JobTypeStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.JobTypeStatisticsSort;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.Collections;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
+public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatisticsEntity>
+    implements JobMetricsBatchReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(JobMetricsBatchDbReader.class);
+
+  // Fixed sort: jobType asc
+  // we don't allow sorting by other fields for this statistics type
+  private static final JobTypeStatisticsSort JOB_TYPE_STATS_FIXED_SORT =
+      JobTypeStatisticsSort.of(b -> b.jobType().asc());
 
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
   public JobMetricsBatchDbReader(final JobMetricsBatchMapper jobMetricsBatchMapper) {
+    super(JobTypeStatisticsColumn.values());
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
   }
 
@@ -38,7 +51,7 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
     LOG.trace("[RDBMS DB] Aggregate global job statistics with {}", query);
 
     if (shouldReturnEmptyResult(resourceAccessChecks)) {
-      return emptyGlobalJobStatistics();
+      return EmptyResults.GLOBAL_JOB_STATISTICS;
     }
 
     final var dbQuery =
@@ -48,10 +61,6 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
                     .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds()));
 
     final var result = jobMetricsBatchMapper.globalJobStatistics(dbQuery);
-
-    if (result == null) {
-      return emptyGlobalJobStatistics();
-    }
 
     return new GlobalJobStatisticsEntity(
         new StatusMetric(ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
@@ -63,16 +72,55 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    LOG.trace("[RDBMS DB] Search job type statistics with {}", query);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return EmptyResults.JOB_TYPE_STATISTICS;
+    }
+    final var dbSort = convertSort(JOB_TYPE_STATS_FIXED_SORT);
+    final var dbPage =
+        convertPaging(dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+    final var dbQuery =
+        JobTypeStatisticsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .page(dbPage));
+
+    final var results = jobMetricsBatchMapper.jobTypeStatistics(dbQuery);
+    final var entities =
+        results.stream()
+            .map(
+                result ->
+                    new JobTypeStatisticsEntity(
+                        result.jobType(),
+                        new StatusMetric(
+                            ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
+                        new StatusMetric(
+                            ofNullable(result.completedCount()).orElse(0L),
+                            result.lastCompletedAt()),
+                        new StatusMetric(
+                            ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt()),
+                        ofNullable(result.workers()).orElse(0)))
+            .toList();
+
+    return buildSearchQueryResult(
+        entities.size(), entities, convertSort(JOB_TYPE_STATS_FIXED_SORT));
   }
 
-  private GlobalJobStatisticsEntity emptyGlobalJobStatistics() {
-    return new GlobalJobStatisticsEntity(
-        new StatusMetric(0L, null), new StatusMetric(0L, null), new StatusMetric(0L, null), false);
-  }
+  private static final class EmptyResults {
+    private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =
+        SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
-  private boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return resourceAccessChecks.tenantCheck().enabled()
-        && resourceAccessChecks.getAuthorizedTenantIds().isEmpty();
+    private static final GlobalJobStatisticsEntity GLOBAL_JOB_STATISTICS =
+        new GlobalJobStatisticsEntity(
+            new StatusMetric(0L, null),
+            new StatusMetric(0L, null),
+            new StatusMetric(0L, null),
+            false);
+
+    private EmptyResults() {
+      // Utility class
+    }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
@@ -9,14 +9,19 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
+import java.util.List;
 
 public interface JobMetricsBatchMapper {
 
   void insert(JobMetricsBatchDbModel jobMetricsBatch);
 
   GlobalJobStatisticsDbResult globalJobStatistics(GlobalJobStatisticsDbQuery query);
+
+  List<JobTypeStatisticsDbResult> jobTypeStatistics(JobTypeStatisticsDbQuery query);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTypeStatisticsColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTypeStatisticsColumn.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+
+public enum JobTypeStatisticsColumn implements SearchColumn<JobTypeStatisticsEntity> {
+  JOB_TYPE("jobType");
+
+  private final String property;
+
+  JobTypeStatisticsColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobTypeStatisticsEntity> getEntityClass() {
+    return JobTypeStatisticsEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -61,6 +61,63 @@
     </where>
   </sql>
 
+  <resultMap id="JobTypeStatisticsResultMap"
+    type="io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult">
+    <constructor>
+      <arg column="JOB_TYPE" javaType="java.lang.String"/>
+      <arg column="CREATED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_CREATED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="COMPLETED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_COMPLETED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="FAILED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_FAILED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="WORKERS" javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
+  <select id="jobTypeStatistics"
+    parameterType="io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery"
+    resultMap="JobTypeStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT
+      JOB_TYPE,
+      SUM(CREATED_COUNT) AS CREATED_COUNT,
+      MAX(LAST_CREATED_AT) AS LAST_CREATED_AT,
+      SUM(COMPLETED_COUNT) AS COMPLETED_COUNT,
+      MAX(LAST_COMPLETED_AT) AS LAST_COMPLETED_AT,
+      SUM(FAILED_COUNT) AS FAILED_COUNT,
+      MAX(LAST_FAILED_AT) AS LAST_FAILED_AT,
+      COUNT(DISTINCT WORKER) AS WORKERS
+    FROM ${prefix}JOB_METRICS_BATCH
+    <include refid="io.camunda.db.rdbms.sql.JobMetricsBatchMapper.jobTypeStatisticsFilter"/>
+    GROUP BY JOB_TYPE
+    ORDER BY JOB_TYPE
+    <include refid="io.camunda.db.rdbms.sql.Commons.page"/>
+  </select>
+
+  <sql id="jobTypeStatisticsFilter">
+    <where>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <if test="filter.from != null">
+        AND START_TIME &gt;= #{filter.from}
+      </if>
+      <if test="filter.to != null">
+        AND END_TIME &lt;= #{filter.to}
+      </if>
+      <if test="filter.jobTypeOperations != null and !filter.jobTypeOperations.isEmpty()">
+        <foreach collection="filter.jobTypeOperations" item="operation">
+          AND JOB_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+    </where>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">
     INSERT INTO ${prefix}JOB_METRICS_BATCH (JOB_METRICS_BATCH_KEY,
                                             PARTITION_ID,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -14,8 +14,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
@@ -101,27 +103,6 @@ class JobMetricsBatchDbReaderTest {
   }
 
   @Test
-  void shouldReturnEmptyGlobalJobStatisticsWhenMapperReturnsNull() {
-    // given
-    when(jobMetricsBatchMapper.globalJobStatistics(any())).thenReturn(null);
-
-    final var query =
-        GlobalJobStatisticsQuery.of(
-            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
-    final ResourceAccessChecks resourceAccessChecks =
-        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
-
-    // when
-    final var result = jobMetricsBatchDbReader.getGlobalJobStatistics(query, resourceAccessChecks);
-
-    // then
-    assertThat(result.created().count()).isZero();
-    assertThat(result.completed().count()).isZero();
-    assertThat(result.failed().count()).isZero();
-    assertThat(result.isIncomplete()).isFalse();
-  }
-
-  @Test
   void shouldHandleNullCountsInDbResult() {
     // given
     final var dbResult = new GlobalJobStatisticsDbResult(null, null, null, null, null, null, null);
@@ -141,5 +122,269 @@ class JobMetricsBatchDbReaderTest {
     assertThat(result.completed().count()).isZero();
     assertThat(result.failed().count()).isZero();
     assertThat(result.isIncomplete()).isFalse();
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsWhenTenantCheckEnabledButNoTenants() {
+    // given
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+    verifyNoInteractions(jobMetricsBatchMapper);
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsFromMapper() {
+    // given
+    final var lastCreatedAt1 = OffsetDateTime.now().minusHours(1);
+    final var lastCompletedAt1 = OffsetDateTime.now().minusHours(2);
+    final var lastFailedAt1 = OffsetDateTime.now().minusHours(3);
+    final var lastCreatedAt2 = OffsetDateTime.now().minusHours(4);
+    final var lastCompletedAt2 = OffsetDateTime.now().minusHours(5);
+    final var lastFailedAt2 = OffsetDateTime.now().minusHours(6);
+
+    final var dbResult1 =
+        new JobTypeStatisticsDbResult(
+            "task-a", 100L, lastCreatedAt1, 80L, lastCompletedAt1, 5L, lastFailedAt1, 3);
+    final var dbResult2 =
+        new JobTypeStatisticsDbResult(
+            "task-b", 50L, lastCreatedAt2, 40L, lastCompletedAt2, 2L, lastFailedAt2, 2);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult1, dbResult2));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+
+    final var item1 = result.items().get(0);
+    assertThat(item1.jobType()).isEqualTo("task-a");
+    assertThat(item1.created().count()).isEqualTo(100L);
+    assertThat(item1.created().lastUpdatedAt()).isEqualTo(lastCreatedAt1);
+    assertThat(item1.completed().count()).isEqualTo(80L);
+    assertThat(item1.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt1);
+    assertThat(item1.failed().count()).isEqualTo(5L);
+    assertThat(item1.failed().lastUpdatedAt()).isEqualTo(lastFailedAt1);
+    assertThat(item1.workers()).isEqualTo(3);
+
+    final var item2 = result.items().get(1);
+    assertThat(item2.jobType()).isEqualTo("task-b");
+    assertThat(item2.created().count()).isEqualTo(50L);
+    assertThat(item2.created().lastUpdatedAt()).isEqualTo(lastCreatedAt2);
+    assertThat(item2.completed().count()).isEqualTo(40L);
+    assertThat(item2.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt2);
+    assertThat(item2.failed().count()).isEqualTo(2L);
+    assertThat(item2.failed().lastUpdatedAt()).isEqualTo(lastFailedAt2);
+    assertThat(item2.workers()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsWhenCountIsZero() {
+    // given no results from the mapper, which is different from an empty list (which would indicate
+    // that there are job types but all counts are zero)
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullCountsInJobTypeStatisticsDbResult() {
+    // given
+    final var dbResult =
+        new JobTypeStatisticsDbResult("task-a", null, null, null, null, null, null, null);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).hasSize(1);
+
+    final var item = result.items().getFirst();
+    assertThat(item.jobType()).isEqualTo("task-a");
+    assertThat(item.created().count()).isZero();
+    assertThat(item.created().lastUpdatedAt()).isNull();
+    assertThat(item.completed().count()).isZero();
+    assertThat(item.completed().lastUpdatedAt()).isNull();
+    assertThat(item.failed().count()).isZero();
+    assertThat(item.failed().lastUpdatedAt()).isNull();
+    assertThat(item.workers()).isZero();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithMultipleJobTypes() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult1 = new JobTypeStatisticsDbResult("type-a", 100L, now, 90L, now, 5L, now, 3);
+    final var dbResult2 = new JobTypeStatisticsDbResult("type-b", 50L, now, 45L, now, 2L, now, 2);
+    final var dbResult3 = new JobTypeStatisticsDbResult("type-c", 25L, now, 20L, now, 1L, now, 1);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any()))
+        .thenReturn(List.of(dbResult1, dbResult2, dbResult3));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(3L);
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items()).extracting("jobType").containsExactly("type-a", "type-b", "type-c");
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithZeroWorkersCount() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult = new JobTypeStatisticsDbResult("task-type", 10L, now, 8L, now, 0L, now, 0);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().workers()).isZero();
+    assertThat(result.items().getFirst().failed().count()).isZero();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithHighVolumeMetrics() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult =
+        new JobTypeStatisticsDbResult(
+            "high-volume-task", 1_000_000L, now, 950_000L, now, 50_000L, now, 100);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(7)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().jobType()).isEqualTo("high-volume-task");
+    assertThat(result.items().getFirst().created().count()).isEqualTo(1_000_000L);
+    assertThat(result.items().getFirst().completed().count()).isEqualTo(950_000L);
+    assertThat(result.items().getFirst().failed().count()).isEqualTo(50_000L);
+    assertThat(result.items().getFirst().workers()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithMixedTimestamps() {
+    // given
+    final var oldTimestamp = OffsetDateTime.now().minusDays(30);
+    final var recentTimestamp = OffsetDateTime.now().minusHours(1);
+
+    final var dbResult =
+        new JobTypeStatisticsDbResult(
+            "mixed-task", 100L, oldTimestamp, 80L, recentTimestamp, 5L, oldTimestamp, 5);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(oldTimestamp).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    final var item = result.items().getFirst();
+    assertThat(item.created().lastUpdatedAt()).isEqualTo(oldTimestamp);
+    assertThat(item.completed().lastUpdatedAt()).isEqualTo(recentTimestamp);
+    assertThat(item.failed().lastUpdatedAt()).isEqualTo(oldTimestamp);
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsListWhenMapperReturnsEmptyList() {
+    // given
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of());
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsForLongJobTypeNames() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var longJobTypeName =
+        "io.camunda.example.very.long.package.name.with.multiple.segments.MyVeryLongJobTypeName";
+    final var dbResult =
+        new JobTypeStatisticsDbResult(longJobTypeName, 10L, now, 9L, now, 1L, now, 2);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().jobType()).isEqualTo(longJobTypeName);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobTypeStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobTypeStatisticsSort.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobTypeStatisticsSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobTypeStatisticsSort of(
+      final Function<JobTypeStatisticsSort.Builder, ObjectBuilder<JobTypeStatisticsSort>> fn) {
+    return SortOptionBuilders.jobTypeStatistics(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<JobTypeStatisticsSort.Builder>
+      implements ObjectBuilder<JobTypeStatisticsSort> {
+
+    public Builder jobType() {
+      currentOrdering = new FieldSorting("jobType", null);
+      return this;
+    }
+
+    @Override
+    protected JobTypeStatisticsSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobTypeStatisticsSort build() {
+      return new JobTypeStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -272,6 +272,15 @@ public final class SortOptionBuilders {
     return fn.apply(processDefinitionMessageSubscriptionStatistics()).build();
   }
 
+  public static JobTypeStatisticsSort.Builder jobTypeStatistics() {
+    return new JobTypeStatisticsSort.Builder();
+  }
+
+  public static JobTypeStatisticsSort jobTypeStatistics(
+      final Function<JobTypeStatisticsSort.Builder, ObjectBuilder<JobTypeStatisticsSort>> fn) {
+    return fn.apply(jobTypeStatistics()).build();
+  }
+
   public static CorrelatedMessageSubscriptionSort.Builder correlatedMessageSubscription() {
     return new CorrelatedMessageSubscriptionSort.Builder();
   }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -165,6 +165,16 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                 .getJobTypeStatistics(query));
   }
 
+  public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
+      final JobTypeStatisticsQuery query) {
+    final var authJobSearchClient =
+        jobSearchClient.withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.system().readJobMetric())));
+
+    return authJobSearchClient.getJobTypeStatistics(query);
+  }
+
   public record ActivateJobsRequest(
       String type,
       int maxJobsToActivate,

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -165,16 +165,6 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                 .getJobTypeStatistics(query));
   }
 
-  public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
-      final JobTypeStatisticsQuery query) {
-    final var authJobSearchClient =
-        jobSearchClient.withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.system().readJobMetric())));
-
-    return authJobSearchClient.getJobTypeStatistics(query);
-  }
-
   public record ActivateJobsRequest(
       String type,
       int maxJobsToActivate,


### PR DESCRIPTION
## Description

This pull request implements support for querying job type statistics from the RDBMS layer, including new domain/query/result classes, SQL mapping, and integration into the service and test layers. It also introduces fixed sorting for job type statistics and ensures proper handling of empty or null results.

**Job Type Statistics Query Support:**

* Added new domain classes: `JobTypeStatisticsDbQuery` and `JobTypeStatisticsDbResult` to represent queries and results for job type statistics. [[1]](diffhunk://#diff-5a391228c05f408fcf9a626933a00e605e193d261342cec37869945203dbb391R1-R61) [[2]](diffhunk://#diff-850bd2029beb0a52ec2264fd295cf13361a81545c1a7fa588bac5c56a40b24f6R1-R20)
* Introduced `JobTypeStatisticsColumn` enum to support column mapping for job type statistics entities.
* Added a fixed sort option for job type statistics via the new `JobTypeStatisticsSort` class and integrated it into the sort option builders. [[1]](diffhunk://#diff-e95fb4b92ac7717740afbc0a552b678ab9e6fa6ede8ed95c3f71c0fad17ad959R1-R44) [[2]](diffhunk://#diff-bf53b7b548e5bfee91d9fe1cf8e73a3e726ee6db2e5b93d788e9f762742d1c67R275-R283)

**Service and SQL Layer Integration:**

* Updated `JobMetricsBatchDbReader` to implement job type statistics queries, including result mapping, paging, and access check logic. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R13-R42) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289L66-R121)
* Extended the `JobMetricsBatchMapper` interface and its MyBatis XML mapping to support the new job type statistics query and result mapping. [[1]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R12-R25) [[2]](diffhunk://#diff-76bcc9d46c6f7e8b18ff6be8b66f8d6fed24f524445f0c27077b2d93ec2679a8R64-R117)

**Testing Enhancements:**

* Added comprehensive tests to `JobMetricsBatchDbReaderTest` to verify correct behavior for job type statistics queries, including handling of empty, null, and valid results. [[1]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1R17-R20) [[2]](diffhunk://#diff-cd39ec6e6acccdb0c3ec262a19eb7f63a0e0154aceb8fb7da2945ed486ce26e1R147-R268)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).


