### PR TITLE
test: add MCP Remote Client connector authentication tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -72,26 +72,23 @@ services:
       - zeebe_network
 
   keycloak:
-    depends_on:
-      - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: quay.io/keycloak/keycloak:23.0
+    command: start-dev --import-realm
     ports:
       - '18080:8080'
+    volumes:
+      - ./keycloak/camunda-platform-realm.json:/opt/keycloak/data/import/camunda-platform-realm.json:ro
     environment:
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
-      KEYCLOAK_DATABASE_HOST: postgres
-      KEYCLOAK_DATABASE_NAME: identity
-      KEYCLOAK_DATABASE_USER: identity
-      KEYCLOAK_DATABASE_PASSWORD: 't2L@!AqSMg8%I%NmHM'
-      KEYCLOAK_ADMIN_USER: admin
+      KC_HTTP_RELATIVE_PATH: /auth
+      KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth']
+      test: ['CMD-SHELL', 'exec 3<>/dev/tcp/127.0.0.1/8080;echo -e "GET /auth/health/ready HTTP/1.1\r\nhost: 127.0.0.1:8080\r\nConnection: close\r\n\r\n" >&3;if [ $? -eq 0 ]; then exit 0;else exit 1;fi;']
       interval: 30s
       timeout: 15s
       retries: 8
-      start_period: 30s
+      start_period: 60s
     networks:
       - zeebe_network
 
@@ -108,6 +105,59 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+
+  mcp-test-server-basic:
+    container_name: mcp-test-server-basic
+    image: registry.camunda.cloud/mcp/mcp-test-server:latest
+    ports:
+      - 12002:12001
+    networks:
+      - zeebe_network
+    environment:
+      - SPRING_PROFILES_ACTIVE=auth-basic
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-u", "test-user:test-password", "http://localhost:12001/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  mcp-test-server-apikey:
+    container_name: mcp-test-server-apikey
+    image: registry.camunda.cloud/mcp/mcp-test-server:latest
+    ports:
+      - 12003:12001
+    networks:
+      - zeebe_network
+    environment:
+      - SPRING_PROFILES_ACTIVE=auth-api-key
+    healthcheck:
+      test: ["CMD", "curl", "-s", "http://localhost:12001/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  mcp-test-server-oauth:
+    container_name: mcp-test-server-oauth
+    image: registry.camunda.cloud/mcp/mcp-test-server:latest
+    ports:
+      - 12004:12001
+    networks:
+      - zeebe_network
+    environment:
+      - SPRING_PROFILES_ACTIVE=auth-oauth2
+      - MCP_SERVER_AUTH_OAUTH2_ISSUERURL=http://keycloak:8080/auth/realms/camunda-platform
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "curl", "-s", "http://localhost:12001/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
 
   connectors:
     container_name: connectors
@@ -130,6 +180,12 @@ services:
       camunda:
         condition: service_started
       mcp-test-server:
+        condition: service_healthy
+      mcp-test-server-basic:
+        condition: service_healthy
+      mcp-test-server-apikey:
+        condition: service_healthy
+      mcp-test-server-oauth:
         condition: service_healthy
     networks:
       - zeebe_network

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/keycloak/camunda-platform-realm.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/keycloak/camunda-platform-realm.json
@@ -1,0 +1,78 @@
+{
+  "realm": "camunda-platform",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "clients": [
+    {
+      "clientId": "zeebe",
+      "name": "Zeebe Client for E2E Tests",
+      "description": "Client for OAuth2 client credentials flow testing",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "zecobe-secret",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "client.secret.creation.time": "1740000000",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "client_credentials.use_refresh_token": "false"
+      },
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "users": [],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_basic_auth.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_basic_auth.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="mcp_remote_client_basic_auth" name="mcp_remote_client_basic_auth" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1jxr5k6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1jxr5k6" sourceRef="StartEvent_1" targetRef="Activity_1jtuozy" />
+    <bpmn:endEvent id="Event_0ap30yg">
+      <bpmn:incoming>Flow_04vys7c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_04vys7c" sourceRef="Activity_1jtuozy" targetRef="Event_0ap30yg" />
+    <bpmn:serviceTask id="Activity_1jtuozy" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="http" target="data.transport.type" />
+          <zeebe:input source="http://mcp-test-server-basic:12001/mcp" target="data.transport.http.url" />
+          <zeebe:input source="basic" target="data.transport.http.authentication.type" />
+          <zeebe:input source="test-user" target="data.transport.http.authentication.username" />
+          <zeebe:input source="test-password" target="data.transport.http.authentication.password" />
+          <zeebe:input source="=false" target="data.options.clientCache" />
+          <zeebe:input source="standalone" target="data.connectorMode.type" />
+          <zeebe:input source="tools/list" target="data.connectorMode.operation.type" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="2" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+          <zeebe:header key="resultVariable" value="listToolsResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1jxr5k6</bpmn:incoming>
+      <bpmn:outgoing>Flow_04vys7c</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcp_remote_client_basic_auth">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ap30yg_di" bpmnElement="Event_0ap30yg">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0igv5yz_di" bpmnElement="Activity_1jtuozy">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1jxr5k6_di" bpmnElement="Flow_1jxr5k6">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04vys7c_di" bpmnElement="Flow_04vys7c">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_bearer_auth.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_bearer_auth.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="mcp_remote_client_bearer_auth" name="mcp_remote_client_bearer_auth" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1jxr5k6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1jxr5k6" sourceRef="StartEvent_1" targetRef="Activity_1jtuozy" />
+    <bpmn:endEvent id="Event_0ap30yg">
+      <bpmn:incoming>Flow_04vys7c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_04vys7c" sourceRef="Activity_1jtuozy" targetRef="Event_0ap30yg" />
+    <bpmn:serviceTask id="Activity_1jtuozy" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="http" target="data.transport.type" />
+          <zeebe:input source="http://mcp-test-server-oauth:12001/mcp" target="data.transport.http.url" />
+          <zeebe:input source="bearer" target="data.transport.http.authentication.type" />
+          <zeebe:input source="=bearerToken" target="data.transport.http.authentication.token" />
+          <zeebe:input source="=false" target="data.options.clientCache" />
+          <zeebe:input source="standalone" target="data.connectorMode.type" />
+          <zeebe:input source="tools/list" target="data.connectorMode.operation.type" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="2" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+          <zeebe:header key="resultVariable" value="listToolsResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1jxr5k6</bpmn:incoming>
+      <bpmn:outgoing>Flow_04vys7c</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcp_remote_client_bearer_auth">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ap30yg_di" bpmnElement="Event_0ap30yg">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0igv5yz_di" bpmnElement="Activity_1jtuozy">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1jxr5k6_di" bpmnElement="Flow_1jxr5k6">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04vys7c_di" bpmnElement="Flow_04vys7c">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_oauth_auth.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/agentic_orchestration/mcp_remote_client_oauth_auth.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="mcp_remote_client_oauth_auth" name="mcp_remote_client_oauth_auth" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1jxr5k6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1jxr5k6" sourceRef="StartEvent_1" targetRef="Activity_1jtuozy" />
+    <bpmn:endEvent id="Event_0ap30yg">
+      <bpmn:incoming>Flow_04vys7c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_04vys7c" sourceRef="Activity_1jtuozy" targetRef="Event_0ap30yg" />
+    <bpmn:serviceTask id="Activity_1jtuozy" zeebe:modelerTemplate="io.camunda.connectors.agenticai.mcp.remoteclient.v0" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgICA8cGF0aCBkPSJNMjUgOTcuODUyOEw5Mi44ODIzIDI5Ljk3MDZDMTAyLjI1NSAyMC41OTggMTE3LjQ1MSAyMC41OTggMTI2LjgyMyAyOS45NzA2VjI5Ljk3MDZDMTM2LjE5NiAzOS4zNDMxIDEzNi4xOTYgNTQuNTM5MSAxMjYuODIzIDYzLjkxMTdMNzUuNTU4MSAxMTUuMTc3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjEyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxwYXRoIGQ9Ik03Ni4yNjUzIDExNC40N0wxMjYuODIzIDYzLjkxMTdDMTM2LjE5NiA1NC41MzkxIDE1MS4zOTIgNTQuNTM5MSAxNjAuNzY1IDYzLjkxMTdMMTYxLjExOCA2NC4yNjUyQzE3MC40OTEgNzMuNjM3OCAxNzAuNDkxIDg4LjgzMzggMTYxLjExOCA5OC4yMDYzTDk5LjcyNDggMTU5LjZDOTYuNjAwNiAxNjIuNzI0IDk2LjYwMDYgMTY3Ljc4OSA5OS43MjQ4IDE3MC45MTNMMTEyLjMzMSAxODMuNTIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogICAgPHBhdGggZD0iTTEwOS44NTMgNDYuOTQxMUw1OS42NDgyIDk3LjE0NTdDNTAuMjc1NyAxMDYuNTE4IDUwLjI3NTcgMTIxLjcxNCA1OS42NDgyIDEzMS4wODdWMTMxLjA4N0M2OS4wMjA4IDE0MC40NTkgODQuMjE2OCAxNDAuNDU5IDkzLjU4OTQgMTMxLjA4N0wxNDMuNzk0IDgwLjg4MjIiIHN0cm9rZT0iYmxhY2siIHN0cm9rZS13aWR0aD0iMTIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:mcpremoteclient:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="http" target="data.transport.type" />
+          <zeebe:input source="http://mcp-test-server-oauth:12001/mcp" target="data.transport.http.url" />
+          <zeebe:input source="oauth-client-credentials-flow" target="data.transport.http.authentication.type" />
+          <zeebe:input source="http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/token" target="data.transport.http.authentication.oauthTokenEndpoint" />
+          <zeebe:input source="zeebe" target="data.transport.http.authentication.clientId" />
+          <zeebe:input source="zecobe-secret" target="data.transport.http.authentication.clientSecret" />
+          <zeebe:input source="BASIC_AUTH_HEADER" target="data.transport.http.authentication.clientAuthentication" />
+          <zeebe:input source="=false" target="data.options.clientCache" />
+          <zeebe:input source="standalone" target="data.connectorMode.type" />
+          <zeebe:input source="tools/list" target="data.connectorMode.operation.type" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="2" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.mcp.remoteclient.v0" />
+          <zeebe:header key="resultVariable" value="listToolsResult" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1jxr5k6</bpmn:incoming>
+      <bpmn:outgoing>Flow_04vys7c</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcp_remote_client_oauth_auth">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ap30yg_di" bpmnElement="Event_0ap30yg">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0igv5yz_di" bpmnElement="Activity_1jtuozy">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1jxr5k6_di" bpmnElement="Flow_1jxr5k6">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04vys7c_di" bpmnElement="Flow_04vys7c">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/agentic_orchestration/mcp-client-connector-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/agentic_orchestration/mcp-client-connector-user-flows.spec.ts
@@ -14,6 +14,7 @@ import {validateConnectorsHealth} from 'utils/connectorsRuntimeHelpers';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {getAccessToken} from 'utils/keycloakHelpers';
 
 test.beforeAll(async () => {
   await validateMcpServerHealth();
@@ -149,6 +150,143 @@ test.describe('MCP Client connector tests', () => {
           expect(value.messages[0].role).toBe('user');
           expect(value.messages[0].content.text).toContain('John');
           expect(value.messages[0].content.text).toContain('greet tool');
+        },
+      );
+    });
+  });
+});
+
+test.describe('MCP Client connector authentication tests', () => {
+  let bearerToken: string;
+
+  test.beforeAll(async () => {
+    await validateMcpServerHealth();
+    await validateConnectorsHealth();
+
+    // Fetch Bearer token from Keycloak for bearer auth test
+    bearerToken = await getAccessToken();
+
+    // Deploy all authentication test BPMNs
+    await deploy([
+      './resources/agentic_orchestration/mcp_remote_client_basic_auth.bpmn',
+      './resources/agentic_orchestration/mcp_remote_client_bearer_auth.bpmn',
+      './resources/agentic_orchestration/mcp_remote_client_oauth_auth.bpmn',
+    ]);
+  });
+
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('As a user I can authenticate with Basic Auth', async ({
+    operateHomePage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    test.slow();
+
+    await test.step('Create process instance with Basic Auth', async () => {
+      await createInstances('mcp_remote_client_basic_auth', 1, 1);
+      await sleep(2000);
+    });
+
+    await test.step('Navigate to completed process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.selectProcess('mcp_remote_client_basic_auth');
+      await sleep(100);
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.completedIcon).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify authenticated request succeeded', async () => {
+      await operateProcessInstancePage.verifyVariableJsonContent(
+        'listToolsResult',
+        (value) => {
+          expect(value.toolDefinitions).toBeDefined();
+          expect(value.toolDefinitions.length).toBeGreaterThan(0);
+        },
+      );
+    });
+  });
+
+  test('As a user I can authenticate with Bearer Token', async ({
+    operateHomePage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    test.slow();
+
+    await test.step('Create process instance with Bearer Token', async () => {
+      await createInstances('mcp_remote_client_bearer_auth', 1, 1, {
+        bearerToken,
+      });
+      await sleep(2000);
+    });
+
+    await test.step('Navigate to completed process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.selectProcess('mcp_remote_client_bearer_auth');
+      await sleep(100);
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.completedIcon).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify authenticated request succeeded', async () => {
+      await operateProcessInstancePage.verifyVariableJsonContent(
+        'listToolsResult',
+        (value) => {
+          expect(value.toolDefinitions).toBeDefined();
+          expect(value.toolDefinitions.length).toBeGreaterThan(0);
+        },
+      );
+    });
+  });
+
+  test('As a user I can authenticate with OAuth Client Credentials', async ({
+    operateHomePage,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    test.slow();
+
+    await test.step('Create process instance with OAuth', async () => {
+      await createInstances('mcp_remote_client_oauth_auth', 1, 1);
+      await sleep(2000);
+    });
+
+    await test.step('Navigate to completed process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+      await operateFiltersPanelPage.selectProcess('mcp_remote_client_oauth_auth');
+      await sleep(100);
+      await operateProcessesPage.clickProcessInstanceLink();
+      await expect(operateProcessInstancePage.completedIcon).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify OAuth auto-fetched token and succeeded', async () => {
+      await operateProcessInstancePage.verifyVariableJsonContent(
+        'listToolsResult',
+        (value) => {
+          expect(value.toolDefinitions).toBeDefined();
+          expect(value.toolDefinitions.length).toBeGreaterThan(0);
         },
       );
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/keycloakHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/keycloakHelpers.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {request} from '@playwright/test';
+
+const KEYCLOAK_URL =
+  process.env.KEYCLOAK_URL || 'http://localhost:18080/auth';
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_expires_in: number;
+  token_type: string;
+  scope?: string;
+}
+
+/**
+ * Fetch an access token from Keycloak using client credentials flow.
+ *
+ * @param realm - The Keycloak realm name
+ * @param clientId - The client ID
+ * @param clientSecret - The client secret
+ * @returns The access token string
+ */
+export async function getAccessToken(
+  realm: string = 'camunda-platform',
+  clientId: string = 'zeebe',
+  clientSecret: string = 'zecobe-secret',
+): Promise<string> {
+  const tokenEndpoint = `${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token`;
+
+  const apiRequestContext = await request.newContext();
+
+  try {
+    const response = await apiRequestContext.post(tokenEndpoint, {
+      form: {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+      },
+    });
+
+    if (!response.ok()) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Failed to fetch access token from Keycloak. Status: ${response.status()}, Response: ${errorBody}`,
+      );
+    }
+
+    const tokenResponse: TokenResponse = await response.json();
+    return tokenResponse.access_token;
+  } catch (error: unknown) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(
+      `Keycloak token fetch failed: ${errorMessage}. ` +
+        `Ensure Keycloak is running and the realm/client is configured correctly.`,
+    );
+  } finally {
+    await apiRequestContext.dispose();
+  }
+}


### PR DESCRIPTION
## Overview

Add comprehensive authentication testing for the MCP Remote Client connector covering all supported authentication methods.

## Changes

### Infrastructure
- Add Keycloak service with `camunda-platform` realm configuration
- Add 4 MCP test server instances:
  - No authentication (port 12001)
  - Basic authentication (port 12002)
  - API Key authentication (port 12003)
  - OAuth 2.0 authentication (port 12004)
- Configure OAuth MCP server to use Keycloak for token validation

### Test Implementation
- Add 3 BPMN process definitions for authentication methods:
  - Basic auth (username/password)
  - Bearer token (from Keycloak)
  - OAuth 2.0 client credentials flow (auto-fetch)
- Add Keycloak helper utility to fetch access tokens
- Add 3 positive path authentication test cases

### Test Results
✅ All authentication tests passing locally

## Next Steps
- [ ] Review and merge base PR #46144
- [ ] Add negative test cases for authentication failures
- [ ] Add API Key authentication test

## Related
- Base PR: #46144
