### PR TITLE
Harden spec response contract for 8.9

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -72,6 +72,8 @@ components:
     AuditLogResult:
       description: Audit log item.
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         auditLogKey:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -31,6 +31,7 @@ components:
     CamundaUserResult:
       type: object
       required:
+        - authorizedComponents
         - tenants
         - groups
         - roles

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -301,6 +301,8 @@ components:
             - $ref: '#/components/schemas/ResourceTypeEnum'
 
     AuthorizationResult:
+      required:
+        - permissionTypes
       type: object
       properties:
         ownerId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -436,6 +436,8 @@ components:
 
     BatchOperationItemResponse:
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         operationType:
           $ref: '#/components/schemas/BatchOperationTypeEnum'

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -305,6 +305,8 @@ components:
             $ref: '#/components/schemas/BatchOperationResponse'
 
     BatchOperationResponse:
+      required:
+        - errors
       type: object
       properties:
         batchOperationKey:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -391,7 +391,6 @@ components:
       type: object
       required:
         - name
-        - value
         - scope
       properties:
         name:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -406,6 +406,9 @@ components:
             $ref: '#/components/schemas/EvaluatedDecisionResult'
 
     EvaluatedDecisionResult:
+      required: 
+        - evaluatedInputs
+        - matchedRules
       x-semantic-provider:
         - decisionEvaluationInstanceKey
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -283,6 +283,8 @@ components:
 
     DecisionInstanceResult:
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         decisionEvaluationInstanceKey:
           $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -396,6 +396,8 @@ components:
           format: int32
 
     MatchedDecisionRuleItem:
+      required: 
+        - evaluatedOutputs
       type: object
       description: A decision rule that matched within this decision evaluation.
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -374,9 +374,12 @@ components:
       properties:
         inputId:
           type: string
+          description: The identifier of the decision input.
         inputName:
           type: string
+          description: The name of the decision input.
         inputValue:
+          description: The description of the decision input.
           type: string
 
     EvaluatedDecisionOutputItem:
@@ -384,14 +387,19 @@ components:
       description: The evaluated decision outputs.
       properties:
         outputId:
+          description: The ID of the evaluated decison output item.
           type: string
         outputName:
+          description: The name of the of the evaluated decison output item.
           type: string
         outputValue:
+          description: The value of the evaluated decison output item.
           type: string
         ruleId:
+          description: The ID of the matched rule.
           type: string
         ruleIndex:
+          description: The index of the matched rule.
           type: integer
           format: int32
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -199,15 +199,30 @@ components:
       type: object
       properties:
         processDefinition:
-          $ref: '#/components/schemas/DeploymentProcessResult'
+          nullable: true
+          description: Deployed process.
+          allOf: 
+            - $ref: '#/components/schemas/DeploymentProcessResult'
         decisionDefinition:
-          $ref: '#/components/schemas/DeploymentDecisionResult'
+          nullable: true
+          description: Deployed decision.
+          allOf: 
+            - $ref: '#/components/schemas/DeploymentDecisionResult'
         decisionRequirements:
-          $ref: '#/components/schemas/DeploymentDecisionRequirementsResult'
+          nullable: true
+          description: Deployed decision requirement definition.
+          allOf: 
+            - $ref: '#/components/schemas/DeploymentDecisionRequirementsResult'
         form:
-          $ref: '#/components/schemas/DeploymentFormResult'
+          nullable: true
+          description: Deployed form.
+          allOf: 
+            - $ref: '#/components/schemas/DeploymentFormResult'
         resource:
-          $ref: '#/components/schemas/DeploymentResourceResult'
+          nullable: true
+          description: Deployed resource.
+          allOf: 
+            - $ref: '#/components/schemas/DeploymentResourceResult'
 
     DeploymentProcessResult:
       description: A deployed process.
@@ -290,13 +305,17 @@ components:
         - decisionRequirementsKey
       properties:
         decisionRequirementsId:
+          description: The id of the deployed decision requirements.
           type: string
         decisionRequirementsName:
+          description: The name of the deployed decision requirements.
           type: string
         version:
           type: integer
           format: int32
+          description: The version of the deployed decision requirements.
         resourceName:
+          description: The name of the resource.
           type: string
         tenantId:
           description: The tenant ID of the deployed decision requirements.
@@ -321,9 +340,11 @@ components:
             The form ID, as parsed during deployment, together with the version forms a
             unique identifier for a specific form.
         version:
+          description: The version of the deployed form.
           type: integer
           format: int32
         resourceName:
+          description: The name of the resource.
           type: string
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
@@ -339,10 +360,13 @@ components:
       type: object
       properties:
         resourceId:
+          description: The resource id of the deployed resource.
           type: string
         resourceName:
+          description: The name of the deployed resource.
           type: string
         version:
+          description: The description of the deployed resource.
           type: integer
           format: int32
         tenantId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -328,6 +328,8 @@ components:
                 $ref: '#/components/schemas/DocumentReference'
 
     DocumentMetadata:
+      required: 
+        - customProperties
       description: Information about the document.
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -398,6 +398,7 @@ components:
         - elementInstanceKey
         - processInstanceKey
         - processDefinitionKey
+        - rootProcessInstanceKey
       properties:
         processDefinitionId:
           description: The process definition ID associated to this element instance.

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -404,6 +404,7 @@ components:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The process definition ID associated to this incident.
         errorType:
+          description: The type of the incident error.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
         errorMessage:
@@ -414,9 +415,11 @@ components:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
           description: The element ID associated to this incident.
         creationTime:
+          description: The creation time of the incident.
           type: string
           format: date-time
         state:
+          description: The incident state.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
         tenantId:

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -396,6 +396,8 @@ components:
 
     IncidentResult:
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         processDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -133,6 +133,7 @@ components:
         filter:
           $ref: '#/components/schemas/JobTypeStatisticsFilter'
         page:
+          description: Search cursor pagination.
           allOf:
             - $ref: 'search-models.yaml#/components/schemas/CursorForwardPagination'
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -347,6 +347,7 @@ components:
         - elementInstanceKey
         - kind
         - listenerEventType
+        - rootProcessInstanceKey
       properties:
         type:
           description: The type of the job (should match what was requested).
@@ -647,6 +648,7 @@ components:
         - tenantId
         - type
         - worker
+        - rootProcessInstanceKey
       properties:
         customHeaders:
           description: A set of custom headers defined during modelling.

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -407,6 +407,7 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The key of the job's process definition.
         elementInstanceKey:
+          description: The element instance key of the task.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         kind:

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -348,6 +348,7 @@ components:
         - kind
         - listenerEventType
         - rootProcessInstanceKey
+        - tags
       properties:
         type:
           description: The type of the job (should match what was requested).
@@ -426,6 +427,10 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
 
     UserTaskProperties:
+      required: 
+        - candidateGroups
+        - candidateUsers 
+        - changedAttributes
       type: object
       description: Contains properties of a user task.
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -30,6 +30,7 @@ components:
         - validLicense
         - licenseType
         - isCommercial
+        - expiresAt
       properties:
         validLicense:
           description: True if the Camunda license is valid, false if otherwise
@@ -43,7 +44,7 @@ components:
           description: Will be false when a license contains a non-commerical=true property
           type: boolean
         expiresAt:
+          nullable: true
           description: The date when the Camunda license expires
           type: string
           format: date-time
-          nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -240,6 +240,8 @@ components:
 
     MessageSubscriptionResult:
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         messageSubscriptionKey:
           allOf:
@@ -453,6 +455,7 @@ components:
         - processInstanceKey
         - subscriptionKey
         - tenantId
+        - rootProcessInstanceKey
 
     CorrelatedMessageSubscriptionSearchQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -461,6 +461,7 @@ components:
       type: object
       properties:
         page:
+          description: Search cursor pagination.
           allOf:
             - $ref: "search-models.yaml#/components/schemas/CursorForwardPagination"
         filter:
@@ -507,6 +508,7 @@ components:
       type: object
       properties:
         page:
+          description: Search cursor pagination.
           allOf:
             - $ref: 'search-models.yaml#/components/schemas/OffsetPagination'
         sort:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1189,6 +1189,7 @@ components:
         - tenantId
         - processInstanceKey
         - processDefinitionKey
+        - rootProcessInstanceKey
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
@@ -1289,6 +1290,8 @@ components:
     ProcessInstanceSequenceFlowResult:
       description: Process instance sequence flow result.
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         sequenceFlowId:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1190,6 +1190,8 @@ components:
         - tenantId
         - processInstanceKey
         - processDefinitionKey
+        - parentProcessInstanceKey
+        - parentElementInstanceKey
         - rootProcessInstanceKey
         - tags
       properties:
@@ -1201,15 +1203,18 @@ components:
         processDefinitionVersion:
           type: integer
           format: int32
+          description: The process definition version.
         processDefinitionVersionTag:
           type: string
           description: The process definition version tag.
         startDate:
           type: string
           format: date-time
+          description: The start time of the process instance.
         endDate:
           type: string
           format: date-time
+          description: The completion or termination time of the process instance.
         state:
           $ref: '#/components/schemas/ProcessInstanceStateEnum'
         hasIncident:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -902,6 +902,7 @@ components:
         - tenantId
         - variables
         - processInstanceKey
+        - tags
       type: object
       properties:
         processDefinitionId:
@@ -1190,6 +1191,7 @@ components:
         - processInstanceKey
         - processDefinitionKey
         - rootProcessInstanceKey
+        - tags
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -83,6 +83,8 @@ paths:
 components:
   schemas:
     UsageMetricsResponse:
+      required: 
+        - tenants
       type: object
       allOf:
         - $ref: '#/components/schemas/UsageMetricsResponseItem'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -497,6 +497,10 @@ components:
       type: object
       required:
         - rootProcessInstanceKey
+        - candidateGroups
+        - candidateUsers
+        - customHeaders 
+        - tags
       properties:
         name:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -456,10 +456,12 @@ components:
           description: The user task due date.
         processInstanceVariables:
           type: array
+          description: The variables of the process instance.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
         localVariables:
           type: array
+          description: The local variables of the user task.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
         userTaskKey:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -495,6 +495,8 @@ components:
 
     UserTaskResult:
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         name:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -203,6 +203,8 @@ components:
     VariableResultBase:
       description: Variable response item.
       type: object
+      required:
+        - rootProcessInstanceKey
       properties:
         name:
           description: Name of this variable.


### PR DESCRIPTION
## Description

This PR hardens the response contract for the OCA API in 8.9, and unblocks QA's failing tests.

There are four things stacked in the PR in atomic commits:

1. Make `rootProcessInstanceKey` `required` and `nullable` wherever it appears in response schema.
2. Make all collections `required` in response schemas (_new Gateway behaviour_).
3. Fix schema defects that snuck in (see #46273) while CI was failing (_it's still failing. Will address CI separately in_ #46274) 
4. Urgent unblocking fix for QA. See #46271.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46271
closes #46273
