### PR TITLE
Clarify FAILED state in V2 Task API as legacy/job-worker-based only

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/UserTaskState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/UserTaskState.java
@@ -24,6 +24,10 @@ public enum UserTaskState {
   COMPLETED,
   CANCELING,
   CANCELED,
+  /**
+   * The FAILED state is only applicable to legacy, job-worker-based user tasks. Native Camunda User
+   * Tasks (non-job-worker-based) do not reach this state.
+   */
   FAILED,
   UNKNOWN_ENUM_VALUE;
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -528,6 +528,10 @@ public class UserTaskDbModel implements Copyable<UserTaskDbModel> {
     COMPLETED,
     CANCELING,
     CANCELED,
+    /**
+     * The FAILED state is only applicable to legacy, job-worker-based user tasks. Native Camunda
+     * User Tasks (non-job-worker-based) do not reach this state.
+     */
     FAILED
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskResponse.java
@@ -43,7 +43,10 @@ public class TaskResponse {
   @Schema(description = "The username/id of who is assigned to the task.")
   private String assignee;
 
-  @Schema(description = "The state of the task.", accessMode = AccessMode.READ_ONLY)
+  @Schema(
+      description =
+          "The state of the task. Note: FAILED state is only for legacy job-worker-based tasks.",
+      accessMode = AccessMode.READ_ONLY)
   private TaskState taskState;
 
   @Schema(description = "Reference to the task form.")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchRequest.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchRequest.java
@@ -24,7 +24,9 @@ import java.util.Objects;
 @Schema(description = "Request object to search tasks by provided params.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TaskSearchRequest {
-  @Schema(description = "The state of the tasks.")
+  @Schema(
+      description =
+          "The state of the tasks. Note: FAILED state is only for legacy job-worker-based tasks.")
   private TaskState state;
 
   @Schema(description = "Are the tasks assigned?")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchResponse.java
@@ -42,7 +42,9 @@ public class TaskSearchResponse {
   @Schema(description = "The username/id of who is assigned to the task.")
   private String assignee;
 
-  @Schema(description = "The state of the task.")
+  @Schema(
+      description =
+          "The state of the task. Note: FAILED state is only for legacy job-worker-based tasks.")
   private TaskState taskState;
 
   @ArraySchema(

--- a/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertUserTask/UserTaskState.java
+++ b/testing/camunda-process-test-dsl/src/main/java/io/camunda/process/test/api/dsl/instructions/assertUserTask/UserTaskState.java
@@ -20,5 +20,9 @@ public enum UserTaskState {
   IS_CREATED,
   IS_COMPLETED,
   IS_CANCELED,
+  /**
+   * The FAILED state is only applicable to legacy, job-worker-based user tasks. Native Camunda User
+   * Tasks (non-job-worker-based) do not reach this state.
+   */
   IS_FAILED
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskState.java
@@ -16,5 +16,9 @@ public enum TaskState {
   COMPLETED,
   CANCELING,
   CANCELED,
+  /**
+   * The FAILED state is only applicable to legacy, job-worker-based user tasks. Native Camunda User
+   * Tasks (non-job-worker-based) do not reach this state.
+   */
   FAILED
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -758,7 +758,9 @@ components:
     ## Enums
 
     UserTaskStateEnum:
-      description: The state of the user task.
+      description: |
+        The state of the user task.
+        Note: FAILED state is only for legacy job-worker-based tasks.
       type: string
       enum:
         - CREATING


### PR DESCRIPTION
## Description

Added clarifications that the FAILED state (in V2 Task API) is only applicable to legacy (job-worker-based) user tasks.

## Checklist

## Related issues

closes #42698
