### PR TITLE
test: fixed Decision Sort API

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -366,12 +366,15 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
         totalItemGreaterThan: 1,
       });
       const json = await res.json();
-      expect(json.items[0].decisionDefinitionId).toBe(
-        decisionDefinition1.decisionDefinitionId,
+      const ids = json.items.map(
+        (item: {decisionDefinitionId: string}) => item.decisionDefinitionId,
       );
-      expect(json.items[1].decisionDefinitionId).toBe(
-        decisionDefinition2.decisionDefinitionId,
-      );
+      const index1 = ids.indexOf(decisionDefinition1.decisionDefinitionId);
+      const index2 = ids.indexOf(decisionDefinition2.decisionDefinitionId);
+      expect(index1).not.toBe(-1);
+      expect(index2).not.toBe(-1);
+      expect(index1).toBeLessThan(index2);
+
       assertDecisionDefinitionInResponse(
         json,
         expectedBody1,
@@ -408,12 +411,14 @@ test.describe.parallel('Search Decision Definitions API Tests', () => {
         totalItemGreaterThan: 1,
       });
       const json = await res.json();
-      expect(json.items[0].decisionDefinitionId).toBe(
-        decisionDefinition2.decisionDefinitionId,
+      const ids = json.items.map(
+        (item: {decisionDefinitionId: string}) => item.decisionDefinitionId,
       );
-      expect(json.items[1].decisionDefinitionId).toBe(
-        decisionDefinition1.decisionDefinitionId,
-      );
+      const index1 = ids.indexOf(decisionDefinition1.decisionDefinitionId);
+      const index2 = ids.indexOf(decisionDefinition2.decisionDefinitionId);
+      expect(index1).not.toBe(-1);
+      expect(index2).not.toBe(-1);
+      expect(index1).toBeGreaterThan(index2);
       assertDecisionDefinitionInResponse(
         json,
         expectedBody1,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We have multiple decision diagrams now so checking the indexes in a safer way.


[Successful run](https://github.com/camunda/camunda/actions/runs/22147764173) ✅ 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
