### PR TITLE
feat: use title case for Operations Log in Identity frontend

### DIFF
--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -15,7 +15,7 @@
   "authorization": "Authorization",
   "clusterVariables": "Cluster variables",
   "clusterVariable": "Cluster variable",
-  "operationsLog": "Operations log",
+  "operationsLog": "Operations Log",
   "unauthorized": "Unauthorized",
   "sessionExpired": "Looks like your session has expired",
   "forbidden": "Forbidden",

--- a/identity/client/src/utility/localization/en/operationsLog.json
+++ b/identity/client/src/utility/localization/en/operationsLog.json
@@ -1,5 +1,5 @@
 {
-  "operationsLog": "Operations log",
+  "operationsLog": "Operations Log",
   "operationType": "Operation type",
   "entityType": "Entity type",
   "status": "Status",
@@ -8,7 +8,7 @@
   "actor": "Actor",
   "actorPlaceholder": "Username or client ID",
   "date": "Date",
-  "operationsLogCouldNotLoad": "Operations log could not be loaded",
+  "operationsLogCouldNotLoad": "Operations Log could not be loaded",
   "selectLabel": "Choose option",
   "multiSelectLabel": "Choose option(s)",
   "selectAll": "All",


### PR DESCRIPTION
## Description

use Title Case for "Operations Log" labeling in Identity

Note: the issue also mentions Operate, but that was done already

## Screenshots

<img width="1714" height="898" alt="image" src="https://github.com/user-attachments/assets/03c97374-b16d-4f68-aeee-f55f2dc95247" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45202
