### PR TITLE
fix: remove RootProcessInstanceKey phantom domain type from OpenAPI spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -127,7 +127,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -451,7 +451,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: the process instance key of the processed item.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         state:
           description: State of the item.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -328,7 +328,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         decisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -469,7 +469,13 @@ components:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
           description: The process instance key associated to this element instance.
         rootProcessInstanceKey:
-          $ref: "keys.yaml#/components/schemas/RootProcessInstanceKey"
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
         processDefinitionKey:
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessDefinitionKey"

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -434,7 +434,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The process instance key associated to this incident.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -416,7 +416,13 @@ components:
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
 
     UserTaskProperties:
       type: object
@@ -704,7 +710,13 @@ components:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
           description: The process instance key associated with the job.
         rootProcessInstanceKey:
-          $ref: "keys.yaml#/components/schemas/RootProcessInstanceKey"
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
         retries:
           description: The amount of retries left to this job.
           type: integer

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -18,18 +18,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/LongKey'
 
-    RootProcessInstanceKey:
-      description: |
-        The key of the root process instance. The root process instance is the top-level
-        ancestor in the process instance hierarchy. This field is only present for data
-        belonging to process instance hierarchies created in version 8.9 or later.
-      format: ProcessInstanceKey
-      x-semantic-type: ProcessInstanceKey
-      example: "2251799813690746"
-      type: string
-      allOf:
-        - $ref: '#/components/schemas/LongKey'
-
     ProcessDefinitionKey:
       description: System-generated key for a deployed process definition.
       format: ProcessDefinitionKey

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -258,7 +258,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The process instance key associated with this message subscription.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
@@ -421,7 +427,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The process instance key associated with this correlated message subscription.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         subscriptionKey:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1231,7 +1231,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The parent element instance key.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
 
@@ -1292,7 +1298,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of this process instance.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -578,7 +578,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         formKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/FormKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -228,7 +228,13 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance of this variable.
         rootProcessInstanceKey:
-          $ref: 'keys.yaml#/components/schemas/RootProcessInstanceKey'
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy. This field is only present for data
+            belonging to process instance hierarchies created in version 8.9 or later.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
 
     VariableValueFilterProperty:
       type: object


### PR DESCRIPTION
# Description

`RootProcessInstanceKey` was defined as a named schema in `keys.yaml` with identical `format: ProcessInstanceKey` and `x-semantic-type: ProcessInstanceKey` as the existing `ProcessInstanceKey` schema. This is not a distinct domain type — it's semantically the same as `ProcessInstanceKey`, just with a different description and `nullable: true` semantics.

Having it as a named schema causes SDK generators to create a **separate domain type** (e.g., a distinct TypeScript type, Python class, or C# record struct) for what is the same concept. This leads to:
- Type mismatches in the JS SDK (branding plugin fails with `Type 'null' is not assignable to type 'string'`)
- Loss of semantic typing in the Python SDK (`None | str` instead of `None | ProcessInstanceKey`)
- A non-nullable distinct struct in the C# SDK (`RootProcessInstanceKey` instead of `ProcessInstanceKey?`)

## Changes

1. **Removed** the `RootProcessInstanceKey` schema definition from `keys.yaml` (12 lines)
2. **Replaced** all 13 bare `$ref` references across 10 YAML files with inline `allOf` referencing `ProcessInstanceKey`, adding `nullable: true` and the original description at each site

The `rootProcessInstanceKey` field is nullable because it is only populated for process instance hierarchies created in version 8.9 or later.

### Files changed

| File | Sites |
|------|-------|
| `keys.yaml` | Schema definition removed |
| `audit-logs.yaml` | 1 |
| `batch-operations.yaml` | 1 |
| `decision-instances.yaml` | 1 |
| `element-instances.yaml` | 1 |
| `incidents.yaml` | 1 |
| `jobs.yaml` | 2 |
| `messages.yaml` | 2 |
| `process-instances.yaml` | 2 |
| `user-tasks.yaml` | 1 |
| `variables.yaml` | 1 |

## Checklist

_This change only affects OpenAPI spec YAML files — no backport needed._

- [ ] This change does not need to be backported

## Related issues

closes #46207