### PR TITLE
chore: use nexus and maven central to download dependencies, use artifactory to publish camunda artifacts

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -189,12 +189,17 @@ runs:
         [{
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
-          "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots"
+          "url": "https://repository.nexus.camunda.cloud/repository/internal/",
+          "mirrorOf": "*,!central"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{
           "id": "camunda-nexus",
+          "username": "${{ steps.secrets.outputs.ci-account-username }}",
+          "password": "${{ steps.secrets.outputs.ci-account-password }}"
+        },
+        {
+          "id": "camunda-artifactory",
           "username": "${{ steps.secrets.outputs.ci-account-username }}",
           "password": "${{ steps.secrets.outputs.ci-account-password }}"
         }]

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,11 +37,6 @@
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
-    <!-- Override server IDs from camunda-release-parent to separate
-         Artifactory (upload) credentials from Nexus (download) credentials -->
-    <nexus.release.repository.id>camunda-artifactory</nexus.release.repository.id>
-    <nexus.snapshot.repository.id>camunda-artifactory</nexus.snapshot.repository.id>
-    <nexus.staging.deploy.id>camunda-artifactory</nexus.staging.deploy.id>
 
     <!-- Camunda License v1.0 header -->
     <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,6 +37,11 @@
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
+    <!-- Override server IDs from camunda-release-parent to separate
+         Artifactory (upload) credentials from Nexus (download) credentials -->
+    <nexus.release.repository.id>camunda-artifactory</nexus.release.repository.id>
+    <nexus.snapshot.repository.id>camunda-artifactory</nexus.snapshot.repository.id>
+    <nexus.staging.deploy.id>camunda-artifactory</nexus.staging.deploy.id>
 
     <!-- Camunda License v1.0 header -->
     <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>
@@ -136,7 +141,7 @@
       </snapshots>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-releases/</url>
     </repository>
 
     <repository>
@@ -148,7 +153,7 @@
       </snapshots>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-snapshots/</url>
     </repository>
 
     <repository>
@@ -160,7 +165,7 @@
       </snapshots>
       <id>camunda-identity</id>
       <name>Camunda Identity Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-releases/</url>
     </repository>
 
     <repository>
@@ -172,7 +177,7 @@
       </snapshots>
       <id>camunda-identity-snapshots</id>
       <name>Camunda Identity Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-snapshots/</url>
     </repository>
 
     <repository>
@@ -184,7 +189,7 @@
       </snapshots>
       <id>camunda-bpm</id>
       <name>Camunda BPM Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-bpm/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-releases/</url>
     </repository>
 
     <repository>
@@ -196,7 +201,7 @@
       </snapshots>
       <id>camunda-bpm-snapshots</id>
       <name>Camunda BPM Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-snapshots/</url>
     </repository>
   </repositories>
 

--- a/load-tests/load-tester/pom.xml
+++ b/load-tests/load-tester/pom.xml
@@ -154,7 +154,7 @@
       </snapshots>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-releases/</url>
     </repository>
 
     <repository>
@@ -166,7 +166,7 @@
       </snapshots>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/camunda-nexus-snapshots/</url>
     </repository>
   </repositories>
 

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -18,10 +18,5 @@
       <username>${env.NEXUS_USR}</username>
       <password>${env.NEXUS_PSW}</password>
     </server>
-    <server>
-      <id>camunda-artifactory</id>
-      <username>${env.ARTIFACTORY_USR}</username>
-      <password>${env.ARTIFACTORY_PSW}</password>
-    </server>
   </servers>
 </settings>

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -6,9 +6,9 @@
   <mirrors>
     <mirror>
       <id>camunda-nexus</id>
-      <mirrorOf>*</mirrorOf>
+      <mirrorOf>*,!central</mirrorOf>
       <name>Camunda Nexus</name>
-      <url>https://artifacts.camunda.com/artifactory/internal/</url>
+      <url>https://repository.nexus.camunda.cloud/repository/internal/</url>
     </mirror>
   </mirrors>
 
@@ -17,6 +17,11 @@
       <id>camunda-nexus</id>
       <username>${env.NEXUS_USR}</username>
       <password>${env.NEXUS_PSW}</password>
+    </server>
+    <server>
+      <id>camunda-artifactory</id>
+      <username>${env.ARTIFACTORY_USR}</username>
+      <password>${env.ARTIFACTORY_PSW}</password>
     </server>
   </servers>
 </settings>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -351,7 +351,7 @@
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <extensions>true</extensions>
           <configuration>
-            <serverId>camunda-artifactory</serverId>
+            <serverId>camunda-nexus</serverId>
             <nexusUrl>https://artifacts.camunda.com/artifactory/</nexusUrl>
             <skipStaging>true</skipStaging>
           </configuration>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -351,7 +351,7 @@
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <extensions>true</extensions>
           <configuration>
-            <serverId>camunda-nexus</serverId>
+            <serverId>camunda-artifactory</serverId>
             <nexusUrl>https://artifacts.camunda.com/artifactory/</nexusUrl>
             <skipStaging>true</skipStaging>
           </configuration>


### PR DESCRIPTION
## Description

Currently, Artifactory is used as the source for all Camunda artifacts, and when the `maven-settings.xml` configuration is used, it's also used as a mirror for Maven Central. Recently, this has generated high download traffic, pushing February's Artifactory consumption above the regular threshold and incurring additional costs.
Since a **Nexus** caching proxy (`repository.nexus.camunda.cloud`) exists, it should absorb this read traffic, leaving Artifactory for publishing camunda artifacts only.

### What changed and why

**1. `maven-settings.xml`** — Local developer mirror
- Mirror URL changed from `artifacts.camunda.com/artifactory/internal/` → `repository.nexus.camunda.cloud/repository/internal/`
- `mirrorOf` changed from `*` → `*,!central` (excludes Maven Central from the mirror)

*Why:* This is the file developers may be using for local development. The mirror intercepts all Camunda repo requests and routes them through the Nexus cache.

**2. `.github/actions/setup-build/action.yml`** — CI pipeline
- Mirror URL updated to Nexus 3 path format (`/repository/internal/`)
- `mirrorOf` expanded from `zeebe,zeebe-snapshots` → `*,!central` (all Camunda repos, not just zeebe)

*Why:* CI uses Nexus for all camunda repositories, not only Zeebe.

**3. `bom/pom.xml`** — Repository declarations + deploy server IDs
- 6 repository URLs changed from `artifacts.camunda.com/artifactory/...` → `repository.nexus.camunda.cloud/repository/camunda-nexus-{releases,snapshots}/`

*Why:* POM repositories affect developers who don't use the settings.xml mirror. All dependencies not available on Maven Central are now coming through Nexus.

**4. `load-tests/load-tester/pom.xml`** — Repository declarations
- 2 repository URLs changed from Artifactory → Nexus proxy URLs

*Why:* This module declares its own repositories outside the BOM inheritance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

This is related to incident [#4582](https://app.incident.io/camunda/incidents/4582)
