### PR TITLE
refactor: use client config typed util

### DIFF
--- a/operate/client/src/App/Dashboard/IncidentsByError/Details.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/Details.tsx
@@ -18,6 +18,7 @@ import {InstancesBar} from 'modules/components/InstancesBar';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useIncidentProcessInstanceStatisticsByDefinition} from 'modules/queries/incidentStatistics/useIncidentProcessInstanceStatisticsByDefinition';
 import {DEFAULT_TENANT} from 'modules/constants';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 type Props = {
   errorMessage: string;
@@ -31,7 +32,7 @@ const Details: React.FC<Props> = ({
   tabIndex,
 }) => {
   const tenantsById = useAvailableTenants();
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
 
   const result = useIncidentProcessInstanceStatisticsByDefinition({
     payload: {

--- a/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
@@ -32,6 +32,21 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {useEffect} from 'react';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {truncateErrorMessage} from './utils/truncateErrorMessage';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 function createWrapper(initialPath: string = Paths.dashboard()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -55,6 +70,7 @@ function createWrapper(initialPath: string = Paths.dashboard()) {
 
 describe('IncidentsByError', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockMe().withSuccess(createUser());
   });
 
@@ -178,7 +194,10 @@ describe('IncidentsByError', () => {
   });
 
   it('should include tenant in link when multi-tenancy is enabled', async () => {
-    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
+    });
 
     mockIncidentQueries();
 

--- a/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/index.test.tsx
@@ -32,21 +32,7 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {useEffect} from 'react';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {truncateErrorMessage} from './utils/truncateErrorMessage';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 function createWrapper(initialPath: string = Paths.dashboard()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -70,7 +56,6 @@ function createWrapper(initialPath: string = Paths.dashboard()) {
 
 describe('IncidentsByError', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockMe().withSuccess(createUser());
   });
 
@@ -194,8 +179,8 @@ describe('IncidentsByError', () => {
   });
 
   it('should include tenant in link when multi-tenancy is enabled', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/Details.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/Details.tsx
@@ -18,6 +18,7 @@ import {useProcessDefinitionVersionStatistics} from 'modules/queries/processDefi
 import {InlineLoading} from '@carbon/react';
 import type {ProcessDefinitionInstanceVersionStatistics} from '@camunda/camunda-api-zod-schemas/8.8';
 import {DEFAULT_TENANT} from 'modules/constants';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 type Props = {
   processDefinitionId: string;
@@ -32,7 +33,7 @@ const Details: React.FC<Props> = ({
   tenantId,
   tabIndex,
 }) => {
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const tenantsById = useAvailableTenants();
 
   const result = useProcessDefinitionVersionStatistics(processDefinitionId, {

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/index.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/index.tsx
@@ -22,6 +22,7 @@ import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import type {ProcessDefinitionInstanceStatistics} from '@camunda/camunda-api-zod-schemas/8.8';
 import {DEFAULT_TENANT} from 'modules/constants';
 import {InlineLoading} from '@carbon/react';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 type Props = {
   status: 'pending' | 'error' | 'success';
@@ -43,7 +44,7 @@ const InstancesByProcessDefinition: React.FC<Props> = ({
   onScrollEndReach,
 }) => {
   const tenantsById = useAvailableTenants();
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
 
   const rows = useMemo(
     () =>

--- a/operate/client/src/App/DecisionInstance/Header/index.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/index.tsx
@@ -16,6 +16,7 @@ import {formatDate} from 'modules/utils/date';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useDecisionInstance} from 'modules/queries/decisionInstances/useDecisionInstance';
 import type {DrdPanelState} from 'modules/queries/decisionInstances/useDrdPanelState';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const getHeaderColumns = (isMultiTenancyEnabled: boolean = false) => {
   return [
@@ -59,7 +60,7 @@ const Header: React.FC<HeaderProps> = ({
   decisionEvaluationInstanceKey,
   onChangeDrdPanelState,
 }) => {
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const headerColumns = getHeaderColumns(isMultiTenancyEnabled);
   const tenantsById = useAvailableTenants();
   const {data: decisionInstance, status} = useDecisionInstance(

--- a/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
@@ -20,6 +20,21 @@ import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/
 import {invoiceClassification} from 'modules/mocks/mockDecisionInstance';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const MOCK_DECISION_INSTANCE_ID = '123567';
 
@@ -34,8 +49,13 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('InstanceHeader', () => {
+  beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
+  });
+
   it('should render multi tenancy column and include tenant in version link', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/DecisionInstance/Header/tests/multiTenancy.test.tsx
@@ -20,21 +20,7 @@ import {mockFetchDecisionInstance} from 'modules/mocks/api/v2/decisionInstances/
 import {invoiceClassification} from 'modules/mocks/mockDecisionInstance';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const MOCK_DECISION_INSTANCE_ID = '123567';
 
@@ -49,13 +35,9 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('InstanceHeader', () => {
-  beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
-  });
-
   it('should render multi tenancy column and include tenant in version link', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/Decisions/Filters/DecisionsFormGroup.tsx
+++ b/operate/client/src/App/Decisions/Filters/DecisionsFormGroup.tsx
@@ -17,9 +17,10 @@ import {
   useDecisionDefinitions,
   useDecisionDefinitionVersions,
 } from 'modules/hooks/decisionDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const DecisionsFormGroup: React.FC = observer(() => {
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const tenantsById = useAvailableTenants();
 
   const form = useForm();

--- a/operate/client/src/App/Decisions/Filters/index.tsx
+++ b/operate/client/src/App/Decisions/Filters/index.tsx
@@ -36,6 +36,7 @@ import {
   getDefinitionIdentifier,
   getDefinitionIdFromIdentifier,
 } from 'modules/hooks/decisionDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const initialValues: DecisionsFilter = {
   evaluated: true,
@@ -43,6 +44,7 @@ const initialValues: DecisionsFilter = {
 };
 
 const Filters: React.FC = observer(() => {
+  const clientConfig = getClientConfig();
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const [visibleFilters, setVisibleFilters] = useState<OptionalFilter[]>([]);
@@ -95,7 +97,7 @@ const Filters: React.FC = observer(() => {
               />
               <Stack gap={8}>
                 <Stack gap={5}>
-                  {window.clientConfig?.multiTenancyEnabled && (
+                  {clientConfig.multiTenancyEnabled && (
                     <div>
                       <Title>Tenant</Title>
                       <TenantField

--- a/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
@@ -22,6 +22,21 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
 import {createDecisionDefinition} from 'modules/mocks/mockDecisionDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 function getWrapper(initialPath: string = Paths.decisions()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -61,6 +76,7 @@ const MOCK_FILTERS_PARAMS = {
 
 describe('<Filters />', () => {
   beforeEach(async () => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchDecisionDefinitions().withSuccess(
       searchResult([
         createDecisionDefinition({
@@ -104,7 +120,10 @@ describe('<Filters />', () => {
   });
 
   it('should write filters to url', async () => {
-    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
+    });
 
     const MOCK_VALUES = {
       name: 'invoice-assign-approver',
@@ -160,7 +179,10 @@ describe('<Filters />', () => {
   });
 
   it('initialize filter values from url', async () => {
-    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
+    });
 
     render(<Filters />, {
       wrapper: getWrapper(`/?${new URLSearchParams(MOCK_FILTERS_PARAMS)}`),
@@ -195,7 +217,10 @@ describe('<Filters />', () => {
   });
 
   it('should disable decision name field when tenant is not selected', async () => {
-    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
+    });
     render(<Filters />, {wrapper: getWrapper()});
 
     expect(screen.getByRole('combobox', {name: 'Name'})).toBeDisabled();
@@ -208,7 +233,10 @@ describe('<Filters />', () => {
     mockSearchDecisionDefinitions().withSuccess(
       searchResult([createDecisionDefinition()]),
     );
-    vi.stubGlobal('clientConfig', {multiTenancyEnabled: true});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
+    });
     const {user} = render(<Filters />, {wrapper: getWrapper()});
 
     expect(screen.getByRole('combobox', {name: 'Name'})).toBeDisabled();

--- a/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Decisions/Filters/tests/multiTenancy.test.tsx
@@ -22,21 +22,7 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockSearchDecisionDefinitions} from 'modules/mocks/api/v2/decisionDefinitions/searchDecisionDefinitions';
 import {createDecisionDefinition} from 'modules/mocks/mockDecisionDefinitions';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 function getWrapper(initialPath: string = Paths.decisions()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -76,7 +62,6 @@ const MOCK_FILTERS_PARAMS = {
 
 describe('<Filters />', () => {
   beforeEach(async () => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchDecisionDefinitions().withSuccess(
       searchResult([
         createDecisionDefinition({
@@ -120,8 +105,8 @@ describe('<Filters />', () => {
   });
 
   it('should write filters to url', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 
@@ -179,8 +164,8 @@ describe('<Filters />', () => {
   });
 
   it('initialize filter values from url', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 
@@ -217,8 +202,8 @@ describe('<Filters />', () => {
   });
 
   it('should disable decision name field when tenant is not selected', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
     render(<Filters />, {wrapper: getWrapper()});
@@ -233,8 +218,8 @@ describe('<Filters />', () => {
     mockSearchDecisionDefinitions().withSuccess(
       searchResult([createDecisionDefinition()]),
     );
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
     const {user} = render(<Filters />, {wrapper: getWrapper()});

--- a/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
@@ -28,6 +28,21 @@ import {
   assignApproverGroup,
   invoiceClassification,
 } from 'modules/mocks/mockDecisionInstance';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const createWrapper = (
   initialPath: string = `${Paths.decisions()}?evaluated=true`,
@@ -52,6 +67,7 @@ const createWrapper = (
 
 describe('<InstancesTable />', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchDecisionInstances().withSuccess(
       mockDecisionInstancesSearchResult,
     );
@@ -275,7 +291,8 @@ describe('<InstancesTable />', () => {
   it.each(['all', undefined])(
     'should show tenant column when multi tenancy is enabled and tenant filter is %p',
     async (tenant) => {
-      vi.stubGlobal('clientConfig', {
+      mockGetClientConfig.mockReturnValue({
+        ...actualGetClientConfig(),
         multiTenancyEnabled: true,
       });
 
@@ -296,7 +313,8 @@ describe('<InstancesTable />', () => {
   );
 
   it('should hide tenant column when multi tenancy is enabled and tenant filter is a specific tenant', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
@@ -28,21 +28,7 @@ import {
   assignApproverGroup,
   invoiceClassification,
 } from 'modules/mocks/mockDecisionInstance';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const createWrapper = (
   initialPath: string = `${Paths.decisions()}?evaluated=true`,
@@ -67,7 +53,6 @@ const createWrapper = (
 
 describe('<InstancesTable />', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchDecisionInstances().withSuccess(
       mockDecisionInstancesSearchResult,
     );
@@ -291,8 +276,8 @@ describe('<InstancesTable />', () => {
   it.each(['all', undefined])(
     'should show tenant column when multi tenancy is enabled and tenant filter is %p',
     async (tenant) => {
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         multiTenancyEnabled: true,
       });
 
@@ -313,8 +298,8 @@ describe('<InstancesTable />', () => {
   );
 
   it('should hide tenant column when multi tenancy is enabled and tenant filter is a specific tenant', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/Decisions/InstancesTable/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.tsx
@@ -20,6 +20,7 @@ import {
   useDecisionInstancesSearchFilter,
   useDecisionInstancesSearchSort,
 } from 'modules/hooks/decisionInstancesSearch';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const InstancesTable: React.FC = observer(() => {
   const filter = useDecisionInstancesSearchFilter();
@@ -52,6 +53,7 @@ const InstancesTable: React.FC = observer(() => {
   });
   const decisionInstances = data?.decisionInstances ?? [];
   const filteredDecisionInstancesCount = data?.totalCount ?? 0;
+  const clientConfig = getClientConfig();
 
   const getTableState = () => {
     switch (true) {
@@ -81,7 +83,7 @@ const InstancesTable: React.FC = observer(() => {
   };
 
   const isTenantColumnVisible =
-    window.clientConfig?.multiTenancyEnabled &&
+    clientConfig.multiTenancyEnabled &&
     (filter?.tenantId === undefined || filter?.tenantId === 'all');
 
   return (

--- a/operate/client/src/App/Layout/AppHeader/index.tsx
+++ b/operate/client/src/App/Layout/AppHeader/index.tsx
@@ -19,6 +19,7 @@ import {licenseTagStore} from 'modules/stores/licenseTag';
 import {currentTheme} from 'modules/stores/currentTheme';
 import {useCurrentUser} from 'modules/queries/useCurrentUser';
 import {isForbidden} from 'modules/auth/isForbidden';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 import {notificationsStore} from 'modules/stores/notifications';
 
 function getInfoSidebarItems(isPaidPlan: boolean) {
@@ -86,7 +87,8 @@ const LOGOUT_DELAY = 1000;
 
 const AppHeader: React.FC = observer(() => {
   const {data: currentUser} = useCurrentUser();
-  const IS_SAAS = typeof window.clientConfig?.organizationId === 'string';
+  const clientConfig = getClientConfig();
+  const IS_SAAS = typeof clientConfig.organizationId === 'string';
   const {currentPage} = useCurrentPage();
   const {theme, changeTheme} = currentTheme;
   const [isAppBarOpen, setIsAppBarOpen] = useState(false);
@@ -306,7 +308,7 @@ const AppHeader: React.FC = observer(() => {
             },
           },
         ],
-        bottomElements: window.clientConfig?.canLogout
+        bottomElements: clientConfig.canLogout
           ? [
               {
                 key: 'logout',

--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -13,21 +13,7 @@ import {createUser} from 'modules/testUtils';
 import {Wrapper as BaseWrapper} from './mocks';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
@@ -39,8 +25,8 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 
 describe('App switcher', () => {
   it('should not render links for CCSM', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
       organizationId: null,
     });

--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -13,6 +13,21 @@ import {createUser} from 'modules/testUtils';
 import {Wrapper as BaseWrapper} from './mocks';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
@@ -24,8 +39,9 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 
 describe('App switcher', () => {
   it('should not render links for CCSM', async () => {
-    vi.stubGlobal('clientConfig', {
-      isEnterprise: false,
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      multiTenancyEnabled: true,
       organizationId: null,
     });
 

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -15,21 +15,7 @@ import {Wrapper as BaseWrapper} from './mocks';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {authenticationStore} from 'modules/stores/authentication';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
@@ -51,10 +37,6 @@ const mockSsoUser = createUser({
 });
 
 describe('User info', () => {
-  beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
-  });
-
   it('should render user display name', async () => {
     mockMe().withSuccess(mockUser);
 
@@ -72,8 +54,8 @@ describe('User info', () => {
   });
 
   it('should handle a SSO user', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: false,
     });
     mockMe().withSuccess(mockSsoUser);

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -15,6 +15,21 @@ import {Wrapper as BaseWrapper} from './mocks';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {authenticationStore} from 'modules/stores/authentication';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
@@ -36,6 +51,10 @@ const mockSsoUser = createUser({
 });
 
 describe('User info', () => {
+  beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
+  });
+
   it('should render user display name', async () => {
     mockMe().withSuccess(mockUser);
 
@@ -53,8 +72,8 @@ describe('User info', () => {
   });
 
   it('should handle a SSO user', async () => {
-    vi.stubGlobal('clientConfig', {
-      ...window.clientConfig,
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       canLogout: false,
     });
     mockMe().withSuccess(mockSsoUser);

--- a/operate/client/src/App/Layout/C3Provider.tsx
+++ b/operate/client/src/App/Layout/C3Provider.tsx
@@ -12,6 +12,7 @@ import {useEffect, useState} from 'react';
 import {logger} from 'modules/logger';
 import {getStage} from 'modules/tracking/getStage';
 import {getSaasUserToken} from 'modules/api/v2/authentication/token';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const STAGE = getStage(window.location.host);
 
@@ -31,13 +32,14 @@ type Props = {
 };
 
 const C3Provider: React.FC<Props> = ({children}) => {
+  const clientConfig = getClientConfig();
   const [token, setToken] = useState<string | null>(null);
-  const organizationId = window.clientConfig?.organizationId;
-  const clusterId = window.clientConfig?.clusterId;
+  const organizationId = clientConfig.organizationId;
+  const clusterId = clientConfig.clusterId;
 
   useEffect(() => {
     async function init() {
-      const organizationId = window.clientConfig?.organizationId;
+      const {organizationId} = getClientConfig();
 
       if (typeof organizationId === 'string') {
         setToken(await fetchToken());

--- a/operate/client/src/App/Login/Disclaimer/index.test.tsx
+++ b/operate/client/src/App/Login/Disclaimer/index.test.tsx
@@ -8,30 +8,12 @@
 
 import {render, screen} from 'modules/testing-library';
 import {Disclaimer} from './index';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const DISCLAIMER_TEXT =
   'Non-Production License. If you would like information on production usage, please refer to our terms & conditions page or contact sales.';
 
 describe('<Disclaimer />', () => {
-  beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
-  });
-
   it('should show the disclaimer', () => {
     const {rerender} = render(<Disclaimer />);
 
@@ -76,8 +58,8 @@ describe('<Disclaimer />', () => {
   });
 
   it('should not render the disclaimer', () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isEnterprise: true,
     });
 

--- a/operate/client/src/App/Login/Disclaimer/index.tsx
+++ b/operate/client/src/App/Login/Disclaimer/index.tsx
@@ -8,9 +8,12 @@
 
 import {Link} from '@carbon/react';
 import {Container} from './styled';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const Disclaimer: React.FC = () => {
-  return window.clientConfig?.isEnterprise ? null : (
+  const clientConfig = getClientConfig();
+
+  return clientConfig.isEnterprise ? null : (
     <Container>
       Non-Production License. If you would like information on production usage,
       please refer to our{' '}

--- a/operate/client/src/App/OperationsLog/Filters/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.test.tsx
@@ -14,21 +14,7 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 function getWrapper(initialPath = '/operations-log') {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -48,7 +34,6 @@ function getWrapper(initialPath = '/operations-log') {
 
 describe('OperationsLog Filters', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockMe().withSuccess(createUser());
     mockSearchProcessDefinitions().withSuccess({
       items: [
@@ -85,8 +70,8 @@ describe('OperationsLog Filters', () => {
   });
 
   it('should render tenant field when multi-tenancy is enabled', () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/OperationsLog/Filters/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.test.tsx
@@ -14,6 +14,21 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 function getWrapper(initialPath = '/operations-log') {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
@@ -33,6 +48,7 @@ function getWrapper(initialPath = '/operations-log') {
 
 describe('OperationsLog Filters', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockMe().withSuccess(createUser());
     mockSearchProcessDefinitions().withSuccess({
       items: [
@@ -69,7 +85,8 @@ describe('OperationsLog Filters', () => {
   });
 
   it('should render tenant field when multi-tenancy is enabled', () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/OperationsLog/Filters/index.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.tsx
@@ -39,10 +39,12 @@ import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
 import {DateRangeField} from 'modules/components/DateRangeField';
 import {useState} from 'react';
 import {FilterMultiselect} from 'modules/components/FilterMultiSelect';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const initialValues: OperationsLogFilters = {};
 
 const Filters: React.FC = observer(() => {
+  const clientConfig = getClientConfig();
   const navigate = useNavigate();
   const location = useLocation();
   const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
@@ -106,7 +108,7 @@ const Filters: React.FC = observer(() => {
                   ]}
                 />
                 <Stack gap={5}>
-                  {window.clientConfig?.multiTenancyEnabled && (
+                  {clientConfig.multiTenancyEnabled && (
                     <div>
                       <Title>Tenant</Title>
                       <Stack gap={5}>

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -22,6 +22,7 @@ import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProce
 import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessInstances';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const headerColumns = [
   'Process Name',
@@ -89,7 +90,7 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const tenantsById = useAvailableTenants();
   const tenantName = tenantsById[tenantId] ?? tenantId;
 
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
 
   const processDefinitionKey = useProcessDefinitionKeyContext();
   const {isPending, data: processInstanceXmlData} = useProcessInstanceXml({

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/multiTenancy.test.tsx
@@ -25,6 +25,21 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 vi.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: vi.fn()},
@@ -50,8 +65,13 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('InstanceHeader', () => {
+  beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
+  });
+
   it('should render multi tenancy column and include tenant in version link', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/multiTenancy.test.tsx
@@ -25,21 +25,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 vi.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: vi.fn()},
@@ -65,13 +51,9 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('InstanceHeader', () => {
-  beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
-  });
-
   it('should render multi tenancy column and include tenant in version link', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
@@ -33,21 +33,7 @@ import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTask
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const mockSingleIncident: Incident = {
   incidentKey: '2251799813696584',
@@ -67,7 +53,6 @@ const mockSingleIncident: Incident = {
 
 describe('MetadataPopover <Details />', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchUserTasks().withSuccess({items: [], page: {totalItems: 0}});
@@ -241,8 +226,8 @@ describe('MetadataPopover <Details />', () => {
 
   it('should render Tasklist link for user tasks when configured', () => {
     const tasklistUrl = 'https://tasklist.example.com';
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       tasklistUrl,
     });
 
@@ -270,8 +255,8 @@ describe('MetadataPopover <Details />', () => {
 
   it('should not render Tasklist link for non-user tasks', () => {
     const tasklistUrl = 'https://tasklist.example.com';
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       tasklistUrl,
     });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.test.tsx
@@ -33,6 +33,21 @@ import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTask
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const mockSingleIncident: Incident = {
   incidentKey: '2251799813696584',
@@ -52,6 +67,7 @@ const mockSingleIncident: Incident = {
 
 describe('MetadataPopover <Details />', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockFetchProcessDefinitionXml().withSuccess('');
     mockSearchJobs().withSuccess({items: [], page: {totalItems: 0}});
     mockSearchUserTasks().withSuccess({items: [], page: {totalItems: 0}});
@@ -225,7 +241,10 @@ describe('MetadataPopover <Details />', () => {
 
   it('should render Tasklist link for user tasks when configured', () => {
     const tasklistUrl = 'https://tasklist.example.com';
-    vi.stubGlobal('clientConfig', {tasklistUrl});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      tasklistUrl,
+    });
 
     const userTaskInstance: ElementInstance = {
       ...mockElementInstance,
@@ -251,7 +270,10 @@ describe('MetadataPopover <Details />', () => {
 
   it('should not render Tasklist link for non-user tasks', () => {
     const tasklistUrl = 'https://tasklist.example.com';
-    vi.stubGlobal('clientConfig', {tasklistUrl});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      tasklistUrl,
+    });
 
     mockSearchJobs().withSuccess({items: [mockJob], page: {totalItems: 1}});
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -22,6 +22,7 @@ import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProc
 import {useJobs} from 'modules/queries/jobs/useJobs';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {isCamundaUserTask} from 'modules/bpmn-js/utils/isCamundaUserTask';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 type Props = {
   elementInstance: ElementInstance;
@@ -29,6 +30,7 @@ type Props = {
 };
 
 const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
+  const clientConfig = getClientConfig();
   const [isModalVisible, setIsModalVisible] = useState(false);
 
   const {startDate, endDate, type, elementInstanceKey} = elementInstance;
@@ -84,9 +86,9 @@ const Details: React.FC<Props> = ({elementInstance, businessObject}) => {
         title="Details"
         titleId="metadata-popover-details-title"
         link={
-          !isNil(window.clientConfig?.tasklistUrl) && type === 'USER_TASK'
+          !isNil(clientConfig.tasklistUrl) && type === 'USER_TASK'
             ? {
-                href: window.clientConfig!.tasklistUrl,
+                href: clientConfig.tasklistUrl,
                 label: 'Open Tasklist',
                 onClick: () => {
                   tracking.track({

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -37,21 +37,7 @@ import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscr
 import {mockFetchDecisionDefinition} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinition';
 import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
 import {searchResult} from 'modules/testUtils';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -106,7 +92,6 @@ const mockSingleIncident: Incident = {
 
 describe('MetadataPopover', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchElementInstance('2251799813699889').withSuccess(
@@ -409,8 +394,8 @@ describe('MetadataPopover', () => {
   it('should render link to tasklist', async () => {
     const tasklistUrl = 'https://tasklist:8080';
 
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       tasklistUrl,
     });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -37,6 +37,21 @@ import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscr
 import {mockFetchDecisionDefinition} from 'modules/mocks/api/v2/decisionDefinitions/fetchDecisionDefinition';
 import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
 import {searchResult} from 'modules/testUtils';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -91,6 +106,7 @@ const mockSingleIncident: Incident = {
 
 describe('MetadataPopover', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchElementInstance('2251799813699889').withSuccess(
@@ -393,7 +409,10 @@ describe('MetadataPopover', () => {
   it('should render link to tasklist', async () => {
     const tasklistUrl = 'https://tasklist:8080';
 
-    vi.stubGlobal('clientConfig', {tasklistUrl});
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
+      tasklistUrl,
+    });
 
     mockFetchElementInstance('2251799813699889').withSuccess({
       ...mockElementInstance,

--- a/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
@@ -13,9 +13,10 @@ import {ComboBox} from 'modules/components/ComboBox';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
 import {useProcessDefinitions} from 'modules/hooks/processDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const ProcessField: React.FC = observer(() => {
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const tenantsById = useAvailableTenants();
 
   const form = useForm();

--- a/operate/client/src/App/Processes/ListView/Filters/ProcessVersionField.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/ProcessVersionField.tsx
@@ -15,9 +15,10 @@ import {
   splitDefinitionIdentifier,
   useProcessDefinitionVersions,
 } from 'modules/hooks/processDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const ProcessVersionField: React.FC = observer(() => {
-  const isMultiTenancyEnabled = window.clientConfig?.multiTenancyEnabled;
+  const isMultiTenancyEnabled = getClientConfig().multiTenancyEnabled;
   const form = useForm();
   const processValue = useField('process').input.value;
   const {definitionId, tenantId} = splitDefinitionIdentifier(processValue);

--- a/operate/client/src/App/Processes/ListView/Filters/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/index.tsx
@@ -45,6 +45,7 @@ import {
   getDefinitionIdentifier,
   splitDefinitionIdentifier,
 } from 'modules/hooks/processDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 const initialValues: ProcessInstancesFilter = {
   active: true,
@@ -52,6 +53,7 @@ const initialValues: ProcessInstancesFilter = {
 };
 
 const Filters: React.FC = observer(() => {
+  const clientConfig = getClientConfig();
   const isBatchModificationEnabled = batchModificationStore.state.isEnabled;
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -132,7 +134,7 @@ const Filters: React.FC = observer(() => {
                 ]}
               />
               <Stack gap={5}>
-                {window.clientConfig?.multiTenancyEnabled && (
+                {clientConfig.multiTenancyEnabled && (
                   <div>
                     <Title>Tenant</Title>
                     <TenantField

--- a/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
@@ -22,9 +22,25 @@ import {
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 describe('Filters', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
@@ -40,7 +56,8 @@ describe('Filters', () => {
   });
 
   it('should load values from the URL when multi tenancy is enabled', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(
@@ -125,7 +142,8 @@ describe('Filters', () => {
   });
 
   it('should set modified values to the URL when multi tenancy is enabled', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(
@@ -204,7 +222,8 @@ describe('Filters', () => {
   });
 
   it('should disable processes field when tenant is not selected', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
 
@@ -216,7 +235,8 @@ describe('Filters', () => {
   });
 
   it('should clear process and version field when tenant filter is changed', async () => {
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(

--- a/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
@@ -22,25 +22,10 @@ import {
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 describe('Filters', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockSearchProcessDefinitions().withSuccess(searchResult([]));
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
@@ -56,8 +41,8 @@ describe('Filters', () => {
   });
 
   it('should load values from the URL when multi tenancy is enabled', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(
@@ -142,8 +127,8 @@ describe('Filters', () => {
   });
 
   it('should set modified values to the URL when multi tenancy is enabled', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(
@@ -222,8 +207,8 @@ describe('Filters', () => {
   });
 
   it('should disable processes field when tenant is not selected', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 
@@ -235,8 +220,8 @@ describe('Filters', () => {
   });
 
   it('should clear process and version field when tenant filter is changed', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
     mockSearchProcessDefinitions().withSuccess(

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
@@ -210,12 +210,8 @@ describe('<MigrateAction />', () => {
     ).toBeInTheDocument();
   });
 
-  it.skip('should set correct store states after migrate click', async () => {
+  it.todo('should set correct store states after migrate click', async () => {
     const SEARCH_STRING = `?process=${PROCESS_DEFINITION_ID}&version=1&active=true&incidents=false`;
-    vi.stubGlobal('clientConfig', {
-      ...window.clientConfig,
-      search: SEARCH_STRING,
-    });
 
     const {user} = render(<MigrateAction />, {
       wrapper: createWrapper({

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.test.tsx
@@ -17,7 +17,7 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import type {ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.8';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
-import {getClientConfig} from 'modules/utils/getClientConfig';
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 vi.mock('modules/utils/bpmn');
 vi.mock('modules/hooks/useCallbackPrompt', () => {
@@ -29,19 +29,6 @@ vi.mock('modules/hooks/useCallbackPrompt', () => {
     }),
   };
 });
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const mockProcessInstances: ProcessInstance[] = [
   {
@@ -88,7 +75,6 @@ function getWrapper(initialPath: string = Paths.processes()) {
 
 describe('<InstancesTable />', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     mockQueryBatchOperationItems().withSuccess({
       items: [],
       page: {totalItems: 0},
@@ -98,8 +84,8 @@ describe('<InstancesTable />', () => {
   it.each(['all', undefined])(
     'should show tenant column when multi tenancy is enabled and tenant filter is %p',
     async (tenant) => {
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         multiTenancyEnabled: true,
       });
       render(
@@ -124,8 +110,8 @@ describe('<InstancesTable />', () => {
   );
 
   it('should hide tenant column when multi tenancy is enabled and tenant filter is a specific tenant', async () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       multiTenancyEnabled: true,
     });
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -33,6 +33,7 @@ import {getProcessDefinitionName} from 'modules/utils/instance';
 import {useOperationItemsForInstances} from 'modules/queries/batch-operations/useOperationItemsForInstances';
 import {useActiveOperationItemsForInstances} from 'modules/queries/batch-operations/useActiveOperationItemsForInstances';
 import {InlineLoading} from '@carbon/react';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 type InstancesTableProps = {
   state: 'skeleton' | 'loading' | 'error' | 'empty' | 'content';
@@ -62,9 +63,10 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
       location.search,
     );
     const listHasFinishedInstances = canceled || completed;
+    const clientConfig = getClientConfig();
 
     const isTenantColumnVisible =
-      window.clientConfig?.multiTenancyEnabled &&
+      clientConfig.multiTenancyEnabled &&
       (tenant === undefined || tenant === 'all');
 
     const batchOperationId = searchParams.get('operationId') ?? undefined;

--- a/operate/client/src/App/Processes/MigrationView/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/index.test.tsx
@@ -21,21 +21,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {open} from 'modules/mocks/diagrams';
 import {createUser, searchResult} from 'modules/testUtils';
 import {mockMe} from 'modules/mocks/api/v2/me';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 vi.mock('App/Processes/ListView', () => {
   const ListView: React.FC = () => {
@@ -92,7 +78,6 @@ function createWrapper(options?: {initialPath?: string; contextPath?: string}) {
 
 describe('MigrationView', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     processInstanceMigrationStore.enable();
     mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     mockMe({contextPath: '/custom'}).withSuccess(
@@ -103,8 +88,8 @@ describe('MigrationView', () => {
   it.each(['/custom', ''])(
     'should block navigation to dashboard page when migration mode is enabled - context path: %p',
     async (contextPath) => {
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         contextPath,
       });
       mockFetchProcessDefinitionXml({contextPath}).withSuccess(
@@ -172,8 +157,8 @@ describe('MigrationView', () => {
     'should block navigation to processes page when migration mode is enabled - context path: %p',
 
     async (contextPath) => {
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         contextPath,
       });
       mockFetchProcessDefinitionXml({contextPath}).withSuccess(

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -26,6 +26,7 @@ import {TrackPagination} from 'modules/tracking/TrackPagination';
 import {useEffect} from 'react';
 import {tracking} from 'modules/tracking';
 import {currentTheme} from 'modules/stores/currentTheme';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 import {ThemeSwitcher} from 'modules/components/ThemeSwitcher';
 import {ForbiddenPage} from 'modules/components/ForbiddenPage';
@@ -128,7 +129,7 @@ const routes = createRoutesFromElements(
 );
 
 const router = createBrowserRouter(routes, {
-  basename: import.meta.env.DEV ? '/' : (window.clientConfig?.baseName ?? '/'),
+  basename: import.meta.env.DEV ? '/' : getClientConfig().baseName,
 });
 
 const App: React.FC = () => {

--- a/operate/client/src/modules/stores/authentication.test.ts
+++ b/operate/client/src/modules/stores/authentication.test.ts
@@ -12,11 +12,27 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
 import {mockLogin} from 'modules/mocks/api/login';
 import {mockLogout} from 'modules/mocks/api/logout';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+
+vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('modules/utils/getClientConfig')>();
+  return {
+    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
+  };
+});
+
+const {getClientConfig: actualGetClientConfig} = await vi.importActual<
+  typeof import('modules/utils/getClientConfig')
+>('modules/utils/getClientConfig');
+
+const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const mockUserResponse = createUser();
 
 describe('authentication store', () => {
   beforeEach(() => {
+    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     authenticationStore.reset();
   });
 
@@ -91,7 +107,8 @@ describe('authentication store', () => {
       href: mockHref,
     });
 
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       canLogout: true,
       isLoginDelegated: false,
     });
@@ -133,7 +150,8 @@ describe('authentication store', () => {
         href: mockHref,
       });
 
-      vi.stubGlobal('clientConfig', {
+      mockGetClientConfig.mockReturnValue({
+        ...actualGetClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -175,7 +193,8 @@ describe('authentication store', () => {
         reload: mockReload,
       });
 
-      vi.stubGlobal('clientConfig', {
+      mockGetClientConfig.mockReturnValue({
+        ...actualGetClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -218,7 +237,8 @@ describe('authentication store', () => {
       href: mockHref,
     });
 
-    vi.stubGlobal('clientConfig', {
+    mockGetClientConfig.mockReturnValue({
+      ...actualGetClientConfig(),
       canLogout: true,
       isLoginDelegated: true,
     });

--- a/operate/client/src/modules/stores/authentication.test.ts
+++ b/operate/client/src/modules/stores/authentication.test.ts
@@ -12,27 +12,12 @@ import {mockMe} from 'modules/mocks/api/v2/me';
 import {createUser} from 'modules/testUtils';
 import {mockLogin} from 'modules/mocks/api/login';
 import {mockLogout} from 'modules/mocks/api/logout';
-import {getClientConfig} from 'modules/utils/getClientConfig';
-
-vi.mock('modules/utils/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('modules/utils/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('modules/utils/getClientConfig')
->('modules/utils/getClientConfig');
-
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const mockUserResponse = createUser();
 
 describe('authentication store', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     authenticationStore.reset();
   });
 
@@ -107,8 +92,8 @@ describe('authentication store', () => {
       href: mockHref,
     });
 
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: true,
       isLoginDelegated: false,
     });
@@ -150,8 +135,8 @@ describe('authentication store', () => {
         href: mockHref,
       });
 
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -193,8 +178,8 @@ describe('authentication store', () => {
         reload: mockReload,
       });
 
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -237,8 +222,8 @@ describe('authentication store', () => {
       href: mockHref,
     });
 
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: true,
       isLoginDelegated: true,
     });

--- a/operate/client/src/modules/stores/authentication.ts
+++ b/operate/client/src/modules/stores/authentication.ts
@@ -11,6 +11,7 @@ import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
 import {currentUserQueryOptions} from 'modules/queries/useCurrentUser';
 import {reactQueryClient} from 'modules/react-query/reactQueryClient';
 import {request} from 'modules/request';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 import z from 'zod';
 
 type Status =
@@ -116,11 +117,9 @@ class Authentication {
       }
 
       reactQueryClient.clear();
+      const clientConfig = getClientConfig();
 
-      if (
-        !window?.clientConfig?.canLogout ||
-        window?.clientConfig?.isLoginDelegated
-      ) {
+      if (!clientConfig.canLogout || clientConfig.isLoginDelegated) {
         /*
          * In case an IdP supports RP-initiated logout,
          * its logout endpoint will be returned in a JSON response.
@@ -147,10 +146,9 @@ class Authentication {
   };
 
   disableSession = () => {
-    if (
-      !window?.clientConfig?.canLogout ||
-      window?.clientConfig?.isLoginDelegated
-    ) {
+    const clientConfig = getClientConfig();
+
+    if (!clientConfig.canLogout || clientConfig.isLoginDelegated) {
       this.#handleThirdPartySessionExpiration();
 
       return;

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -26,20 +26,25 @@ const ClientConfigSchema = z.object({
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;
 
-function getClientConfig() {
-  if (typeof window === 'undefined') {
-    return DEFAULT_CLIENT_CONFIG;
-  }
+const getClientConfig = (() => {
+  let cachedConfig: z.infer<typeof ClientConfigSchema> | undefined;
 
-  const {success, data} = ClientConfigSchema.safeParse(
-    window?.clientConfig ?? {},
-  );
+  return () => {
+    if (cachedConfig !== undefined) {
+      return cachedConfig;
+    }
 
-  if (success) {
-    return data;
-  }
+    if (typeof window === 'undefined') {
+      return DEFAULT_CLIENT_CONFIG;
+    }
 
-  return DEFAULT_CLIENT_CONFIG;
-}
+    const {success, data} = ClientConfigSchema.safeParse(
+      window?.clientConfig ?? {},
+    );
+
+    cachedConfig = success ? data : DEFAULT_CLIENT_CONFIG;
+    return cachedConfig;
+  };
+})();
 
 export {getClientConfig};

--- a/tasklist/client/src/common/auth/AuthorizationCheck/index.test.tsx
+++ b/tasklist/client/src/common/auth/AuthorizationCheck/index.test.tsx
@@ -10,7 +10,6 @@ import {render, screen} from 'common/testing/testing-library';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {AuthorizationCheck} from './index';
 import {pages} from 'common/routing';
-import {vi} from 'vitest';
 import {nodeMockServer} from 'common/testing/nodeMockServer';
 import {http, HttpResponse} from 'msw';
 import * as userMocks from 'common/mocks/current-user';

--- a/tasklist/client/src/common/auth/Login/Disclaimer/index.test.tsx
+++ b/tasklist/client/src/common/auth/Login/Disclaimer/index.test.tsx
@@ -8,29 +8,13 @@
 
 import {render, screen} from 'common/testing/testing-library';
 import {Disclaimer} from './index';
-import {vi} from 'vitest';
-import {getClientConfig} from 'common/config/getClientConfig';
-
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('common/config/getClientConfig')
->('common/config/getClientConfig');
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'common/config/getClientConfig';
 
 const DISCLAIMER_TEXT =
   'Non-Production License. If you would like information on production usage, please refer to our terms & conditions page or contact sales.';
 
 describe('<Disclaimer />', () => {
   it('should show the disclaimer', () => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
-
     const {rerender} = render(<Disclaimer />);
 
     // we need this custom selector because the text contains a link
@@ -70,8 +54,8 @@ describe('<Disclaimer />', () => {
   });
 
   it('should not render the disclaimer', () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isEnterprise: true,
     });
 

--- a/tasklist/client/src/common/auth/authentication.test.tsx
+++ b/tasklist/client/src/common/auth/authentication.test.tsx
@@ -10,28 +10,14 @@ import {http, HttpResponse} from 'msw';
 import {authenticationStore} from './authentication';
 import {nodeMockServer} from 'common/testing/nodeMockServer';
 import {getStateLocally} from 'common/local-storage';
-import {getClientConfig} from 'common/config/getClientConfig';
+import * as clientConfig from 'common/config/getClientConfig';
 import {currentUser} from 'common/mocks/current-user';
-
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('common/config/getClientConfig')
->('common/config/getClientConfig');
-const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const unchangedHref = window.location.href;
 
 describe('authentication store', () => {
   beforeEach(() => {
     authenticationStore.reset();
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
   });
 
   it('should assume that there is an existing session', () => {
@@ -111,9 +97,8 @@ describe('authentication store', () => {
       ...window.location,
       reload: mockReload,
     });
-
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: true,
       isLoginDelegated: true,
     });
@@ -161,9 +146,8 @@ describe('authentication store', () => {
       ...window.location,
       reload: mockReload,
     });
-
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: true,
       isLoginDelegated: false,
     });
@@ -199,9 +183,8 @@ describe('authentication store', () => {
         ...window.location,
         reload: mockReload,
       });
-
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -238,9 +221,8 @@ describe('authentication store', () => {
         ...window.location,
         reload: mockReload,
       });
-
-      mockGetClientConfig.mockReturnValue({
-        ...actualGetClientConfig(),
+      vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+        ...clientConfig.getClientConfig(),
         canLogout,
         isLoginDelegated,
       });
@@ -290,9 +272,8 @@ describe('authentication store', () => {
       ...window.location,
       reload: mockReload,
     });
-
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       canLogout: true,
       isLoginDelegated: true,
     });

--- a/tasklist/client/src/common/config/getClientConfig.ts
+++ b/tasklist/client/src/common/config/getClientConfig.ts
@@ -29,20 +29,25 @@ const ClientConfigSchema = z.object({
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;
 
-function getClientConfig() {
-  if (typeof window === 'undefined') {
-    return DEFAULT_CLIENT_CONFIG;
-  }
+const getClientConfig = (() => {
+  let cachedConfig: z.infer<typeof ClientConfigSchema> | undefined;
 
-  const {success, data} = ClientConfigSchema.safeParse(
-    window?.clientConfig ?? {},
-  );
+  return () => {
+    if (cachedConfig !== undefined) {
+      return cachedConfig;
+    }
 
-  if (success) {
-    return data;
-  }
+    if (typeof window === 'undefined') {
+      return DEFAULT_CLIENT_CONFIG;
+    }
 
-  return DEFAULT_CLIENT_CONFIG;
-}
+    const {success, data} = ClientConfigSchema.safeParse(
+      window?.clientConfig ?? {},
+    );
+
+    cachedConfig = success ? data : DEFAULT_CLIENT_CONFIG;
+    return cachedConfig;
+  };
+})();
 
 export {getClientConfig};

--- a/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v1.test.tsx
+++ b/tasklist/client/src/common/tasks/available-tasks/CollapsiblePanel/index.v1.test.tsx
@@ -16,6 +16,7 @@ import {nodeMockServer} from 'common/testing/nodeMockServer';
 import * as userMocks from 'common/mocks/current-user';
 import {getStateLocally, storeStateLocally} from 'common/local-storage';
 import {createMockProcess} from 'v1/api/useProcesses.query';
+import * as clientConfig from 'common/config/getClientConfig';
 
 const createWrapper = (
   initialEntries: React.ComponentProps<
@@ -35,21 +36,12 @@ const createWrapper = (
   return Wrapper;
 };
 
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig() {
-      return {
-        ...actual.getClientConfig(),
-        clientMode: 'v1',
-      };
-    },
-  };
-});
-
 describe('<CollapsiblePanel />', () => {
   beforeEach(() => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      clientMode: 'v1',
+    });
     nodeMockServer.use(
       http.get(
         '/v2/authentication/me',

--- a/tasklist/client/src/common/tasks/details/Aside/index.test.tsx
+++ b/tasklist/client/src/common/tasks/details/Aside/index.test.tsx
@@ -15,21 +15,7 @@ import {useCurrentUser} from 'common/api/useCurrentUser.query';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'common/testing/getMockQueryClient';
 import {Aside} from './index';
-import {getClientConfig} from 'common/config/getClientConfig';
-import {vi} from 'vitest';
-
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('common/config/getClientConfig')
->('common/config/getClientConfig');
-const mockGetClientConfig = vi.mocked(getClientConfig);
+import * as clientConfig from 'common/config/getClientConfig';
 
 const completedTaskMock = {
   creationDate: '2024-01-01T00:00:00.000Z',
@@ -80,7 +66,6 @@ const getWrapper = (id: string = '0') => {
 
 describe('<Aside />', () => {
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     nodeMockServer.use(
       http.get('/v2/authentication/me', () => {
         return HttpResponse.json(userMocks.currentUser);
@@ -110,8 +95,8 @@ describe('<Aside />', () => {
   });
 
   it('should render tenant name', () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
 
@@ -130,8 +115,8 @@ describe('<Aside />', () => {
   });
 
   it('should hide tenant name if user only has access to one tenant', () => {
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
 

--- a/tasklist/client/src/v1/ProcessesTab/index.test.tsx
+++ b/tasklist/client/src/v1/ProcessesTab/index.test.tsx
@@ -27,26 +27,13 @@ import {LocationLog} from 'common/testing/LocationLog';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'common/testing/getMockQueryClient';
 import {pages} from 'common/routing';
-import {getClientConfig} from 'common/config/getClientConfig';
+import * as clientConfig from 'common/config/getClientConfig';
 
 vi.mock('common/notifications/notifications.store', () => ({
   notificationsStore: {
     displayNotification: vi.fn(() => () => {}),
   },
 }));
-
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('common/config/getClientConfig')
->('common/config/getClientConfig');
-const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const mockedNotificationsStore = notificationsStore as Mocked<
   typeof notificationsStore
@@ -80,7 +67,6 @@ describe('Processes', () => {
   });
 
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     nodeMockServer.use(
       http.get(
         '/v2/authentication/me',
@@ -237,8 +223,8 @@ describe('Processes', () => {
 
   it('should render a tenant dropdown', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(
@@ -275,8 +261,8 @@ describe('Processes', () => {
   it('should render a tenant dropdown with the current tenant selected', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
     window.localStorage.setItem('tenantId', '"tenantA"');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(
@@ -312,8 +298,8 @@ describe('Processes', () => {
 
   it('should not render dropdown with single tenant', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(

--- a/tasklist/client/src/v2/ProcessesTab/index.test.tsx
+++ b/tasklist/client/src/v2/ProcessesTab/index.test.tsx
@@ -30,7 +30,7 @@ import {LocationLog} from 'common/testing/LocationLog';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'common/testing/getMockQueryClient';
 import {pages} from 'common/routing';
-import {getClientConfig} from 'common/config/getClientConfig';
+import * as clientConfig from 'common/config/getClientConfig';
 import type {QueryProcessDefinitionsRequestBody} from '@camunda/camunda-api-zod-schemas/8.8';
 
 vi.mock('common/notifications/notifications.store', () => ({
@@ -38,19 +38,6 @@ vi.mock('common/notifications/notifications.store', () => ({
     displayNotification: vi.fn(() => () => {}),
   },
 }));
-
-vi.mock('common/config/getClientConfig', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('common/config/getClientConfig')>();
-  return {
-    getClientConfig: vi.fn().mockImplementation(actual.getClientConfig),
-  };
-});
-
-const {getClientConfig: actualGetClientConfig} = await vi.importActual<
-  typeof import('common/config/getClientConfig')
->('common/config/getClientConfig');
-const mockGetClientConfig = vi.mocked(getClientConfig);
 
 const mockedNotificationsStore = notificationsStore as Mocked<
   typeof notificationsStore
@@ -84,7 +71,6 @@ describe('Processes', () => {
   });
 
   beforeEach(() => {
-    mockGetClientConfig.mockReturnValue(actualGetClientConfig());
     nodeMockServer.use(
       http.get(
         '/v2/authentication/me',
@@ -245,8 +231,8 @@ describe('Processes', () => {
 
   it('should render a tenant dropdown', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(
@@ -283,8 +269,8 @@ describe('Processes', () => {
   it('should render a tenant dropdown with the current tenant selected', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
     window.localStorage.setItem('tenantId', '"tenantA"');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(
@@ -320,8 +306,8 @@ describe('Processes', () => {
 
   it('should not render dropdown with single tenant', async () => {
     window.localStorage.setItem('hasConsentedToStartProcess', 'true');
-    mockGetClientConfig.mockReturnValue({
-      ...actualGetClientConfig(),
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
       isMultiTenancyEnabled: true,
     });
     nodeMockServer.use(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Consume `clientConfig` from typesafe util

Closes #44740
