### PR TITLE
fix: Fix shouldApplyOptimizeModeFilterWhenOptimizeModeEnabled flaky test

### DIFF
--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -317,6 +317,7 @@ final class DefaultRecordFilterTest {
     final Record<?> jobRecord = (Record<?>) mock(Record.class);
     when(jobRecord.getRecordType()).thenReturn(RecordType.EVENT);
     when(jobRecord.getValueType()).thenReturn(ValueType.JOB);
+    when(jobRecord.getBrokerVersion()).thenReturn("8.9.0");
 
     // when / then
     assertThat(filter.acceptRecord(jobRecord))


### PR DESCRIPTION
Fix shouldApplyOptimizeModeFilterWhenOptimizeModeEnabled flaky test
It was missing the record version in the mock response

## Related issues

closes # https://github.com/camunda/camunda/issues/46263
