### PR TITLE
[Backport stable/8.8] fix: add wait between zcl operations for eventual consistency

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -833,6 +833,8 @@ jobs:
           --label="version:$ZCL_TARGET_REV" \
           --org camunda --repo camunda
 
+          sleep 15 # eventual consistency wait for GitHub to return labeled issues in the API call
+
           # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
           changelog=$(./zcl generate \
           --token=${{ secrets.GITHUB_TOKEN }} \


### PR DESCRIPTION
# Description
Backport of #46152 to `stable/8.8`.

relates to 