### PR TITLE
build: add pre-push git hook for local validation

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+# Pre-push hook for Camunda repository
+# This hook automatically formats code and runs build checks before pushing
+#
+# Setup (one-time): git config core.hooksPath .githooks
+# To bypass this hook (emergency only), use: git push --no-verify
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Running pre-push checks...${NC}"
+echo -e "${BLUE}========================================${NC}"
+
+# Source SDKMAN if available to ensure correct Java version
+if [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+fi
+
+# Ensure Java 21 is available
+if ! command -v java &> /dev/null; then
+    echo -e "${RED}❌ Java not found. Please install Java 21.${NC}"
+    exit 1
+fi
+
+# Verify Java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d'.' -f1)
+if [ "$JAVA_VERSION" -lt 21 ]; then
+    echo -e "${RED}❌ Java 21+ required. Current version: $JAVA_VERSION${NC}"
+    echo -e "${YELLOW}   Install Java 21 with: sdk install java 21.0.10-tem${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Java ${JAVA_VERSION} detected${NC}"
+
+# Determine base ref for diffing changed files
+BASE_REF="origin/main"
+if ! git rev-parse --verify "${BASE_REF}" &>/dev/null; then
+    echo -e "${YELLOW}⚠ ${BASE_REF} not found, falling back to HEAD~1${NC}"
+    BASE_REF="HEAD~1"
+fi
+
+# ============================================================
+# Step 1/3: Format code
+# ============================================================
+echo -e "\n${BLUE}Step 1/3: Formatting code...${NC}"
+if ./mvnw license:format spotless:apply -T1C -q; then
+    echo -e "${GREEN}✓ Code formatting completed${NC}"
+else
+    echo -e "${RED}❌ Code formatting failed${NC}"
+    exit 1
+fi
+
+# Check if formatting created any changes
+if ! git diff --quiet; then
+    echo -e "${YELLOW}⚠ Formatting made changes. Stage them and amend your commit:${NC}"
+    echo -e "${YELLOW}   git add -u && git commit --amend --no-edit${NC}"
+    exit 1
+fi
+
+# ============================================================
+# Step 2/3: License check
+# ============================================================
+echo -e "\n${BLUE}Step 2/3: Checking license headers...${NC}"
+if ./mvnw license:check -T1C -q; then
+    echo -e "${GREEN}✓ License check passed${NC}"
+else
+    echo -e "${RED}❌ License check failed${NC}"
+    echo -e "${YELLOW}   Run: ./mvnw license:format${NC}"
+    exit 1
+fi
+
+# ============================================================
+# Step 3/3: Build changed modules
+# ============================================================
+echo -e "\n${BLUE}Step 3/3: Building changed modules...${NC}"
+
+# Detect changed Maven modules using native git + filesystem checks.
+#
+# For each changed file, walks up the directory tree to find the nearest
+# ancestor directory containing a pom.xml — that directory is the Maven module.
+#
+# This correctly handles:
+#   - Source file changes (not just pom.xml edits)
+#   - Nested modules (e.g. gateways/gateway-model, zeebe/gateway-rest)
+#   - Non-module files (e.g. docs/, .github/) are naturally skipped
+detect_changed_modules() {
+    local changed_files
+    changed_files=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null) || {
+        echo -e "${YELLOW}⚠ Could not diff against ${BASE_REF}${NC}" >&2
+        changed_files=$(git diff --name-only HEAD~1 HEAD)
+    }
+
+    if [ -z "$changed_files" ]; then
+        return
+    fi
+
+    # If root pom.xml itself changed, signal a full reactor build
+    if echo "$changed_files" | grep -qE '^pom\.xml$'; then
+        echo "ROOT"
+        return
+    fi
+
+    # For each changed file, find its owning Maven module
+    echo "$changed_files" | while IFS= read -r file; do
+        dir=$(dirname "$file")
+        while [ "$dir" != "." ]; do
+            if [ -f "$dir/pom.xml" ]; then
+                echo "$dir"
+                break
+            fi
+            dir=$(dirname "$dir")
+        done
+    done | sort -u
+}
+
+CHANGED_MODULES=$(detect_changed_modules)
+
+if [ -z "$CHANGED_MODULES" ]; then
+    echo -e "${GREEN}✓ No Maven module changes detected, skipping build${NC}"
+elif echo "$CHANGED_MODULES" | grep -q "^ROOT$"; then
+    echo -e "${YELLOW}⚠ Root pom.xml changed, running full reactor build${NC}"
+    if ./mvnw clean install -Dquickly -T1C; then
+        echo -e "${GREEN}✓ Full build passed${NC}"
+    else
+        echo -e "${RED}❌ Full build failed${NC}"
+        exit 1
+    fi
+else
+    # Build comma-separated module list for Maven -pl
+    MODULE_LIST=$(echo "$CHANGED_MODULES" | paste -sd ',' -)
+    echo -e "${BLUE}Changed modules:${NC}"
+    echo "$CHANGED_MODULES" | while IFS= read -r mod; do
+        echo -e "${BLUE}  - ${mod}${NC}"
+    done
+    echo -e "${BLUE}Building changed modules and upstream dependencies (-am)...${NC}"
+
+    if ./mvnw clean install -pl "${MODULE_LIST}" -am -Dquickly -T1C; then
+        echo -e "${GREEN}✓ Build passed${NC}"
+    else
+        echo -e "${RED}❌ Build failed${NC}"
+        echo -e "${YELLOW}   Fix build errors before pushing${NC}"
+        exit 1
+    fi
+fi
+
+# All checks passed
+echo -e "\n${GREEN}========================================${NC}"
+echo -e "${GREEN}✓ All pre-push checks passed!${NC}"
+echo -e "${GREEN}========================================${NC}"
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ For more details, see the [documentation site README](monorepo-docs-site/README.
 * [Java Client](https://docs.camunda.io/docs/apis-tools/java-client/)
 * [Camunda Spring Boot Starter](https://docs.camunda.io/docs/apis-tools/spring-zeebe-sdk/getting-started/)
 
+## Git Hooks
+
+This repository includes a pre-push hook in [`.githooks/pre-push`](.githooks/pre-push) that runs
+formatting, license checks, and a quick build of changed modules before pushing.
+This catches common issues locally so you don't have to wait for CI to report them.
+
+**What the hook does:**
+
+1. Runs `spotless:apply` and `license:format` to auto-fix formatting
+2. Verifies license headers with `license:check`
+3. Detects which Maven modules you changed and builds them with `-Dquickly`
+
+**Setup:**
+
+The [`git-build-hook-maven-plugin`](https://github.com/rudikershaw/git-build-hook) in the root
+`pom.xml` automatically installs the pre-push hook into `.git/hooks/` on your first Maven build.
+If you haven't run a build yet, you can set it up manually:
+
+```bash
+cp .githooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+```
+
+To bypass the hook in an emergency: `git push --no-verify`
+
 ## Contributing
 
 Read the [Contributions Guide](/CONTRIBUTING.md).

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,24 @@
           </markdown>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.rudikershaw.gitbuildhook</groupId>
+        <artifactId>git-build-hook-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <inherited>false</inherited>
+        <configuration>
+          <installHooks>
+            <pre-push>.githooks/pre-push</pre-push>
+          </installHooks>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Summary

- Adds a **pre-push git hook** (`.githooks/pre-push`) that validates changes locally before pushing, catching common issues without waiting for CI pipelines
- Integrates [`git-build-hook-maven-plugin`](https://github.com/rudikershaw/git-build-hook) in the root `pom.xml` to automatically install the hook into `.git/hooks/` on the first Maven build
- Documents the hook setup and its benefits in the README

## What the hook does

| Step | Action | Purpose |
|------|--------|---------|
| 1/3 | `spotless:apply` + `license:format` | Auto-fix code formatting and license headers |
| 2/3 | `license:check` | Verify license headers are correct |
| 3/3 | Build changed modules with `-Dquickly` | Catch compilation errors in affected modules |

### Changed module detection (rewritten)

The hook detects which Maven modules were affected using native `git diff` and filesystem checks. For each changed file, it walks up the directory tree to find the nearest `pom.xml` — that directory is the Maven module. This correctly handles:

- **Source file changes** (not just `pom.xml` edits)
- **Nested modules** (e.g. `gateways/gateway-model`, `zeebe/gateway-rest`)
- **Non-module files** (e.g. `docs/`, `.github/`) are naturally skipped
- **Root `pom.xml` changes** trigger a full reactor build

The detected modules are passed to Maven as `-pl module1,module2,... -am -Dquickly -T1C`.

## Hook activation

| Scenario | How it activates |
|----------|-----------------|
| Developer runs any Maven build | `git-build-hook-maven-plugin` installs it automatically |
| Developer never builds locally | Manual: `cp .githooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push` |
| Emergency bypass | `git push --no-verify` |

## Files changed

- **`.githooks/pre-push`** (new) — the hook script
- **`pom.xml`** — added `git-build-hook-maven-plugin` with `<installHooks>` targeting only the pre-push hook
- **`README.md`** — new "Git Hooks" section documenting setup and usage

## Test plan

- [ ] Clone fresh repo, run `./mvnw validate`, verify `.git/hooks/pre-push` is installed
- [ ] Make a change in a single module, push, verify only that module + dependencies are built
- [ ] Make a change to root `pom.xml`, push, verify full reactor build runs
- [ ] Change a non-module file (e.g. docs), push, verify build step is skipped
- [ ] Run `git push --no-verify` to confirm bypass works