### PR TITLE
JobType statistics RDBMS layer

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobTypeStatisticsFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobTypeStatisticsDbQuery(
+    JobTypeStatisticsFilter filter,
+    List<String> authorizedTenantIds,
+    DbQueryPage page,
+    DbQuerySorting<JobTypeStatisticsEntity> sort) {
+
+  public static JobTypeStatisticsDbQuery of(
+      final Function<JobTypeStatisticsDbQuery.Builder, ObjectBuilder<JobTypeStatisticsDbQuery>>
+          fn) {
+    return fn.apply(new JobTypeStatisticsDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobTypeStatisticsDbQuery> {
+    private JobTypeStatisticsFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQueryPage page;
+    private DbQuerySorting<JobTypeStatisticsEntity> sort;
+
+    public Builder filter(final JobTypeStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobTypeStatisticsFilter.Builder, ObjectBuilder<JobTypeStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobTypeStatistics(fn));
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<JobTypeStatisticsEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    @Override
+    public JobTypeStatisticsDbQuery build() {
+      Objects.requireNonNull(filter, "filter must not be null");
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      authorizedTenantIds =
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList());
+      return new JobTypeStatisticsDbQuery(filter, authorizedTenantIds, page, sort);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbResult.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobTypeStatisticsDbResult.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import java.time.OffsetDateTime;
+
+public record JobTypeStatisticsDbResult(
+    String jobType,
+    Long createdCount,
+    OffsetDateTime lastCreatedAt,
+    Long completedCount,
+    OffsetDateTime lastCompletedAt,
+    Long failedCount,
+    OffsetDateTime lastFailedAt,
+    Integer workers) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -10,25 +10,38 @@ package io.camunda.db.rdbms.read.service;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.columns.JobTypeStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.JobTypeStatisticsSort;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.Collections;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
+public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatisticsEntity>
+    implements JobMetricsBatchReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(JobMetricsBatchDbReader.class);
+
+  // Fixed sort: jobType asc
+  // we don't allow sorting by other fields for this statistics type
+  private static final JobTypeStatisticsSort JOB_TYPE_STATS_FIXED_SORT =
+      JobTypeStatisticsSort.of(b -> b.jobType().asc());
 
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
   public JobMetricsBatchDbReader(final JobMetricsBatchMapper jobMetricsBatchMapper) {
+    super(JobTypeStatisticsColumn.values());
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
   }
 
@@ -38,7 +51,7 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
     LOG.trace("[RDBMS DB] Aggregate global job statistics with {}", query);
 
     if (shouldReturnEmptyResult(resourceAccessChecks)) {
-      return emptyGlobalJobStatistics();
+      return EmptyResults.GLOBAL_JOB_STATISTICS;
     }
 
     final var dbQuery =
@@ -48,10 +61,6 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
                     .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds()));
 
     final var result = jobMetricsBatchMapper.globalJobStatistics(dbQuery);
-
-    if (result == null) {
-      return emptyGlobalJobStatistics();
-    }
 
     return new GlobalJobStatisticsEntity(
         new StatusMetric(ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
@@ -63,16 +72,56 @@ public class JobMetricsBatchDbReader implements JobMetricsBatchReader {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    LOG.trace("[RDBMS DB] Search job type statistics with {}", query);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return EmptyResults.JOB_TYPE_STATISTICS;
+    }
+    final var dbSort = convertSort(JOB_TYPE_STATS_FIXED_SORT);
+    final var dbPage =
+        convertPaging(dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+    final var dbQuery =
+        JobTypeStatisticsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    final var results = jobMetricsBatchMapper.jobTypeStatistics(dbQuery);
+    final var entities =
+        results.stream()
+            .map(
+                result ->
+                    new JobTypeStatisticsEntity(
+                        result.jobType(),
+                        new StatusMetric(
+                            ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
+                        new StatusMetric(
+                            ofNullable(result.completedCount()).orElse(0L),
+                            result.lastCompletedAt()),
+                        new StatusMetric(
+                            ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt()),
+                        ofNullable(result.workers()).orElse(0)))
+            .toList();
+
+    return buildSearchQueryResult(
+        entities.size(), entities, convertSort(JOB_TYPE_STATS_FIXED_SORT));
   }
 
-  private GlobalJobStatisticsEntity emptyGlobalJobStatistics() {
-    return new GlobalJobStatisticsEntity(
-        new StatusMetric(0L, null), new StatusMetric(0L, null), new StatusMetric(0L, null), false);
-  }
+  private static final class EmptyResults {
+    private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =
+        SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
-  private boolean shouldReturnEmptyResult(final ResourceAccessChecks resourceAccessChecks) {
-    return resourceAccessChecks.tenantCheck().enabled()
-        && resourceAccessChecks.getAuthorizedTenantIds().isEmpty();
+    private static final GlobalJobStatisticsEntity GLOBAL_JOB_STATISTICS =
+        new GlobalJobStatisticsEntity(
+            new StatusMetric(0L, null),
+            new StatusMetric(0L, null),
+            new StatusMetric(0L, null),
+            false);
+
+    private EmptyResults() {
+      // Utility class
+    }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
@@ -9,14 +9,19 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
+import java.util.List;
 
 public interface JobMetricsBatchMapper {
 
   void insert(JobMetricsBatchDbModel jobMetricsBatch);
 
   GlobalJobStatisticsDbResult globalJobStatistics(GlobalJobStatisticsDbQuery query);
+
+  List<JobTypeStatisticsDbResult> jobTypeStatistics(JobTypeStatisticsDbQuery query);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTypeStatisticsColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobTypeStatisticsColumn.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+
+public enum JobTypeStatisticsColumn implements SearchColumn<JobTypeStatisticsEntity> {
+  JOB_TYPE("jobType");
+
+  private final String property;
+
+  JobTypeStatisticsColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobTypeStatisticsEntity> getEntityClass() {
+    return JobTypeStatisticsEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -61,6 +61,66 @@
     </where>
   </sql>
 
+  <resultMap id="JobTypeStatisticsResultMap"
+    type="io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult">
+    <constructor>
+      <arg column="JOB_TYPE" javaType="java.lang.String"/>
+      <arg column="CREATED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_CREATED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="COMPLETED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_COMPLETED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="FAILED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_FAILED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="WORKERS" javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
+  <select id="jobTypeStatistics"
+    parameterType="io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery"
+    resultMap="JobTypeStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT
+      JOB_TYPE,
+      SUM(CREATED_COUNT) AS CREATED_COUNT,
+      MAX(LAST_CREATED_AT) AS LAST_CREATED_AT,
+      SUM(COMPLETED_COUNT) AS COMPLETED_COUNT,
+      MAX(LAST_COMPLETED_AT) AS LAST_COMPLETED_AT,
+      SUM(FAILED_COUNT) AS FAILED_COUNT,
+      MAX(LAST_FAILED_AT) AS LAST_FAILED_AT,
+      COUNT(DISTINCT WORKER) AS WORKERS
+    FROM ${prefix}JOB_METRICS_BATCH
+    <trim prefix="WHERE" prefixOverrides="AND">
+      <include refid="io.camunda.db.rdbms.sql.JobMetricsBatchMapper.jobTypeStatisticsFilter"/>
+      <trim prefix="AND" prefixOverrides="WHERE">
+        <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+      </trim>
+    </trim>
+    GROUP BY JOB_TYPE
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="jobTypeStatisticsFilter">
+    <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+        #{tenantId}
+      </foreach>
+    </if>
+    <if test="filter.from != null">
+      AND START_TIME &gt;= #{filter.from}
+    </if>
+    <if test="filter.to != null">
+      AND END_TIME &lt;= #{filter.to}
+    </if>
+    <if test="filter.jobTypeOperations != null and !filter.jobTypeOperations.isEmpty()">
+      <foreach collection="filter.jobTypeOperations" item="operation">
+        AND JOB_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">
     INSERT INTO ${prefix}JOB_METRICS_BATCH (JOB_METRICS_BATCH_KEY,
                                             PARTITION_ID,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -14,8 +14,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
@@ -101,27 +103,6 @@ class JobMetricsBatchDbReaderTest {
   }
 
   @Test
-  void shouldReturnEmptyGlobalJobStatisticsWhenMapperReturnsNull() {
-    // given
-    when(jobMetricsBatchMapper.globalJobStatistics(any())).thenReturn(null);
-
-    final var query =
-        GlobalJobStatisticsQuery.of(
-            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
-    final ResourceAccessChecks resourceAccessChecks =
-        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
-
-    // when
-    final var result = jobMetricsBatchDbReader.getGlobalJobStatistics(query, resourceAccessChecks);
-
-    // then
-    assertThat(result.created().count()).isZero();
-    assertThat(result.completed().count()).isZero();
-    assertThat(result.failed().count()).isZero();
-    assertThat(result.isIncomplete()).isFalse();
-  }
-
-  @Test
   void shouldHandleNullCountsInDbResult() {
     // given
     final var dbResult = new GlobalJobStatisticsDbResult(null, null, null, null, null, null, null);
@@ -141,5 +122,269 @@ class JobMetricsBatchDbReaderTest {
     assertThat(result.completed().count()).isZero();
     assertThat(result.failed().count()).isZero();
     assertThat(result.isIncomplete()).isFalse();
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsWhenTenantCheckEnabledButNoTenants() {
+    // given
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+    verifyNoInteractions(jobMetricsBatchMapper);
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsFromMapper() {
+    // given
+    final var lastCreatedAt1 = OffsetDateTime.now().minusHours(1);
+    final var lastCompletedAt1 = OffsetDateTime.now().minusHours(2);
+    final var lastFailedAt1 = OffsetDateTime.now().minusHours(3);
+    final var lastCreatedAt2 = OffsetDateTime.now().minusHours(4);
+    final var lastCompletedAt2 = OffsetDateTime.now().minusHours(5);
+    final var lastFailedAt2 = OffsetDateTime.now().minusHours(6);
+
+    final var dbResult1 =
+        new JobTypeStatisticsDbResult(
+            "task-a", 100L, lastCreatedAt1, 80L, lastCompletedAt1, 5L, lastFailedAt1, 3);
+    final var dbResult2 =
+        new JobTypeStatisticsDbResult(
+            "task-b", 50L, lastCreatedAt2, 40L, lastCompletedAt2, 2L, lastFailedAt2, 2);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult1, dbResult2));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+
+    final var item1 = result.items().get(0);
+    assertThat(item1.jobType()).isEqualTo("task-a");
+    assertThat(item1.created().count()).isEqualTo(100L);
+    assertThat(item1.created().lastUpdatedAt()).isEqualTo(lastCreatedAt1);
+    assertThat(item1.completed().count()).isEqualTo(80L);
+    assertThat(item1.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt1);
+    assertThat(item1.failed().count()).isEqualTo(5L);
+    assertThat(item1.failed().lastUpdatedAt()).isEqualTo(lastFailedAt1);
+    assertThat(item1.workers()).isEqualTo(3);
+
+    final var item2 = result.items().get(1);
+    assertThat(item2.jobType()).isEqualTo("task-b");
+    assertThat(item2.created().count()).isEqualTo(50L);
+    assertThat(item2.created().lastUpdatedAt()).isEqualTo(lastCreatedAt2);
+    assertThat(item2.completed().count()).isEqualTo(40L);
+    assertThat(item2.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt2);
+    assertThat(item2.failed().count()).isEqualTo(2L);
+    assertThat(item2.failed().lastUpdatedAt()).isEqualTo(lastFailedAt2);
+    assertThat(item2.workers()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsWhenCountIsZero() {
+    // given no results from the mapper, which is different from an empty list (which would indicate
+    // that there are job types but all counts are zero)
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullCountsInJobTypeStatisticsDbResult() {
+    // given
+    final var dbResult =
+        new JobTypeStatisticsDbResult("task-a", null, null, null, null, null, null, null);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).hasSize(1);
+
+    final var item = result.items().getFirst();
+    assertThat(item.jobType()).isEqualTo("task-a");
+    assertThat(item.created().count()).isZero();
+    assertThat(item.created().lastUpdatedAt()).isNull();
+    assertThat(item.completed().count()).isZero();
+    assertThat(item.completed().lastUpdatedAt()).isNull();
+    assertThat(item.failed().count()).isZero();
+    assertThat(item.failed().lastUpdatedAt()).isNull();
+    assertThat(item.workers()).isZero();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithMultipleJobTypes() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult1 = new JobTypeStatisticsDbResult("type-a", 100L, now, 90L, now, 5L, now, 3);
+    final var dbResult2 = new JobTypeStatisticsDbResult("type-b", 50L, now, 45L, now, 2L, now, 2);
+    final var dbResult3 = new JobTypeStatisticsDbResult("type-c", 25L, now, 20L, now, 1L, now, 1);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any()))
+        .thenReturn(List.of(dbResult1, dbResult2, dbResult3));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(3L);
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items()).extracting("jobType").containsExactly("type-a", "type-b", "type-c");
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithZeroWorkersCount() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult = new JobTypeStatisticsDbResult("task-type", 10L, now, 8L, now, 0L, now, 0);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().workers()).isZero();
+    assertThat(result.items().getFirst().failed().count()).isZero();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithHighVolumeMetrics() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult =
+        new JobTypeStatisticsDbResult(
+            "high-volume-task", 1_000_000L, now, 950_000L, now, 50_000L, now, 100);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(7)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().jobType()).isEqualTo("high-volume-task");
+    assertThat(result.items().getFirst().created().count()).isEqualTo(1_000_000L);
+    assertThat(result.items().getFirst().completed().count()).isEqualTo(950_000L);
+    assertThat(result.items().getFirst().failed().count()).isEqualTo(50_000L);
+    assertThat(result.items().getFirst().workers()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithMixedTimestamps() {
+    // given
+    final var oldTimestamp = OffsetDateTime.now().minusDays(30);
+    final var recentTimestamp = OffsetDateTime.now().minusHours(1);
+
+    final var dbResult =
+        new JobTypeStatisticsDbResult(
+            "mixed-task", 100L, oldTimestamp, 80L, recentTimestamp, 5L, oldTimestamp, 5);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(oldTimestamp).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    final var item = result.items().getFirst();
+    assertThat(item.created().lastUpdatedAt()).isEqualTo(oldTimestamp);
+    assertThat(item.completed().lastUpdatedAt()).isEqualTo(recentTimestamp);
+    assertThat(item.failed().lastUpdatedAt()).isEqualTo(oldTimestamp);
+  }
+
+  @Test
+  void shouldReturnEmptyJobTypeStatisticsListWhenMapperReturnsEmptyList() {
+    // given
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of());
+
+    final var query =
+        JobTypeStatisticsQuery.of(
+            b -> b.filter(f -> f.from(OffsetDateTime.now()).to(OffsetDateTime.now())));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsForLongJobTypeNames() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var longJobTypeName =
+        "io.camunda.example.very.long.package.name.with.multiple.segments.MyVeryLongJobTypeName";
+    final var dbResult =
+        new JobTypeStatisticsDbResult(longJobTypeName, 10L, now, 9L, now, 1L, now, 2);
+
+    when(jobMetricsBatchMapper.jobTypeStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobTypeStatisticsQuery.of(b -> b.filter(f -> f.from(now.minusDays(1)).to(now)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobTypeStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().jobType()).isEqualTo(longJobTypeName);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import static java.time.ZoneOffset.UTC;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
+import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel.Builder;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Function;
+
+public final class JobMetricsBatchFixtures extends CommonFixtures {
+  public static final OffsetDateTime NOW = OffsetDateTime.now(UTC).truncatedTo(ChronoUnit.MILLIS);
+  public static final int PARTITION_ID = 10;
+
+  private JobMetricsBatchFixtures() {}
+
+  public static JobMetricsBatchDbModel createRandomized(
+      final Function<Builder, Builder> builderFunction) {
+    final var startTime = NOW.minus(RANDOM.nextInt(100), ChronoUnit.MINUTES);
+    final var endTime = startTime.plus(RANDOM.nextInt(10) + 1, ChronoUnit.MINUTES);
+    final var lastCreatedAt =
+        startTime.plus(
+            RANDOM.nextInt((int) ChronoUnit.MINUTES.between(startTime, endTime) + 1),
+            ChronoUnit.MINUTES);
+    final var lastCompletedAt =
+        startTime.plus(
+            RANDOM.nextInt((int) ChronoUnit.MINUTES.between(startTime, endTime) + 1),
+            ChronoUnit.MINUTES);
+    final var lastFailedAt =
+        startTime.plus(
+            RANDOM.nextInt((int) ChronoUnit.MINUTES.between(startTime, endTime) + 1),
+            ChronoUnit.MINUTES);
+
+    final var builder =
+        new Builder()
+            .key(nextStringKey())
+            .partitionId(PARTITION_ID)
+            .startTime(startTime)
+            .endTime(endTime)
+            .tenantId("tenant-" + RANDOM.nextInt(1000))
+            .jobType("jobType-" + RANDOM.nextInt(100))
+            .worker("worker-" + RANDOM.nextInt(50))
+            .createdCount(RANDOM.nextInt(100))
+            .lastCreatedAt(lastCreatedAt)
+            .completedCount(RANDOM.nextInt(100))
+            .lastCompletedAt(lastCompletedAt)
+            .failedCount(RANDOM.nextInt(50))
+            .lastFailedAt(lastFailedAt)
+            .incompleteBatch(RANDOM.nextBoolean());
+
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveMetric(
+      final RdbmsWriters rdbmsWriters, final JobMetricsBatchDbModel metric) {
+    createAndSaveMetrics(rdbmsWriters, List.of(metric));
+  }
+
+  public static void createAndSaveMetrics(
+      final RdbmsWriters rdbmsWriters, final List<JobMetricsBatchDbModel> metrics) {
+    for (final JobMetricsBatchDbModel metric : metrics) {
+      rdbmsWriters.getJobMetricsBatchWriter().create(metric);
+    }
+    rdbmsWriters.flush();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.it.rdbms.db.jobmetrics;
 
+import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.NOW;
+import static io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures.PARTITION_ID;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,19 +18,21 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import io.camunda.db.rdbms.write.service.JobMetricsBatchWriter;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
+import io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
+import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
-import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
-import org.awaitility.Awaitility;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -39,20 +43,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class JobMetricsBatchIT {
 
-  private static final int PARTITION_ID = 10;
-  private static final OffsetDateTime NOW = OffsetDateTime.now(UTC).truncatedTo(ChronoUnit.MILLIS);
-  private static final OffsetDateTime NOW_MINUS_2M = NOW.minusMinutes(2);
-  private static final OffsetDateTime NOW_MINUS_3M = NOW.minusMinutes(3);
-  private static final OffsetDateTime NOW_MINUS_4M = NOW.minusMinutes(4);
-  private static final OffsetDateTime NOW_MINUS_5M = NOW.minusMinutes(5);
-  private static final OffsetDateTime NOW_MINUS_7M = NOW.minusMinutes(7);
-  private static final OffsetDateTime NOW_MINUS_8M = NOW.minusMinutes(8);
-  private static final OffsetDateTime NOW_MINUS_9M = NOW.minusMinutes(9);
-  private static final OffsetDateTime NOW_MINUS_10M = NOW.minusMinutes(10);
-  private static final OffsetDateTime NOW_MINUS_12M = NOW.minusMinutes(12);
-  private static final OffsetDateTime NOW_MINUS_13M = NOW.minusMinutes(13);
-  private static final OffsetDateTime NOW_MINUS_14M = NOW.minusMinutes(14);
-  private static final OffsetDateTime NOW_MINUS_15M = NOW.minusMinutes(15);
   private static final String TENANT1 = "tenant1";
   private static final String TENANT2 = "tenant2";
   private static final String JOB_TYPE_A = "jobTypeA";
@@ -74,48 +64,30 @@ public class JobMetricsBatchIT {
   }
 
   /**
-   * Normalizes a GlobalJobStatisticsEntity to have all timestamps in UTC for comparison across
+   * Normalizes a JobTypeStatisticsEntity to have all timestamps in UTC for comparison across
    * different database types.
    */
-  private GlobalJobStatisticsEntity normalizeToUtc(final GlobalJobStatisticsEntity entity) {
-    return new GlobalJobStatisticsEntity(
+  private JobTypeStatisticsEntity normalizeToUtc(final JobTypeStatisticsEntity entity) {
+    return new JobTypeStatisticsEntity(
+        entity.jobType(),
         new StatusMetric(entity.created().count(), toUtc(entity.created().lastUpdatedAt())),
         new StatusMetric(entity.completed().count(), toUtc(entity.completed().lastUpdatedAt())),
         new StatusMetric(entity.failed().count(), toUtc(entity.failed().lastUpdatedAt())),
-        entity.isIncomplete());
+        entity.workers());
   }
 
-  private void writeMetric(
-      final JobMetricsBatchWriter writer,
-      final OffsetDateTime startTime,
-      final OffsetDateTime endTime,
-      final String tenantId,
-      final String jobType,
-      final String worker,
-      final int createdCount,
-      final OffsetDateTime lastCreatedAt,
-      final int completedCount,
-      final OffsetDateTime lastCompletedAt,
-      final int failedCount,
-      final OffsetDateTime lastFailedAt,
-      final boolean incomplete) {
-    writer.create(
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(startTime)
-            .endTime(endTime)
-            .tenantId(tenantId)
-            .jobType(jobType)
-            .worker(worker)
-            .createdCount(createdCount)
-            .lastCreatedAt(lastCreatedAt)
-            .completedCount(completedCount)
-            .lastCompletedAt(lastCompletedAt)
-            .failedCount(failedCount)
-            .lastFailedAt(lastFailedAt)
-            .incompleteBatch(incomplete)
-            .build());
+  private OffsetDateTime getMinStartTime(final List<JobMetricsBatchDbModel> metrics) {
+    return metrics.stream()
+        .map(JobMetricsBatchDbModel::startTime)
+        .min(OffsetDateTime::compareTo)
+        .orElseThrow();
+  }
+
+  private OffsetDateTime getMaxEndTime(final List<JobMetricsBatchDbModel> metrics) {
+    return metrics.stream()
+        .map(JobMetricsBatchDbModel::endTime)
+        .max(OffsetDateTime::compareTo)
+        .orElseThrow();
   }
 
   @BeforeEach
@@ -124,327 +96,204 @@ public class JobMetricsBatchIT {
     rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     jobMetricsBatchReader = rdbmsService.getJobMetricsBatchDbReader();
     jobMetricsBatchWriter = rdbmsWriters.getJobMetricsBatchWriter();
-
-    // Clean up any existing data before each test
-    jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.plusDays(1), Integer.MAX_VALUE);
-    rdbmsWriters.flush();
   }
 
   @AfterEach
   void tearDown() {
-    jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.plusDays(1), Integer.MAX_VALUE);
-    rdbmsWriters.flush();
+    // Note: If you add other partition ids in your tests, make sure to clean them up here as well
+    jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.plusDays(100), Integer.MAX_VALUE);
   }
 
   @TestTemplate
   public void shouldAggregateGlobalJobStatistics() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).incompleteBatch(false));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_4M,
-        7,
-        NOW_MINUS_3M,
-        1,
-        NOW_MINUS_2M,
-        false);
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).incompleteBatch(false));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
-    // then
-    assertThat(normalizeToUtc(actual))
+    // then - verify aggregation of both metrics
+    assertThat(actual.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(toUtc(actual.created().lastUpdatedAt()))
         .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(8L, NOW_MINUS_4M),
-                new StatusMetric(17L, NOW_MINUS_3M),
-                new StatusMetric(3L, NOW_MINUS_2M),
-                false));
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCreatedAt)
+                .max(OffsetDateTime::compareTo)
+                .orElseThrow());
+    assertThat(actual.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(toUtc(actual.completed().lastUpdatedAt()))
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCompletedAt)
+                .max(OffsetDateTime::compareTo)
+                .orElseThrow());
+    assertThat(actual.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    assertThat(toUtc(actual.failed().lastUpdatedAt()))
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastFailedAt)
+                .max(OffsetDateTime::compareTo)
+                .orElseThrow());
+    assertThat(actual.isIncomplete()).isFalse();
   }
 
   @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleTenants() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT2,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_9M,
-        6,
-        NOW_MINUS_8M,
-        1,
-        NOW_MINUS_7M,
-        false);
+    final var metricTenant2 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT2));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricTenant1, metricTenant2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
-    // then
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(8L, NOW_MINUS_9M),
-                new StatusMetric(16L, NOW_MINUS_8M),
-                new StatusMetric(3L, NOW_MINUS_7M),
-                false));
+    // then - verify aggregation across tenants
+    assertThat(actual.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(actual.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(actual.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
   }
 
   @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleJobTypes() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_B,
-        WORKER_1,
-        3,
-        NOW_MINUS_9M,
-        6,
-        NOW_MINUS_8M,
-        1,
-        NOW_MINUS_7M,
-        false);
+    final var metricJobTypeB = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_B));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricJobTypeA, metricJobTypeB);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
-    // then
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(8L, NOW_MINUS_9M),
-                new StatusMetric(16L, NOW_MINUS_8M),
-                new StatusMetric(3L, NOW_MINUS_7M),
-                false));
+    // then - verify aggregation across job types
+    assertThat(actual.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(actual.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(actual.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
   }
 
   @TestTemplate
   public void shouldAggregateMetricsAcrossMultipleWorkers() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metricWorker1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).worker(WORKER_1));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_2,
-        3,
-        NOW_MINUS_9M,
-        6,
-        NOW_MINUS_8M,
-        1,
-        NOW_MINUS_7M,
-        false);
+    final var metricWorker2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).worker(WORKER_2));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricWorker1, metricWorker2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
-    // then
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(8L, NOW_MINUS_9M),
-                new StatusMetric(16L, NOW_MINUS_8M),
-                new StatusMetric(3L, NOW_MINUS_7M),
-                false));
+    // then - verify aggregation across workers
+    assertThat(actual.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(actual.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(actual.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
   }
 
   @TestTemplate
   public void shouldFilterMetricsByTimeRange() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_15M,
-        NOW_MINUS_10M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        1,
-        NOW_MINUS_14M,
-        2,
-        NOW_MINUS_13M,
-        1,
-        NOW_MINUS_12M,
-        false);
+    final var metricOld =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.startTime(NOW.minusMinutes(100)).endTime(NOW.minusMinutes(50)));
+    final var metricMiddle =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.startTime(NOW.minusMinutes(30)).endTime(NOW.minusMinutes(20)));
+    final var metricRecent =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.startTime(NOW.minusMinutes(10)).endTime(NOW));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
-
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_4M,
-        7,
-        NOW_MINUS_3M,
-        1,
-        NOW_MINUS_2M,
-        false);
-
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricOld, metricMiddle, metricRecent);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when - filter to only get middle batch
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_10M).to(NOW_MINUS_5M.plusSeconds(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metricMiddle.startTime().minusSeconds(1))
+                                .to(metricMiddle.endTime().plusSeconds(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - only middle batch data
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(5L, NOW_MINUS_9M),
-                new StatusMetric(10L, NOW_MINUS_8M),
-                new StatusMetric(2L, NOW_MINUS_7M),
-                false));
+    assertThat(actual.created().count()).isEqualTo(metricMiddle.createdCount());
+    assertThat(actual.completed().count()).isEqualTo(metricMiddle.completedCount());
+    assertThat(actual.failed().count()).isEqualTo(metricMiddle.failedCount());
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metricMiddle.lastCreatedAt());
+    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metricMiddle.lastCompletedAt());
+    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metricMiddle.lastFailedAt());
   }
 
   @TestTemplate
   public void shouldFilterMetricsByJobType() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metricJobTypeA =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_B,
-        WORKER_1,
-        3,
-        NOW_MINUS_9M,
-        6,
-        NOW_MINUS_8M,
-        1,
-        NOW_MINUS_7M,
-        false);
+    final var metricJobTypeB =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricJobTypeA, metricJobTypeB);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when - filter by JOB_TYPE_A only
     final var actual =
@@ -452,107 +301,85 @@ public class JobMetricsBatchIT {
             GlobalJobStatisticsQuery.of(
                 q ->
                     q.filter(
-                        f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)).jobType(JOB_TYPE_A))),
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - only JOB_TYPE_A data
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(5L, NOW_MINUS_9M),
-                new StatusMetric(10L, NOW_MINUS_8M),
-                new StatusMetric(2L, NOW_MINUS_7M),
-                false));
+    assertThat(actual.created().count()).isEqualTo(metricJobTypeA.createdCount());
+    assertThat(actual.completed().count()).isEqualTo(metricJobTypeA.completedCount());
+    assertThat(actual.failed().count()).isEqualTo(metricJobTypeA.failedCount());
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metricJobTypeA.lastCreatedAt());
+    assertThat(toUtc(actual.completed().lastUpdatedAt()))
+        .isEqualTo(metricJobTypeA.lastCompletedAt());
+    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metricJobTypeA.lastFailedAt());
   }
 
   @TestTemplate
   public void shouldReturnMaxLastUpdatedAtTimestamp() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b);
+    final var metric2 = JobMetricsBatchFixtures.createRandomized(b -> b);
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_4M, // Most recent created
-        7,
-        NOW_MINUS_3M, // Most recent completed
-        1,
-        NOW_MINUS_2M, // Most recent failed
-        false);
-
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - should return max timestamps
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(NOW_MINUS_4M);
-    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(NOW_MINUS_3M);
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(NOW_MINUS_2M);
+    final var expectedMaxCreatedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastCreatedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+    final var expectedMaxCompletedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastCompletedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+    final var expectedMaxFailedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastFailedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(expectedMaxCreatedAt);
+    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(expectedMaxCompletedAt);
+    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(expectedMaxFailedAt);
   }
 
   @TestTemplate
   public void shouldReturnIncompleteWhenAnyBatchIsIncomplete() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false); // Complete
+    final var metricComplete =
+        JobMetricsBatchFixtures.createRandomized(b -> b.incompleteBatch(false));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_4M,
-        7,
-        NOW_MINUS_3M,
-        1,
-        NOW_MINUS_2M,
-        true); // Incomplete
+    final var metricIncomplete =
+        JobMetricsBatchFixtures.createRandomized(b -> b.incompleteBatch(true));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricComplete, metricIncomplete);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
@@ -565,7 +392,7 @@ public class JobMetricsBatchIT {
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q -> q.filter(f -> f.from(NOW.minusMinutes(15)).to(NOW.plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
@@ -581,22 +408,8 @@ public class JobMetricsBatchIT {
   @TestTemplate
   public void shouldReturnEmptyResultWhenNoMetricsMatchFilter() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
-
-    rdbmsWriters.flush();
+    final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
 
     // when - query for a different time range
     final var actual =
@@ -617,81 +430,47 @@ public class JobMetricsBatchIT {
   @TestTemplate
   public void shouldFilterByAuthorizedTenants() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metricTenant1 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
 
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT2,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW_MINUS_9M,
-        6,
-        NOW_MINUS_8M,
-        1,
-        NOW_MINUS_7M,
-        false);
+    final var metricTenant2 = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT2));
 
-    rdbmsWriters.flush();
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricTenant1, metricTenant2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when - only authorize TENANT1
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(
                 AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT1))));
 
     // then - only TENANT1 data
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(5L, NOW_MINUS_9M),
-                new StatusMetric(10L, NOW_MINUS_8M),
-                new StatusMetric(2L, NOW_MINUS_7M),
-                false));
+    assertThat(actual.created().count()).isEqualTo(metricTenant1.createdCount());
+    assertThat(actual.completed().count()).isEqualTo(metricTenant1.completedCount());
+    assertThat(actual.failed().count()).isEqualTo(metricTenant1.failedCount());
   }
 
   @TestTemplate
   public void shouldReturnEmptyResultWhenNoAuthorizedTenants() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
+    final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1));
 
-    rdbmsWriters.flush();
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
 
     // when - authorize no tenants
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of())));
 
     // then
@@ -707,161 +486,106 @@ public class JobMetricsBatchIT {
   @TestTemplate
   public void shouldHandleMetricsWithNullTimestamps() {
     // given - metrics with some zero counts (null timestamps)
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        0, // No completed jobs
-        null,
-        0, // No failed jobs
-        null,
-        false);
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .completedCount(0)
+                    .lastCompletedAt(null)
+                    .failedCount(0)
+                    .lastFailedAt(null));
 
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getGlobalJobStatistics(
+            GlobalJobStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metric.lastCreatedAt());
+    assertThat(actual.completed().count()).isZero();
+    assertThat(actual.completed().lastUpdatedAt()).isNull();
+    assertThat(actual.failed().count()).isZero();
+    assertThat(actual.failed().lastUpdatedAt()).isNull();
+  }
+
+  @TestTemplate
+  public void shouldAsyncWriteAndReadMetrics() {
+    // given
+    final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
+
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
     rdbmsWriters.flush();
 
     // when
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(normalizeToUtc(actual))
-        .isEqualTo(
-            new GlobalJobStatisticsEntity(
-                new StatusMetric(5L, NOW_MINUS_9M),
-                new StatusMetric(0L, null),
-                new StatusMetric(0L, null),
-                false));
-  }
-
-  @TestTemplate
-  public void shouldAsyncWriteAndReadMetrics() {
-    // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW_MINUS_9M,
-        10,
-        NOW_MINUS_8M,
-        2,
-        NOW_MINUS_7M,
-        false);
-
-    rdbmsWriters.flush();
-
-    // when/then - verify the data is eventually available
-    Awaitility.await("should find created job metrics")
-        .atMost(Duration.ofSeconds(4))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var actual =
-                  jobMetricsBatchReader.getGlobalJobStatistics(
-                      GlobalJobStatisticsQuery.of(
-                          q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
-                      ResourceAccessChecks.of(
-                          AuthorizationCheck.disabled(), TenantCheck.disabled()));
-
-              assertThat(actual.created().count()).isEqualTo(5L);
-              assertThat(actual.completed().count()).isEqualTo(10L);
-              assertThat(actual.failed().count()).isEqualTo(2L);
-            });
+    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
+    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
   }
 
   @TestTemplate
   public void shouldInsertJobMetricsBatch() {
     // given
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(NOW)
-            .endTime(NOW)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(5)
-            .lastFailedAt(NOW)
-            .completedCount(10)
-            .lastCompletedAt(NOW)
-            .createdCount(15)
-            .lastCreatedAt(NOW)
-            .incompleteBatch(false)
-            .build();
-    jobMetricsBatchWriter.create(model);
+    final var metric = JobMetricsBatchFixtures.createRandomized(b -> b);
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
     rdbmsWriters.flush();
 
+    // when
+    final var actual =
+        jobMetricsBatchReader.getGlobalJobStatistics(
+            GlobalJobStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
     // then
-    assertThat(model.key()).isNotNull();
-    assertThat(model.tenantId()).isEqualTo(TENANT1);
-    assertThat(model.jobType()).isEqualTo(JOB_TYPE_A);
-    assertThat(model.worker()).isEqualTo(WORKER_1);
-    assertThat(model.failedCount()).isEqualTo(5);
-    assertThat(model.completedCount()).isEqualTo(10);
-    assertThat(model.createdCount()).isEqualTo(15);
-    assertThat(model.incompleteBatch()).isFalse();
+    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metric.lastCreatedAt());
+    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metric.lastCompletedAt());
+    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metric.lastFailedAt());
+    assertThat(actual.isIncomplete()).isEqualTo(metric.incompleteBatch());
   }
 
   @TestTemplate
   public void shouldInsertMultipleJobMetricsBatches() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        1,
-        NOW,
-        2,
-        NOW,
-        3,
-        NOW,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_B,
-        WORKER_2,
-        4,
-        NOW_MINUS_5M,
-        5,
-        NOW_MINUS_5M,
-        6,
-        NOW_MINUS_5M,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_10M,
-        NOW_MINUS_10M,
-        TENANT2,
-        JOB_TYPE_A,
-        WORKER_1,
-        7,
-        NOW_MINUS_10M,
-        8,
-        NOW_MINUS_10M,
-        9,
-        NOW_MINUS_10M,
-        true);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
 
-    // when
-    rdbmsWriters.flush();
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B).worker(WORKER_2));
+
+    final var metric3 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT2).jobType(JOB_TYPE_A).worker(WORKER_1).incompleteBatch(true));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2, metric3));
 
     // when - then
     assertThat(rdbmsWriters).isNotNull();
@@ -870,70 +594,54 @@ public class JobMetricsBatchIT {
   @TestTemplate
   public void shouldInsertJobMetricsBatchWithDifferentTenants() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW,
-        10,
-        NOW,
-        15,
-        NOW,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT2,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW,
-        6,
-        NOW,
-        9,
-        NOW,
-        false);
-    rdbmsWriters.flush();
+    final var metricTenant1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A));
+
+    final var metricTenant2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.tenantId(TENANT2).jobType(JOB_TYPE_A));
+
+    final var metrics = List.of(metricTenant1, metricTenant2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // then - verify both were written successfully
     final var actual =
         jobMetricsBatchReader.getGlobalJobStatistics(
             GlobalJobStatisticsQuery.of(
-                q -> q.filter(f -> f.from(NOW_MINUS_15M).to(NOW.plusMinutes(1)))),
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
-    assertThat(actual.created().count()).isEqualTo(8L); // 5 from TENANT1 + 3 from TENANT2
+    assertThat(actual.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
   }
 
   @TestTemplate
   public void shouldInsertJobMetricsBatchWithIncompleteBatch() {
     // given
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(NOW)
-            .endTime(NOW)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(5)
-            .lastFailedAt(NOW)
-            .completedCount(10)
-            .lastCompletedAt(NOW)
-            .createdCount(15)
-            .lastCreatedAt(NOW)
-            .incompleteBatch(true)
-            .build();
-    jobMetricsBatchWriter.create(model);
-    rdbmsWriters.flush();
+    final var metric = JobMetricsBatchFixtures.createRandomized(b -> b.incompleteBatch(true));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getGlobalJobStatistics(
+            GlobalJobStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(model.incompleteBatch()).isTrue();
+    assertThat(actual.isIncomplete()).isTrue();
+    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
+    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metric.lastCreatedAt());
+    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metric.lastCompletedAt());
+    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metric.lastFailedAt());
   }
 
   @TestTemplate
@@ -942,7 +650,6 @@ public class JobMetricsBatchIT {
     final var model =
         new JobMetricsBatchDbModel.Builder()
             .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
             .startTime(NOW)
             .endTime(NOW)
             .tenantId(TENANT1)
@@ -968,141 +675,107 @@ public class JobMetricsBatchIT {
   @TestTemplate
   public void shouldCleanupJobMetricsBatchesProperly() {
     // given
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW,
-        10,
-        NOW,
-        15,
-        NOW,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT1,
-        JOB_TYPE_B,
-        WORKER_1,
-        5,
-        NOW,
-        10,
-        NOW,
-        15,
-        NOW,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW.minusYears(3),
-        NOW.minusYears(3),
-        TENANT2,
-        JOB_TYPE_A,
-        WORKER_1,
-        3,
-        NOW.minusYears(3),
-        6,
-        NOW.minusYears(3),
-        9,
-        NOW.minusYears(3),
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW.minusYears(3),
-        NOW.minusYears(3),
-        TENANT2,
-        JOB_TYPE_B,
-        WORKER_2,
-        1,
-        NOW.minusYears(3),
-        2,
-        NOW.minusYears(3),
-        3,
-        NOW.minusYears(3),
-        false);
-    rdbmsWriters.flush();
+    final var recentA =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(NOW)
+                    .endTime(NOW)
+                    .lastCreatedAt(NOW)
+                    .lastCompletedAt(NOW)
+                    .lastFailedAt(NOW)
+                    .incompleteBatch(false));
+
+    final var recentB =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT1)
+                    .jobType(JOB_TYPE_B)
+                    .worker(WORKER_1)
+                    .startTime(NOW)
+                    .endTime(NOW)
+                    .lastCreatedAt(NOW)
+                    .lastCompletedAt(NOW)
+                    .lastFailedAt(NOW)
+                    .incompleteBatch(false));
+
+    final var oldTimestamp = NOW.minusYears(3);
+    final var oldA =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT2)
+                    .jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(oldTimestamp)
+                    .endTime(oldTimestamp)
+                    .lastCreatedAt(oldTimestamp)
+                    .lastCompletedAt(oldTimestamp)
+                    .lastFailedAt(oldTimestamp)
+                    .incompleteBatch(false));
+
+    final var oldB =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.tenantId(TENANT2)
+                    .jobType(JOB_TYPE_B)
+                    .worker(WORKER_2)
+                    .startTime(oldTimestamp)
+                    .endTime(oldTimestamp)
+                    .lastCreatedAt(oldTimestamp)
+                    .lastCompletedAt(oldTimestamp)
+                    .lastFailedAt(oldTimestamp)
+                    .incompleteBatch(false));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(
+        rdbmsWriters, List.of(recentA, recentB, oldA, oldB));
 
     // when - cleanup records older than 2 years
-    Awaitility.await("should cleanup old job metrics batches")
-        .atMost(Duration.ofSeconds(4))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final int deletedCount =
-                  jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.minusYears(2), 100);
-              assertThat(deletedCount).isEqualTo(2);
-            });
+    final int deletedCount =
+        jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.minusYears(2), 100);
+
+    // then
+    assertThat(deletedCount).isEqualTo(2);
   }
 
   @TestTemplate
   public void shouldCleanupJobMetricsBatchesWithLimit() {
     // given - create 5 old records
-    for (int i = 0; i < 5; i++) {
-      writeMetric(
-          jobMetricsBatchWriter,
-          NOW.minusYears(3),
-          NOW.minusYears(3),
-          TENANT1,
-          JOB_TYPE_A + i,
-          WORKER_1,
-          1,
-          NOW.minusYears(3),
-          2,
-          NOW.minusYears(3),
-          3,
-          NOW.minusYears(3),
-          false);
-    }
-    rdbmsWriters.flush();
+    final var oldTimestamp = NOW.minusYears(3);
+    final var metrics =
+        Stream.iterate(0, i -> i + 1)
+            .limit(5)
+            .map(
+                i ->
+                    JobMetricsBatchFixtures.createRandomized(
+                        b -> b.startTime(oldTimestamp).endTime(oldTimestamp)))
+            .toList();
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
 
     // when - cleanup with limit of 3
-    Awaitility.await("should cleanup limited job metrics batches")
-        .atMost(Duration.ofSeconds(4))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final int deletedCount =
-                  jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.minusYears(2), 3);
-              assertThat(deletedCount).isEqualTo(3);
-            });
+    final int deletedCount =
+        jobMetricsBatchWriter.cleanupMetrics(PARTITION_ID, NOW.minusYears(2), 3);
+
+    // then
+    assertThat(deletedCount).isEqualTo(3);
   }
 
   @TestTemplate
   public void shouldNotCleanupRecentJobMetricsBatches() {
     // given - create only recent records
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW,
-        NOW,
-        TENANT1,
-        JOB_TYPE_A,
-        WORKER_1,
-        5,
-        NOW,
-        10,
-        NOW,
-        15,
-        NOW,
-        false);
-    writeMetric(
-        jobMetricsBatchWriter,
-        NOW_MINUS_5M,
-        NOW_MINUS_5M,
-        TENANT1,
-        JOB_TYPE_B,
-        WORKER_2,
-        3,
-        NOW_MINUS_5M,
-        6,
-        NOW_MINUS_5M,
-        9,
-        NOW_MINUS_5M,
-        false);
-    rdbmsWriters.flush();
+    final var startTime1 = NOW.minusMinutes(3);
+    final var endTime1 = NOW.minusMinutes(2);
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.startTime(startTime1).endTime(endTime1));
+
+    final var startTime2 = NOW.minusMinutes(2);
+    final var endTime2 = NOW.minusMinutes(1);
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.startTime(startTime2).endTime(endTime2));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, List.of(metric1, metric2));
 
     // when - cleanup records older than 2 years (none should be affected)
     final int deletedCount =
@@ -1112,135 +785,291 @@ public class JobMetricsBatchIT {
     assertThat(deletedCount).isEqualTo(0);
   }
 
+  // ==========================================================================
+  // Job Type Statistics Tests
+  // ==========================================================================
+
   @TestTemplate
-  public void shouldInsertJobMetricsBatchWithAllFields() {
+  public void shouldAggregateJobStatisticsByJobType() {
     // given
-    final var startTime = NOW.minusMinutes(30);
-    final var endTime = NOW;
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(startTime)
-            .endTime(endTime)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(100)
-            .lastFailedAt(NOW.minusMinutes(5))
-            .completedCount(200)
-            .lastCompletedAt(NOW.minusMinutes(3))
-            .createdCount(300)
-            .lastCreatedAt(NOW.minusMinutes(1))
-            .incompleteBatch(false)
-            .build();
-    jobMetricsBatchWriter.create(model);
-    rdbmsWriters.flush();
+    final var metricJobTypeA = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
+
+    final var metricJobTypeB = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_B));
+
+    JobMetricsBatchFixtures.createAndSaveMetrics(
+        rdbmsWriters, List.of(metricJobTypeA, metricJobTypeB));
+
+    final var createdMetrics = List.of(metricJobTypeA, metricJobTypeB);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(createdMetrics).minusMinutes(1))
+                                .to(getMaxEndTime(createdMetrics).plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(model.startTime()).isEqualTo(startTime);
-    assertThat(model.endTime()).isEqualTo(endTime);
-    assertThat(model.failedCount()).isEqualTo(100);
-    assertThat(model.completedCount()).isEqualTo(200);
-    assertThat(model.createdCount()).isEqualTo(300);
-    assertThat(model.lastFailedAt()).isNotNull();
-    assertThat(model.lastCompletedAt()).isNotNull();
-    assertThat(model.lastCreatedAt()).isNotNull();
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+
+    // Verify SQL ORDER BY JOB_TYPE ASC - results should already be sorted
+    assertThat(actual.items().get(0).jobType()).isEqualTo(JOB_TYPE_A);
+    assertThat(actual.items().get(1).jobType()).isEqualTo(JOB_TYPE_B);
+
+    final var jobTypeA = normalizeToUtc(actual.items().get(0));
+    assertThat(jobTypeA.jobType()).isEqualTo(JOB_TYPE_A);
+    assertThat(jobTypeA.created().count()).isEqualTo(metricJobTypeA.createdCount());
+    assertThat(jobTypeA.created().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastCreatedAt());
+    assertThat(jobTypeA.completed().count()).isEqualTo(metricJobTypeA.completedCount());
+    assertThat(jobTypeA.completed().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastCompletedAt());
+    assertThat(jobTypeA.failed().count()).isEqualTo(metricJobTypeA.failedCount());
+    assertThat(jobTypeA.failed().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastFailedAt());
+    assertThat(jobTypeA.workers()).isEqualTo(1);
+
+    final var jobTypeB = normalizeToUtc(actual.items().get(1));
+    assertThat(jobTypeB.jobType()).isEqualTo(JOB_TYPE_B);
+    assertThat(jobTypeB.created().count()).isEqualTo(metricJobTypeB.createdCount());
+    assertThat(jobTypeB.created().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastCreatedAt());
+    assertThat(jobTypeB.completed().count()).isEqualTo(metricJobTypeB.completedCount());
+    assertThat(jobTypeB.completed().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastCompletedAt());
+    assertThat(jobTypeB.failed().count()).isEqualTo(metricJobTypeB.failedCount());
+    assertThat(jobTypeB.failed().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastFailedAt());
+    assertThat(jobTypeB.workers()).isEqualTo(1);
   }
 
   @TestTemplate
-  public void shouldHandleBatchWithOnlyFailedJobs() {
-    // given
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(NOW)
-            .endTime(NOW)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(10)
-            .lastFailedAt(NOW)
-            .completedCount(0)
-            .lastCompletedAt(null)
-            .createdCount(0)
-            .lastCreatedAt(null)
-            .incompleteBatch(false)
-            .build();
-    jobMetricsBatchWriter.create(model);
-    rdbmsWriters.flush();
+  public void shouldAggregateJobTypeStatsAcrossMultipleBatches() {
+    // given - multiple batches for same job type
+    final var metric1 = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
 
-    // then
-    assertThat(model.failedCount()).isEqualTo(10);
-    assertThat(model.completedCount()).isZero();
-    assertThat(model.createdCount()).isZero();
-    assertThat(model.lastFailedAt()).isNotNull();
-    assertThat(model.lastCompletedAt()).isNull();
-    assertThat(model.lastCreatedAt()).isNull();
+    final var metric2 = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
+
+    final var metric3 = JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2, metric3);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - aggregated across both batches
+    assertThat(actual.total()).isEqualTo(1);
+    assertThat(actual.items()).hasSize(1);
+
+    final var stats = normalizeToUtc(actual.items().get(0));
+    assertThat(stats.jobType()).isEqualTo(JOB_TYPE_A);
+    assertThat(stats.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(stats.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(stats.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+
+    final var expectedLastCreatedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastCreatedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+    final var expectedLastCompletedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastCompletedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+    final var expectedLastFailedAt =
+        metrics.stream()
+            .map(JobMetricsBatchDbModel::lastFailedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElseThrow();
+
+    assertThat(stats.created().lastUpdatedAt()).isEqualTo(expectedLastCreatedAt);
+    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(expectedLastCompletedAt);
+    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(expectedLastFailedAt);
+    final var workersNb = metrics.stream().map(JobMetricsBatchDbModel::worker).distinct().count();
+    assertThat(stats.workers()).isEqualTo(workersNb);
   }
 
   @TestTemplate
-  public void shouldHandleBatchWithOnlyCompletedJobs() {
-    // given
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(NOW)
-            .endTime(NOW)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(0)
-            .lastFailedAt(null)
-            .completedCount(20)
-            .lastCompletedAt(NOW)
-            .createdCount(0)
-            .lastCreatedAt(null)
-            .incompleteBatch(false)
-            .build();
-    jobMetricsBatchWriter.create(model);
-    rdbmsWriters.flush();
+  public void shouldCountDistinctWorkersPerJobType() {
+    // given - multiple workers for same job type
+    final var metricWorker1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricWorker2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_2));
+
+    final var metrics = List.of(metricWorker1, metricWorker2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(model.failedCount()).isZero();
-    assertThat(model.completedCount()).isEqualTo(20);
-    assertThat(model.createdCount()).isZero();
-    assertThat(model.lastFailedAt()).isNull();
-    assertThat(model.lastCompletedAt()).isNotNull();
-    assertThat(model.lastCreatedAt()).isNull();
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().get(0).jobType()).isEqualTo(JOB_TYPE_A);
+    assertThat(actual.items().get(0).workers()).isEqualTo(2); // WORKER_1 and WORKER_2
   }
 
   @TestTemplate
-  public void shouldHandleBatchWithOnlyCreatedJobs() {
+  public void shouldFilterJobTypeStatsByTimeRange() {
     // given
-    final var model =
-        new JobMetricsBatchDbModel.Builder()
-            .key(String.valueOf(CommonFixtures.nextKey()))
-            .partitionId(PARTITION_ID)
-            .startTime(NOW)
-            .endTime(NOW)
-            .tenantId(TENANT1)
-            .jobType(JOB_TYPE_A)
-            .worker(WORKER_1)
-            .failedCount(0)
-            .lastFailedAt(null)
-            .completedCount(0)
-            .lastCompletedAt(null)
-            .createdCount(30)
-            .lastCreatedAt(NOW)
-            .incompleteBatch(false)
-            .build();
-    jobMetricsBatchWriter.create(model);
-    rdbmsWriters.flush();
+    final var metricOld =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.startTime(NOW.minusMinutes(30)).endTime(NOW.minusMinutes(20)));
 
-    // then
-    assertThat(model.failedCount()).isZero();
-    assertThat(model.completedCount()).isZero();
-    assertThat(model.createdCount()).isEqualTo(30);
-    assertThat(model.lastFailedAt()).isNull();
-    assertThat(model.lastCompletedAt()).isNull();
-    assertThat(model.lastCreatedAt()).isNotNull();
+    final var metricMiddle =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.startTime(NOW.minusMinutes(10)).endTime(NOW));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricOld, metricMiddle);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter to only get middle batch
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metricMiddle.startTime().minusSeconds(1))
+                                .to(metricMiddle.endTime().plusSeconds(1)))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only JOB_TYPE_B
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().get(0).jobType()).isEqualTo(metricMiddle.jobType());
+  }
+
+  @TestTemplate
+  public void shouldFilterJobTypeStatsByJobTypeExactMatch() {
+    // given
+    final var metricJobTypeA =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricJobTypeB =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B).worker(WORKER_1));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricJobTypeA, metricJobTypeB);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter by JOB_TYPE_A only
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobTypeOperations(List.of(Operation.eq(JOB_TYPE_A))))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only JOB_TYPE_A
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().jobType()).isEqualTo(JOB_TYPE_A);
+    assertThat(actual.items().getFirst().created().count())
+        .isEqualTo(metricJobTypeA.createdCount());
+    assertThat(actual.items().getFirst().completed().count())
+        .isEqualTo(metricJobTypeA.completedCount());
+    assertThat(actual.items().getFirst().failed().count()).isEqualTo(metricJobTypeA.failedCount());
+    assertThat(toUtc(actual.items().getFirst().completed().lastUpdatedAt()))
+        .isEqualTo(metricJobTypeA.lastCompletedAt());
+    assertThat(toUtc(actual.items().getFirst().created().lastUpdatedAt()))
+        .isEqualTo(metricJobTypeA.lastCreatedAt());
+    assertThat(toUtc(actual.items().getFirst().failed().lastUpdatedAt()))
+        .isEqualTo(metricJobTypeA.lastFailedAt());
+  }
+
+  @TestTemplate
+  public void shouldFilterJobTypeStatsByJobTypeLike() {
+    // given
+    final var metricFetchOrders =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType("fetch-orders"));
+
+    final var metricFetchCustomers =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType("fetch-customers"));
+
+    final var metricProcessPayment =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType("process-payment"));
+
+    final List<JobMetricsBatchDbModel> metrics =
+        List.of(metricFetchOrders, metricFetchCustomers, metricProcessPayment);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter using like operation (use * wildcard, not %)
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobTypeOperations(List.of(Operation.like("fetch-*"))))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only fetch-* job types, ordered by JOB_TYPE ASC from SQL
+    assertThat(actual.items()).hasSize(2);
+    final var jobTypes = actual.items().stream().map(JobTypeStatisticsEntity::jobType).toList();
+    assertThat(jobTypes).containsExactly("fetch-customers", "fetch-orders");
+  }
+
+  @TestTemplate
+  public void shouldFilterJobTypeStatsByJobTypeIn() {
+    // given
+    final var metricA =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricB =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B).worker(WORKER_1));
+
+    final var metricC =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType("jobTypeC").worker(WORKER_1));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricA, metricB, metricC);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter using in operation
+    final var actual =
+        jobMetricsBatchReader.getJobTypeStatistics(
+            JobTypeStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobTypeOperations(List.of(Operation.in(JOB_TYPE_A, JOB_TYPE_B))))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only JOB_TYPE_A and JOB_TYPE_B, ordered by JOB_TYPE ASC from SQL
+    assertThat(actual.items()).hasSize(2);
+    final var jobTypes = actual.items().stream().map(JobTypeStatisticsEntity::jobType).toList();
+    assertThat(jobTypes).containsExactly(JOB_TYPE_A, JOB_TYPE_B);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobTypeStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobTypeStatisticsSort.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobTypeStatisticsSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobTypeStatisticsSort of(
+      final Function<JobTypeStatisticsSort.Builder, ObjectBuilder<JobTypeStatisticsSort>> fn) {
+    return SortOptionBuilders.jobTypeStatistics(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<JobTypeStatisticsSort.Builder>
+      implements ObjectBuilder<JobTypeStatisticsSort> {
+
+    public Builder jobType() {
+      currentOrdering = new FieldSorting("jobType", null);
+      return this;
+    }
+
+    @Override
+    protected JobTypeStatisticsSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobTypeStatisticsSort build() {
+      return new JobTypeStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -272,6 +272,15 @@ public final class SortOptionBuilders {
     return fn.apply(processDefinitionMessageSubscriptionStatistics()).build();
   }
 
+  public static JobTypeStatisticsSort.Builder jobTypeStatistics() {
+    return new JobTypeStatisticsSort.Builder();
+  }
+
+  public static JobTypeStatisticsSort jobTypeStatistics(
+      final Function<JobTypeStatisticsSort.Builder, ObjectBuilder<JobTypeStatisticsSort>> fn) {
+    return fn.apply(jobTypeStatistics()).build();
+  }
+
   public static CorrelatedMessageSubscriptionSort.Builder correlatedMessageSubscription() {
     return new CorrelatedMessageSubscriptionSort.Builder();
   }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -165,6 +165,16 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                 .getJobTypeStatistics(query));
   }
 
+  public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
+      final JobTypeStatisticsQuery query) {
+    final var authJobSearchClient =
+        jobSearchClient.withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.system().readJobMetric())));
+
+    return authJobSearchClient.getJobTypeStatistics(query);
+  }
+
   public record ActivateJobsRequest(
       String type,
       int maxJobsToActivate,

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -165,16 +165,6 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                 .getJobTypeStatistics(query));
   }
 
-  public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
-      final JobTypeStatisticsQuery query) {
-    final var authJobSearchClient =
-        jobSearchClient.withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.system().readJobMetric())));
-
-    return authJobSearchClient.getJobTypeStatistics(query);
-  }
-
   public record ActivateJobsRequest(
       String type,
       int maxJobsToActivate,


### PR DESCRIPTION
## Description

This pull request introduces support for querying job type statistics in the RDBMS implementation, including the necessary domain objects, SQL mapping, and service logic. It also refactors the handling of empty results and improves test coverage for null values in database results.

**Job Type Statistics Query Implementation:**

* Added `JobTypeStatisticsDbQuery` and `JobTypeStatisticsDbResult` records to represent the query and result for job type statistics (`JobTypeStatisticsDbQuery.java`, `JobTypeStatisticsDbResult.java`). [[1]](diffhunk://#diff-5a391228c05f408fcf9a626933a00e605e193d261342cec37869945203dbb391R1-R61) [[2]](diffhunk://#diff-850bd2029beb0a52ec2264fd295cf13361a81545c1a7fa588bac5c56a40b24f6R1-R20)
* Implemented the `getJobTypeStatistics` method in `JobMetricsBatchDbReader`, including mapping, sorting, paging, and conversion from database results to entities.
* Created the `JobTypeStatisticsColumn` enum for column mapping and sorting support.
* Added the `jobTypeStatistics` method to the `JobMetricsBatchMapper` interface and its corresponding SQL mapping in `JobMetricsBatchMapper.xml`. [[1]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R12-R25) [[2]](diffhunk://#diff-76bcc9d46c6f7e8b18ff6be8b66f8d6fed24f524445f0c27077b2d93ec2679a8R64-R120)

**Refactoring and Utility Improvements:**

* Refactored empty result handling by introducing the `EmptyResults` utility class for reusable empty results in `JobMetricsBatchDbReader`. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289L41-R54) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289L66-R124)
* Removed redundant null checks for the global job statistics mapper result, relying on default values instead.

**Testing Enhancements:**

* Improved test coverage by adding a test case for handling null counts in the database result for global job statistics.
* Updated test imports to support the new job type statistics query and result classes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43068
