### PR TITLE
test: reduce flakyness of GlobalListenerInitializerIT

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -157,6 +157,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
@@ -1819,24 +1820,56 @@ public class CompactRecordLogger {
   }
 
   private String summarizeGlobalListener(final GlobalListenerRecordValue value) {
-    return String.format(
-        "%s<%s> x %s%s",
-        formatId(value.getType()),
-        value.getEventTypes().stream().collect(Collectors.joining(", ")),
-        value.getRetries(),
-        value.isAfterNonGlobal() ? " [after]" : "");
+    final String summary =
+        String.format(
+            "%s<%s> %s(%s) %s %s x %d (prio: %d)",
+            value.getListenerType(),
+            value.getSource(),
+            formatId(value.getId()),
+            formatId(value.getType()),
+            value.isAfterNonGlobal() ? "after" : "before",
+            value.getEventTypes(),
+            value.getRetries(),
+            value.getPriority());
+    if (value.getConfigKey() != -1) {
+      return summary + " config: " + shortenKey(value.getConfigKey());
+    }
+    return summary;
   }
 
   private String summarizeGlobalListenerBatch(final Record<?> record) {
     final var value = (GlobalListenerBatchRecordValue) record.getValue();
     final StringBuilder summary = new StringBuilder();
-    if (record.getKey() != value.getGlobalListenerBatchKey()) {
-      summary.append("key: ").append(shortenKey(value.getGlobalListenerBatchKey())).append(" ");
+
+    if (!value.getCreatedListenerKeys().isEmpty()) {
+      summary.append(
+          value.getCreatedListenerKeys().stream()
+              .map(this::shortenKey)
+              .collect(Collectors.joining(", ", "created: [", "] ")));
+    }
+    if (!value.getUpdatedListenerKeys().isEmpty()) {
+      summary.append(
+          value.getUpdatedListenerKeys().stream()
+              .map(this::shortenKey)
+              .collect(Collectors.joining(", ", "updated: [", "]")));
+    }
+    if (!value.getDeletedListenerKeys().isEmpty()) {
+      summary.append(
+          value.getDeletedListenerKeys().stream()
+              .map(this::shortenKey)
+              .collect(Collectors.joining(", ", "deleted: [", "]")));
     }
     summary.append(
         value.getListeners().stream()
-            .map(this::summarizeGlobalListener)
-            .collect(Collectors.joining("; ", "taskListeners: {", "}")));
+            .map(
+                listener -> {
+                  final String listenerSummary = summarizeGlobalListener(listener);
+                  return Optional.of(listener.getGlobalListenerKey())
+                      .filter(key -> key > 0)
+                      .map(key -> shortenKey(key) + ": " + listenerSummary)
+                      .orElse(listenerSummary);
+                })
+            .collect(Collectors.joining("; ", "listeners: {", "}")));
     return summary.toString();
   }
 


### PR DESCRIPTION
In the tests contained in GlobalListenerInitializerIT, the test cluster is restarted multiple times and assertions are made on the records generated after the last restart.

This was previously accomplished by calling `RecordingExporter.reset()` after stopping the cluster and before starting it again. While this does remove the old records from the `RecordingExporter` cache, records can sometimes still be exported a second time after the restart, even if they were already exported before it.

The new approach waits for the CONFIGURED event (marking the end of the global listener configuration initialization) to be exported on all partitions and its distribution to be complete on the main partition and tracks the position of the CONFIGURED event in each partition. This way, following asserts only consider records actually exported AFTER the restart.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46209
