### PR TITLE
45688 limit cluster variable name size

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -364,7 +364,8 @@ public final class EngineProcessors {
         processingState.getClusterVariableState(),
         writers,
         commandDistributionBehavior,
-        authCheckBehavior);
+        authCheckBehavior,
+        config);
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -44,13 +43,13 @@ public class ClusterVariableCreateProcessor
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
       final ClusterVariableState clusterVariableState,
-      final EngineConfiguration engineConfiguration) {
+      final ClusterVariableValidationConfiguration validationConfig) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
     clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
+        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -42,14 +41,12 @@ public class ClusterVariableCreateProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState,
-      final ClusterVariableValidationConfiguration validationConfig) {
+      final ClusterVariableRecordValidator clusterVariableRecordValidator) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
+    this.clusterVariableRecordValidator = clusterVariableRecordValidator;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -42,12 +43,14 @@ public class ClusterVariableCreateProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState) {
+      final ClusterVariableState clusterVariableState,
+      final EngineConfiguration engineConfiguration) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator = new ClusterVariableRecordValidator(clusterVariableState);
+    clusterVariableRecordValidator =
+        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -44,13 +43,13 @@ public class ClusterVariableDeleteProcessor
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
       final ClusterVariableState clusterVariableState,
-      final EngineConfiguration engineConfiguration) {
+      final ClusterVariableValidationConfiguration validationConfig) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
     clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
+        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -42,12 +43,14 @@ public class ClusterVariableDeleteProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState) {
+      final ClusterVariableState clusterVariableState,
+      final EngineConfiguration engineConfiguration) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator = new ClusterVariableRecordValidator(clusterVariableState);
+    clusterVariableRecordValidator =
+        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -42,14 +41,12 @@ public class ClusterVariableDeleteProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState,
-      final ClusterVariableValidationConfiguration validationConfig) {
+      final ClusterVariableRecordValidator clusterVariableRecordValidator) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
+    this.clusterVariableRecordValidator = clusterVariableRecordValidator;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
@@ -26,8 +26,11 @@ public class ClusterVariableProcessors {
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineConfiguration engineConfiguration) {
-    final var validationConfig =
-        new ClusterVariableValidationConfiguration(engineConfiguration.getMaxNameFieldLength());
+    final var clusterVariableRecordValidator =
+        new ClusterVariableRecordValidator(
+            clusterVariableState,
+            new ClusterVariableValidationConfiguration(
+                engineConfiguration.getMaxNameFieldLength()));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.CREATE,
@@ -36,8 +39,7 @@ public class ClusterVariableProcessors {
             writers,
             authCheckBehavior,
             distributionBehavior,
-            clusterVariableState,
-            validationConfig));
+            clusterVariableRecordValidator));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.UPDATE,
@@ -46,8 +48,7 @@ public class ClusterVariableProcessors {
             writers,
             authCheckBehavior,
             distributionBehavior,
-            clusterVariableState,
-            validationConfig));
+            clusterVariableRecordValidator));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.DELETE,
@@ -56,7 +57,6 @@ public class ClusterVariableProcessors {
             writers,
             authCheckBehavior,
             distributionBehavior,
-            clusterVariableState,
-            validationConfig));
+            clusterVariableRecordValidator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -23,21 +24,37 @@ public class ClusterVariableProcessors {
       final ClusterVariableState clusterVariableState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineConfiguration engineConfiguration) {
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.CREATE,
         new ClusterVariableCreateProcessor(
-            keyGenerator, writers, authCheckBehavior, distributionBehavior, clusterVariableState));
+            keyGenerator,
+            writers,
+            authCheckBehavior,
+            distributionBehavior,
+            clusterVariableState,
+            engineConfiguration));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.UPDATE,
         new ClusterVariableUpdateProcessor(
-            keyGenerator, writers, authCheckBehavior, distributionBehavior, clusterVariableState));
+            keyGenerator,
+            writers,
+            authCheckBehavior,
+            distributionBehavior,
+            clusterVariableState,
+            engineConfiguration));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.DELETE,
         new ClusterVariableDeleteProcessor(
-            keyGenerator, writers, authCheckBehavior, distributionBehavior, clusterVariableState));
+            keyGenerator,
+            writers,
+            authCheckBehavior,
+            distributionBehavior,
+            clusterVariableState,
+            engineConfiguration));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableProcessors.java
@@ -26,6 +26,8 @@ public class ClusterVariableProcessors {
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineConfiguration engineConfiguration) {
+    final var validationConfig =
+        new ClusterVariableValidationConfiguration(engineConfiguration.getMaxNameFieldLength());
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.CREATE,
@@ -35,7 +37,7 @@ public class ClusterVariableProcessors {
             authCheckBehavior,
             distributionBehavior,
             clusterVariableState,
-            engineConfiguration));
+            validationConfig));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.UPDATE,
@@ -45,7 +47,7 @@ public class ClusterVariableProcessors {
             authCheckBehavior,
             distributionBehavior,
             clusterVariableState,
-            engineConfiguration));
+            validationConfig));
     typedRecordProcessors.onCommand(
         ValueType.CLUSTER_VARIABLE,
         ClusterVariableIntent.DELETE,
@@ -55,6 +57,6 @@ public class ClusterVariableProcessors {
             authCheckBehavior,
             distributionBehavior,
             clusterVariableState,
-            engineConfiguration));
+            validationConfig));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
@@ -18,13 +17,13 @@ import org.apache.commons.lang3.StringUtils;
 public class ClusterVariableRecordValidator {
 
   private final ClusterVariableState clusterVariableState;
-  private final EngineConfiguration engineConfiguration;
+  private final ClusterVariableValidationConfiguration validationConfig;
 
   public ClusterVariableRecordValidator(
       final ClusterVariableState clusterVariableState,
-      final EngineConfiguration engineConfiguration) {
+      final ClusterVariableValidationConfiguration validationConfig) {
     this.clusterVariableState = clusterVariableState;
-    this.engineConfiguration = engineConfiguration;
+    this.validationConfig = validationConfig;
   }
 
   public Either<Rejection, ClusterVariableRecord> validateName(final ClusterVariableRecord record) {
@@ -43,15 +42,13 @@ public class ClusterVariableRecordValidator {
               "Invalid cluster variable name: '%s'. The name must not contains any whitespace."
                   .formatted(name)));
     }
-
-    if (name.length() > engineConfiguration.getMaxNameFieldLength()) {
+    if (name.length() > validationConfig.maxNameFieldLength()) {
       return Either.left(
           new Rejection(
               RejectionType.INVALID_ARGUMENT,
               "Invalid cluster variable name: '%s'. The name must not be longer than %s characters."
-                  .formatted(name, engineConfiguration.getMaxNameFieldLength())));
+                  .formatted(name, validationConfig.maxNameFieldLength())));
     }
-
     return Either.right(record);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
@@ -17,9 +18,13 @@ import org.apache.commons.lang3.StringUtils;
 public class ClusterVariableRecordValidator {
 
   private final ClusterVariableState clusterVariableState;
+  private final EngineConfiguration engineConfiguration;
 
-  public ClusterVariableRecordValidator(final ClusterVariableState clusterVariableState) {
+  public ClusterVariableRecordValidator(
+      final ClusterVariableState clusterVariableState,
+      final EngineConfiguration engineConfiguration) {
     this.clusterVariableState = clusterVariableState;
+    this.engineConfiguration = engineConfiguration;
   }
 
   public Either<Rejection, ClusterVariableRecord> validateName(final ClusterVariableRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -43,6 +43,15 @@ public class ClusterVariableRecordValidator {
               "Invalid cluster variable name: '%s'. The name must not contains any whitespace."
                   .formatted(name)));
     }
+
+    if (name.length() > engineConfiguration.getMaxNameFieldLength()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Invalid cluster variable name: '%s'. The name must not be longer than %s characters."
+                  .formatted(name, engineConfiguration.getMaxNameFieldLength())));
+    }
+
     return Either.right(record);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -42,14 +41,12 @@ public class ClusterVariableUpdateProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState,
-      final ClusterVariableValidationConfiguration validationConfig) {
+      final ClusterVariableRecordValidator clusterVariableRecordValidator) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
+    this.clusterVariableRecordValidator = clusterVariableRecordValidator;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -42,12 +43,14 @@ public class ClusterVariableUpdateProcessor
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final ClusterVariableState clusterVariableState) {
+      final ClusterVariableState clusterVariableState,
+      final EngineConfiguration engineConfiguration) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
-    clusterVariableRecordValidator = new ClusterVariableRecordValidator(clusterVariableState);
+    clusterVariableRecordValidator =
+        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.clustervariable;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -44,13 +43,13 @@ public class ClusterVariableUpdateProcessor
       final AuthorizationCheckBehavior authCheckBehavior,
       final CommandDistributionBehavior commandDistributionBehavior,
       final ClusterVariableState clusterVariableState,
-      final EngineConfiguration engineConfiguration) {
+      final ClusterVariableValidationConfiguration validationConfig) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
     this.authCheckBehavior = authCheckBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
     clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
+        new ClusterVariableRecordValidator(clusterVariableState, validationConfig);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableValidationConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableValidationConfiguration.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clustervariable;
+
+/** Holds configuration for cluster variable validation, e.g. max name length. */
+public record ClusterVariableValidationConfiguration(int maxNameFieldLength) {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.clustervariable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
@@ -166,15 +165,13 @@ public final class CreateClusterVariableTest {
   public void checkClusterVariableRecordValidator(
       final String clusterVariableName, final String rejectionReason) {
 
-    final var engineConfiguration = new EngineConfiguration();
-    engineConfiguration.setMaxNameFieldLength(10);
-
     // given
     final ClusterVariableRecord clusterVariableRecord =
         new ClusterVariableRecord().setName(clusterVariableName);
     final ClusterVariableState clusterVariableState = mock(ClusterVariableState.class);
     final ClusterVariableRecordValidator clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
+        new ClusterVariableRecordValidator(
+            clusterVariableState, new ClusterVariableValidationConfiguration(10));
     // when
     final var result = clusterVariableRecordValidator.validateName(clusterVariableRecord);
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.clustervariable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.ClusterVariableState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
@@ -164,12 +165,16 @@ public final class CreateClusterVariableTest {
   @MethodSource("retrieveInvalidClusterVariableName")
   public void checkClusterVariableRecordValidator(
       final String clusterVariableName, final String rejectionReason) {
+
+    final var engineConfiguration = new EngineConfiguration();
+    engineConfiguration.setMaxNameFieldLength(10);
+
     // given
     final ClusterVariableRecord clusterVariableRecord =
         new ClusterVariableRecord().setName(clusterVariableName);
     final ClusterVariableState clusterVariableState = mock(ClusterVariableState.class);
     final ClusterVariableRecordValidator clusterVariableRecordValidator =
-        new ClusterVariableRecordValidator(clusterVariableState);
+        new ClusterVariableRecordValidator(clusterVariableState, engineConfiguration);
     // when
     final var result = clusterVariableRecordValidator.validateName(clusterVariableRecord);
     // then
@@ -182,6 +187,9 @@ public final class CreateClusterVariableTest {
             "test key",
             "Invalid cluster variable name: 'test key'. The name must not contains any whitespace."),
         Arguments.of(
-            "", "Invalid cluster variable name: ''. Cluster variable can not be null or empty."));
+            "", "Invalid cluster variable name: ''. Cluster variable can not be null or empty."),
+        Arguments.of(
+            "this-is-a-very-long-cluster-variable-name-that-exceeds-the-maximum-length",
+            "Invalid cluster variable name: 'this-is-a-very-long-cluster-variable-name-that-exceeds-the-maximum-length'. The name must not be longer than 10 characters."));
   }
 }


### PR DESCRIPTION
## Description

* Validates cluster variables name lenght against EngineConfiguration and reject commands if length is exceeded

## Related issues

closes #45688
