### PR TITLE
perf: do not copy RecordMetadata when acquire on the sequencer fails

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.FlowControlKeyNames;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.FlowControlOutcome;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetricsDoc.RecordAppendedKeyNames;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
-import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.log.WriteContext.InterPartition;
 import io.camunda.zeebe.logstreams.log.WriteContext.Internal;
@@ -148,8 +147,7 @@ public final class LogStreamMetrics {
         .increment(amount);
   }
 
-  public void flowControlAccepted(
-      final WriteContext context, final LogAppendEntryMetadata batchMetadata) {
+  public void flowControlAccepted(final WriteContext context, final int size) {
     triedAppends.increment();
 
     if (context instanceof UserCommand) {
@@ -161,13 +159,11 @@ public final class LogStreamMetrics {
             tagForContext(context),
             FlowControlOutcome.ACCEPTED,
             this::registerFlowControlOutcomeCounter)
-        .increment(batchMetadata.size());
+        .increment(size);
   }
 
   public void flowControlRejected(
-      final WriteContext context,
-      final LogAppendEntryMetadata batchMetadata,
-      final Rejection reason) {
+      final WriteContext context, final int size, final Rejection reason) {
     triedAppends.increment();
     deferredAppends.increment();
 
@@ -181,7 +177,7 @@ public final class LogStreamMetrics {
             tagForContext(context),
             tagForRejection(reason),
             this::registerFlowControlOutcomeCounter)
-        .increment(batchMetadata.size());
+        .increment(size);
   }
 
   public void setExportingRate(final long value) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
-import static io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata.copyMetadata;
 import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.FRAME_ALIGNMENT;
 import static io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializer.calculateBatchLength;
 
@@ -94,7 +93,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
       }
     }
     final InFlightEntry inFlightEntry;
-    switch (flowControl.tryAcquire(context, copyMetadata(appendEntries))) {
+    switch (flowControl.tryAcquire(context, appendEntries)) {
       case Either.Left<Rejection, InFlightEntry>(final var rejected) -> {
         return switch (rejected) {
           case RequestLimitExhausted -> Either.left(WriteFailure.REQUEST_LIMIT_EXHAUSTED);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit.Throttling;
-import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.log.WriteContext.UserCommand;
@@ -107,14 +106,13 @@ public class FlowControlTest {
             i ->
                 flowControl.tryAcquire(
                     writeContext,
-                    LogAppendEntryMetadata.copyMetadata(
-                        List.of(
-                            LogAppendEntry.of(
-                                new RecordMetadata()
-                                    .recordType(RecordType.COMMAND)
-                                    .valueType(valueType)
-                                    .intent(intent),
-                                new UnifiedRecordValue(0))))))
+                    List.of(
+                        LogAppendEntry.of(
+                            new RecordMetadata()
+                                .recordType(RecordType.COMMAND)
+                                .valueType(valueType)
+                                .intent(intent),
+                            new UnifiedRecordValue(0)))))
         .toList();
   }
 }


### PR DESCRIPTION
## Description
Even though this has been recently optimized, it still appears in the profiler when the cluster is under heavy backpressure. I think this is caused by the StreamProcessor trying to write continuously to the sequencer, without being able to persist the entire batch. This is done in an actor "yield loop", so it can be retried quite frequently

I noticed this becasue after the first optimization the `Sequencer` stack was gone. After a week or so we migrated the daily tests to `max` throughput which makes backpressure always around 40-60%


A recent profiler run is [this](https://github.com/camunda/camunda/pull/45515#issuecomment-3928671371)
 (even though it's using agrona 2.0)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
