### PR TITLE
feat: support tenant filter in streaming paths

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.jobstream.YieldingJobStreamErrorHandler;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
@@ -127,6 +128,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
         mutable.timeout(),
         mutable.fetchVariables(),
         mutable.tenantIds(),
+        mutable.tenantFilter(),
         mutable.claims());
   }
 
@@ -140,6 +142,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       long timeout,
       Collection<DirectBuffer> fetchVariables,
       Collection<String> tenantIds,
+      TenantFilter tenantFilter,
       Map<String, Object> claims)
       implements JobActivationProperties {
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +30,8 @@ final class JobStreamServiceStepTest {
               .setTimeout(250)
               .setFetchVariables(List.of(new StringValue("foo"), new StringValue("bar")))
               .setWorker(worker, 0, worker.capacity())
-              .setTenantIds(List.of("tenant1", "tenant2"));
+              .setTenantIds(List.of("tenant1", "tenant2"))
+              .setTenantFilter(TenantFilter.ASSIGNED);
       final var buffer = BufferUtil.createCopy(properties);
 
       // when
@@ -41,6 +43,7 @@ final class JobStreamServiceStepTest {
       assertThat(immutable.fetchVariables())
           .containsExactlyInAnyOrder(BufferUtil.wrapString("foo"), BufferUtil.wrapString("bar"));
       assertThat(immutable.tenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+      assertThat(immutable.tenantFilter()).isEqualTo(TenantFilter.ASSIGNED);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
-import io.camunda.zeebe.engine.processing.identity.AnonymouslyAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
@@ -169,7 +168,7 @@ public class BpmnJobActivationBehavior {
           case ASSIGNED -> {
             final var authorizedTenants =
                 authorizationCheckBehavior.getAuthorizedTenantIds(jobActivationProperties.claims());
-            yield !(authorizedTenants instanceof AnonymouslyAuthorizedTenants)
+            yield !authorizedTenants.isAnonymous()
                 && authorizedTenants.isAuthorizedForTenantId(ownerTenantId);
           }
           case PROVIDED -> jobActivationProperties.tenantIds().contains(ownerTenantId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -163,7 +163,17 @@ public class BpmnJobActivationBehavior {
       final JobActivationProperties jobActivationProperties, final JobRecord jobRecord) {
 
     final var ownerTenantId = jobRecord.getTenantId();
-    final var tenantIds = jobActivationProperties.tenantIds().stream().toList();
+    final var tenantIds =
+        switch (jobActivationProperties.tenantFilter()) {
+          case ASSIGNED ->
+              authorizationCheckBehavior
+                  .getAuthorizedTenantIds(jobActivationProperties.claims())
+                  .getAuthorizedTenantIds();
+          case PROVIDED -> jobActivationProperties.tenantIds().stream().toList();
+          default ->
+              throw new IllegalStateException(
+                  "Unexpected tenant filter: " + jobActivationProperties.tenantFilter());
+        };
     if (!tenantIds.contains(ownerTenantId)) {
       // don't push jobs to workers that don't request them from the job's tenant
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AnonymouslyAuthorizedTenants.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AnonymouslyAuthorizedTenants.java
@@ -30,4 +30,9 @@ public final class AnonymouslyAuthorizedTenants implements AuthorizedTenants {
     throw new UnsupportedOperationException(
         "Retrieval of authorized tenants is not supported when authenticated anonymously");
   }
+
+  @Override
+  public boolean isAnonymous() {
+    return true;
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthenticatedAuthorizedTenants.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthenticatedAuthorizedTenants.java
@@ -40,4 +40,9 @@ public final class AuthenticatedAuthorizedTenants implements AuthorizedTenants {
   public List<String> getAuthorizedTenantIds() {
     return new ArrayList<>(authorizedTenantIds);
   }
+
+  @Override
+  public boolean isAnonymous() {
+    return false;
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizedTenants.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizedTenants.java
@@ -25,4 +25,7 @@ public interface AuthorizedTenants {
 
   /** Returns the list of authorized tenants. */
   List<String> getAuthorizedTenantIds();
+
+  /** Returns true if this represents anonymous (unauthenticated) access. */
+  boolean isAnonymous();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -484,7 +484,19 @@ public final class AuthorizationCheckBehavior {
    *     authorized to access
    */
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
-    return tenantResolver.getAuthorizedTenants(command.getAuthorizations());
+    return getAuthorizedTenantIds(command.getAuthorizations());
+  }
+
+  /**
+   * Retrieves all authorized tenants for the given claims. Includes tenants from user/client,
+   * groups, roles, and mapping rules.
+   *
+   * @param claims the authorization claims
+   * @return an {@link AuthorizedTenants} object containing all tenant IDs the principal is
+   *     authorized to access
+   */
+  public AuthorizedTenants getAuthorizedTenantIds(final Map<String, Object> claims) {
+    return tenantResolver.getAuthorizedTenants(claims);
   }
 
   private Stream<PersistedMappingRule> getPersistedMappingRules(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
@@ -41,6 +41,10 @@ public class RecordingJobStreamer implements JobStreamer {
             .get());
   }
 
+  public void clearStreams() {
+    jobStreams.clear();
+  }
+
   public RecordingJobStream addJobStream(
       final DirectBuffer jobType, final JobActivationProperties jobActivationProperties) {
     final var jobStream = new RecordingJobStream(jobActivationProperties);

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -22,6 +22,8 @@ message StreamActivatedJobsRequest {
   repeated string fetchVariable = 5;
   // a list of identifiers of tenants for which to stream jobs
   repeated string tenantIds = 6;
+  // the tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs
+  TenantFilter tenantFilter = 7;
 }
 
 message ActivateJobsRequest {
@@ -970,7 +972,7 @@ service Gateway {
      INVALID_ARGUMENT:
       - type is blank (empty string, null)
       - timeout less than 1
-      - If multi-tenancy is enabled, and tenantIds is empty (empty list)
+      - If multi-tenancy is enabled, tenantFilter is PROVIDED (default value) and tenantIds is empty (empty list)
       - If multi-tenancy is enabled, and an invalid tenant ID is provided. A tenant ID is considered invalid if:
         - The tenant ID is blank (empty string, null)
         - The tenant ID is longer than 31 characters

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.stream.job;
 
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.Map;
@@ -46,9 +47,25 @@ public interface JobActivationProperties extends BufferWriter {
    * Returns the identifiers of the tenants that own the jobs requested to be activated by the
    * worker.
    *
+   * <p>If {@link TenantFilter#ASSIGNED} then these tenantIds will be ignored and the assigned
+   * tenant IDs will be resolved during job activation.
+   *
    * @return the identifiers of the tenants for which to activate jobs
    */
   Collection<String> tenantIds();
+
+  /**
+   * Returns the type of tenant filter to apply when activating jobs.
+   *
+   * <ul>
+   *   <li>If {@link TenantFilter#ASSIGNED}, then {@link #tenantIds()} will be ignored, and the
+   *       accessible tenant IDs will be resolved during job activation.
+   *   <li>If {@link TenantFilter#PROVIDED}, then {@link #tenantIds()} will be used.
+   * </ul>
+   *
+   * @see TenantFilter
+   */
+  TenantFilter tenantFilter();
 
   /**
    * Returns the claim data of the user that triggered the creation of this stream. The following

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -10,11 +10,13 @@ package io.camunda.zeebe.protocol.impl.stream.job;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
@@ -31,14 +33,17 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
       new ArrayProperty<>(
           "tenantIds", () -> new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   private final DocumentProperty claimsProp = new DocumentProperty("claims");
+  private final EnumProperty<TenantFilter> tenantFilterProp =
+      new EnumProperty<>("tenantFilter", TenantFilter.class, TenantFilter.PROVIDED);
 
   public JobActivationPropertiesImpl() {
-    super(5);
+    super(6);
     declareProperty(workerProp)
         .declareProperty(timeoutProp)
         .declareProperty(fetchVariablesProp)
         .declareProperty(tenantIdsProp)
-        .declareProperty(claimsProp);
+        .declareProperty(claimsProp)
+        .declareProperty(tenantFilterProp);
   }
 
   public JobActivationPropertiesImpl setWorker(
@@ -85,8 +90,18 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
   }
 
   @Override
+  public TenantFilter tenantFilter() {
+    return tenantFilterProp.getValue();
+  }
+
+  @Override
   public Map<String, Object> claims() {
     return MsgPackConverter.convertToMap(claimsProp.getValue());
+  }
+
+  public JobActivationPropertiesImpl setTenantFilter(final TenantFilter tenantFilter) {
+    tenantFilterProp.setValue(tenantFilter);
+    return this;
   }
 
   public JobActivationPropertiesImpl setClaims(final Map<String, Object> authorizations) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR introduces the changes in the engine/broker to support tenantFilter when using streaming. Notably the changes are:

1. Add the TenantFilter to the JobActivationProperties class and impl
2. Set the TenantFilter on the object when converting from request to properties in the RequestMapper
3. Consider the tenantFilter value when pushing jobs in BpmnJobActivationBehavior

The Client and Actuator changes will be included in the next PR (using this as a foundation)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45353, closes https://github.com/camunda/camunda/issues/45354, closes https://github.com/camunda/camunda/issues/45355
