### PR TITLE
Remove leases after scale down

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
@@ -253,6 +254,15 @@ final class ClusterApiUtils {
               .brokerId(Integer.parseInt(preScalingOperation.memberId().id()))
               .brokers(
                   preScalingOperation.clusterMembers().stream()
+                      .map(MemberId::id)
+                      .map(Integer::parseInt)
+                      .toList());
+      case final PostScalingOperation postScalingOperation ->
+          new Operation()
+              .operation(OperationEnum.POST_SCALING)
+              .brokerId(Integer.parseInt(postScalingOperation.memberId().id()))
+              .brokers(
+                  postScalingOperation.clusterMembers().stream()
                       .map(MemberId::id)
                       .map(Integer::parseInt)
                       .toList());
@@ -523,6 +533,15 @@ final class ClusterApiUtils {
                   .brokerId(Integer.parseInt(preScalingOperation.memberId().id()))
                   .brokers(
                       preScalingOperation.clusterMembers().stream()
+                          .map(MemberId::id)
+                          .map(Integer::parseInt)
+                          .toList());
+          case final PostScalingOperation postScalingOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.POST_SCALING)
+                  .brokerId(Integer.parseInt(postScalingOperation.memberId().id()))
+                  .brokers(
+                      postScalingOperation.clusterMembers().stream()
                           .map(MemberId::id)
                           .map(Integer::parseInt)
                           .toList());

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -330,6 +330,7 @@ schemas:
           - PARTITION_DELETE_EXPORTER
           - UPDATE_INCARNATION_NUMBER
           - PRE_SCALING
+          - POST_SCALING
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
@@ -303,6 +304,7 @@ final class ClusterApiUtilsTest {
         new UpdateRoutingState(memberId1, emptyRoutingState),
         new UpdateIncarnationNumberOperation(memberId1),
         new PreScalingOperation(memberId1, memberCollection),
+        new PostScalingOperation(memberId1, memberCollection),
 
         // Scale up operations
         new StartPartitionScaleUp(memberId1, 8),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
@@ -88,6 +89,12 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
         });
 
     return result;
+  }
+
+  @Override
+  public ActorFuture<Void> postScaling(final Set<MemberId> clusterMembers) {
+    // TODO: implement actual logic here
+    return CompletableActorFuture.completed();
   }
 
   private void purgeExporter(final String id, final ExporterDescriptor descriptor) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -31,96 +31,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class ClusterChangeExecutorImplTest {
-
-  @Test
-  void shouldRunPurgeForEveryExporter() {
-    // given
-    final ExporterRepository repository = new ExporterRepository();
-    try {
-      repository.validateAndAddExporterDescriptor("test-1", AuditExporter.class, null);
-      repository.validateAndAddExporterDescriptor("test-2", AuditExporter.class, null);
-    } catch (final ExporterLoadException e) {
-      Assertions.fail(e);
-    }
-
-    final var executor =
-        new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(),
-            repository,
-            mock(NodeIdProvider.class),
-            new SimpleMeterRegistry());
-
-    // when
-    final Future<Void> result = executor.deleteHistory();
-
-    // then
-    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
-    Assertions.assertThat(AuditExporter.AUDITS)
-        .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1")
-        .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
-        .doesNotContainAnyElementsOf(
-            Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
-  }
-
-  @Test
-  void shouldCallNodeIdProviderScale() {
-    // given
-    final var nodeIdProvider = mock(NodeIdProvider.class);
-    when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
-    final var executor =
-        new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
-
-    // when
-    final var result =
-        executor.preScaling(1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
-
-    // then
-    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
-    verify(nodeIdProvider, times(1)).scale(3);
-  }
-
-  @Test
-  void shouldOnlyCallNodeIdProviderScaleWhenScalingUp() {
-    // given
-    final var nodeIdProvider = mock(NodeIdProvider.class);
-    when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
-    final var executor =
-        new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
-
-    // when
-    final var result = executor.preScaling(3, Set.of(MemberId.from("0"), MemberId.from("1")));
-
-    // then
-    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
-    verify(nodeIdProvider, times(0)).scale(anyInt());
-  }
-
-  @Test
-  void shouldCompleteExceptionallyWhenNodeIdProviderScaleFails() {
-    // given
-    final var nodeIdProvider = mock(NodeIdProvider.class);
-    when(nodeIdProvider.scale(anyInt()))
-        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
-    final var executor =
-        new ClusterChangeExecutorImpl(
-            new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
-
-    // when
-    final var result =
-        executor.preScaling(1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
-
-    // then
-    Assertions.assertThat(result)
-        .failsWithin(Duration.ofSeconds(5))
-        .withThrowableOfType(ExecutionException.class)
-        .withMessageContaining("scale failed");
-    verify(nodeIdProvider, times(1)).scale(3);
-  }
 
   public static class AuditExporter implements Exporter {
     static final List<String> AUDITS = new ArrayList<>();
@@ -150,6 +64,146 @@ public class ClusterChangeExecutorImplTest {
 
     private void audit(final String name) {
       AUDITS.add(name + "-" + (exporterId != null ? exporterId : "unknown"));
+    }
+  }
+
+  @Nested
+  class DeleteHistoryTest {
+    @Test
+    void shouldRunPurgeForEveryExporter() {
+      // given
+      final ExporterRepository repository = new ExporterRepository();
+      try {
+        repository.validateAndAddExporterDescriptor("test-1", AuditExporter.class, null);
+        repository.validateAndAddExporterDescriptor("test-2", AuditExporter.class, null);
+      } catch (final ExporterLoadException e) {
+        Assertions.fail(e);
+      }
+
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(),
+              repository,
+              mock(NodeIdProvider.class),
+              new SimpleMeterRegistry());
+
+      // when
+      final Future<Void> result = executor.deleteHistory();
+
+      // then
+      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      Assertions.assertThat(AuditExporter.AUDITS)
+          .containsSubsequence("configure-test-1", "purge-test-1", "close-test-1")
+          .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
+          .doesNotContainAnyElementsOf(
+              Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
+    }
+  }
+
+  @Nested
+  class PreScalingTest {
+
+    @Test
+    void shouldCallNodeIdProviderScale() {
+      // given
+      final var nodeIdProvider = mock(NodeIdProvider.class);
+      when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+      // when
+      final var result =
+          executor.preScaling(
+              1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // then
+      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      verify(nodeIdProvider, times(1)).scale(3);
+    }
+
+    @Test
+    void shouldOnlyCallNodeIdProviderScaleWhenScalingUp() {
+      // given
+      final var nodeIdProvider = mock(NodeIdProvider.class);
+      when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+      // when
+      final var result = executor.preScaling(3, Set.of(MemberId.from("0"), MemberId.from("1")));
+
+      // then
+      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      verify(nodeIdProvider, times(0)).scale(anyInt());
+    }
+
+    @Test
+    void shouldCompleteExceptionallyWhenNodeIdProviderScaleFails() {
+      // given
+      final var nodeIdProvider = mock(NodeIdProvider.class);
+      when(nodeIdProvider.scale(anyInt()))
+          .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+      // when
+      final var result =
+          executor.preScaling(
+              1, Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // then
+      Assertions.assertThat(result)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .withMessageContaining("scale failed");
+      verify(nodeIdProvider, times(1)).scale(3);
+    }
+  }
+
+  @Nested
+  class PostScalingTest {
+
+    @Test
+    void shouldCallNodeIdProviderScaleOnPostScale() {
+      // given
+      final var nodeIdProvider = mock(NodeIdProvider.class);
+      when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+      // when
+      final var result =
+          executor.postScaling(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // then
+      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      verify(nodeIdProvider, times(1)).scale(3);
+    }
+
+    @Test
+    void shouldCompleteExceptionallyWhenNodeIdProviderScaleFails() {
+      // given
+      final var nodeIdProvider = mock(NodeIdProvider.class);
+      when(nodeIdProvider.scale(anyInt()))
+          .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+
+      // when
+      final var result =
+          executor.postScaling(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")));
+
+      // then
+      Assertions.assertThat(result)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .withMessageContaining("scale failed");
+      verify(nodeIdProvider, times(1)).scale(3);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
@@ -39,6 +39,17 @@ public interface ClusterChangeExecutor {
    */
   ActorFuture<Void> preScaling(final int currentClusterSize, Set<MemberId> clusterMembers);
 
+  /**
+   * This method will start an asynchronous post-scaling operation, finalizing the member after a
+   * cluster scaling event.
+   *
+   * <p>This operation should be idempotent, as it may be retried multiple times until successful.
+   *
+   * @param clusterMembers the set of member ids that are part of the cluster after scaling
+   * @return future when the operation is completed
+   */
+  ActorFuture<Void> postScaling(Set<MemberId> clusterMembers);
+
   final class NoopClusterChangeExecutor implements ClusterChangeExecutor {
     @Override
     public ActorFuture<Void> deleteHistory() {
@@ -48,6 +59,11 @@ public interface ClusterChangeExecutor {
     @Override
     public ActorFuture<Void> preScaling(
         final int currentClusterSize, final Set<MemberId> clusterMembers) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public ActorFuture<Void> postScaling(final Set<MemberId> clusterMembers) {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
@@ -124,6 +125,11 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
           new PreScalingApplier(
               preScalingOperation.memberId(),
               preScalingOperation.clusterMembers(),
+              clusterChangeExecutor);
+      case final PostScalingOperation postScalingOperation ->
+          new PostScalingApplier(
+              postScalingOperation.memberId(),
+              postScalingOperation.clusterMembers(),
               clusterChangeExecutor);
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PostScalingApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PostScalingApplier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Applier for the PostScalingOperation. This applier finalizes a member after scaling by invoking
+ * the post-scaling callback on the ClusterChangeExecutor.
+ */
+final class PostScalingApplier implements ClusterOperationApplier {
+  private final MemberId memberId;
+  private final Set<MemberId> clusterMembers;
+  private final ClusterChangeExecutor clusterChangeExecutor;
+
+  public PostScalingApplier(
+      final MemberId memberId,
+      final Set<MemberId> clusterMembers,
+      final ClusterChangeExecutor clusterChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembers = clusterMembers;
+    this.clusterChangeExecutor = clusterChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    // Validate that the member applying this operation is part of the cluster
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot apply post-scaling operation: member "
+                  + memberId
+                  + " is not part of the current cluster configuration."));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    // Post-scaling is called after all scaling operations complete.
+    // We always notify the nodeIdProvider of the final cluster size
+    // regardless of whether it was scale-up or scale-down.
+    return clusterChangeExecutor
+        .postScaling(clusterMembers)
+        .thenApply(ignore -> UnaryOperator.identity());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateIncarnationNumberOperation;
@@ -515,6 +516,12 @@ public class ProtoBufSerializer
                   .addAllClusterMembers(
                       preScalingOperation.clusterMembers().stream().map(MemberId::id).toList())
                   .build());
+      case final PostScalingOperation postScalingOperation ->
+          builder.setPostScaling(
+              Topology.PostScalingOperation.newBuilder()
+                  .addAllClusterMembers(
+                      postScalingOperation.clusterMembers().stream().map(MemberId::id).toList())
+                  .build());
     }
     return builder.build();
   }
@@ -774,6 +781,13 @@ public class ProtoBufSerializer
       return new PreScalingOperation(
           memberId,
           preScalingOperation.getClusterMembersList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()));
+    } else if (topologyChangeOperation.hasPostScaling()) {
+      final var postScalingOperation = topologyChangeOperation.getPostScaling();
+      return new PostScalingOperation(
+          memberId,
+          postScalingOperation.getClusterMembersList().stream()
               .map(MemberId::from)
               .collect(Collectors.toSet()));
     } else {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -86,6 +86,21 @@ public sealed interface ClusterConfigurationChangeOperation {
     }
   }
 
+  /**
+   * Operation to finalize scaling. This operation is executed after scaling is complete.
+   *
+   * @param memberId the member id of the member that will apply this operation
+   * @param clusterMembers the list of member ids that are part of the cluster after scaling is
+   *     completed
+   */
+  record PostScalingOperation(MemberId memberId, SortedSet<MemberId> clusterMembers)
+      implements ClusterConfigurationChangeOperation {
+
+    public PostScalingOperation(final MemberId memberId, final Set<MemberId> clusterMembers) {
+      this(memberId, ImmutableSortedSet.copyOf(clusterMembers));
+    }
+  }
+
   sealed interface ScaleUpOperation extends ClusterConfigurationChangeOperation {
     /**
      * Operation to initiate partition scale up. This instructs the cluster to redistribute

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -107,6 +107,7 @@ message TopologyChangeOperation {
     PartitionDeleteExporterOperation partitionDeleteExporter = 17;
     UpdateIncarnationNumberOperation updateIncarnationNumber = 18;
     PreScalingOperation preScaling = 19;
+    PostScalingOperation postScaling = 20;
   }
 }
 
@@ -177,6 +178,10 @@ message UpdateRoutingState{
 message UpdateIncarnationNumberOperation {}
 
 message PreScalingOperation {
+  repeated string clusterMembers = 1;
+}
+
+message PostScalingOperation {
   repeated string clusterMembers = 1;
 }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
@@ -251,7 +252,8 @@ final class ClusterConfigurationManagementApiTest {
             new PreScalingOperation(id0, Set.of(id0, id1)),
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2, 1));
+            new PartitionLeaveOperation(id0, 2, 1),
+            new PostScalingOperation(id0, Set.of(id0, id1)));
   }
 
   @Test
@@ -270,8 +272,9 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .hasSize(5)
+        .hasSize(6)
         .startsWith(new PreScalingOperation(id0, Set.of(id0, id1)))
+        .endsWith(new PostScalingOperation(id0, Set.of(id0, id1)))
         .contains(new MemberJoinOperation(id1), new PartitionJoinOperation(id1, 2, 2))
         .containsSequence(
             new PartitionJoinOperation(id1, 1, 1),
@@ -379,7 +382,8 @@ final class ClusterConfigurationManagementApiTest {
             new StartPartitionScaleUp(id0, 3),
             new PartitionBootstrapOperation(id0, 3, 1, true),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));
+            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))),
+            new PostScalingOperation(id0, Set.of(id0, id1)));
   }
 
   @Test
@@ -407,7 +411,8 @@ final class ClusterConfigurationManagementApiTest {
             new StartPartitionScaleUp(id0, 3),
             new PartitionBootstrapOperation(id0, 3, 1, true),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));
+            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))),
+            new PostScalingOperation(id0, Set.of(id0, id1)));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PreScalingOperation;
 import java.util.Optional;
 import java.util.Set;
@@ -71,6 +72,9 @@ final class ConfigurationChangeAppliersImplTest {
         Arguments.of(new DeleteHistoryOperation(localMemberId), DeleteHistoryApplier.class),
         Arguments.of(
             new PreScalingOperation(localMemberId, Set.of(localMemberId, MemberId.from("2"))),
-            PreScalingApplier.class));
+            PreScalingApplier.class),
+        Arguments.of(
+            new PostScalingOperation(localMemberId, Set.of(localMemberId, MemberId.from("2"))),
+            PostScalingApplier.class));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -99,8 +99,6 @@ public class DynamicNodeIdScalingIT {
   }
 
   private static void configureS3NodeIdProvider(final Camunda cfg) {
-    // cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
-
     cfg.getCluster().getNodeIdProvider().setType(Type.S3);
     final S3 s3 = cfg.getCluster().getNodeIdProvider().s3();
     s3.setTaskId(UUID.randomUUID().toString());


### PR DESCRIPTION
## Description

This PR adds a `PostScalingOperation` that call backs to NodeIdProvider. If scaling down, the leases for the removed nodes will be deleted. Removing the leases would fail the renewal of leases for those nodes. This would force them to shutdown. This is acceptable as there is no point in keeping them running. 

Note:- We do not support gaps in the leases yet.

## Related issues

closes #45812 
