### PR TITLE
feat: schedule audit log deletion on resource deletion in RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AuditLogEntityMapper.java
@@ -47,6 +47,7 @@ public class AuditLogEntityMapper {
         .relatedEntityType(auditLogDbModel.relatedEntityType())
         .relatedEntityKey(auditLogDbModel.relatedEntityKey())
         .entityDescription(auditLogDbModel.entityDescription())
+        .historyCleanupDate(auditLogDbModel.historyCleanupDate())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -33,10 +33,11 @@ public interface AuditLogMapper extends ProcessInstanceDependantMapper, HistoryC
 
   int updateAuditLogEntityHistoryCleanupDate(UpdateHistoryCleanupDateDto dto);
 
-  void updateUnsetAuditLogEntityHistoryCleanupDates(
+  int updateUnsetAuditLogEntityHistoryCleanupDates(
       List<Long> keys,
       HistoryDeletionTypeDbModel historyDeletionType,
-      OffsetDateTime historyCleanupDate);
+      OffsetDateTime historyCleanupDate,
+      int limit);
 
   record UpdateHistoryCleanupDateDto(
       List<String> entityKeys, String entityType, OffsetDateTime historyCleanupDate)

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.domain.Copyable;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
@@ -31,6 +32,11 @@ public interface AuditLogMapper extends ProcessInstanceDependantMapper, HistoryC
   int cleanupHistory(HistoryCleanupMapper.CleanupHistoryDto dto);
 
   int updateAuditLogEntityHistoryCleanupDate(UpdateHistoryCleanupDateDto dto);
+
+  void updateUnsetAuditLogEntityHistoryCleanupDates(
+      List<Long> keys,
+      HistoryDeletionTypeDbModel historyDeletionType,
+      OffsetDateTime historyCleanupDate);
 
   record UpdateHistoryCleanupDateDto(
       List<String> entityKeys, String entityType, OffsetDateTime historyCleanupDate)

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write;
 
 import io.camunda.util.ObjectBuilder;
 import java.time.Duration;
+import java.time.InstantSource;
 
 public record RdbmsWriterConfig(
     int partitionId,
@@ -29,7 +30,8 @@ public record RdbmsWriterConfig(
      */
     boolean exportBatchOperationItemsOnCreation,
     HistoryConfig history,
-    InsertBatchingConfig insertBatchingConfig) {
+    InsertBatchingConfig insertBatchingConfig,
+    InstantSource clock) {
 
   public static final int DEFAULT_QUEUE_SIZE = 1000;
   // Default memory limit: 20MB - aligned with CamundaExporter's default
@@ -51,6 +53,7 @@ public record RdbmsWriterConfig(
         DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
     private HistoryConfig history = new HistoryConfig.Builder().build();
     private InsertBatchingConfig insertBatchingConfig = new InsertBatchingConfig.Builder().build();
+    private InstantSource clock = InstantSource.system();
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
@@ -88,6 +91,11 @@ public record RdbmsWriterConfig(
       return this;
     }
 
+    public Builder clock(final InstantSource clock) {
+      this.clock = clock;
+      return this;
+    }
+
     @Override
     public RdbmsWriterConfig build() {
       return new RdbmsWriterConfig(
@@ -97,7 +105,8 @@ public record RdbmsWriterConfig(
           batchOperationItemInsertBlockSize,
           exportBatchOperationItemsOnCreation,
           history,
-          insertBatchingConfig);
+          insertBatchingConfig,
+          clock);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.sql.AuditLogMapper.UpdateHistoryCleanupDateDto;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
@@ -93,10 +94,27 @@ public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWri
                 .build()));
   }
 
+  public void scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+      final List<Long> keys, final HistoryDeletionTypeDbModel historyDeletionType) {
+    final OffsetDateTime historyCleanupDate =
+        OffsetDateTime.now().plus(resolveRetentionTime(historyDeletionType));
+    mapper.updateUnsetAuditLogEntityHistoryCleanupDates(
+        keys, historyDeletionType, historyCleanupDate);
+  }
+
   public int cleanupHistory(
       final int partitionId, final OffsetDateTime cleanupDate, final int limit) {
     return mapper.cleanupHistory(
         new HistoryCleanupMapper.CleanupHistoryDto(partitionId, cleanupDate, limit));
+  }
+
+  private Duration resolveRetentionTime(final HistoryDeletionTypeDbModel historyDeletionType) {
+    return switch (historyDeletionType) {
+      case PROCESS_INSTANCE -> resolveRetentionTime(AuditLogEntityType.PROCESS_INSTANCE);
+      case PROCESS_DEFINITION, DECISION_REQUIREMENTS ->
+          resolveRetentionTime(AuditLogEntityType.RESOURCE);
+      case DECISION_INSTANCE -> resolveRetentionTime(AuditLogEntityType.DECISION);
+    };
   }
 
   private Duration resolveRetentionTime(final AuditLogEntityType entityType) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -22,7 +22,9 @@ import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWriter {
@@ -31,17 +33,28 @@ public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWri
   private final AuditLogMapper mapper;
   private final VendorDatabaseProperties vendorDatabaseProperties;
   private final RdbmsWriterConfig config;
+  private final InstantSource clock;
 
   public AuditLogWriter(
       final ExecutionQueue executionQueue,
       final AuditLogMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties,
       final RdbmsWriterConfig config) {
+    this(executionQueue, mapper, vendorDatabaseProperties, config, config.clock());
+  }
+
+  public AuditLogWriter(
+      final ExecutionQueue executionQueue,
+      final AuditLogMapper mapper,
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final RdbmsWriterConfig config,
+      final InstantSource clock) {
     super(mapper);
     this.executionQueue = executionQueue;
     this.mapper = mapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
     this.config = config;
+    this.clock = clock;
   }
 
   public void create(final AuditLogDbModel auditLog) {
@@ -99,7 +112,8 @@ public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWri
       final HistoryDeletionTypeDbModel historyDeletionType,
       final int limit) {
     final OffsetDateTime historyCleanupDate =
-        OffsetDateTime.now().plus(resolveRetentionTime(historyDeletionType));
+        OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
+            .plus(resolveRetentionTime(historyDeletionType));
     return mapper.updateUnsetAuditLogEntityHistoryCleanupDates(
         keys, historyDeletionType, historyCleanupDate, limit);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuditLogWriter.java
@@ -94,12 +94,14 @@ public class AuditLogWriter extends ProcessInstanceDependant implements RdbmsWri
                 .build()));
   }
 
-  public void scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-      final List<Long> keys, final HistoryDeletionTypeDbModel historyDeletionType) {
+  public int scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+      final List<Long> keys,
+      final HistoryDeletionTypeDbModel historyDeletionType,
+      final int limit) {
     final OffsetDateTime historyCleanupDate =
         OffsetDateTime.now().plus(resolveRetentionTime(historyDeletionType));
-    mapper.updateUnsetAuditLogEntityHistoryCleanupDates(
-        keys, historyDeletionType, historyCleanupDate);
+    return mapper.updateUnsetAuditLogEntityHistoryCleanupDates(
+        keys, historyDeletionType, historyCleanupDate, limit);
   }
 
   public int cleanupHistory(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -70,6 +70,30 @@ public class HistoryDeletionService {
     final List<Long> deletedProcessDefinitions = deleteProcessDefinitions(batch);
     final List<Long> deletedDecisionInstances = deleteDecisionInstances(batch);
     final List<Long> deletedDecisionRequirements = deleteDecisionRequirements(batch);
+    if (!deletedProcessInstances.isEmpty()) {
+      rdbmsWriters
+          .getAuditLogWriter()
+          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+              deletedProcessInstances, HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+    }
+    if (!deletedProcessDefinitions.isEmpty()) {
+      rdbmsWriters
+          .getAuditLogWriter()
+          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+              deletedProcessDefinitions, HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
+    }
+    if (!deletedDecisionInstances.isEmpty()) {
+      rdbmsWriters
+          .getAuditLogWriter()
+          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+              deletedDecisionInstances, HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+    }
+    if (!deletedDecisionRequirements.isEmpty()) {
+      rdbmsWriters
+          .getAuditLogWriter()
+          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+              deletedDecisionRequirements, HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
+    }
 
     final List<Long> deletedResources =
         Stream.of(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -70,30 +70,6 @@ public class HistoryDeletionService {
     final List<Long> deletedProcessDefinitions = deleteProcessDefinitions(batch);
     final List<Long> deletedDecisionInstances = deleteDecisionInstances(batch);
     final List<Long> deletedDecisionRequirements = deleteDecisionRequirements(batch);
-    if (!deletedProcessInstances.isEmpty()) {
-      rdbmsWriters
-          .getAuditLogWriter()
-          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-              deletedProcessInstances, HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
-    }
-    if (!deletedProcessDefinitions.isEmpty()) {
-      rdbmsWriters
-          .getAuditLogWriter()
-          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-              deletedProcessDefinitions, HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
-    }
-    if (!deletedDecisionInstances.isEmpty()) {
-      rdbmsWriters
-          .getAuditLogWriter()
-          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-              deletedDecisionInstances, HistoryDeletionTypeDbModel.DECISION_INSTANCE);
-    }
-    if (!deletedDecisionRequirements.isEmpty()) {
-      rdbmsWriters
-          .getAuditLogWriter()
-          .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-              deletedDecisionRequirements, HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
-    }
 
     final List<Long> deletedResources =
         Stream.of(
@@ -131,6 +107,8 @@ public class HistoryDeletionService {
 
     if (allProcessInstanceDependantDataDeleted) {
       rdbmsWriters.getProcessInstanceWriter().deleteByKeys(processInstanceKeys);
+      scheduleAuditLogDataForDeletion(
+          processInstanceKeys, HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
       return processInstanceKeys;
     }
 
@@ -147,6 +125,8 @@ public class HistoryDeletionService {
     }
 
     rdbmsWriters.getProcessDefinitionWriter().deleteByKeys(processDefinitionKeys);
+    scheduleAuditLogDataForDeletion(
+        processDefinitionKeys, HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
 
     return processDefinitionKeys;
   }
@@ -160,6 +140,9 @@ public class HistoryDeletionService {
     }
 
     rdbmsWriters.getDecisionInstanceWriter().deleteByKeys(decisionInstanceKeys);
+    scheduleAuditLogDataForDeletion(
+        decisionInstanceKeys, HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+
     return decisionInstanceKeys;
   }
 
@@ -184,6 +167,8 @@ public class HistoryDeletionService {
 
     if (allDecisionRequirementsDependantDataDeleted) {
       rdbmsWriters.getDecisionRequirementsWriter().deleteByKeys(decisionRequirementsKeys);
+      scheduleAuditLogDataForDeletion(
+          decisionRequirementsKeys, HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
       return decisionRequirementsKeys;
     }
 
@@ -232,6 +217,21 @@ public class HistoryDeletionService {
           historyDeletionDbModel.resourceKey());
     }
     return !hasDependents;
+  }
+
+  private void scheduleAuditLogDataForDeletion(
+      final List<Long> deletedKeys, final HistoryDeletionTypeDbModel deletionType) {
+    if (deletedKeys.isEmpty()) {
+      return;
+    }
+    final int limit = config.dependentRowLimit();
+    int updated;
+    do {
+      updated =
+          rdbmsWriters
+              .getAuditLogWriter()
+              .scheduleKeyRelatedAuditLogsHistoryCleanupTime(deletedKeys, deletionType, limit);
+    } while (updated >= limit);
   }
 
   private int deleteFromHistoryDeletionTable(final List<Long> deletedResourceKeys) {

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -405,6 +405,42 @@
     AND ENTITY_TYPE = #{entityType}
   </update>
 
+  <update id="updateUnsetAuditLogEntityHistoryCleanupDates">
+    UPDATE ${prefix}AUDIT_LOG SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE
+    <choose>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_INSTANCE'">
+        PROCESS_INSTANCE_KEY IN
+        <foreach collection="keys" item="key" open="(" separator="," close=")">
+          #{key}
+        </foreach>
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_DEFINITION'">
+        PROCESS_DEFINITION_KEY IN
+        <foreach collection="keys" item="key" open="(" separator="," close=")">
+          #{key}
+        </foreach>
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_INSTANCE'">
+        DECISION_EVALUATION_KEY IN
+        <foreach collection="keys" item="key" open="(" separator="," close=")">
+          #{key}
+        </foreach>
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_REQUIREMENTS'">
+        DECISION_REQUIREMENTS_KEY IN
+        <foreach collection="keys" item="key" open="(" separator="," close=")">
+          #{key}
+        </foreach>
+      </when>
+      <otherwise>
+        1 = 0
+      </otherwise>
+    </choose>
+    AND HISTORY_CLEANUP_DATE IS NULL
+  </update>
+
   <delete id="deleteRootProcessInstanceRelatedData">
     <bind name="tableName" value="'AUDIT_LOG'"/>
     <bind name="primaryKeyColumn" value="'AUDIT_LOG_KEY'"/>

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -405,10 +405,7 @@
     AND ENTITY_TYPE = #{entityType}
   </update>
 
-  <update id="updateUnsetAuditLogEntityHistoryCleanupDates">
-    UPDATE ${prefix}AUDIT_LOG SET
-    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
-    WHERE
+  <sql id="updateUnsetAuditLogEntityHistoryCleanupDatesFilter">
     <choose>
       <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_INSTANCE'">
         PROCESS_INSTANCE_KEY IN
@@ -439,6 +436,85 @@
       </otherwise>
     </choose>
     AND HISTORY_CLEANUP_DATE IS NULL
+  </sql>
+
+  <update id="updateUnsetAuditLogEntityHistoryCleanupDates">
+    UPDATE ${prefix}AUDIT_LOG SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE
+    <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.updateUnsetAuditLogEntityHistoryCleanupDatesFilter"/>
+    LIMIT #{limit}
+  </update>
+  <update id="updateUnsetAuditLogEntityHistoryCleanupDates" databaseId="mssql">
+    UPDATE TOP (#{limit}) ${prefix}AUDIT_LOG SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE
+    <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.updateUnsetAuditLogEntityHistoryCleanupDatesFilter"/>
+  </update>
+  <!--
+    Special handling for Oracle to handle large lists of keys.
+    We use XMLTABLE to pass the list of keys as an XML document, avoiding Oracle's 1000-element IN clause limit.
+    The keys list is joined directly against the AUDIT_LOG table via XMLTABLE — no IN clause on the keys.
+  -->
+  <update id="updateUnsetAuditLogEntityHistoryCleanupDates" databaseId="oracle">
+    UPDATE ${prefix}AUDIT_LOG t SET
+    t.HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE t.HISTORY_CLEANUP_DATE IS NULL
+    AND
+    <choose>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_INSTANCE'">
+        t.PROCESS_INSTANCE_KEY
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_DEFINITION'">
+        t.PROCESS_DEFINITION_KEY
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_INSTANCE'">
+        t.DECISION_EVALUATION_KEY
+      </when>
+      <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_REQUIREMENTS'">
+        t.DECISION_REQUIREMENTS_KEY
+      </when>
+      <otherwise>
+        NULL
+      </otherwise>
+    </choose>
+    IN (SELECT COLUMN_VALUE FROM XMLTABLE('/d/r'
+        PASSING XMLTYPE(#{keys, typeHandler=io.camunda.db.rdbms.sql.typehandler.OracleXmlArrayTypeHandler})
+        COLUMNS COLUMN_VALUE NUMBER PATH 'text()'))
+    AND ROWNUM &lt;= #{limit}
+  </update>
+  <!--
+    Special handling for PostgreSQL to delete using ctid or a specified primary key column.
+    This avoids issues with large IN clauses by using ANY with an array parameter.
+  -->
+  <update id="updateUnsetAuditLogEntityHistoryCleanupDates" databaseId="postgresql">
+    UPDATE ${prefix}AUDIT_LOG t SET
+    HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    FROM (
+      SELECT AUDIT_LOG_KEY FROM ${prefix}AUDIT_LOG
+      WHERE HISTORY_CLEANUP_DATE IS NULL
+      AND
+      <choose>
+        <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_INSTANCE'">
+          PROCESS_INSTANCE_KEY
+        </when>
+        <when test="historyDeletionType != null and historyDeletionType.name() == 'PROCESS_DEFINITION'">
+          PROCESS_DEFINITION_KEY
+        </when>
+        <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_INSTANCE'">
+          DECISION_EVALUATION_KEY
+        </when>
+        <when test="historyDeletionType != null and historyDeletionType.name() == 'DECISION_REQUIREMENTS'">
+          DECISION_REQUIREMENTS_KEY
+        </when>
+        <otherwise>
+          NULL
+        </otherwise>
+      </choose>
+      = ANY(#{keys, jdbcType=ARRAY, typeHandler=io.camunda.db.rdbms.sql.typehandler.PostgresLongListToArrayTypeHandler})
+      LIMIT #{limit}
+    ) sub
+    WHERE t.AUDIT_LOG_KEY = sub.AUDIT_LOG_KEY
   </update>
 
   <delete id="deleteRootProcessInstanceRelatedData">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -541,16 +541,18 @@ public class HistoryDeletionServiceTest {
     // then
     verify(auditLogWriterMock)
         .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-            List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+            List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE, LIMIT);
     verify(auditLogWriterMock)
         .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-            List.of(processDefinitionKey), HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
+            List.of(processDefinitionKey), HistoryDeletionTypeDbModel.PROCESS_DEFINITION, LIMIT);
     verify(auditLogWriterMock)
         .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-            List.of(decisionInstanceKey), HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+            List.of(decisionInstanceKey), HistoryDeletionTypeDbModel.DECISION_INSTANCE, LIMIT);
     verify(auditLogWriterMock)
         .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-            List.of(decisionRequirementsKey), HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
+            List.of(decisionRequirementsKey),
+            HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS,
+            LIMIT);
   }
 
   @Test
@@ -567,7 +569,8 @@ public class HistoryDeletionServiceTest {
     historyDeletionService.deleteHistory(partitionId);
 
     // then
-    verify(auditLogWriterMock, never()).scheduleKeyRelatedAuditLogsHistoryCleanupTime(any(), any());
+    verify(auditLogWriterMock, never())
+        .scheduleKeyRelatedAuditLogsHistoryCleanupTime(any(), any(), anyInt());
   }
 
   private static HistoryDeletionDbModel createModel(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -507,6 +507,69 @@ public class HistoryDeletionServiceTest {
     verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
   }
 
+  @Test
+  void shouldScheduleAuditLogHistoryDeletionTimes() {
+    // given
+    final var partitionId = 1;
+    final var processInstanceKey = 1L;
+    final var processDefinitionKey = 2L;
+    final var decisionInstanceKey = 3L;
+    final var decisionRequirementsKey = 4L;
+
+    final AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
+    when(rdbmsWritersMock.getAuditLogWriter()).thenReturn(auditLogWriterMock);
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(processInstanceKey, HistoryDeletionTypeDbModel.PROCESS_INSTANCE),
+                    createModel(
+                        processDefinitionKey, HistoryDeletionTypeDbModel.PROCESS_DEFINITION),
+                    createModel(decisionInstanceKey, HistoryDeletionTypeDbModel.DECISION_INSTANCE),
+                    createModel(
+                        decisionRequirementsKey,
+                        HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS))));
+    final var mapperMock = mock(ProcessInstanceDependantMapper.class);
+    when(rdbmsWritersMock.getProcessInstanceDependantWriters())
+        .thenReturn(List.of(new TestProcessInstanceDependantWriter(mapperMock)));
+    when(processInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+    when(decisionInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(auditLogWriterMock)
+        .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+            List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+    verify(auditLogWriterMock)
+        .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+            List.of(processDefinitionKey), HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
+    verify(auditLogWriterMock)
+        .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+            List.of(decisionInstanceKey), HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+    verify(auditLogWriterMock)
+        .scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+            List.of(decisionRequirementsKey), HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
+  }
+
+  @Test
+  void shouldNotScheduleAuditLogHistoryDeletionTimesIfNothingDeleted() {
+    // given
+    final var partitionId = 1;
+
+    final AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
+    when(rdbmsWritersMock.getAuditLogWriter()).thenReturn(auditLogWriterMock);
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(new HistoryDeletionBatch(List.of()));
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(auditLogWriterMock, never()).scheduleKeyRelatedAuditLogsHistoryCleanupTime(any(), any());
+  }
+
   private static HistoryDeletionDbModel createModel(
       final long processInstanceKey, final HistoryDeletionTypeDbModel type) {
     return new HistoryDeletionDbModel(processInstanceKey, type, 2L, 1);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.rdbms.db.auditlog;
 
 import static io.camunda.it.rdbms.db.fixtures.AuditLogFixtures.createAndSaveAuditLog;
+import static io.camunda.it.rdbms.db.fixtures.AuditLogFixtures.createAndSaveAuditLogs;
 import static io.camunda.it.rdbms.db.fixtures.AuditLogFixtures.createAndSaveRandomAuditLogs;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromTenantIds;
@@ -21,6 +22,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
 import io.camunda.db.rdbms.write.service.AuditLogWriter;
 import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
@@ -34,6 +36,8 @@ import io.camunda.security.auth.condition.AuthorizationConditions;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -796,5 +800,225 @@ public class AuditLogIT {
         .isNotEmpty()
         .extracting(AuditLogEntity::processInstanceKey)
         .containsOnly(processInstanceKey1);
+  }
+
+  @TestTemplate
+  public void shouldSetCleanupDateForProcessInstances(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+    final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
+
+    final var processInstanceKey1 = nextKey();
+    final var processInstanceKey2 = nextKey();
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey1));
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey2));
+
+    final AuditLogQuery auditLogQuery =
+        AuditLogQuery.of(
+            b ->
+                b.filter(f -> f.processInstanceKeys(processInstanceKey1, processInstanceKey2))
+                    .page(p -> p.from(0).size(1000)));
+    var searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .isNotEmpty()
+        .extracting(AuditLogEntity::processInstanceKey)
+        .containsOnly(processInstanceKey1, processInstanceKey2);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNull());
+
+    // when
+    auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+        List.of(processInstanceKey1, processInstanceKey2),
+        HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+
+    // then
+    searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
+  }
+
+  @TestTemplate
+  public void shouldSetCleanupDateForProcessDefinitions(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var processDefinitionKey1 = nextKey();
+    final var processDefinitionKey2 = nextKey();
+
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+    final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey1));
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey2));
+
+    final AuditLogQuery auditLogQuery =
+        AuditLogQuery.of(
+            b ->
+                b.filter(f -> f.processDefinitionKeys(processDefinitionKey1, processDefinitionKey2))
+                    .page(p -> p.from(0).size(1000)));
+    var searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .isNotEmpty()
+        .extracting(AuditLogEntity::processDefinitionKey)
+        .containsOnly(processDefinitionKey1, processDefinitionKey2);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNull());
+
+    // when
+    auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+        List.of(processDefinitionKey1, processDefinitionKey2),
+        HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
+
+    // then
+    searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
+  }
+
+  @TestTemplate
+  public void shouldSetCleanupDateForDecisionInstances(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var decisionInstanceKey1 = nextKey();
+    final var decisionInstanceKey2 = nextKey();
+
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+    final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionEvaluationKey(decisionInstanceKey1));
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionEvaluationKey(decisionInstanceKey2));
+
+    final AuditLogQuery auditLogQuery =
+        AuditLogQuery.of(
+            b ->
+                b.filter(f -> f.decisionEvaluationKeys(decisionInstanceKey1, decisionInstanceKey2))
+                    .page(p -> p.from(0).size(1000)));
+    var searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .isNotEmpty()
+        .extracting(AuditLogEntity::decisionEvaluationKey)
+        .containsOnly(decisionInstanceKey1, decisionInstanceKey2);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNull());
+
+    // when
+    auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+        List.of(decisionInstanceKey1, decisionInstanceKey2),
+        HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+
+    // then
+    searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
+  }
+
+  @TestTemplate
+  public void shouldSetCleanupDateForDecisionDefinitions(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var decisionReqKey1 = nextKey();
+    final var decisionReqKey2 = nextKey();
+
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+    final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionRequirementsKey(decisionReqKey1));
+    createAndSaveRandomAuditLogs(rdbmsWriters, b -> b.decisionRequirementsKey(decisionReqKey2));
+
+    final AuditLogQuery auditLogQuery =
+        AuditLogQuery.of(
+            b ->
+                b.filter(f -> f.decisionRequirementsKeys(decisionReqKey1, decisionReqKey2))
+                    .page(p -> p.from(0).size(1000)));
+    var searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .isNotEmpty()
+        .extracting(AuditLogEntity::decisionRequirementsKey)
+        .containsOnly(decisionReqKey1, decisionReqKey2);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNull());
+
+    // when
+    auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+        List.of(decisionReqKey1, decisionReqKey2),
+        HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
+
+    // then
+    searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult.items())
+        .allSatisfy(item -> assertThat(item.historyCleanupDate()).isNotNull());
+  }
+
+  @TestTemplate
+  public void shouldNotOverwriteNonNullCleanupDates(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+    final AuditLogWriter auditLogWriter = rdbmsWriters.getAuditLogWriter();
+
+    final var processInstanceKey = nextKey();
+    final OffsetDateTime alreadySetDate =
+        OffsetDateTime.now().plusDays(1).truncatedTo(ChronoUnit.SECONDS);
+    final AuditLogDbModel shouldNotBeOverwritten =
+        AuditLogFixtures.createRandomized(
+            b ->
+                b.entityKey("123")
+                    .processInstanceKey(processInstanceKey)
+                    .historyCleanupDate(alreadySetDate));
+    final AuditLogDbModel shouldBeOverwritten =
+        AuditLogFixtures.createRandomized(
+            b -> b.entityKey("456").processInstanceKey(processInstanceKey));
+    createAndSaveAuditLogs(rdbmsWriters, List.of(shouldNotBeOverwritten, shouldBeOverwritten));
+
+    final AuditLogQuery auditLogQuery =
+        AuditLogQuery.of(
+            b ->
+                b.filter(f -> f.processInstanceKeys(processInstanceKey))
+                    .page(p -> p.from(0).size(10)));
+    var searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .anySatisfy(
+            e -> {
+              assertThat(e.entityKey()).isEqualTo("123");
+              assertThat(e.historyCleanupDate().truncatedTo(ChronoUnit.SECONDS))
+                  .isEqualTo(alreadySetDate.truncatedTo(ChronoUnit.SECONDS));
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.entityKey()).isEqualTo("456");
+              assertThat(e.historyCleanupDate()).isNull();
+            });
+
+    // when
+    auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
+        List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+
+    // then
+    searchResult = auditLogReader.search(auditLogQuery);
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items())
+        .anySatisfy(
+            e -> {
+              assertThat(e.entityKey()).isEqualTo("123");
+              assertThat(e.historyCleanupDate().truncatedTo(ChronoUnit.SECONDS))
+                  .isEqualTo(alreadySetDate.truncatedTo(ChronoUnit.SECONDS));
+            })
+        .anySatisfy(
+            e -> {
+              assertThat(e.entityKey()).isEqualTo("456");
+              assertThat(e.historyCleanupDate()).isNotNull();
+            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class AuditLogIT {
 
   public static final int PARTITION_ID = 0;
+  private static final int LIMIT = 10000;
 
   @TestTemplate
   public void shouldGetAuditLogById(final CamundaRdbmsTestApplication testApplication) {
@@ -678,7 +679,7 @@ public class AuditLogIT {
 
     // when
     auditLogWriter.deleteProcessDefinitionRelatedData(
-        List.of(processDefinitionKey1, processDefinitionKey2), 1000);
+        List.of(processDefinitionKey1, processDefinitionKey2), LIMIT);
 
     // then
     searchResult =
@@ -690,7 +691,7 @@ public class AuditLogIT {
                                 f.processDefinitionKeys(
                                     processDefinitionKey1, processDefinitionKey2))
                         .sort(s -> s)
-                        .page(p -> p.from(0).size(1000))));
+                        .page(p -> p.from(0).size(LIMIT))));
     assertThat(searchResult).isNotNull();
     assertThat(searchResult.items()).isEmpty();
   }
@@ -713,7 +714,7 @@ public class AuditLogIT {
         AuditLogQuery.of(
             b ->
                 b.filter(f -> f.processInstanceKeys(processInstanceKey1, processInstanceKey2))
-                    .page(p -> p.from(0).size(1000)));
+                    .page(p -> p.from(0).size(LIMIT)));
     var searchResult = auditLogReader.search(auditLogQuery);
     assertThat(searchResult).isNotNull();
     assertThat(searchResult.items())
@@ -723,7 +724,7 @@ public class AuditLogIT {
 
     // when
     final int deleted =
-        auditLogWriter.deleteProcessInstanceRelatedData(List.of(processInstanceKey1), 1000);
+        auditLogWriter.deleteProcessInstanceRelatedData(List.of(processInstanceKey1), LIMIT);
 
     // then
     assertThat(deleted).isEqualTo(20);
@@ -772,7 +773,7 @@ public class AuditLogIT {
                         f ->
                             f.processInstanceKeys(
                                 processInstanceKey1, processInstanceKey2, processInstanceKey3))
-                    .page(p -> p.from(0).size(1000)));
+                    .page(p -> p.from(0).size(LIMIT)));
     var searchResult = auditLogReader.search(auditLogQuery);
     assertThat(searchResult).isNotNull();
     assertThat(searchResult.items())
@@ -786,7 +787,8 @@ public class AuditLogIT {
 
     // when
     final int deleted =
-        auditLogWriter.deleteRootProcessInstanceRelatedData(List.of(rootProcessInstanceKey2), 1000);
+        auditLogWriter.deleteRootProcessInstanceRelatedData(
+            List.of(rootProcessInstanceKey2), LIMIT);
 
     // then
     assertThat(deleted).isEqualTo(40);
@@ -833,7 +835,8 @@ public class AuditLogIT {
     // when
     auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
         List.of(processInstanceKey1, processInstanceKey2),
-        HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+        HistoryDeletionTypeDbModel.PROCESS_INSTANCE,
+        LIMIT);
 
     // then
     searchResult = auditLogReader.search(auditLogQuery);
@@ -872,7 +875,8 @@ public class AuditLogIT {
     // when
     auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
         List.of(processDefinitionKey1, processDefinitionKey2),
-        HistoryDeletionTypeDbModel.PROCESS_DEFINITION);
+        HistoryDeletionTypeDbModel.PROCESS_DEFINITION,
+        LIMIT);
 
     // then
     searchResult = auditLogReader.search(auditLogQuery);
@@ -911,7 +915,8 @@ public class AuditLogIT {
     // when
     auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
         List.of(decisionInstanceKey1, decisionInstanceKey2),
-        HistoryDeletionTypeDbModel.DECISION_INSTANCE);
+        HistoryDeletionTypeDbModel.DECISION_INSTANCE,
+        LIMIT);
 
     // then
     searchResult = auditLogReader.search(auditLogQuery);
@@ -920,7 +925,7 @@ public class AuditLogIT {
   }
 
   @TestTemplate
-  public void shouldSetCleanupDateForDecisionDefinitions(
+  public void shouldSetCleanupDateForDecisionRequirements(
       final CamundaRdbmsTestApplication testApplication) {
     // given
     final var decisionReqKey1 = nextKey();
@@ -950,7 +955,8 @@ public class AuditLogIT {
     // when
     auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
         List.of(decisionReqKey1, decisionReqKey2),
-        HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS);
+        HistoryDeletionTypeDbModel.DECISION_REQUIREMENTS,
+        LIMIT);
 
     // then
     searchResult = auditLogReader.search(auditLogQuery);
@@ -1003,7 +1009,7 @@ public class AuditLogIT {
 
     // when
     auditLogWriter.scheduleKeyRelatedAuditLogsHistoryCleanupTime(
-        List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+        List.of(processInstanceKey), HistoryDeletionTypeDbModel.PROCESS_INSTANCE, LIMIT);
 
     // then
     searchResult = auditLogReader.search(auditLogQuery);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuditLogEntityTransformer.java
@@ -51,7 +51,8 @@ public class AuditLogEntityTransformer
         value.getResourceKey(),
         mapEntityType(value.getRelatedEntityType()),
         value.getRelatedEntityKey(),
-        value.getEntityDescription());
+        value.getEntityDescription(),
+        null);
   }
 
   private AuditLogEntity.AuditLogEntityType mapEntityType(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -45,7 +45,8 @@ public record AuditLogEntity(
     Long resourceKey,
     AuditLogEntityType relatedEntityType,
     String relatedEntityKey,
-    String entityDescription)
+    String entityDescription,
+    OffsetDateTime historyCleanupDate)
     implements TenantOwnedEntity {
 
   @Override
@@ -87,6 +88,7 @@ public record AuditLogEntity(
     private AuditLogEntityType relatedEntityType;
     private String relatedEntityKey;
     private String entityDescription;
+    private OffsetDateTime historyCleanupDate;
 
     public Builder auditLogKey(final String auditLogKey) {
       this.auditLogKey = auditLogKey;
@@ -253,6 +255,11 @@ public record AuditLogEntity(
       return this;
     }
 
+    public Builder historyCleanupDate(final OffsetDateTime historyCleanupDate) {
+      this.historyCleanupDate = historyCleanupDate;
+      return this;
+    }
+
     @Override
     public AuditLogEntity build() {
       return new AuditLogEntity(
@@ -288,7 +295,8 @@ public record AuditLogEntity(
           resourceKey,
           relatedEntityType,
           relatedEntityKey,
-          entityDescription);
+          entityDescription,
+          historyCleanupDate);
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -194,7 +195,9 @@ public class ExporterConfiguration {
   }
 
   public RdbmsWriterConfig createRdbmsWriterConfig(
-      final int partitionId, final VendorDatabaseProperties vendorDatabaseProperties) {
+      final int partitionId,
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final InstantSource clock) {
     final var historyConfig =
         new HistoryConfig.Builder()
             .defaultHistoryTTL(history.getDefaultHistoryTTL())
@@ -226,6 +229,7 @@ public class ExporterConfiguration {
         .exportBatchOperationItemsOnCreation(exportBatchOperationItemsOnCreation)
         .history(historyConfig)
         .insertBatchingConfig(createInsertBatchingConfig(vendorDatabaseProperties))
+        .clock(clock)
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -108,7 +108,7 @@ public class RdbmsExporterWrapper implements Exporter {
 
     final int partitionId = context.getPartitionId();
     final var rdbmsWriterConfig =
-        config.createRdbmsWriterConfig(partitionId, vendorDatabaseProperties);
+        config.createRdbmsWriterConfig(partitionId, vendorDatabaseProperties, context.clock());
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(rdbmsWriterConfig);
 
     final var builder =

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.junit.jupiter.api.Test;
 
 class ExporterConfigurationTest {
@@ -426,7 +427,8 @@ class ExporterConfigurationTest {
     when(vendorProps.supportsInsertBatching()).thenReturn(false);
 
     // when
-    final var writerConfig = configuration.createRdbmsWriterConfig(1, vendorProps);
+    final var writerConfig =
+        configuration.createRdbmsWriterConfig(1, vendorProps, InstantSource.system());
 
     // then
     assertThat(writerConfig.insertBatchingConfig().variableInsertBatchSize()).isEqualTo(1);
@@ -448,7 +450,8 @@ class ExporterConfigurationTest {
     when(vendorProps.supportsInsertBatching()).thenReturn(true);
 
     // when
-    final var writerConfig = configuration.createRdbmsWriterConfig(1, vendorProps);
+    final var writerConfig =
+        configuration.createRdbmsWriterConfig(1, vendorProps, InstantSource.system());
 
     // then
     assertThat(writerConfig.insertBatchingConfig().variableInsertBatchSize()).isEqualTo(25);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Schedule related audit log data for deletion based on retention period if associated resources get deleted.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/45977
