### PR TITLE
docs: Include the link to the Camunda Platform Developer Documentation on README

### DIFF
--- a/monorepo-docs-site/README.md
+++ b/monorepo-docs-site/README.md
@@ -11,6 +11,19 @@ This site automatically generates documentation from markdown files in the `../d
 - ⚙️ **Configuration**: This directory contains Docusaurus setup and themes
 - 🌐 **Output**: Generates a complete documentation website
 
+## 🌐 Published Camunda Platform Developer Documentation
+
+This documentation site is automatically published to GitHub Pages:
+
+### 📖 **Live Documentation**
+- **Main Branch**: https://camunda.github.io/camunda/
+- **PR Previews**: `https://camunda.github.io/camunda/pr-preview/pr-<PR_NUMBER>/`
+
+### How It Works
+- **Every PR** gets its own preview site for reviewing documentation changes
+- **Main branch** publishes the Camunda Platform Developer Documentation automatically
+- **Real-time updates** - changes are deployed within minutes of merging
+
 ## Quick Start
 
 **First time setup:**
@@ -206,10 +219,22 @@ Use these Copilot prompts to efficiently fix link issues in your migrated conten
 
 ## 🚀 Deployment
 
-The site is configured for GitHub Pages with these settings:
-- **URL**: `/camunda/` (customizable via `BASE_URL` env var)
+The documentation site is automatically deployed using GitHub Pages:
+
+### 📋 **Deployment Details**
+- **Main Camunda Platform Developer Documentation**: https://camunda.github.io/camunda/
+  - Deploys automatically on push to `main` branch
+  - Official documentation for users and contributors
+
+- **Camunda Platform Developer Documentation PR Preview**: `https://camunda.github.io/camunda/pr-preview/pr-<PR_NUMBER>/`
+  - Each pull request gets its own preview URL
+  - Perfect for reviewing documentation changes before merging
+  - Automatically cleaned up when PR is closed
+
+### ⚙️ **Configuration**
+- **Base URL**: `/camunda/` (customizable via `BASE_URL` env var)
 - **Repository**: `camunda/camunda`
-- **Builds**: Automatically on push to main branch
+- **GitHub Pages**: Configured for automatic deployment
 
 ## 🆘 Troubleshooting
 

--- a/monorepo-docs-site/README.md
+++ b/monorepo-docs-site/README.md
@@ -16,10 +16,12 @@ This site automatically generates documentation from markdown files in the `../d
 This documentation site is automatically published to GitHub Pages:
 
 ### 📖 **Live Documentation**
+
 - **Main Branch**: https://camunda.github.io/camunda/
 - **PR Previews**: `https://camunda.github.io/camunda/pr-preview/pr-<PR_NUMBER>/`
 
 ### How It Works
+
 - **Every PR** gets its own preview site for reviewing documentation changes
 - **Main branch** publishes the Camunda Platform Developer Documentation automatically
 - **Real-time updates** - changes are deployed within minutes of merging
@@ -222,16 +224,17 @@ Use these Copilot prompts to efficiently fix link issues in your migrated conten
 The documentation site is automatically deployed using GitHub Pages:
 
 ### 📋 **Deployment Details**
+
 - **Main Camunda Platform Developer Documentation**: https://camunda.github.io/camunda/
   - Deploys automatically on push to `main` branch
   - Official documentation for users and contributors
-
 - **Camunda Platform Developer Documentation PR Preview**: `https://camunda.github.io/camunda/pr-preview/pr-<PR_NUMBER>/`
   - Each pull request gets its own preview URL
   - Perfect for reviewing documentation changes before merging
   - Automatically cleaned up when PR is closed
 
 ### ⚙️ **Configuration**
+
 - **Base URL**: `/camunda/` (customizable via `BASE_URL` env var)
 - **Repository**: `camunda/camunda`
 - **GitHub Pages**: Configured for automatic deployment


### PR DESCRIPTION
## Description

This pull request updates the `monorepo-docs-site/README.md` to clarify and document the automatic publishing and deployment process for the Camunda Platform Developer Documentation. The changes emphasize how documentation is published to GitHub Pages, including live documentation and PR preview sites, and provide more detailed deployment information.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
