### PR TITLE
Inherit business id from parent process instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -657,7 +657,7 @@ public final class BpmnStateTransitionBehavior {
   }
 
   public long createChildProcessInstance(
-      final DeployedProcess process, final BpmnElementContext context) {
+      final DeployedProcess process, final BpmnElementContext context, final String businessId) {
 
     final var processInstanceKey = keyGenerator.nextKey();
 
@@ -672,7 +672,8 @@ public final class BpmnStateTransitionBehavior {
         .setElementId(process.getProcess().getId())
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(context.getTenantId())
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setBusinessId(businessId);
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -97,8 +97,12 @@ public final class CallActivityProcessor
               final var activated =
                   stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
+              final var processIntance =
+                  stateBehavior.getElementInstance(context.getProcessInstanceKey());
+              final String businessId = processIntance.getValue().getBusinessId();
+
               final var childProcessInstanceKey =
-                  stateTransitionBehavior.createChildProcessInstance(process, context);
+                  stateTransitionBehavior.createChildProcessInstance(process, context, businessId);
 
               final var propagateAllParentVariablesEnabled =
                   element.isPropagateAllParentVariablesEnabled();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -97,9 +97,9 @@ public final class CallActivityProcessor
               final var activated =
                   stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
-              final var processIntance =
+              final var processInstance =
                   stateBehavior.getElementInstance(context.getProcessInstanceKey());
-              final String businessId = processIntance.getValue().getBusinessId();
+              final String businessId = processInstance.getValue().getBusinessId();
 
               final var childProcessInstanceKey =
                   stateTransitionBehavior.createChildProcessInstance(process, context, businessId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
-import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -215,7 +215,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .create();
 
     // then
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processInstanceCreationRecords()
                 .withIntent(ProcessInstanceCreationIntent.CREATED)
                 .withBpmnProcessId(processId)
@@ -259,7 +259,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .create();
 
     // then
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processInstanceCreationRecords()
                 .withIntent(ProcessInstanceCreationIntent.CREATED)
                 .withBpmnProcessId(processId)
@@ -300,7 +300,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .create();
 
     // then
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.processInstanceCreationRecords()
                 .withIntent(ProcessInstanceCreationIntent.CREATED)
                 .withBpmnProcessId(processId)
@@ -354,5 +354,52 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .describedAs(
             "Expect the called process instance to inherit the business id from the call activity instance")
         .hasBusinessId(businessId);
+  }
+
+  @Test
+  public void shouldAllowMultipleChildProcessInstancesWithSameBusinessId() {
+    final String parentProcessId = helper.getBpmnProcessId() + "_parent";
+    final String childProcessId = helper.getBpmnProcessId() + "_child";
+    final String businessId = "biz-123";
+
+    // given two processes:
+    // - parent process with a parallel gateway that creates two child instances in parallel
+    // - child process with a user task
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .parallelGateway("fork")
+                .callActivity("call1", c -> c.zeebeProcessId(childProcessId))
+                .endEvent()
+                .moveToLastGateway()
+                .callActivity("call2", c -> c.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var parentInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(parentProcessId)
+            .withBusinessId(businessId)
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(childProcessId)
+                .withParentProcessInstanceKey(parentInstanceKey)
+                .limit(2))
+        .describedAs("Expect two active child instances with the same business id")
+        .allSatisfy(r -> assertThat(r.getValue()).hasBusinessId(businessId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -337,7 +337,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .deploy();
 
     // when
-    final var callActivityInstanceKey =
+    final var parentProcessInstanceKey =
         ENGINE
             .processInstance()
             .ofBpmnProcessId(processWithCallActivityId)
@@ -348,7 +348,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withBpmnProcessId(processUnderTestId)
-                .withParentProcessInstanceKey(callActivityInstanceKey)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
                 .getFirst()
                 .getValue())
         .describedAs(


### PR DESCRIPTION
## Description

When a parent process instance has a business ID and activates a call activity, the newly created child process instance now inherits that business ID.

This allows operators and monitoring tools to correlate all process instances belonging to the same business case — across both root and child instances.

**Note on uniqueness:**
The existing business ID uniqueness check applies only to **root** process instances, not child instances. This is intentional: business ID is a business-case identifier meant to prevent duplicate root business cases. Extending uniqueness enforcement to child instances would:
- Mix "business case" semantics with "execution detail" semantics.
- Break common fan-out patterns where a single business case legitimately spawns multiple child workflows that all reference the same business entity (e.g., multiple parallel call activities, multiple payments or follow-up tasks referencing the same checkout or claim).

**Changes:**
- `CallActivityProcessor`: Reads the business ID from the current process instance and passes it along when creating the child process instance.
- `BpmnStateTransitionBehavior`: Extended `createChildProcessInstance` to accept and forward a `businessId`, which is set on the child instance record.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44980