### PR TITLE
fix: add elementInstanceState filter to API requests

### DIFF
--- a/operate/client/src/modules/hooks/useBatchOperationMutationRequestBody.test.tsx
+++ b/operate/client/src/modules/hooks/useBatchOperationMutationRequestBody.test.tsx
@@ -325,6 +325,7 @@ describe('useBatchOperationMutationRequestBody', () => {
     expect(result.current).toEqual({
       filter: {
         elementId: {$eq: 'task-1'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         state: {$eq: 'ACTIVE'},
         hasIncident: false,
       },

--- a/operate/client/src/modules/utils/buildMutationRequestBody.test.ts
+++ b/operate/client/src/modules/utils/buildMutationRequestBody.test.ts
@@ -36,6 +36,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2']},
       },
@@ -57,6 +58,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$notIn: ['3', '4']},
       },
@@ -78,6 +80,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2'], $notIn: ['3']},
       },
@@ -99,6 +102,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['only'], $notIn: ['x']},
       },
@@ -120,6 +124,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -141,6 +146,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         $or: [{state: {$in: ['ACTIVE']}}, {hasIncident: true}],
       },
     });
@@ -161,6 +167,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -181,6 +188,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         state: {$eq: 'ACTIVE'},
         hasIncident: false,
       },
@@ -208,6 +216,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         errorMessage: {$in: ['some error']},
         tenantId: {$eq: 'tenant-xyz'},
         batchOperationId: {$eq: 'batch-123'},
@@ -236,6 +245,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         processDefinitionId: {$eq: 'orderProcess'},
         state: {$eq: 'ACTIVE'},
         hasIncident: false,
@@ -531,6 +541,7 @@ describe('buildMutationRequestBody', () => {
         hasIncident: false,
         state: {$eq: 'ACTIVE'},
         elementId: {$eq: 'taskA'},
+        elementInstanceState: {$eq: 'ACTIVE'},
         processDefinitionKey: '2837942984928642',
       },
     });

--- a/operate/client/src/modules/utils/filter/v2/processInstancesSearch.ts
+++ b/operate/client/src/modules/utils/filter/v2/processInstancesSearch.ts
@@ -120,6 +120,7 @@ const parseProcessInstancesSearchFilter = (
 
   if (filter.flowNodeId) {
     apiFilter.elementId = {$eq: filter.flowNodeId};
+    apiFilter.elementInstanceState = {$eq: 'ACTIVE'};
   }
 
   if (filter.operationId) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

add `elementInstanceState: "ACTIVE"` to the following API requests:

- process instances search
- process instances batch operations:  modify (move), migrate, cancel, retry

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #43728 
