### PR TITLE
build: bump feel-scala to 1.19.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
     <version.postgressql-testcontainer>2.0.2</version.postgressql-testcontainer>
     <version.netflix.concurrency>0.5.4</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
-    <version.feel-scala>1.19.3</version.feel-scala>
+    <version.feel-scala>1.19.5</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.7</version.rest-assured>
     <version.spring>6.2.16</version.spring>


### PR DESCRIPTION
## Description

Bumps feel-scala to 1.19.5, which contains a performance improvements that was considered a bottleneck in a support case
