### PR TITLE
fix: user task deprecation hint shown for non-user task elements

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
@@ -125,6 +125,20 @@ describe('MetadataPopover <Details />', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should not display deprecation warning for non-user task elements', () => {
+    render(
+      <Details
+        elementInstance={mockElementInstance}
+        businessObject={mockJobWorkerUserTaskBusinessObject}
+      />,
+      {wrapper: TestWrapper},
+    );
+
+    expect(
+      screen.queryByText(/job worker implementation are deprecated/),
+    ).not.toBeInTheDocument();
+  });
+
   it('should display job retries when available', async () => {
     mockSearchJobs().withSuccess({items: [mockJob], page: {totalItems: 1}});
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -108,7 +108,7 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
         }}
       />
       <Stack gap={5}>
-        {!isCamundaUserTask(businessObject) && (
+        {type === 'USER_TASK' && !isCamundaUserTask(businessObject) && (
           <SummaryText>
             User tasks with job worker implementation are deprecated. Consider
             migrating to Camunda user tasks.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes non-user task elements showing the job worker user task deprecation hint (see https://github.com/camunda/camunda/pull/45986/changes#r2816779863)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/45816
