### PR TITLE
feat: add JobTypeStatistics ES/OS part

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
+import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
@@ -36,6 +37,14 @@ public class JobMetricsBatchDocumentReader extends DocumentBasedReader
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    final var aggResult =
+        getSearchExecutor()
+            .aggregate(query, JobTypeStatisticsAggregationResult.class, resourceAccessChecks);
+    return new SearchQueryResult<>(
+        aggResult.items().size(),
+        !aggResult.items().isEmpty(),
+        aggResult.items(),
+        null,
+        aggResult.endCursor());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -12,6 +12,7 @@ import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByErrorAggregation;
+import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionInstanceStatisticsAggregation;
 import io.camunda.search.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregation;
@@ -25,6 +26,7 @@ import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggre
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResult;
+import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResult;
@@ -42,6 +44,7 @@ import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLate
 import io.camunda.search.clients.transformers.aggregation.GlobalJobStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByErrorAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.JobTypeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionInstanceVersionStatisticsAggregationTransformer;
@@ -55,6 +58,7 @@ import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinit
 import io.camunda.search.clients.transformers.aggregation.result.GlobalJobStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByErrorAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.JobTypeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionInstanceVersionStatisticsAggregationResultTransformer;
@@ -108,6 +112,7 @@ import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupMemberFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
 import io.camunda.search.clients.transformers.filter.JobFilterTransformer;
+import io.camunda.search.clients.transformers.filter.JobTypeStatisticsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.MappingRuleFilterTransformer;
 import io.camunda.search.clients.transformers.filter.MessageSubscriptionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionFilterTransformer;
@@ -176,6 +181,7 @@ import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.GroupMemberFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.JobFilter;
+import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.filter.MessageSubscriptionFilter;
 import io.camunda.search.filter.ProcessDefinitionFilter;
@@ -212,6 +218,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuer
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
@@ -421,7 +428,8 @@ public final class ServiceTransformers {
             AuditLogQuery.class,
             IncidentProcessInstanceStatisticsByErrorQuery.class,
             IncidentProcessInstanceStatisticsByDefinitionQuery.class,
-            GlobalJobStatisticsQuery.class)
+            GlobalJobStatisticsQuery.class,
+            JobTypeStatisticsQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -569,6 +577,10 @@ public final class ServiceTransformers {
         new GlobalJobStatisticsFilterTransformer(
             indexDescriptors.get(JobMetricsBatchTemplate.class)));
     mappers.put(
+        JobTypeStatisticsFilter.class,
+        new JobTypeStatisticsFilterTransformer(
+            indexDescriptors.get(JobMetricsBatchTemplate.class)));
+    mappers.put(
         ProcessDefinitionStatisticsFilter.class,
         new ProcessDefinitionStatisticsFilterTransformer(
             mappers, indexDescriptors.get(ListViewTemplate.class)));
@@ -639,6 +651,7 @@ public final class ServiceTransformers {
         new DecisionDefinitionLatestVersionAggregationTransformer());
     mappers.put(
         GlobalJobStatisticsAggregation.class, new GlobalJobStatisticsAggregationTransformer());
+    mappers.put(JobTypeStatisticsAggregation.class, new JobTypeStatisticsAggregationTransformer());
 
     // aggregation result
     mappers.put(
@@ -675,5 +688,8 @@ public final class ServiceTransformers {
     mappers.put(
         GlobalJobStatisticsAggregationResult.class,
         new GlobalJobStatisticsAggregationResultTransformer());
+    mappers.put(
+        JobTypeStatisticsAggregationResult.class,
+        new JobTypeStatisticsAggregationResultTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobTypeStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/JobTypeStatisticsAggregationTransformer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_BY_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COMPOSITE_SIZE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_SOURCE_NAME_JOB_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_WORKERS;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_JOB_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_WORKER;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.cardinality;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.max;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.sum;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+
+import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import java.util.Optional;
+
+public class JobTypeStatisticsAggregationTransformer
+    implements AggregationTransformer<JobTypeStatisticsAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<JobTypeStatisticsAggregation, ServiceTransformers> value) {
+
+    final var aggregation = value.getLeft();
+
+    // Created filter bucket with count and lastUpdatedAt sub-aggregations
+    final var createdAgg =
+        filter()
+            .name(AGGREGATION_CREATED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_CREATED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_CREATED_AT))
+            .build();
+
+    // Completed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var completedAgg =
+        filter()
+            .name(AGGREGATION_COMPLETED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_COMPLETED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_COMPLETED_AT))
+            .build();
+
+    // Failed filter bucket with count and lastUpdatedAt sub-aggregations
+    final var failedAgg =
+        filter()
+            .name(AGGREGATION_FAILED)
+            .query(matchAll())
+            .aggregations(
+                sum(AGGREGATION_COUNT, FIELD_FAILED_COUNT),
+                max(AGGREGATION_LAST_UPDATED_AT, FIELD_LAST_FAILED_AT))
+            .build();
+
+    // Cardinality aggregation to count distinct workers
+    final var workersAgg = cardinality(AGGREGATION_WORKERS, FIELD_WORKER);
+
+    // Terms source for composite aggregation by job type
+    final var byJobTypeSource =
+        terms().name(AGGREGATION_SOURCE_NAME_JOB_TYPE).field(FIELD_JOB_TYPE).build();
+
+    // Composite aggregation for pagination support
+    final var page = aggregation.page();
+    final var byTypeAgg =
+        composite()
+            .name(AGGREGATION_BY_TYPE)
+            .size(
+                Optional.ofNullable(page)
+                    .map(SearchQueryPage::size)
+                    .orElse(AGGREGATION_COMPOSITE_SIZE))
+            .after(Optional.ofNullable(page).map(SearchQueryPage::after).orElse(null))
+            .sources(List.of(byJobTypeSource))
+            .aggregations(createdAgg, completedAgg, failedAgg, workersAgg)
+            .build();
+
+    return List.of(byTypeAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobTypeStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/JobTypeStatisticsAggregationResultTransformer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_BY_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_WORKERS;
+
+import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class JobTypeStatisticsAggregationResultTransformer
+    implements AggregationResultTransformer<JobTypeStatisticsAggregationResult> {
+
+  @Override
+  public JobTypeStatisticsAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+
+    final var byTypeAgg = aggregations.get(AGGREGATION_BY_TYPE);
+    if (byTypeAgg == null || byTypeAgg.aggregations() == null) {
+      return new JobTypeStatisticsAggregationResult(Collections.emptyList(), null);
+    }
+
+    final var perTypeBuckets = byTypeAgg.aggregations();
+
+    final List<JobTypeStatisticsEntity> items =
+        perTypeBuckets.entrySet().stream()
+            .map(
+                entry -> {
+                  final String jobType = entry.getKey();
+                  final var agg = entry.getValue();
+                  if (agg == null || agg.aggregations() == null || agg.aggregations().isEmpty()) {
+                    return null;
+                  }
+
+                  final var subAggregations = agg.aggregations();
+
+                  // Extract metrics from nested filter bucket aggregations
+                  final var createdMetric =
+                      extractStatusMetric(subAggregations, AGGREGATION_CREATED);
+                  final var completedMetric =
+                      extractStatusMetric(subAggregations, AGGREGATION_COMPLETED);
+                  final var failedMetric = extractStatusMetric(subAggregations, AGGREGATION_FAILED);
+
+                  // Extract workers count
+                  final int workers = extractWorkersCount(subAggregations);
+
+                  return new JobTypeStatisticsEntity(
+                      jobType, createdMetric, completedMetric, failedMetric, workers);
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
+    return new JobTypeStatisticsAggregationResult(items, byTypeAgg.endCursor());
+  }
+
+  private StatusMetric extractStatusMetric(
+      final Map<String, AggregationResult> aggregations, final String bucketName) {
+    final var bucketAgg = aggregations.get(bucketName);
+    if (bucketAgg == null || bucketAgg.aggregations() == null) {
+      return new StatusMetric(0L, null);
+    }
+
+    final var subAggregations = bucketAgg.aggregations();
+    final long count = extractDocCount(subAggregations);
+    final OffsetDateTime lastUpdatedAt = extractMaxTimestamp(subAggregations);
+
+    return new StatusMetric(count, lastUpdatedAt);
+  }
+
+  private long extractDocCount(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_COUNT);
+    if (agg != null && agg.docCount() != null) {
+      return agg.docCount();
+    }
+    return 0L;
+  }
+
+  private OffsetDateTime extractMaxTimestamp(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_LAST_UPDATED_AT);
+    if (agg != null && agg.docCount() != null) {
+      final long epochMillis = agg.docCount();
+      if (epochMillis > 0) {
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+      }
+    }
+    return null;
+  }
+
+  private int extractWorkersCount(final Map<String, AggregationResult> aggregations) {
+    final var agg = aggregations.get(AGGREGATION_WORKERS);
+    if (agg != null && agg.docCount() != null) {
+      return Math.toIntExact(agg.docCount());
+    }
+    return 0;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobTypeStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobTypeStatisticsFilterTransformer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.JobTypeStatisticsFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobTypeStatisticsFilterTransformer
+    extends IndexFilterTransformer<JobTypeStatisticsFilter> {
+
+  public JobTypeStatisticsFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final JobTypeStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    if (filter.from() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.START_TIME, List.of(Operation.gte(filter.from()))));
+    }
+
+    if (filter.to() != null) {
+      queries.addAll(
+          dateTimeOperations(
+              JobMetricsBatchTemplate.END_TIME, List.of(Operation.lte(filter.to()))));
+    }
+
+    // Optional jobType operations filter with advanced search capabilities
+    if (filter.jobTypeOperations() != null && !filter.jobTypeOperations().isEmpty()) {
+      queries.addAll(
+          stringOperations(JobMetricsBatchTemplate.JOB_TYPE, filter.jobTypeOperations()));
+    }
+
+    return queries.isEmpty() ? matchAll() : and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobTypeStatisticsAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/JobTypeStatisticsAggregationTransformerTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_BY_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_SOURCE_NAME_JOB_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_WORKERS;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_COMPLETED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_CREATED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_FAILED_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_JOB_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_COMPLETED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_CREATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_LAST_FAILED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.FIELD_WORKER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchCardinalityAggregator;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchFilterAggregator;
+import io.camunda.search.clients.aggregator.SearchMaxAggregator;
+import io.camunda.search.clients.aggregator.SearchSumAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.query.SearchMatchAllQuery;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JobTypeStatisticsAggregationTransformerTest {
+
+  private final JobTypeStatisticsAggregationTransformer transformer =
+      new JobTypeStatisticsAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldBuildExpectedAggregationStructure() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(50).after("cursor123"));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(1);
+
+    // Verify composite aggregation by job type
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchCompositeAggregator.class,
+            compositeAgg -> {
+              assertThat(compositeAgg.name()).isEqualTo(AGGREGATION_BY_TYPE);
+              assertThat(compositeAgg.size()).isEqualTo(50);
+              assertThat(compositeAgg.after()).isEqualTo("cursor123");
+              assertThat(compositeAgg.sources()).hasSize(1);
+              assertThat(compositeAgg.aggregations()).hasSize(4);
+            });
+  }
+
+  @Test
+  void shouldBuildFilterBucketsForEachStatus() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    final var subAggregations = compositeAgg.aggregations();
+
+    // Verify created filter bucket
+    assertThat(subAggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            createdAgg -> {
+              assertThat(createdAgg.name()).isEqualTo(AGGREGATION_CREATED);
+              assertThat(createdAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  createdAgg.aggregations(), FIELD_CREATED_COUNT, FIELD_LAST_CREATED_AT);
+            });
+
+    // Verify completed filter bucket
+    assertThat(subAggregations.get(1))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            completedAgg -> {
+              assertThat(completedAgg.name()).isEqualTo(AGGREGATION_COMPLETED);
+              assertThat(completedAgg.query().queryOption())
+                  .isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  completedAgg.aggregations(), FIELD_COMPLETED_COUNT, FIELD_LAST_COMPLETED_AT);
+            });
+
+    // Verify failed filter bucket
+    assertThat(subAggregations.get(2))
+        .isInstanceOfSatisfying(
+            SearchFilterAggregator.class,
+            failedAgg -> {
+              assertThat(failedAgg.name()).isEqualTo(AGGREGATION_FAILED);
+              assertThat(failedAgg.query().queryOption()).isInstanceOf(SearchMatchAllQuery.class);
+              assertSubAggregations(
+                  failedAgg.aggregations(), FIELD_FAILED_COUNT, FIELD_LAST_FAILED_AT);
+            });
+
+    // Verify workers cardinality aggregation
+    assertThat(subAggregations.get(3))
+        .isInstanceOfSatisfying(
+            SearchCardinalityAggregator.class,
+            workersAgg -> {
+              assertThat(workersAgg.name()).isEqualTo(AGGREGATION_WORKERS);
+              assertThat(workersAgg.field()).isEqualTo(FIELD_WORKER);
+            });
+  }
+
+  @Test
+  void shouldBuildFilterBucketsWithMatchAllQuery() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+
+    // All filter buckets should use match_all query
+    compositeAgg.aggregations().stream()
+        .filter(SearchFilterAggregator.class::isInstance)
+        .map(SearchFilterAggregator.class::cast)
+        .forEach(
+            filterAgg ->
+                assertThat(filterAgg.query().queryOption())
+                    .isInstanceOf(SearchMatchAllQuery.class));
+  }
+
+  @Test
+  void shouldBuildSubAggregationsWithCorrectTypes() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+
+    // Verify each filter bucket has exactly 2 sub-aggregations: sum and max
+    compositeAgg.aggregations().stream()
+        .filter(SearchFilterAggregator.class::isInstance)
+        .map(SearchFilterAggregator.class::cast)
+        .forEach(
+            filterAgg -> {
+              assertThat(filterAgg.aggregations()).hasSize(2);
+
+              // First sub-aggregation should be sum for count
+              assertThat(filterAgg.aggregations().get(0))
+                  .isInstanceOfSatisfying(
+                      SearchSumAggregator.class,
+                      sumAgg -> assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT));
+
+              // Second sub-aggregation should be max for lastUpdatedAt
+              assertThat(filterAgg.aggregations().get(1))
+                  .isInstanceOfSatisfying(
+                      SearchMaxAggregator.class,
+                      maxAgg -> assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT));
+            });
+  }
+
+  @Test
+  void shouldBuildCompositeAggregationWithTermsSource() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(100));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+
+    // Verify composite has one terms source for job type
+    assertThat(compositeAgg.sources()).hasSize(1);
+    assertThat(compositeAgg.sources().get(0))
+        .isInstanceOfSatisfying(
+            SearchTermsAggregator.class,
+            termsSource -> {
+              assertThat(termsSource.name()).isEqualTo(AGGREGATION_SOURCE_NAME_JOB_TYPE);
+              assertThat(termsSource.field()).isEqualTo(FIELD_JOB_TYPE);
+            });
+  }
+
+  @Test
+  void shouldUsePageSizeFromQuery() {
+    // given
+    final var page = SearchQueryPage.of(b -> b.size(42).after("someCursor"));
+    final var aggregation = new JobTypeStatisticsAggregation(page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    assertThat(compositeAgg.size()).isEqualTo(42);
+    assertThat(compositeAgg.after()).isEqualTo("someCursor");
+  }
+
+  @Test
+  void shouldUseDefaultSizeWhenPageIsNull() {
+    // given
+    final var aggregation = new JobTypeStatisticsAggregation(null);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var compositeAgg = (SearchCompositeAggregator) aggregations.get(0);
+    assertThat(compositeAgg.size()).isEqualTo(10000);
+    assertThat(compositeAgg.after()).isNull();
+  }
+
+  private void assertSubAggregations(
+      final List<SearchAggregator> subAggs,
+      final String expectedCountField,
+      final String expectedLastUpdatedAtField) {
+    assertThat(subAggs).hasSize(2);
+
+    // Verify count sum aggregation
+    assertThat(subAggs.get(0))
+        .isInstanceOfSatisfying(
+            SearchSumAggregator.class,
+            sumAgg -> {
+              assertThat(sumAgg.name()).isEqualTo(AGGREGATION_COUNT);
+              assertThat(sumAgg.field()).isEqualTo(expectedCountField);
+            });
+
+    // Verify lastUpdatedAt max aggregation
+    assertThat(subAggs.get(1))
+        .isInstanceOfSatisfying(
+            SearchMaxAggregator.class,
+            maxAgg -> {
+              assertThat(maxAgg.name()).isEqualTo(AGGREGATION_LAST_UPDATED_AT);
+              assertThat(maxAgg.field()).isEqualTo(expectedLastUpdatedAtField);
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobTypeStatisticsAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/JobTypeStatisticsAggregationResultTransformerTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_BY_TYPE;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COMPLETED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_COUNT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_CREATED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_FAILED;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_LAST_UPDATED_AT;
+import static io.camunda.search.aggregation.JobTypeStatisticsAggregation.AGGREGATION_WORKERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class JobTypeStatisticsAggregationResultTransformerTest {
+
+  private final JobTypeStatisticsAggregationResultTransformer transformer =
+      new JobTypeStatisticsAggregationResultTransformer();
+
+  @Test
+  public void shouldReturnEmptyListWhenAggregationsEmpty() {
+    // given
+    final Map<String, AggregationResult> input = Map.of();
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  public void shouldTransformSingleJobTypeStatistics() {
+    // given
+    final String jobType = "task-handler";
+    final long createdCount = 100L;
+    final long completedCount = 80L;
+    final long failedCount = 5L;
+    final int workersCount = 3;
+    final long createdTimestamp = 1706800000000L;
+    final long completedTimestamp = 1706800100000L;
+    final long failedTimestamp = 1706800200000L;
+    final String endCursor = "cursorABC";
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(
+                Map.of(
+                    jobType,
+                    jobTypeBucket(
+                        createdCount,
+                        createdTimestamp,
+                        completedCount,
+                        completedTimestamp,
+                        failedCount,
+                        failedTimestamp,
+                        workersCount)),
+                endCursor));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isEqualTo(endCursor);
+
+    final var entity = result.items().get(0);
+    assertThat(entity.jobType()).isEqualTo(jobType);
+
+    assertThat(entity.created().count()).isEqualTo(createdCount);
+    assertThat(entity.created().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(createdTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.completed().count()).isEqualTo(completedCount);
+    assertThat(entity.completed().lastUpdatedAt())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(completedTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.failed().count()).isEqualTo(failedCount);
+    assertThat(entity.failed().lastUpdatedAt())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(failedTimestamp), ZoneOffset.UTC));
+
+    assertThat(entity.workers()).isEqualTo(workersCount);
+  }
+
+  @Test
+  public void shouldTransformMultipleJobTypeStatistics() {
+    // given
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(
+                Map.of(
+                    "type1", jobTypeBucket(10, 1000L, 8, 2000L, 1, 3000L, 2),
+                    "type2", jobTypeBucket(20, 4000L, 15, 5000L, 2, 6000L, 3),
+                    "type3", jobTypeBucket(5, 7000L, 5, 8000L, 0, 0L, 1)),
+                "endCursorXYZ"));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items())
+        .extracting("jobType")
+        .containsExactlyInAnyOrder("type1", "type2", "type3");
+    assertThat(result.endCursor()).isEqualTo("endCursorXYZ");
+  }
+
+  @Test
+  public void shouldHandleZeroCountsAndNullTimestamps() {
+    // given
+    final String jobType = "zero-count-type";
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(Map.of(jobType, jobTypeBucket(0, 0L, 0, 0L, 0, 0L, 0)), null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isNull();
+
+    final var entity = result.items().get(0);
+    assertThat(entity.jobType()).isEqualTo(jobType);
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+    assertThat(entity.workers()).isZero();
+  }
+
+  @Test
+  public void shouldHandleMissingSubAggregations() {
+    // given - bucket exists but has no sub-aggregations
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(Map.of("missing-subs", new AggregationResult(10L, Map.of())), null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then - entity with null aggregations should be filtered out
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  @Test
+  public void shouldHandlePartialSubAggregations() {
+    // given - only created aggregation is present
+    final String jobType = "partial-type";
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_CREATED,
+            statusBucket(25L, 1706800000000L),
+            AGGREGATION_WORKERS,
+            new AggregationResult(2L, Map.of()));
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(Map.of(jobType, new AggregationResult(0L, subAggs)), "cursor"));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.endCursor()).isEqualTo("cursor");
+
+    final var entity = result.items().get(0);
+    assertThat(entity.jobType()).isEqualTo(jobType);
+    assertThat(entity.created().count()).isEqualTo(25L);
+    assertThat(entity.created().lastUpdatedAt()).isNotNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+    assertThat(entity.workers()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldHandleNullDocCountInSubAggregations() {
+    // given
+    final String jobType = "null-counts";
+    final Map<String, AggregationResult> statusSubAggs =
+        Map.of(
+            AGGREGATION_COUNT, new AggregationResult(null, Map.of()),
+            AGGREGATION_LAST_UPDATED_AT, new AggregationResult(null, Map.of()));
+
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_CREATED, new AggregationResult(10L, statusSubAggs),
+            AGGREGATION_COMPLETED, new AggregationResult(10L, statusSubAggs),
+            AGGREGATION_FAILED, new AggregationResult(10L, statusSubAggs),
+            AGGREGATION_WORKERS, new AggregationResult(null, Map.of()));
+
+    final Map<String, AggregationResult> input =
+        Map.of(
+            AGGREGATION_BY_TYPE,
+            byTypeBucket(Map.of(jobType, new AggregationResult(0L, subAggs)), null));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).hasSize(1);
+
+    final var entity = result.items().get(0);
+    assertThat(entity.created().count()).isZero();
+    assertThat(entity.created().lastUpdatedAt()).isNull();
+    assertThat(entity.completed().count()).isZero();
+    assertThat(entity.completed().lastUpdatedAt()).isNull();
+    assertThat(entity.failed().count()).isZero();
+    assertThat(entity.failed().lastUpdatedAt()).isNull();
+    assertThat(entity.workers()).isZero();
+  }
+
+  @Test
+  public void shouldHandleNullByTypeAggregation() {
+    // given
+    final Map<String, AggregationResult> input =
+        Map.of(AGGREGATION_BY_TYPE, new AggregationResult(0L, Map.of()));
+
+    // when
+    final var result = transformer.apply(input);
+
+    // then
+    assertThat(result.items()).isEmpty();
+    assertThat(result.endCursor()).isNull();
+  }
+
+  private static AggregationResult byTypeBucket(
+      final Map<String, AggregationResult> jobTypeBuckets) {
+    return byTypeBucket(jobTypeBuckets, null);
+  }
+
+  private static AggregationResult byTypeBucket(
+      final Map<String, AggregationResult> jobTypeBuckets, final String endCursor) {
+    return new AggregationResult(0L, jobTypeBuckets, List.of(), endCursor);
+  }
+
+  private static AggregationResult jobTypeBucket(
+      final long createdCount,
+      final long createdTimestamp,
+      final long completedCount,
+      final long completedTimestamp,
+      final long failedCount,
+      final long failedTimestamp,
+      final int workersCount) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_CREATED, statusBucket(createdCount, createdTimestamp),
+            AGGREGATION_COMPLETED, statusBucket(completedCount, completedTimestamp),
+            AGGREGATION_FAILED, statusBucket(failedCount, failedTimestamp),
+            AGGREGATION_WORKERS, new AggregationResult((long) workersCount, Map.of()));
+
+    return new AggregationResult(0L, subAggs);
+  }
+
+  private static AggregationResult statusBucket(final long count, final long lastUpdatedAtMillis) {
+    final Map<String, AggregationResult> subAggs =
+        Map.of(
+            AGGREGATION_COUNT, new AggregationResult(count, Map.of()),
+            AGGREGATION_LAST_UPDATED_AT, new AggregationResult(lastUpdatedAtMillis, Map.of()));
+
+    return new AggregationResult(0L, subAggs);
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/JobTypeStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/JobTypeStatisticsAggregation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+
+public record JobTypeStatisticsAggregation(SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  // Composite aggregation name
+  public static final String AGGREGATION_BY_TYPE = "byType";
+
+  // Composite aggregation source name
+  public static final String AGGREGATION_SOURCE_NAME_JOB_TYPE = "jobType";
+
+  // Default size for composite aggregation
+  public static final int AGGREGATION_COMPOSITE_SIZE = 10000;
+
+  // Filter bucket names (within each job type bucket)
+  public static final String AGGREGATION_CREATED = "created";
+  public static final String AGGREGATION_COMPLETED = "completed";
+  public static final String AGGREGATION_FAILED = "failed";
+
+  // Sub-aggregation names (used within each filter bucket)
+  public static final String AGGREGATION_COUNT = "count";
+  public static final String AGGREGATION_LAST_UPDATED_AT = "lastUpdatedAt";
+
+  // Workers aggregation
+  public static final String AGGREGATION_WORKERS = "workers";
+
+  // Field names for aggregations
+  public static final String FIELD_JOB_TYPE = "jobType";
+  public static final String FIELD_CREATED_COUNT = "createdCount";
+  public static final String FIELD_COMPLETED_COUNT = "completedCount";
+  public static final String FIELD_FAILED_COUNT = "failedCount";
+  public static final String FIELD_LAST_CREATED_AT = "lastCreatedAt";
+  public static final String FIELD_LAST_COMPLETED_AT = "lastCompletedAt";
+  public static final String FIELD_LAST_FAILED_AT = "lastFailedAt";
+  public static final String FIELD_WORKER = "worker";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTypeStatisticsAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/JobTypeStatisticsAggregationResult.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+import java.util.List;
+
+public record JobTypeStatisticsAggregationResult(
+    List<JobTypeStatisticsEntity> items, String endCursor) implements AggregationResultBase {}


### PR DESCRIPTION
## Description

This pull request adds support for job type statistics aggregation in the search client query transformer. The main changes include implementing the logic to aggregate and transform job type statistics, wiring up the necessary transformers, and updating the reader to return actual results instead of throwing an exception.

**Job Type Statistics Aggregation Support:**

* Implemented `JobTypeStatisticsAggregationTransformer` to build the aggregation query for job type statistics, including metrics for created, completed, failed jobs, and worker counts (`JobTypeStatisticsAggregationTransformer.java`).
* Implemented `JobTypeStatisticsAggregationResultTransformer` to convert aggregation results into `JobTypeStatisticsAggregationResult` objects, extracting relevant metrics for each job type (`JobTypeStatisticsAggregationResultTransformer.java`).
* Registered the new aggregation and result transformers in the `ServiceTransformers` initialization logic (`ServiceTransformers.java`). [[1]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R646-R647) [[2]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R684-R686)

**Integration and Usage:**

* Updated `JobMetricsBatchDocumentReader` to implement the `getJobTypeStatistics` method, enabling actual querying and returning of job type statistics instead of throwing an unsupported operation exception (`JobMetricsBatchDocumentReader.java`).

**Dependency Management:**

* Added necessary imports for the new aggregation and result classes in relevant files (`JobMetricsBatchDocumentReader.java`, `ServiceTransformers.java`). [[1]](diffhunk://#diff-3d08ffb727a5ff5eefa4ab0d72c0e83b4d16e575b46d7532b8e324b91afc770bR11) [[2]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R15) [[3]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R29) [[4]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R47) [[5]](diffhunk://#diff-f562c57454f033f69b55e54a83cdb910e5f1a808b3f70f15c2a8f78638d4e510R61)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/46010
