### PR TITLE
fix: show total count on multi instance body selection

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -79,12 +79,8 @@ const ModificationDropdown: React.FC<Props> = observer(
     const isElementInstanceResolved = resolvedElementInstance !== null;
 
     let selectedElementRunningInstancesCount = totalRunningInstancesCount;
-    if (isElementInstanceResolved) {
-      if (isSelectedInstanceMultiInstanceBody) {
-        selectedElementRunningInstancesCount = totalRunningInstancesVisible;
-      } else {
-        selectedElementRunningInstancesCount = 1;
-      }
+    if (isElementInstanceResolved && !isSelectedInstanceMultiInstanceBody) {
+      selectedElementRunningInstancesCount = 1;
     }
 
     const resolvedElementInstanceKey =

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -69,8 +69,23 @@ const ModificationDropdown: React.FC<Props> = observer(
       );
     const {data: totalRunningInstancesByFlowNode} =
       useTotalRunningInstancesByFlowNode();
-    const selectedElementRunningInstancesCount =
-      resolvedElementInstance === null ? totalRunningInstancesCount : 1;
+
+    // true if an element instance is selected from the element history tree
+    const isSpecificElementInstanceSelected =
+      selectedElementInstanceKey !== null;
+
+    // true if an element is selected from diagram or element history tree,
+    // and a single specific element instance is resolved for the selection
+    const isElementInstanceResolved = resolvedElementInstance !== null;
+
+    let selectedElementRunningInstancesCount = totalRunningInstancesCount;
+    if (isElementInstanceResolved) {
+      if (isSelectedInstanceMultiInstanceBody) {
+        selectedElementRunningInstancesCount = totalRunningInstancesVisible;
+      } else {
+        selectedElementRunningInstancesCount = 1;
+      }
+    }
 
     const resolvedElementInstanceKey =
       resolvedElementInstance?.elementInstanceKey;
@@ -78,11 +93,9 @@ const ModificationDropdown: React.FC<Props> = observer(
     const availableModifications = useAvailableModifications({
       runningElementInstanceCount: selectedElementRunningInstancesCount ?? 0,
       elementId: selectedElementId ?? undefined,
-      isSpecificElementInstanceSelected: selectedElementInstanceKey !== null,
+      isSpecificElementInstanceSelected,
       isMultiInstanceBody: isSelectedInstanceMultiInstanceBody,
-      isElementInstanceKeyAvailable:
-        selectedElementInstanceKey !== null ||
-        resolvedElementInstanceKey !== undefined,
+      isElementInstanceKeyAvailable: isElementInstanceResolved,
     });
     const canBeModified = useCanBeModified(selectedElementId ?? undefined);
     const {data: processInstance} = useProcessInstance();

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/multiScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/multiScopes.test.tsx
@@ -17,6 +17,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {Paths} from 'modules/Routes';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
+import {searchResult} from 'modules/testUtils';
 
 const stats = {
   items: [
@@ -176,5 +177,51 @@ describe('Modification Dropdown - Multi Scopes', () => {
     expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
+  });
+
+  it('should display visible child instances count when multi instance body element with multiple child instances is selected', async () => {
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'TaskB',
+          active: 3,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
+
+    mockSearchElementInstances().withSuccess(
+      searchResult([
+        {
+          elementInstanceKey: '2251799813686200',
+          processInstanceKey: '1',
+          processDefinitionKey: 'processName',
+          processDefinitionId: 'processName',
+          state: 'ACTIVE' as const,
+          type: 'MULTI_INSTANCE_BODY' as const,
+          elementId: 'TaskB',
+          elementName: 'Task B',
+          hasIncident: false,
+          tenantId: '<default>',
+          startDate: '2018-12-12T00:00:02.000+0000',
+        },
+      ]),
+    );
+
+    renderPopover([
+      `${Paths.processInstance('instance_id')}?elementId=TaskB&isMultiInstanceBody=true`,
+    ]);
+
+    expect(
+      await screen.findByText(/Flow Node Modifications/),
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.queryByTitle(/loading/i));
+
+    expect(
+      await screen.findByText(/Selected running instances: 3/),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Show total element instances count on multi instance body selection in modification mode
- Add test coverage

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45553
