### PR TITLE
build: bump feel-scala to 1.20.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,7 +104,7 @@
     <version.postgressql-testcontainer>2.0.2</version.postgressql-testcontainer>
     <version.netflix.concurrency>0.5.4</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
-    <version.feel-scala>1.20.0</version.feel-scala>
+    <version.feel-scala>1.20.1</version.feel-scala>
     <version.dmn-scala>1.11.0</version.dmn-scala>
     <version.rest-assured>6.0.0</version.rest-assured>
     <version.spring>7.0.5</version.spring>


### PR DESCRIPTION
## Description
Bump feel-scala to 1.20.1.

It contains a few performance improvements, see [release notes](https://github.com/camunda/feel-scala/releases/tag/1.20.1), one of which was considered a bottleneck in a support case.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

