### PR TITLE
test: ArchUnit rule for search entity record conventions

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
@@ -22,4 +22,14 @@ public record CamundaUserDTO(
     List<String> roles,
     String salesPlanType,
     Map<ClusterMetadata.AppName, String> c8Links,
-    boolean canLogout) {}
+    boolean canLogout) {
+
+  public CamundaUserDTO {
+    // initialize with empty collections as default in case null was passed on creation
+    authorizedComponents = authorizedComponents != null ? authorizedComponents : List.of();
+    tenants = tenants != null ? tenants : List.of();
+    groups = groups != null ? groups : List.of();
+    roles = roles != null ? roles : List.of();
+    c8Links = c8Links != null ? c8Links : Map.of();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UsageMetricTUDbReaderTest.java
@@ -34,7 +34,7 @@ class UsageMetricTUDbReaderTest {
     final var result = reader.usageMetricTUStatistics(query, resourceAccessChecks);
 
     assertThat(result.totalTu()).isEqualTo(100L);
-    assertThat(result.tenants()).isNull();
+    assertThat(result.tenants()).isNotNull().isEmpty();
     verify(usageMetricTUMapper).usageMetricTUStatistics(any());
   }
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * ArchUnit rules for search entity records in {@code io.camunda.search.entities}.
+ *
+ * <p>These rules enforce:
+ *
+ * <ol>
+ *   <li>All top-level types in the package (excluding enums and interfaces) must be Java {@code
+ *       record}s.
+ *   <li>Every record with collection-type fields ({@link List}, {@link Set}, {@link Map}, {@link
+ *       Collection}) must declare a compact constructor that defaults those fields to empty mutable
+ *       instances (e.g. {@code new ArrayList<>()}, {@code new HashSet<>()}, {@code new
+ *       HashMap<>()}). This is required because MyBatis hydrates collection-mapped fields by
+ *       calling mutating methods on the existing instance; immutable defaults such as {@code
+ *       List.of()} would cause {@code UnsupportedOperationException} at runtime.
+ * </ol>
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.search.entities",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public final class SearchEntityArchTest {
+
+  static final Set<Class<?>> COLLECTION_TYPES =
+      Set.of(List.class, Set.class, Map.class, Collection.class);
+
+  /**
+   * Every concrete top-level type inside {@code io.camunda.search.entities} must be a Java {@code
+   * record}. Enums and interfaces are excluded.
+   */
+  @ArchTest
+  static final ArchRule SEARCH_ENTITIES_MUST_BE_RECORDS =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAPackage("io.camunda.search.entities")
+          .and()
+          .areNotEnums()
+          .and()
+          .areNotInterfaces()
+          .and()
+          .areTopLevelClasses()
+          .should(
+              new ArchCondition<>("be a Java record") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  if (!item.isRecord()) {
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "Class '%s' in io.camunda.search.entities is not a Java record",
+                                item.getName())));
+                  }
+                }
+              })
+          .because(
+              "search entities should be immutable data carriers (records) "
+                  + "to ensure consistency across API gateways");
+
+  /**
+   * Every record in {@code io.camunda.search.entities} that declares collection-type fields must
+   * have a compact constructor that defaults them to empty mutable instances when {@code null} is
+   * passed. This is verified by reflectively instantiating the record with {@code null} for all
+   * collection parameters and checking that the resulting fields are non-null, empty, and mutable.
+   */
+  @ArchTest
+  static final ArchRule COLLECTION_FIELDS_MUST_HAVE_MUTABLE_DEFAULTS =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAPackage("io.camunda.search.entities..")
+          .and()
+          .areRecords()
+          .should(
+              new ArchCondition<>(
+                  "initialize collection-type fields with mutable defaults in a compact constructor") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  final var collectionFields =
+                      item.getFields().stream()
+                          .filter(SearchEntityArchTest::isCollectionField)
+                          .toList();
+
+                  if (collectionFields.isEmpty()) {
+                    return;
+                  }
+
+                  // Reflectively instantiate the record with null for all reference-type
+                  // parameters and default values for primitives.
+                  final Object instance;
+                  try {
+                    instance = instantiateRecordWithNulls(item);
+                  } catch (final Exception e) {
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "Record '%s': could not reflectively instantiate to verify "
+                                    + "collection defaults: %s",
+                                item.getSimpleName(), e.getMessage())));
+                    return;
+                  }
+
+                  for (final JavaField field : collectionFields) {
+                    try {
+                      final var reflectField =
+                          instance.getClass().getDeclaredField(field.getName());
+                      reflectField.setAccessible(true);
+                      final Object value = reflectField.get(instance);
+
+                      if (value == null) {
+                        events.add(
+                            violated(
+                                item,
+                                String.format(
+                                    "Record '%s': collection field '%s' (type %s) is null when "
+                                        + "constructed with null — add a compact constructor that "
+                                        + "assigns an empty mutable default "
+                                        + "(e.g. new ArrayList<>(), new HashSet<>(), new HashMap<>())",
+                                    item.getSimpleName(),
+                                    field.getName(),
+                                    field.getRawType().getSimpleName())));
+                      } else {
+                        // Verify the collection is mutable by attempting a benign mutation.
+                        assertMutable(item, field, value, events);
+                      }
+                    } catch (final NoSuchFieldException | IllegalAccessException e) {
+                      events.add(
+                          violated(
+                              item,
+                              String.format(
+                                  "Record '%s': could not read field '%s': %s",
+                                  item.getSimpleName(), field.getName(), e.getMessage())));
+                    }
+                  }
+                }
+              })
+          .because(
+              "MyBatis hydrates collection-mapped fields by calling mutating methods "
+                  + "(e.g. .add(), .put()) on the existing instance; immutable defaults such as "
+                  + "List.of() would cause UnsupportedOperationException at runtime");
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static boolean isCollectionField(final JavaField field) {
+    try {
+      final Class<?> fieldClass = Class.forName(field.getRawType().getName());
+      return COLLECTION_TYPES.stream().anyMatch(ct -> ct.isAssignableFrom(fieldClass));
+    } catch (final ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Reflectively creates an instance of the given record class, passing {@code null} for all
+   * reference-type parameters and zero/false defaults for primitive parameters.
+   */
+  private static Object instantiateRecordWithNulls(final JavaClass archClass) throws Exception {
+    final Class<?> recordClass = Class.forName(archClass.getName());
+    final Constructor<?> canonicalCtor = recordClass.getDeclaredConstructors()[0];
+    canonicalCtor.setAccessible(true);
+
+    final Class<?>[] paramTypes = canonicalCtor.getParameterTypes();
+    final Object[] args = new Object[paramTypes.length];
+    for (int i = 0; i < paramTypes.length; i++) {
+      args[i] = defaultValueFor(paramTypes[i]);
+    }
+    return canonicalCtor.newInstance(args);
+  }
+
+  private static Object defaultValueFor(final Class<?> type) {
+    if (!type.isPrimitive()) {
+      return null;
+    }
+    if (type == boolean.class) {
+      return false;
+    }
+    if (type == byte.class) {
+      return (byte) 0;
+    }
+    if (type == short.class) {
+      return (short) 0;
+    }
+    if (type == int.class) {
+      return 0;
+    }
+    if (type == long.class) {
+      return 0L;
+    }
+    if (type == float.class) {
+      return 0.0f;
+    }
+    if (type == double.class) {
+      return 0.0;
+    }
+    if (type == char.class) {
+      return '\0';
+    }
+    return null;
+  }
+
+  /**
+   * Verifies that the given collection value is mutable by attempting a benign add/put operation.
+   * Reports a violation if the collection throws {@link UnsupportedOperationException}.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static void assertMutable(
+      final JavaClass item,
+      final JavaField field,
+      final Object value,
+      final ConditionEvents events) {
+    try {
+      if (value instanceof final Map map) {
+        final Object key = new Object();
+        map.put(key, new Object());
+        map.remove(key);
+      } else if (value instanceof final Collection collection) {
+        final Object element = new Object();
+        collection.add(element);
+        collection.remove(element);
+      }
+    } catch (final UnsupportedOperationException e) {
+      events.add(
+          violated(
+              item,
+              String.format(
+                  "Record '%s': collection field '%s' (type %s) defaults to an immutable "
+                      + "collection — use a mutable implementation "
+                      + "(e.g. new ArrayList<>(), new HashSet<>(), new HashMap<>())",
+                  item.getSimpleName(), field.getName(), field.getRawType().getSimpleName())));
+    }
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/search/entities/SearchEntityArchTest.java
@@ -25,23 +25,26 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * ArchUnit rules for search entity records in {@code io.camunda.search.entities}.
+ * ArchUnit rules for records in {@code io.camunda.search.entities} and {@code
+ * io.camunda.authentication.entity}.
  *
  * <p>These rules enforce:
  *
  * <ol>
- *   <li>All top-level types in the package (excluding enums and interfaces) must be Java {@code
- *       record}s.
- *   <li>Every record with collection-type fields ({@link List}, {@link Set}, {@link Map}, {@link
- *       Collection}) must declare a compact constructor that defaults those fields to empty mutable
- *       instances (e.g. {@code new ArrayList<>()}, {@code new HashSet<>()}, {@code new
- *       HashMap<>()}). This is required because MyBatis hydrates collection-mapped fields by
- *       calling mutating methods on the existing instance; immutable defaults such as {@code
- *       List.of()} would cause {@code UnsupportedOperationException} at runtime.
+ *   <li>All top-level types in {@code io.camunda.search.entities} (excluding enums and interfaces)
+ *       must be Java {@code record}s.
+ *   <li>Every record in {@code io.camunda.search.entities} with collection-type fields ({@link
+ *       List}, {@link Set}, {@link Map}, {@link Collection}) must declare a compact constructor
+ *       that defaults those fields to empty <b>mutable</b> instances (e.g. {@code new
+ *       ArrayList<>()}). This is required because MyBatis hydrates collection-mapped fields by
+ *       calling mutating methods on the existing instance.
+ *   <li>Every record in {@code io.camunda.authentication.entity} with collection-type fields must
+ *       declare a compact constructor that defaults those fields to empty instances (immutable
+ *       defaults like {@code List.of()} are acceptable here).
  * </ol>
  */
 @AnalyzeClasses(
-    packages = "io.camunda.search.entities",
+    packages = {"io.camunda.search.entities", "io.camunda.authentication.entity"},
     importOptions = ImportOption.DoNotIncludeTests.class)
 public final class SearchEntityArchTest {
 
@@ -162,6 +165,83 @@ public final class SearchEntityArchTest {
               "MyBatis hydrates collection-mapped fields by calling mutating methods "
                   + "(e.g. .add(), .put()) on the existing instance; immutable defaults such as "
                   + "List.of() would cause UnsupportedOperationException at runtime");
+
+  /**
+   * Every record in {@code io.camunda.authentication.entity} that declares collection-type fields
+   * must have a compact constructor that defaults them to non-null empty instances when {@code
+   * null} is passed. Unlike search entities, immutable defaults (e.g. {@code List.of()}) are
+   * acceptable.
+   */
+  @ArchTest
+  static final ArchRule AUTH_ENTITY_COLLECTION_FIELDS_MUST_HAVE_DEFAULTS =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAPackage("io.camunda.authentication.entity..")
+          .and()
+          .areRecords()
+          .should(
+              new ArchCondition<>(
+                  "initialize collection-type fields with non-null defaults in a compact"
+                      + " constructor") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  final var collectionFields =
+                      item.getFields().stream()
+                          .filter(SearchEntityArchTest::isCollectionField)
+                          .toList();
+
+                  if (collectionFields.isEmpty()) {
+                    return;
+                  }
+
+                  final Object instance;
+                  try {
+                    instance = instantiateRecordWithNulls(item);
+                  } catch (final Exception e) {
+                    events.add(
+                        violated(
+                            item,
+                            String.format(
+                                "Record '%s': could not reflectively instantiate to verify "
+                                    + "collection defaults: %s",
+                                item.getSimpleName(), e.getMessage())));
+                    return;
+                  }
+
+                  for (final JavaField field : collectionFields) {
+                    try {
+                      final var reflectField =
+                          instance.getClass().getDeclaredField(field.getName());
+                      reflectField.setAccessible(true);
+                      final Object value = reflectField.get(instance);
+
+                      if (value == null) {
+                        events.add(
+                            violated(
+                                item,
+                                String.format(
+                                    "Record '%s': collection field '%s' (type %s) is null when "
+                                        + "constructed with null — add a compact constructor that "
+                                        + "assigns an empty default "
+                                        + "(e.g. List.of(), Map.of(), new ArrayList<>())",
+                                    item.getSimpleName(),
+                                    field.getName(),
+                                    field.getRawType().getSimpleName())));
+                      }
+                    } catch (final NoSuchFieldException | IllegalAccessException e) {
+                      events.add(
+                          violated(
+                              item,
+                              String.format(
+                                  "Record '%s': could not read field '%s': %s",
+                                  item.getSimpleName(), field.getName(), e.getMessage())));
+                    }
+                  }
+                }
+              })
+          .because(
+              "authentication entity records should default collection fields to non-null "
+                  + "empty instances to avoid NullPointerExceptions");
 
   // ---------------------------------------------------------------------------
   // Helpers

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -10,6 +10,7 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,6 +39,13 @@ public record BatchOperationEntity(
     Integer operationsFailedCount,
     Integer operationsCompletedCount,
     List<BatchOperationErrorEntity> errors) {
+
+  public BatchOperationEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    errors = errors != null ? errors : new ArrayList<>();
+  }
 
   /**
    * Because of backwards compatibility (Legacy Batches have a UUID as ID), batchOperationKey is a

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -9,6 +9,7 @@ package io.camunda.search.entities;
 
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public record DecisionInstanceEntity(
@@ -33,6 +34,14 @@ public record DecisionInstanceEntity(
     List<DecisionInstanceInputEntity> evaluatedInputs,
     List<DecisionInstanceOutputEntity> evaluatedOutputs)
     implements TenantOwnedEntity {
+
+  public DecisionInstanceEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    evaluatedInputs = evaluatedInputs != null ? evaluatedInputs : new ArrayList<>();
+    evaluatedOutputs = evaluatedOutputs != null ? evaluatedOutputs : new ArrayList<>();
+  }
 
   public Builder toBuilder() {
     return new Builder()

--- a/search/search-domain/src/main/java/io/camunda/search/entities/PersistentWebSessionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/PersistentWebSessionEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -16,4 +17,12 @@ public record PersistentWebSessionEntity(
     Long creationTime,
     Long lastAccessedTime,
     Long maxInactiveIntervalInSeconds,
-    Map<String, byte[]> attributes) {}
+    Map<String, byte[]> attributes) {
+
+  public PersistentWebSessionEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
+    attributes = attributes != null ? attributes : new HashMap<>();
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
@@ -8,10 +8,18 @@
 package io.camunda.search.entities;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.HashMap;
 import java.util.Map;
 
 public record UsageMetricStatisticsEntity(
     long totalRpi, long totalEdi, long at, Map<String, UsageMetricStatisticsEntityTenant> tenants) {
+
+  public UsageMetricStatisticsEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
+    tenants = tenants != null ? tenants : new HashMap<>();
+  }
 
   public record UsageMetricStatisticsEntityTenant(long rpi, long edi) {
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
@@ -8,10 +8,18 @@
 package io.camunda.search.entities;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.HashMap;
 import java.util.Map;
 
 public record UsageMetricTUStatisticsEntity(
     long totalTu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+
+  public UsageMetricTUStatisticsEntity {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
+    tenants = tenants != null ? tenants : new HashMap<>();
+  }
 
   public record UsageMetricTUStatisticsEntityTenant(long tu) {
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -10,6 +10,7 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,7 @@ public record UserTaskEntity(
     // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
     candidateGroups = candidateGroups != null ? candidateGroups : new ArrayList<>();
     candidateUsers = candidateUsers != null ? candidateUsers : new ArrayList<>();
+    customHeaders = customHeaders != null ? customHeaders : new HashMap<>();
     tags = tags != null ? tags : new HashSet<>();
   }
 


### PR DESCRIPTION
## Description

In the data layer collection fields may sometimes be returned as `null`, we generally want to ensure that within the service layer values of collection fields default to an empty collection, to not have to defensively check for null. 

This is crucial for the openapi contract response hardening #46165 and ensures entity instances returned comply with it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #46165
