### PR TITLE
feat: add request timeout to PI create tool

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
@@ -44,6 +44,11 @@ public record McpProcessInstanceCreationInstruction(
         Boolean awaitCompletion,
     @McpToolParam(
             description =
+                "Timeout in milliseconds the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied.",
+            required = false)
+        Long requestTimeout,
+    @McpToolParam(
+            description =
                 "List of variables by name to be included in the response when awaitCompletion is set to true. If empty, all visible variables in the root scope will be returned.",
             required = false)
         List<@NotBlank String> fetchVariables,

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -111,7 +111,7 @@ public class ProcessInstanceTools {
           and return its result variables. When using awaitCompletion, always include a unique tag
           `mcp-tool:<uniqueId>` which can be used to search for the started process instance in case
           of timeouts. Processes with wait states, like service tasks, user tasks, or defined listeners,
-          will timeout more likely. You can increase the timeout to wait for completion by defining
+          are more likely to time out. You can increase the timeout to wait for completion by defining
           a longer requestTimeout.""")
   public CallToolResult createProcessInstance(
       @McpToolParamsUnwrapped @Valid

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -110,7 +110,9 @@ public class ProcessInstanceTools {
           When using the awaitCompletion flag, the tool will wait for the process instance to complete
           and return its result variables. When using awaitCompletion, always include a unique tag
           `mcp-tool:<uniqueId>` which can be used to search for the started process instance in case
-          of timeouts.""")
+          of timeouts. Processes with wait states, like service tasks, user tasks, or defined listeners,
+          will timeout more likely. You can increase the timeout to wait for completion by defining
+          a longer requestTimeout.""")
   public CallToolResult createProcessInstance(
       @McpToolParamsUnwrapped @Valid
           final McpProcessInstanceCreationInstruction creationInstruction) {
@@ -128,6 +130,8 @@ public class ProcessInstanceTools {
       Optional.ofNullable(creationInstruction.fetchVariables())
           .ifPresent(instruction::fetchVariables);
       Optional.ofNullable(creationInstruction.tags()).ifPresent(instruction::tags);
+      Optional.ofNullable(creationInstruction.requestTimeout())
+          .ifPresent(instruction::requestTimeout);
 
       final var request =
           SimpleRequestMapper.toCreateProcessInstance(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -103,7 +103,19 @@ public class CustomMcpModelPropertiesTest {
         Arguments.argumentSet(
             "McpUserTaskAssignmentRequest",
             McpUserTaskAssignmentRequest.class,
-            Set.of("action", "allowOverride")));
+            Set.of("action", "allowOverride")),
+        Arguments.argumentSet(
+            "McpProcessInstanceCreationInstruction",
+            McpProcessInstanceCreationInstruction.class,
+            Set.of(
+                "awaitCompletion",
+                "fetchVariables",
+                "processDefinitionId",
+                "processDefinitionKey",
+                "processDefinitionVersion",
+                "requestTimeout",
+                "tags",
+                "variables")));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

Adds the requestTimeout to tool call properties for PI creation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44474 
