### PR TITLE
ci: use correct area/build label for assigning Renovate PRs

### DIFF
--- a/.ci/scripts/renovate-assignments.py
+++ b/.ci/scripts/renovate-assignments.py
@@ -20,7 +20,7 @@ DELAYED_OPTION_ID = "47fc9ee4"  # "Delayed" option ID
 TEAM_SLUGS = {
     "area/backend": "monorepo-backend-engineers",
     "area/frontend": "monorepo-frontend-engineers",
-    "area/devops": "monorepo-devops-engineers"
+    "area/build": "monorepo-devops-engineers"
 }
 
 # Polling parameters


### PR DESCRIPTION
## Description

This PR fixes https://github.com/camunda/camunda/actions/runs/22137557084/job/63993085458#step:6:48 where the script did not take any action on https://github.com/camunda/camunda/pull/45474 despite it being clearly DevOps responsibility.

At some point in letting Copilot rewrite the script it must have swapped out my intended `area/build` label for DevOps PRs to `area/devops` for consistency, but https://github.com/camunda/camunda/blob/1c1a7fc0de874aac1c3b2537f401060b66fc2d46/.github/renovate.json#L86 clearly says `area/build` is the correct label.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed as script is run from `main` on schedule

## Related issues

Related #36956 
