### PR TITLE
refactor: Do not retry requests that return an HTTP 4XX status code

### DIFF
--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
@@ -114,7 +114,7 @@ public class HttpTransportImpl implements Transport<Event> {
     final String responseReason = response.getStatusLine().getReasonPhrase();
     if (statusCode >= 200 && statusCode < 300) {
       log.debug("Successfully posted records to: {}", responseReason);
-    } else if (statusCode >= 400 && statusCode <= 499) {
+    } else if (statusCode >= 400 && statusCode < 500) {
       log.debug("Failed posting records. Status: {} reason: {}", statusCode, responseReason);
       throw new TransportClientException(
           "Failed to post records. Status: " + statusCode + " reason: " + responseReason);

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
@@ -114,6 +114,10 @@ public class HttpTransportImpl implements Transport<Event> {
     final String responseReason = response.getStatusLine().getReasonPhrase();
     if (statusCode >= 200 && statusCode < 300) {
       log.debug("Successfully posted records to: {}", responseReason);
+    } else if (statusCode >= 400 && statusCode <= 499) {
+      log.debug("Failed posting records. Status: {} reason: {}", statusCode, responseReason);
+      throw new TransportClientException(
+          "Failed to post records. Status: " + statusCode + " reason: " + responseReason);
     } else {
       log.debug("Failed posting records. Status: {} reason: {}", statusCode, responseReason);
       throw new TransportException(

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/TransportClientException.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/TransportClientException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+public class TransportClientException extends RuntimeException {
+
+  public TransportClientException(final String message) {
+    super(message);
+  }
+
+  public TransportClientException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
@@ -43,7 +43,7 @@ public class HttpTransportTest {
   }
 
   @Test
-  public void testSuccessfulTransport() {
+  public void testForStatusCode2XX() {
     wireMock.stubFor(post("/").willReturn(ok()));
 
     transport.send(new ArrayList<>());
@@ -54,9 +54,9 @@ public class HttpTransportTest {
   }
 
   @Test
-  public void testRetryForStatusCode500() {
+  public void testRetryForStatusCode3XX() {
     wireMock.stubFor(
-        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(302)));
 
     Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
         .isInstanceOf(TransportException.class);
@@ -76,6 +76,19 @@ public class HttpTransportTest {
 
     wireMock.verify(
         exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  @Test
+  public void testRetryForStatusCode5XX() {
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    wireMock.verify(
+        exactly(3),
         postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
   }
 }

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.subscription.SubscriptionFactory;
+import io.camunda.exporter.appint.transport.Authentication.ApiKey;
+import java.util.ArrayList;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HttpTransportTest {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  private String url;
+  private Transport transport;
+
+  @BeforeEach
+  public void beforeAll() {
+    url = "http://localhost:" + wireMock.getPort();
+    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 500);
+    final var jsonMapper = SubscriptionFactory.createJsonMapper();
+    transport = new HttpTransportImpl(jsonMapper, httpConfig);
+  }
+
+  @Test
+  public void testSuccessfulTransport() {
+    wireMock.stubFor(post("/").willReturn(ok()));
+
+    transport.send(new ArrayList<>());
+
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  @Test
+  public void testRetryForStatusCode500() {
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    wireMock.verify(
+        exactly(3),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  @Test
+  public void testNoRetryForStatusCode4XX() {
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(404)));
+
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportClientException.class);
+
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/resources/log4j2-test.xml
+++ b/zeebe/exporters/app-integrations-exporter/src/test/resources/log4j2-test.xml
@@ -16,7 +16,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.camunda.appint.exporter" level="trace"/>
+    <Logger name="io.camunda.exporter.appint" level="trace"/>
     <Logger name="org.apache.http.client" level="trace"/>
     <Logger name="com.github.tomakehurst.wiremock" level="trace"/>
 


### PR DESCRIPTION
## Description

This pull request improves error handling and test coverage for the HTTP transport layer in the app integrations exporter. It introduces a new exception for client-side HTTP errors, updates the logic to distinguish between retriable and non-retriable errors, and adds comprehensive tests to verify this behavior.

**Error handling improvements:**

* Added a new exception class `TransportClientException` to represent non-retriable client-side HTTP errors (status codes 4xx), ensuring these errors are handled distinctly from server-side or network errors.
* Updated `HttpTransportImpl.java` to throw `TransportClientException` for 4xx HTTP responses, preventing unnecessary retries for client errors.

**Testing enhancements:**

* Added a new test class `HttpTransportTest.java` that verifies:
  - Successful transport operation.
  - Retries on server errors (status code 500).
  - No retry and correct exception on client errors (status code 4xx).

**Logging configuration:**

* Fixed a logger configuration typo in `log4j2-test.xml` to match the correct package name for improved test logging.

## Related issues

relates to #41956
