### PR TITLE
[Backport stable/8.6] build: bump feel-scala to 1.18.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
     <version.testcontainers>2.0.3</version.testcontainers>
     <version.netflix.concurrency>0.5.4</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
-    <version.feel-scala>1.18.3</version.feel-scala>
+    <version.feel-scala>1.18.5</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.7</version.rest-assured>
     <version.spring>6.2.16</version.spring>


### PR DESCRIPTION
# Description
Backport of #46231 to `stable/8.6`.

relates to 