### PR TITLE
ci: optimize ITs have already run in previous step

### DIFF
--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build Optimize Backend
       uses: ./.github/actions/run-maven
       with:
-        parameters: install -f optimize/pom.xml -pl backend -am -PrunAssembly -T1
+        parameters: install -f optimize/pom.xml -pl backend -am -PrunAssembly -DskipTests -T1
 
     - name: Generate production .tar.gz
       uses: ./.github/actions/run-maven


### PR DESCRIPTION
## Description
[Deploy Artifacts / Deploy Artifacts](https://github.com/camunda/camunda/actions/runs/22177363174/job/64144165798#logs) job was failing. 
On `Build Optimize Backend` step, it tried to run tests too, but was failing because `elasticsearch` was not up and running.

### Possible fixes
1. Have `elasticsearch` up and running in previous step -- Not suggested
   1. more time waiting
   2. optimize backend ITs are checked in previous step -- example reference [[IT] Run on Elasticsearch (ccsm-test)](https://github.com/camunda/camunda/actions/runs/22177363174/job/64139483951#logs) 
   3. optimize smoke tests will still run afterwards
4. `-DskipTests` in failing step -- Preferred solution

## Related issues

relates #44302
