### PR TITLE
API support for `business id` on process instance creation

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -216,6 +216,25 @@ public interface CreateProcessInstanceCommandStep1
      *     it to the broker.
      */
     CreateProcessInstanceCommandStep3 tags(Set<String> tags);
+
+    /**
+     * Set the business id of the process instance to be created.
+     *
+     * <p>The business id is an optional, user-defined string identifier that identifies the process
+     * instance within the scope of a process definition (scoped by tenant).
+     *
+     * <p>If provided and uniqueness enforcement is enabled, the engine will reject creation if
+     * another root process instance with the same business id is already active for the same
+     * process definition.
+     *
+     * <p>Note that any active child process instances with the same business id are not taken into
+     * account.
+     *
+     * @param businessId the business id to set
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CreateProcessInstanceCommandStep3 businessId(String businessId);
   }
 
   interface CreateProcessInstanceWithResultCommandStep1

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
@@ -34,5 +34,13 @@ public interface ProcessInstanceEvent {
   /** Tenant identifier that owns this process instance */
   String getTenantId();
 
+  /** Tags attached to this process instance */
   Set<String> getTags();
+
+  /**
+   * The business id of this process instance.
+   *
+   * @return the business id, or an empty string if not set
+   */
+  String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
@@ -71,4 +71,11 @@ public interface ProcessInstanceResult {
    * @return a set of tags
    */
   Set<String> getTags();
+
+  /**
+   * The business id of this process instance.
+   *
+   * @return the business id, or an empty string if not set
+   */
+  String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -169,6 +169,13 @@ public final class CreateProcessInstanceCommandImpl
   }
 
   @Override
+  public CreateProcessInstanceCommandStep3 businessId(final String businessId) {
+    grpcRequestObjectBuilder.setBusinessId(businessId);
+    httpRequestObject.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
   public CreateProcessInstanceCommandStep2 bpmnProcessId(final String id) {
     grpcRequestObjectBuilder.setBpmnProcessId(id);
     httpRequestObject.setProcessDefinitionId(id);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -30,6 +30,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   private final long processInstanceKey;
   private final String tenantId;
   private final Set<String> tags;
+  private final String businessId;
 
   public CreateProcessInstanceResponseImpl(
       final GatewayOuterClass.CreateProcessInstanceResponse response) {
@@ -39,6 +40,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     processInstanceKey = response.getProcessInstanceKey();
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
+    businessId = response.getBusinessId();
   }
 
   public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResult response) {
@@ -51,6 +53,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
         response.getTags() == null
             ? Collections.emptySet()
             : Collections.unmodifiableSet(response.getTags());
+    businessId = response.getBusinessId();
   }
 
   @Override
@@ -84,6 +87,11 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   }
 
   @Override
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceResponseImpl{"
         + "processDefinitionKey="
@@ -97,6 +105,9 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
         + processInstanceKey
         + ", tenantId='"
         + tenantId
+        + '\''
+        + ", businessId='"
+        + businessId
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -37,6 +37,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
 
   private Map<String, Object> variablesAsMap;
   private final Set<String> tags;
+  private final String businessId;
 
   public CreateProcessInstanceWithResultResponseImpl(
       final JsonMapper jsonMapper, final CreateProcessInstanceResult response) {
@@ -48,6 +49,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     tenantId = response.getTenantId();
     variables = jsonMapper.toJson(response.getVariables());
     tags = response.getTags();
+    businessId = response.getBusinessId();
   }
 
   public CreateProcessInstanceWithResultResponseImpl(
@@ -60,6 +62,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     variables = response.getVariables();
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
+    businessId = response.getBusinessId();
   }
 
   @Override
@@ -120,6 +123,11 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   }
 
   @Override
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceWithResultResponseImpl{"
         + "processDefinitionKey="
@@ -139,6 +147,9 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
         + '\''
         + ", tenantId='"
         + tenantId
+        + '\''
+        + ", businessId='"
+        + businessId
         + '\''
         + '}';
   }

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
@@ -385,6 +385,24 @@ public final class CreateProcessInstanceTest extends ClientTest {
     assertThat(response.getTags()).isEqualTo(tags);
   }
 
+  @Test
+  public void shouldCreateWithBusinessId() {
+    // given
+    final String businessId = "order-12345";
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .businessId(businessId)
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBusinessId()).isEqualTo(businessId);
+  }
+
   public static class VariableDocument {
 
     VariableDocument() {}

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceWithResultTest.java
@@ -244,6 +244,27 @@ public final class CreateProcessInstanceWithResultTest extends ClientTest {
     assertThat(new HashSet(piRequest.getTagsList())).isEqualTo(tags);
   }
 
+  @Test
+  public void shouldAddBusinessId() {
+    // given
+    final Long processDefinitionKey = 1L;
+    final String businessId = "order-12345";
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(processDefinitionKey)
+        .businessId(businessId)
+        .withResult()
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceWithResultRequest request = gatewayService.getLastRequest();
+    final CreateProcessInstanceRequest piRequest = request.getRequest();
+    assertThat(piRequest.getBusinessId()).isEqualTo(businessId);
+  }
+
   private static final class VariablesPojo {
     String key;
 

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
@@ -354,6 +354,26 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
     Assertions.assertThat(request.getTags()).isEqualTo(tags);
   }
 
+  @Test
+  public void shouldCreateProcessInstanceWithBusinessId() {
+    // given
+    final String businessId = "order-12345";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .businessId(businessId)
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+    Assertions.assertThat(request.getBusinessId()).isEqualTo(businessId);
+  }
+
   public static class VariableDocument {
 
     VariableDocument() {}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceWithResultRestTest.java
@@ -234,6 +234,27 @@ public class CreateProcessInstanceWithResultRestTest extends ClientRestTest {
     assertThat(request.getTags()).isEqualTo(tags);
   }
 
+  @Test
+  public void shouldCreateProcessInstanceWithBusinessId() {
+    // given
+    final String businessId = "order-12345";
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .businessId(businessId)
+        .withResult()
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+    assertThat(request.getBusinessId()).isEqualTo(businessId);
+  }
+
   private static final class VariablesPojo {
     String key;
 

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -508,6 +508,17 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long processInstanceKey,
       final Set<String> tags) {
+    onCreateProcessInstanceRequest(
+        processDefinitionKey, bpmnProcessId, version, processInstanceKey, tags, "");
+  }
+
+  public void onCreateProcessInstanceRequest(
+      final long processDefinitionKey,
+      final String bpmnProcessId,
+      final int version,
+      final long processInstanceKey,
+      final Set<String> tags,
+      final String businessId) {
     addRequestHandler(
         CreateProcessInstanceRequest.class,
         request ->
@@ -517,6 +528,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
                 .setVersion(version)
                 .setProcessInstanceKey(processInstanceKey)
                 .addAllTags(tags)
+                .setBusinessId(businessId)
                 .build());
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -678,7 +678,8 @@ public class RequestMapper {
                         })
                     .toList(),
                 request.getFetchVariables(),
-                request.getTags()));
+                request.getTags(),
+                request.getBusinessId()));
   }
 
   public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
@@ -720,7 +721,8 @@ public class RequestMapper {
                         })
                     .toList(),
                 request.getFetchVariables(),
-                request.getTags()));
+                request.getTags(),
+                request.getBusinessId()));
   }
 
   public static Either<ProblemDetail, ProcessInstanceCancelRequest> toCancelProcessInstance(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -504,7 +504,8 @@ public final class ResponseMapper {
         brokerResponse.getProcessInstanceKey(),
         brokerResponse.getTenantId(),
         null,
-        brokerResponse.getTags());
+        brokerResponse.getTags(),
+        brokerResponse.getBusinessId());
   }
 
   public static CreateProcessInstanceResult toCreateProcessInstanceWithResultResponse(
@@ -516,7 +517,8 @@ public final class ResponseMapper {
         brokerResponse.getProcessInstanceKey(),
         brokerResponse.getTenantId(),
         brokerResponse.getVariables(),
-        brokerResponse.getTags());
+        brokerResponse.getTags(),
+        brokerResponse.getBusinessId());
   }
 
   private static CreateProcessInstanceResult buildCreateProcessInstanceResponse(
@@ -526,7 +528,8 @@ public final class ResponseMapper {
       final Long processInstanceKey,
       final String tenantId,
       final Map<String, Object> variables,
-      final Set<String> tags) {
+      final Set<String> tags,
+      final String businessId) {
     final var response =
         new CreateProcessInstanceResult()
             .processDefinitionKey(KeyUtil.keyToString(processDefinitionKey))
@@ -539,6 +542,9 @@ public final class ResponseMapper {
     }
     if (tags != null) {
       response.setTags(tags);
+    }
+    if (businessId != null) {
+      response.businessId(businessId);
     }
 
     return response;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
@@ -44,7 +44,8 @@ public class SimpleRequestMapper {
                   .awaitCompletion(request.getAwaitCompletion())
                   .fetchVariables(request.getFetchVariables())
                   .requestTimeout(request.getRequestTimeout())
-                  .tags(request.getTags()),
+                  .tags(request.getTags())
+                  .businessId(request.getBusinessId()),
           multiTenancyEnabled);
     }
 
@@ -62,7 +63,8 @@ public class SimpleRequestMapper {
                 .awaitCompletion(request.getAwaitCompletion())
                 .requestTimeout(request.getRequestTimeout())
                 .fetchVariables(request.getFetchVariables())
-                .tags(request.getTags()),
+                .tags(request.getTags())
+                .businessId(request.getBusinessId()),
         multiTenancyEnabled);
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/SimpleRequestMapperTest.java
@@ -212,5 +212,25 @@ class SimpleRequestMapperTest {
                 assertThat(i.getAfterElementId()).isEqualTo("after-element");
               });
     }
+
+    @Test
+    void shouldMapBusinessId() {
+      // given
+      final var businessId = "order-12345";
+      final var request =
+          new ProcessInstanceCreationInstruction()
+              .processDefinitionKey("123")
+              .businessId(businessId);
+
+      // when
+      final Either<ProblemDetail, ProcessInstanceCreateRequest> result =
+          SimpleRequestMapper.toCreateProcessInstance(request, false);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      final var mapped = result.get();
+      assertThat(mapped.processDefinitionKey()).isEqualTo(123L);
+      assertThat(mapped.businessId()).isEqualTo(businessId);
+    }
   }
 }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/model/McpProcessInstanceCreationInstruction.java
@@ -64,4 +64,11 @@ public record McpProcessInstanceCreationInstruction(
             required = false)
         @Pattern(regexp = "^(<default>|[A-Za-z0-9_@.+-]+)$")
         @Size(min = 1, max = 256)
-        String tenantId) {}
+        String tenantId,
+    @McpToolParam(
+            description =
+                "An optional, user-defined string identifier that identifies the process instance within the scope of the process definition. If provided and uniqueness enforcement is enabled, the engine will reject creation if another root process instance with the same business id is already active for the same process definition. Note that any active child process instances with the same business id are not taken into account.",
+            required = false)
+        @Pattern(regexp = "^(<default>|[A-Za-z0-9_@.+-]+)$")
+        @Size(min = 1, max = 256)
+        String businessId) {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -133,6 +133,7 @@ public class ProcessInstanceTools {
       Optional.ofNullable(creationInstruction.requestTimeout())
           .ifPresent(instruction::requestTimeout);
       Optional.ofNullable(creationInstruction.tenantId()).ifPresent(instruction::tenantId);
+      Optional.ofNullable(creationInstruction.businessId()).ifPresent(instruction::businessId);
 
       final var request =
           SimpleRequestMapper.toCreateProcessInstance(

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/model/CustomMcpModelPropertiesTest.java
@@ -116,7 +116,8 @@ public class CustomMcpModelPropertiesTest {
                 "requestTimeout",
                 "tags",
                 "tenantId",
-                "variables")));
+                "variables",
+                "businessId")));
   }
 
   @ParameterizedTest

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -222,6 +222,10 @@ public final class ProcessInstanceServices
       brokerRequest.setTags(request.tags());
     }
 
+    if (request.businessId() != null) {
+      brokerRequest.setBusinessId(request.businessId());
+    }
+
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
     }
@@ -240,6 +244,10 @@ public final class ProcessInstanceServices
             .setInstructions(request.startInstructions())
             .setFetchVariables(request.fetchVariables())
             .setTags(request.tags());
+
+    if (request.businessId() != null) {
+      brokerRequest.setBusinessId(request.businessId());
+    }
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
@@ -438,7 +446,8 @@ public final class ProcessInstanceServices
       List<ProcessInstanceCreationStartInstruction> startInstructions,
       List<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions,
       List<String> fetchVariables,
-      Set<String> tags) {}
+      Set<String> tags,
+      String businessId) {}
 
   public record ProcessInstanceCancelRequest(Long processInstanceKey, Long operationReference) {}
 

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -608,7 +608,8 @@ public final class ProcessInstanceServiceTest {
             List.of(), // startInstructions
             List.of(), // runtimeInstructions
             List.of(), // fetchVariables
-            null // tags
+            null, // tags
+            null // businessId
             );
 
     final var mockResponse =
@@ -645,7 +646,8 @@ public final class ProcessInstanceServiceTest {
             List.of(), // startInstructions
             List.of(), // runtimeInstructions
             List.of(), // fetchVariables
-            null // tags
+            null, // tags
+            null // businessId
             );
 
     final var mockResponse =
@@ -683,7 +685,8 @@ public final class ProcessInstanceServiceTest {
             List.of(), // startInstructions
             List.of(), // runtimeInstructions
             List.of(), // fetchVariables
-            null // tags
+            null, // tags
+            null // businessId
             );
 
     final var mockResponse =

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -213,7 +213,8 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
         List.of(),
         List.of(),
         null,
-        Set.of());
+        Set.of(),
+        null);
   }
 
   private DeployResourcesRequest toDeployResourcesRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -62,6 +62,8 @@ public interface BpmnElementContext {
 
   Set<String> getTags();
 
+  String getBusinessId();
+
   BpmnElementContext copy(
       long elementInstanceKey, ProcessInstanceRecord recordValue, ProcessInstanceIntent intent);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -103,6 +103,11 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   }
 
   @Override
+  public String getBusinessId() {
+    return recordValue.getBusinessId();
+  }
+
+  @Override
   public BpmnElementContext copy(
       final long elementInstanceKey,
       final ProcessInstanceRecord recordValue,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -67,7 +67,8 @@ public final class BpmnProcessResultSenderBehavior {
         .setVersion(context.getProcessVersion())
         .setVariables(variablesAsDocument)
         .setTenantId(context.getTenantId())
-        .setTags(context.getTags());
+        .setTags(context.getTags())
+        .setBusinessId(context.getBusinessId());
 
     responseWriter.writeResponse(
         context.getProcessInstanceKey(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceWithResultTest.java
@@ -80,6 +80,30 @@ public final class CreateProcessInstanceWithResultTest {
   }
 
   @Test
+  public void shouldSendResultWithBusinessIdAfterCompletion() {
+    // given
+    final String businessId = "order-12345";
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("PROCESS")
+            .withVariables(Map.of("x", "foo"))
+            .withResult()
+            .withRequestId(1L)
+            .withRequestStreamId(1)
+            .withBusinessId(businessId)
+            .create();
+
+    // then
+    verify(mockCommandResponseWriter, timeout(1000).times(1))
+        .intent(ProcessInstanceResultIntent.COMPLETED);
+    verify(mockCommandResponseWriter, timeout(1000).times(1)).tryWriteResponse(1, 1L);
+    assertThat(response.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(response.getBpmnProcessId()).isEqualTo("PROCESS");
+    assertThat(response.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
   public void shouldSendResultWithNoVariablesAfterCompletion() {
     // given
     final long processInstanceKey =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -221,6 +221,11 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public ProcessInstanceCreationWithResultClient withBusinessId(final String businessId) {
+      record.setBusinessId(businessId);
+      return this;
+    }
+
     public long create() {
       final long position =
           writer.writeCommand(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -263,7 +263,8 @@ public final class RequestMapper extends RequestUtil {
         .setTenantId(ensureTenantIdSet("CreateProcessInstance", grpcRequest.getTenantId()))
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
         .setStartInstructions(grpcRequest.getStartInstructionsList())
-        .setTags(Set.copyOf(grpcRequest.getTagsList()));
+        .setTags(Set.copyOf(grpcRequest.getTagsList()))
+        .setBusinessId(grpcRequest.getBusinessId());
 
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
@@ -286,7 +287,8 @@ public final class RequestMapper extends RequestUtil {
         .setVariables(ensureJsonSet(request.getVariables()))
         .setStartInstructions(request.getStartInstructionsList())
         .setTags(Set.copyOf(request.getTagsList()))
-        .setFetchVariables(grpcRequest.getFetchVariablesList());
+        .setFetchVariables(grpcRequest.getFetchVariablesList())
+        .setBusinessId(request.getBusinessId());
 
     if (request.hasOperationReference()) {
       brokerRequest.setOperationReference(request.getOperationReference());

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -198,6 +198,7 @@ public final class ResponseMapper {
         .setTenantId(brokerResponse.getTenantId())
         .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
         .addAllTags(brokerResponse.getTags())
+        .setBusinessId(brokerResponse.getBusinessId())
         .build();
   }
 
@@ -211,6 +212,7 @@ public final class ResponseMapper {
         .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
         .setVariables(bufferAsJson(brokerResponse.getVariablesBuffer()))
         .addAllTags(brokerResponse.getTags())
+        .setBusinessId(brokerResponse.getBusinessId())
         .build();
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceStub.java
@@ -79,7 +79,8 @@ public final class CreateProcessInstanceStub
         .setTenantId(piCreationRecord.getTenantId())
         .setProcessDefinitionKey(PROCESS_KEY)
         .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
-        .setTags(TAGS);
+        .setTags(TAGS)
+        .setBusinessId(piCreationRecord.getBusinessId());
 
     return new BrokerResponse<>(record, 0, PROCESS_INSTANCE_KEY);
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceTest.java
@@ -43,6 +43,7 @@ public final class CreateProcessInstanceTest extends GatewayTest {
     assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(response.getTagsList()).containsAll(stub.getTags());
+    assertThat(response.getBusinessId()).isEmpty();
 
     final BrokerCreateProcessInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(ProcessInstanceCreationIntent.CREATE);
@@ -53,5 +54,30 @@ public final class CreateProcessInstanceTest extends GatewayTest {
         .isEqualTo(stub.getProcessDefinitionKey());
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(brokerRequestValue.getTags()).isEqualTo(stub.getTags());
+  }
+
+  @Test
+  public void shouldMapRequestAndResponseWithBusinessId() {
+    // given
+    final CreateProcessInstanceStub stub = new CreateProcessInstanceStub();
+    stub.registerWith(brokerClient);
+    final String businessId = "order-12345";
+
+    final CreateProcessInstanceRequest request =
+        CreateProcessInstanceRequest.newBuilder()
+            .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+            .setBusinessId(businessId)
+            .build();
+
+    // when
+    final CreateProcessInstanceResponse response = client.createProcessInstance(request);
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
+    assertThat(response.getBusinessId()).isEqualTo(businessId);
+
+    final BrokerCreateProcessInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    final ProcessInstanceCreationRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.getBusinessId()).isEqualTo(businessId);
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultStub.java
@@ -62,7 +62,8 @@ public final class CreateProcessInstanceWithResultStub
         .setTenantId(piCreationRecord.getTenantId())
         .setProcessDefinitionKey(PROCESS_KEY)
         .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
-        .setTags(TAGS);
+        .setTags(TAGS)
+        .setBusinessId(piCreationRecord.getBusinessId());
 
     return new BrokerResponse<>(response, 0, PROCESS_INSTANCE_KEY);
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/CreateProcessInstanceWithResultTest.java
@@ -85,6 +85,37 @@ public final class CreateProcessInstanceWithResultTest extends GatewayTest {
     assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     assertThat(new HashSet(response.getTagsList())).isEqualTo(stub.getTags());
+    assertThat(response.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  public void shouldMapRequestAndResponseWithBusinessId() {
+    // given
+    final CreateProcessInstanceWithResultStub stub = new CreateProcessInstanceWithResultStub();
+    stub.registerWith(brokerClient);
+    final String businessId = "order-12345";
+
+    final CreateProcessInstanceWithResultRequest request =
+        CreateProcessInstanceWithResultRequest.newBuilder()
+            .setRequest(
+                CreateProcessInstanceRequest.newBuilder()
+                    .setProcessDefinitionKey(stub.getProcessDefinitionKey())
+                    .setBusinessId(businessId))
+            .build();
+
+    // when
+    final CreateProcessInstanceWithResultResponse response =
+        client.createProcessInstanceWithResult(request);
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isEqualTo(stub.getProcessInstanceKey());
+    assertThat(response.getBusinessId()).isEqualTo(businessId);
+
+    final ProcessInstanceCreationRecord brokerRequestValue =
+        brokerClient
+            .<BrokerCreateProcessInstanceWithResultRequest>getSingleBrokerRequest()
+            .getRequestWriter();
+    assertThat(brokerRequestValue.getBusinessId()).isEqualTo(businessId);
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -270,6 +270,13 @@ message CreateProcessInstanceRequest {
 
   // a list of tags that can be attached as meta-data to process instances
   repeated string tags = 9;
+
+  // an optional, user-defined string identifier that identifies the process instance
+  // within the scope of the process definition (scoped by tenant). If provided and uniqueness
+  // enforcement is enabled, the engine will reject creation if another root process instance
+  // with the same business id is already active for the same process definition.
+  // Note that any active child process instances with the same business id are not taken into account.
+  string businessId = 10;
 }
 
 message ProcessInstanceCreationStartInstruction {
@@ -312,6 +319,8 @@ message CreateProcessInstanceResponse {
   string tenantId = 5;
   // tags attached to a process instance
   repeated string tags = 6;
+  // the business id of the created process instance, or empty if not set
+  string businessId = 7;
 }
 
 message CreateProcessInstanceWithResultRequest {
@@ -343,6 +352,8 @@ message CreateProcessInstanceWithResultResponse {
   string tenantId = 6;
   // tags attached to a process instance
   repeated string tags = 7;
+  // the business id of the created process instance, or empty if not set
+  string businessId = 8;
 }
 
 message EvaluateDecisionRequest {

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -82,3 +82,18 @@ components:
         $ref: '#/components/schemas/Tag'
       uniqueItems: true
       maxItems: 10
+
+    BusinessId:
+      description: |
+        An optional, user-defined string identifier that identifies the process instance
+        within the scope of a process definition (scoped by tenant). If provided and uniqueness
+        enforcement is enabled, the engine will reject creation if another root process instance
+        with the same business id is already active for the same process definition.
+        Note that any active child process instances with the same business id are not taken into account.
+      format: BusinessId
+      x-semantic-type: BusinessId
+      type: string
+      minLength: 1
+      maxLength: 256
+      example: order-12345
+

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -774,6 +774,8 @@ components:
           default: 0
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        businessId:
+          $ref: 'identifiers.yaml#/components/schemas/BusinessId'
 
     ProcessInstanceCreationInstructionByKey:
       type: object
@@ -849,6 +851,8 @@ components:
             type: string
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        businessId:
+          $ref: 'identifiers.yaml#/components/schemas/BusinessId'
 
     ProcessInstanceCreationStartInstruction:
       type: object
@@ -939,6 +943,11 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        businessId:
+          nullable: true
+          description: Business id as provided on creation.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
 
     ProcessInstanceSearchQuerySortRequest:
       type: object
@@ -1496,8 +1505,8 @@ components:
     SourceElementInstanceKeyInstruction:
       type: object
       description: |
-       Defines an instruction with a sourceElementInstanceKey. The move instruction with this sourceType will terminate one active element
-       instance with the sourceElementInstanceKey and activate a new element instance at targetElementId.
+        Defines an instruction with a sourceElementInstanceKey. The move instruction with this sourceType will terminate one active element
+        instance with the sourceElementInstanceKey and activate a new element instance at targetElementId.
       properties:
         sourceType:
           description: The type of source element instruction.

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
@@ -101,6 +101,11 @@ public class BrokerCreateProcessInstanceRequest
     return this;
   }
 
+  public BrokerCreateProcessInstanceRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId);
+    return this;
+  }
+
   @Override
   public ProcessInstanceCreationRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
@@ -52,6 +52,11 @@ public final class BrokerCreateProcessInstanceWithResultRequest
     return this;
   }
 
+  public BrokerCreateProcessInstanceWithResultRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId);
+    return this;
+  }
+
   public BrokerCreateProcessInstanceWithResultRequest setVariables(final DirectBuffer variables) {
     requestDto.setVariables(variables);
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -39,6 +39,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue VARIABLES_KEY = new StringValue("variables");
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
+  public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -51,16 +52,18 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceResultRecord() {
-    super(7);
+    super(8);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(versionProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
-        .declareProperty(tagsProperty);
+        .declareProperty(tagsProperty)
+        .declareProperty(businessIdProperty);
   }
 
   @Override
@@ -89,22 +92,17 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProperty.getValue();
   }
 
   public ProcessInstanceResultRecord setProcessDefinitionKey(final long key) {
     processDefinitionKeyProperty.setValue(key);
-    return this;
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProperty.getValue();
-  }
-
-  public ProcessInstanceResultRecord setProcessInstanceKey(final long instanceKey) {
-    processInstanceKeyProperty.setValue(instanceKey);
     return this;
   }
 
@@ -122,6 +120,31 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       tags.forEach(tag -> tagsProperty.add().wrap(BufferUtil.wrapString(tag)));
     }
     return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceResultRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceResultRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceResultRecord setProcessInstanceKey(final long instanceKey) {
+    processInstanceKeyProperty.setValue(instanceKey);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProperty.getValue();
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
@@ -39,6 +39,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue VARIABLES_KEY = new StringValue("variables");
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
+  public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -51,16 +52,18 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceResultRecord() {
-    super(7);
+    super(8);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(versionProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
-        .declareProperty(tagsProperty);
+        .declareProperty(tagsProperty)
+        .declareProperty(businessIdProperty);
   }
 
   @Override
@@ -89,22 +92,17 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProperty.getValue();
   }
 
   public ProcessInstanceResultRecord setProcessDefinitionKey(final long key) {
     processDefinitionKeyProperty.setValue(key);
-    return this;
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProperty.getValue();
-  }
-
-  public ProcessInstanceResultRecord setProcessInstanceKey(final long instanceKey) {
-    processInstanceKeyProperty.setValue(instanceKey);
     return this;
   }
 
@@ -122,6 +120,31 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       tags.forEach(tag -> tagsProperty.add().wrap(BufferUtil.wrapString(tag)));
     }
     return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceResultRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceResultRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceResultRecord setProcessInstanceKey(final long instanceKey) {
+    processInstanceKeyProperty.setValue(instanceKey);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProperty.getValue();
   }
 
   @JsonIgnore

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
@@ -41,18 +41,28 @@ public interface ProcessInstanceResultRecordValue
   int getVersion();
 
   /**
-   * @return the key of the deployed process this instance belongs to.
-   */
-  long getProcessDefinitionKey();
-
-  /**
    * @return the key of the process instance
    */
   @Override
   long getProcessInstanceKey();
 
   /**
+   * @return the key of the deployed process this instance belongs to.
+   */
+  @Override
+  long getProcessDefinitionKey();
+
+  /**
    * @return the set of tags of the process instance
    */
   Set<String> getTags();
+
+  /**
+   * Returns the business id for the process instance. The business id is an immutable, user-defined
+   * string identifier that identifies a process instance within the scope of a process definition.
+   *
+   * @return the business id, or an empty string if not set
+   * @since 8.9
+   */
+  String getBusinessId();
 }


### PR DESCRIPTION
## Description

Add API support for setting a `businessId` when creating a process instance, and propagate it end-to-end so it is included in requests and returned in creation responses (where supported).

This enables clients to provide an optional, user-defined identifier for a process instance at creation time.

## What’s included

- Java client: add `.businessId(String)` to process instance creation and include it in both gRPC and REST payloads
- Java client responses: expose `businessId` on process instance creation responses/results
- HTTP gateway mapping: map `businessId` into `ProcessInstanceCreateRequest` and include it in mapped responses
- MCP: extend create process instance tool/input model to accept `businessId` and forward it
- Service + Zeebe gateway/engine: propagate `businessId` through broker requests and “with result” responses
- Tests: unit tests, mapper tests, gateway/engine tests, and acceptance tests covering the new field

## Related issues

closes #44977
