### PR TITLE
fix: handle 404 in e2e zeebeClient cleanup

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -78,7 +78,15 @@ const createSingleInstance = async (
 };
 
 const cancelProcessInstance = async (processInstanceKey: string) => {
-  return zeebe.cancelProcessInstance({processInstanceKey});
+  return zeebe.cancelProcessInstance({processInstanceKey}).catch((e) => {
+    if (e.status === 404) {
+      // an active process with this key was not found. It probably completed already.
+      // we swallow the error, because this is a common cleanup scenario.
+      return;
+    }
+    // Something else happened. Throw the error to surface the problem.
+    throw e;
+  });
 };
 
 const createWorker = (


### PR DESCRIPTION
## Description

This swallows the 404 error during cleanup if a test process has already completed. 

Those are the errors that look like this in test runs: 

```
3) [api-tests] › tests/api/v2/conditional/conditional-evaluation-api-tests.spec.ts:267:3 › Conditional Evaluation API Tests › Evaluate Conditional - Verify Response Schema 

    HTTPError: Response code 404 (Not Found) - {"type":"about:blank", "title":"NOT_FOUND","status":404, "detail": "Command 'CANCEL' rejected with code 'NOT_FOUND': Expected to cancel a process instance with key '2251799813686572', but no such process was found",
    "instance":"/v2/process-instances/2251799813686572/cancellation"} 
    (POST http://localhost:8080/v2/process-instances/2251799813686572/cancellation). {"type":"about:blank","title":"NOT_FOUND","status":404, "detail":"Command 'CANCEL' rejected with code 'NOT_FOUND': Expected to cancel a process instance with key '2251799813686572', but no such process was found", "instance":"/v2/process-instances/2251799813686572/cancellation"}. Enhanced stack trace available as error.source.
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
