### PR TITLE
Add tenant id tool param for PI creation

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
@@ -27,6 +27,8 @@ public final class ErrorMessages {
       "Expected to handle request %s with tenant identifier '%s', but %s";
   public static final String ERROR_MESSAGE_INVALID_TENANTS =
       "Expected to handle request %s with tenant identifiers %s, but %s";
+  public static final String ERROR_MESSAGE_MISSING_TENANT =
+      "Expected to handle request %s with multi-tenancy enabled, but no tenant identifier was provided";
   public static final String ERROR_MESSAGE_ONLY_ONE_FIELD = "Only one of %s is allowed";
   public static final String ERROR_MESSAGE_INVALID_EMAIL = "The provided email '%s' is not valid";
   public static final String ERROR_MESSAGE_ALL_REQUIRED_FIELD = "All %s are required";

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MultiTenancyValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/MultiTenancyValidator.java
@@ -9,6 +9,7 @@ package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_TENANT;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_TENANTS;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_MISSING_TENANT;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.createProblemDetail;
 import static io.camunda.security.validation.IdentifierValidator.TENANT_ID_MASK;
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
@@ -72,9 +73,7 @@ public final class MultiTenancyValidator {
 
     final List<String> violations = new ArrayList<>();
     if (!hasTenantId) {
-      violations.add(
-          ERROR_MESSAGE_INVALID_TENANTS.formatted(
-              commandName, tenantIds, "no tenant identifier was provided"));
+      violations.add(ERROR_MESSAGE_MISSING_TENANT.formatted(commandName));
     } else {
       tenantIds.forEach(
           tenantId -> {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
@@ -57,4 +57,11 @@ public record McpProcessInstanceCreationInstruction(
                 "List of tags to apply to the process instance. Tags must start with a letter, followed by letters, digits, or the special characters `_`, `-`, `:`, or `.`; length ≤ 100.",
             required = false)
         Set<@Pattern(regexp = "^[A-Za-z][A-Za-z0-9_\\-:.]{0,99}$") @Size(min = 1, max = 100) String>
-            tags) {}
+            tags,
+    @McpToolParam(
+            description =
+                "The tenant id of the process definition. If multi-tenancy is enabled, provide the tenant id of the process definition to start a process instance of. If multi-tenancy is disabled, don't provide this parameter.",
+            required = false)
+        @Pattern(regexp = "^(<default>|[A-Za-z0-9_@.+-]+)$")
+        @Size(min = 1, max = 256)
+        String tenantId) {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -132,6 +132,7 @@ public class ProcessInstanceTools {
       Optional.ofNullable(creationInstruction.tags()).ifPresent(instruction::tags);
       Optional.ofNullable(creationInstruction.requestTimeout())
           .ifPresent(instruction::requestTimeout);
+      Optional.ofNullable(creationInstruction.tenantId()).ifPresent(instruction::tenantId);
 
       final var request =
           SimpleRequestMapper.toCreateProcessInstance(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -115,6 +115,7 @@ public class CustomMcpModelPropertiesTest {
                 "processDefinitionVersion",
                 "requestTimeout",
                 "tags",
+                "tenantId",
                 "variables")));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ConditionalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ConditionalControllerTest.java
@@ -157,7 +157,7 @@ public class ConditionalControllerTest extends RestControllerTest {
             "type":"about:blank",
             "title":"INVALID_ARGUMENT",
             "status":400,
-            "detail":"Expected to handle request Evaluate Conditional with tenant identifiers [], but no tenant identifier was provided.",
+            "detail":"Expected to handle request Evaluate Conditional with multi-tenancy enabled, but no tenant identifier was provided.",
             "instance":"/v2/conditionals/evaluation"
          }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -853,7 +853,7 @@ public class JobControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "Expected to handle request Activate Jobs with tenant identifiers [], but no tenant identifier was provided.",
+              "detail": "Expected to handle request Activate Jobs with multi-tenancy enabled, but no tenant identifier was provided.",
               "instance": "%s"
             }"""
                 .formatted(JOBS_BASE_URL + "/activation"),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -278,7 +278,7 @@ public class MessageControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "Expected to handle request Correlate Message with tenant identifiers [], but no tenant identifier was provided.",
+              "detail": "Expected to handle request Correlate Message with multi-tenancy enabled, but no tenant identifier was provided.",
               "instance": "%s"
             }"""
                 .formatted(CORRELATION_ENDPOINT),


### PR DESCRIPTION
## Description

Adds the `tenantId` as a tool parameter for PI creation MCP tooling.
This way, a tenant id can be provided in multi-tenancy scenarios.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46133 
