### PR TITLE
fix: restore app requires no arguments when matching RDMS

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -217,11 +217,6 @@ public class RestoreApp implements ApplicationRunner {
     final boolean hasBackupId = hasBackupId();
     final boolean hasTimeRange = hasTimeRange();
 
-    if (!hasBackupId && !hasTimeRange) {
-      throw new IllegalArgumentException(
-          "Either --backupId or both --from and --to parameters must be provided");
-    }
-
     if (hasBackupId && hasTimeRange) {
       throw new IllegalArgumentException(
           "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
@@ -247,7 +242,7 @@ public class RestoreApp implements ApplicationRunner {
     } else if (hasTimeRange()) {
       return String.valueOf(Objects.hash(from, to));
     } else {
-      throw new IllegalStateException("No valid restore parameters provided");
+      return "latest";
     }
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -137,7 +137,6 @@ public class RestoreManager implements CloseableSilently {
 
     final var exportedPositions = exportedPositions(partitionCount).join();
     LOG.info("Exported positions for all partitions: {}", exportedPositions);
-    final var interval = Interval.closed(from, to);
     final var restoreInfos =
         rangeResolver
             .getRestoreInfoForAllPartitions(


### PR DESCRIPTION
This fixes some leftovers from #45826 and adds a simple test case.

For the "restore id" we use a fixed string "latest" - this will require manual cleanup before the next restore on ECS.