### PR TITLE
fix: add wait between zcl operations for eventual consistency

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -1058,6 +1058,8 @@ jobs:
           --label="version:$ZCL_TARGET_REV" \
           --org camunda --repo camunda
 
+          sleep 15 # eventual consistency wait for GitHub to return labeled issues in the API call
+
           # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
           changelog=$(./zcl generate \
           --token=${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->

fix: add wait between zcl operations for eventual consistency

Labelling issues with `zcl add-labels` takes time for GitHub API to propagate the result in the follow-up API call done in `zcl changelog` - waiting to ensure the changelog data is up-to-date.

context: https://camunda.slack.com/archives/C06UWQNCU7M/p1771444815419849\?thread_ts\=1771427372.406549\&cid\=C06UWQNCU7M

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
