### PR TITLE
fix: upgrade test containers to `1.21.4`

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -357,7 +357,7 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-test-container</artifactId>
-      <version>3.6.5</version>
+      <version>3.6.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -316,6 +316,13 @@
         <version>${jakarta.rs-api.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>1.21.4</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- Override Spring Boot's logback version to address CVEs -->
       <dependency>
         <groupId>ch.qos.logback</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
     <version.asm>9.3</version.asm>
     <version.testcontainers>1.20.1</version.testcontainers>
     <version.netflix.concurrency>0.5.2</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.5</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
     <version.feel-scala>1.18.0</version.feel-scala>
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>


### PR DESCRIPTION
## Description
Fix CI on Ubuntu latest

This PR upgrades Testcontainers from `1.21.3`, transitive via `zeebe-test-container:3.6.9`, to `1.21.4`.
On GitHub Actions runners using `ubuntu-latest`, Testcontainers `1.21.3` fails to detect a valid Docker environment, causing host-port forwarding tests from `ZeebeExtension` - `Testcontainers.exposeHostPorts()` to error with **Could not find a valid Docker environment**.

The newer version `1.21.4` fixes Docker environment detection on Ubuntu `latest` and ensures CI tests run reliably.

### Changes
- Added a direct test-scoped dependency on `org.testcontainers:testcontainers:1.21.4` to override the transitive `1.21.3` version.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
