### PR TITLE
refactor: reroute load tests to new cluster infra (backport)

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -314,7 +314,7 @@ jobs:
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set global.image.pullSecrets[0].name=harbor-registry
           --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
-          --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
+          --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }}
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -290,6 +290,11 @@ jobs:
       - name: Label namespace with registry
         run: >
           kubectl label namespace ${{ env.NAMESPACE }} registry=harbor --overwrite
+      - name: Annotate namespace with workflow run URL
+        run: >
+          kubectl annotate namespace ${{ env.NAMESPACE }}
+          "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --overwrite
       - name: Add Camunda Helm repo
         run: |
           helm repo add camunda https://helm.camunda.io/
@@ -307,8 +312,9 @@ jobs:
           --reset-then-reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set global.image.repository=${{ env.IMAGE_REPOSITORY }}
           --set global.image.pullSecrets[0].name=harbor-registry
+          --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}
+          --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/zeebe' }}
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -5,6 +5,13 @@
 # called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
 # type: CI
 # owner: camunda/orchestration-cluster-team
+#
+# Infos from Infra:
+# - Using the infra benchmark prod cluster requires to use Teleport to authenticate.
+# - Camunda images are pushed to registry.camunda.cloud/team-zeebe and pulled from there.
+#   To use them in a namespace, the namespace must be labeled with "registry=harbor"
+#   You must also set the image pull secret to "harbor-registry" in the helm values.
+
 name: Camunda load test
 on:
   workflow_dispatch:
@@ -102,7 +109,11 @@ on:
         default: false
 
 env:
+  CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe  # change this to "infra-benchmark-dev-github-action-zeebe" when experimenting
   HELM_CHART: camunda-platform-8.8
+  NAMESPACE: c8-${{ inputs.name }}
+  IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
 
 defaults:
   run:
@@ -141,6 +152,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
@@ -168,22 +180,10 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -P\!include-optimize
-      - uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: 'gcr.io/zeebe-io/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/zeebe'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}
@@ -215,30 +215,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GAR
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -P\!include-optimize -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="gcr.io/zeebe-io/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Build Worker Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="gcr.io/zeebe-io/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -P\!include-optimize -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ needs.calculate-image-tag.outputs.image-tag }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -271,31 +259,37 @@ jobs:
         with:
           repository: 'camunda/camunda-platform-helm'
           ref: 'main'
-      - uses: google-github-actions/auth@v2
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Create namespace if not exists
         run: |
-          if ! kubectl get namespace ${{ inputs.name }} >/dev/null 2>&1; then
-            kubectl create namespace ${{ inputs.name }}
+          if ! kubectl get namespace ${{ env.NAMESPACE }} >/dev/null 2>&1; then
+            kubectl create namespace ${{ env.NAMESPACE }}
           else
-            echo "Namespace '${{ inputs.name }}' already exists"
+            echo "Namespace '${{ env.NAMESPACE }}' already exists"
           fi
       - name: Label namespace with creator
         run: >
-          kubectl label namespace ${{ inputs.name }} created-by=${{ github.actor }} --overwrite
+          kubectl label namespace ${{ env.NAMESPACE }} created-by=${{ github.actor }} --overwrite
       - name: Label namespace with deadline
         run: |
           # Calculate deadline date with the TTL days from now
           # Use basic ISO date format (YYYY-MM-DD), as it is compatible with kubectl label values
           # Must use minus (-) instead of / to be compatible with kubectl label value restrictions
           deadlineDate=$(date -d "+${{ inputs.ttl }} days" +%Y-%m-%d)
-          kubectl label namespace ${{ inputs.name }} deadline-date="$deadlineDate" --overwrite
+          kubectl label namespace ${{ env.NAMESPACE }} deadline-date="$deadlineDate" --overwrite
+      - name: Label namespace with registry
+        run: >
+          kubectl label namespace ${{ env.NAMESPACE }} registry=harbor --overwrite
       - name: Add Camunda Helm repo
         run: |
           helm repo add camunda https://helm.camunda.io/
@@ -308,13 +302,13 @@ jobs:
         run: helm dependency build charts/${{ env.HELM_CHART }}/
       - name: Install latest Camunda Platform
         run: >
-          helm upgrade --install ${{ inputs.name }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
-          --namespace ${{ inputs.name }}
+          helm upgrade --install ${{ env.NAMESPACE }} charts/${{ env.HELM_CHART }}/ --wait --timeout 35m0s
+          --namespace ${{ env.NAMESPACE }}
           --reset-then-reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set orchestration.image.registry=${{ inputs.use-official-docker-images && 'docker.io' || 'gcr.io' }}
-          --set orchestration.image.repository=${{ inputs.use-official-docker-images && 'camunda/camunda' || 'zeebe-io/zeebe' }}
+          --set global.image.repository=${{ env.IMAGE_REPOSITORY }}
+          --set global.image.pullSecrets[0].name=harbor-registry
           --set orchestration.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
@@ -327,7 +321,7 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             ## Camunda platform \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }} -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }} -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status
@@ -363,14 +357,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: google-github-actions/auth@v2
+      # Authenticate with Teleport
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Add Load test Helm repo
         run: |
           helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-helm/
@@ -378,23 +375,25 @@ jobs:
       - name: Find previous Helm chart release version
         id: find-chart-release
         run: |
-          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ env.NAMESPACE }} ${{ env.NAMESPACE }}-test | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Install load test
         run: >
-          helm upgrade --install ${{ inputs.name }}-test camunda-load-tests/camunda-load-tests
+          helm upgrade --install ${{ env.NAMESPACE }}-test camunda-load-tests/camunda-load-tests
           --wait --timeout 35m0s
-          --namespace ${{ inputs.name }}
+          --namespace ${{ env.NAMESPACE }}
           --reuse-values
           --render-subchart-notes
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set global.image.repository=${{ env.IMAGE_REPOSITORY }}
+          --set global.image.pullSecrets[0].name=harbor-registry
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.realistic && '-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml' || '' }}
           ${{ inputs.load-test-load }}
       - name: Setup leader balancing
         run: |
-          if ! kubectl get cronjob leader-balancer --namespace ${{ inputs.name }} &>/dev/null; then
+          if ! kubectl get cronjob leader-balancer --namespace ${{ env.NAMESPACE }} &>/dev/null; then
             kubectl create cronjob leader-balancer \
-              --namespace ${{ inputs.name }} \
+              --namespace ${{ env.NAMESPACE }} \
               --image=curlimages/curl:7.87.0 \
               --schedule="*/10 * * * *" \
               -- curl -L -v -X POST http://camunda:9600/actuator/rebalance
@@ -406,10 +405,10 @@ jobs:
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
             # Load test
-            The test has been set up successfully. You can observe it [here](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?var-namespace=${{ inputs.name }})
+            The test has been set up successfully. You can observe it [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})
             ## Load test \`${{ inputs.name }}\` values
             \`\`\`yaml
-            $(helm get values ${{ inputs.name }}-test -n ${{ inputs.name }})
+            $(helm get values ${{ env.NAMESPACE }}-test -n ${{ env.NAMESPACE }})
             \`\`\`
           EOF
       - name: Observe build status

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         name: Build Camunda Docker Image
         with:
-          repository: '${{ env.IMAGE_REPOSITORY }}/zeebe'
+          repository: '${{ env.IMAGE_REPOSITORY }}/camunda'
           revision: ${{ inputs.ref }}
           push: true
           version: ${{ needs.calculate-image-tag.outputs.image-tag }}

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -114,7 +114,7 @@ jobs:
           job_name: "smoke-tests/${{ matrix.os }}-${{ matrix.arch }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          user_description: "team-distributed-systems"
+          user_description: "team-reliability-testing"
           detailed_junit_tests: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}  # feature only supported on Linux for now
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
@@ -457,44 +457,35 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           user_description: "team-distributed-systems"
 
-  deploy-benchmark-images:
-    name: Deploy benchmark images
+  deploy-load-test-images:
+    name: Deploy load test images
     timeout-minutes: 5
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
-      group: deploy-benchmark-images
+      group: deploy-load-test-images
       cancel-in-progress: false
     permissions:
       contents: 'read'
       id-token: 'write'
+    env:
+      IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
     steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
+          harbor: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
       - run: ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:SNAPSHOT"
       - name: Build Worker Image
-        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:SNAPSHOT"
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -12,6 +12,11 @@ on:
         description: 'Specifies the pod name of the load test to profile. Please only specify the suffix like zeebe-0, or zeebe-1, etc.'
         default: 'zeebe-0'
         required: false
+
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
 jobs:
   profile-load-test:
     name: Async profiling running load test
@@ -21,15 +26,17 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
+      - uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: 'zeebe-cluster'
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Set right namespace
         run: |
           kubectl config set-context --current --namespace=${{ inputs.name }}

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -10,6 +10,10 @@ on:
       - synchronize
       - closed
 
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
 jobs:
   create-benchmark:
     name: Benchmark
@@ -32,14 +36,18 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: google-github-actions/auth@v2
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
         with:
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - uses: google-github-actions/get-gke-credentials@v2.3.5
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
         with:
-          cluster_name: zeebe-cluster
-          location: europe-west1-b
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
       - name: Delete benchmarks
         env:
           PR_HEAD_REF: ${{github.event.pull_request.head.ref}}

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -15,13 +15,14 @@ global:
     enabled: false
   image:
     # Image.repository defines the repository from which to fetch the docker images
-    repository: "gcr.io/zeebe-io"
+    repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
     tag: SNAPSHOT
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: []
+    pullSecrets:
+      - name: harbor-registry
   # By default, we run without Identity
   identity:
     auth:
@@ -58,6 +59,8 @@ orchestration:
   # This means we will have pods like: camunda-0, camunda-1, camunda-2
   fullnameOverride: camunda
   image:
+    registry: registry.camunda.cloud
+    repository: team-zeebe/zeebe
     tag: "SNAPSHOT"
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -80,6 +83,12 @@ orchestration:
 
   nodeSelector:
     cloud.google.com/gke-nodepool: n2-standard-4
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
   ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "64Gi"

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -228,5 +228,12 @@ elasticsearch:
       limits:
         cpu: 3
         memory: 6Gi
+    nodeSelector:
+      cloud.google.com/gke-nodepool: n2-standard-4
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-4
+        effect: NoSchedule
   extraConfig:
     logger.org.elasticsearch.deprecation: "OFF"

--- a/zeebe/benchmarks/setup/default/Makefile
+++ b/zeebe/benchmarks/setup/default/Makefile
@@ -5,7 +5,7 @@ all: benchmark
 
 .PHONY: benchmark
 benchmark:
-	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds
+	helm install --namespace $(namespace) $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-preemptible.yaml --skip-crds
 
 # To deploy the Zeebe pods on stable nodes, use this job
 .PHONY: benchmark-stable
@@ -16,7 +16,7 @@ benchmark-stable:
 # To apply the templates use k apply -f zeebe-benchmark/templates/
 .PHONY: template
 template:
-	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml --skip-crds --output-dir .
+	helm template $(namespace) zeebe-benchmark/zeebe-benchmark -f values.yaml -f values-preemptible.yaml --skip-crds --output-dir .
 
 .PHONY: template-stable
 template-stable:

--- a/zeebe/benchmarks/setup/default/values-preemptible.yaml
+++ b/zeebe/benchmarks/setup/default/values-preemptible.yaml
@@ -1,13 +1,13 @@
-# Additional values file to run Zeebe on stable VMs
+# Additional values file to run Zeebe on preemptible/spot VMs
 # https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
 orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node
   # However, that node does not have the required cpu/memory capacity
   nodeSelector:
-    cloud.google.com/gke-nodepool: n2-standard-4-stable
+    cloud.google.com/gke-nodepool: n2-standard-4
 
   tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-4-stable
+    value: n2-standard-4
     effect: NoSchedule


### PR DESCRIPTION
## Description

Backport of #42549 to `stable/8.8`. Migrates load test infrastructure from the old GKE-based `zeebe-cluster` to the new Teleport-based `camunda-benchmark-prod` cluster.

### Key changes

- **Authentication:** Replaced Google Cloud Workload Identity (`google-github-actions/auth` + `get-gke-credentials`) with Teleport (`teleport-actions/setup@v1` + `teleport-actions/auth-k8s@v2`)
- **Image registry:** Switched from `gcr.io/zeebe-io` to `registry.camunda.cloud/team-zeebe` (Harbor), with `harbor-registry` pull secret and `registry=harbor` namespace label
- **Namespace convention:** Added `c8-` prefix to all load test namespaces
- **Grafana URL:** Updated from `grafana.dev.zeebe.io` to `dashboard.benchmark.camunda.cloud`
- **Node scheduling:** Added tolerations for the new cluster's node taints, created `values-preemptible.yaml` for spot VM scheduling

### Files changed

- `.github/workflows/camunda-load-test.yml` — Teleport auth, Harbor registry, `c8-` namespace prefix
- `zeebe/benchmarks/camunda-platform-values.yaml` — Harbor registry + pull secrets, orchestration image config, tolerations
- `zeebe/benchmarks/setup/default/values-stable.yaml` — Updated tolerations for new cluster
- `zeebe/benchmarks/setup/default/values-preemptible.yaml` — New file for spot VM node scheduling
- `zeebe/benchmarks/setup/default/Makefile` — Added `-f values-preemptible.yaml` to default targets

### 8.8-specific adaptations (vs main)

- Kept orchestration CPU at 2000m (main uses 3400m)
- Uses `actions/checkout@v4` (main uses `@v6`)
- Uses `camunda-platform-8.8` helm chart (main uses `8.9`)
- Paths use `zeebe/benchmarks/project` (main uses `load-tests/load-tester`)
- `zeebe-benchmark.yml` and `zeebe-pr-benchmark.yaml` were **not** modified (out of scope for this backport)

## Related issues

Backport of #42549
