### PR TITLE
ci: add Spectral rule to enforce that members of required array exist as properties in schema. fixes #46272

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -6,6 +6,7 @@ functions:
   - verifyKeyTypesPaths
   - verifyKeyTypesSchemas
   - verifyEventuallyConsistent
+  - verifyRequiredPropertiesExist
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -104,6 +105,13 @@ rules:
       function: verifyKeyTypesSchemas
     message: Make the `...Key` property a `string`.
   
+  required-properties-must-exist:
+    description: "Every entry in `required` must match a key in `properties`."
+    severity: error
+    given: "$.components.schemas[*]"
+    then:
+      function: verifyRequiredPropertiesExist
+
   no-eventually-consistent-on-commands:
     description: "Command (mutating) operations must not have x-eventually-consistent: true."
     severity: error

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -17,6 +17,7 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
   - Property description requirements
   - Key property type validation (`...Key` properties must be strings)
   - Eventually-consistent annotation validation (command operations must not be marked as eventually consistent)
+  - Required property existence validation (entries in required array must exist in properties)
 
 ## Running Validation Locally
 

--- a/zeebe/gateway-protocol/spectral-functions/verifyRequiredPropertiesExist.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyRequiredPropertiesExist.js
@@ -1,0 +1,48 @@
+// Spectral custom function to verify that every entry in a schema's `required`
+// array corresponds to a key in its `properties` object or in an `allOf` composed schema.
+
+module.exports = (input, _opts, context) => {
+  const errors = [];
+
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const { required, properties, allOf } = input;
+
+  if (!Array.isArray(required)) {
+    return [];
+  }
+
+  // Collect property names from local properties and allOf composed schemas (recursive)
+  const propertyNames = new Set();
+
+  function collectProperties(schema) {
+    if (!schema || typeof schema !== 'object') return;
+    if (schema.properties && typeof schema.properties === 'object') {
+      Object.keys(schema.properties).forEach((name) => propertyNames.add(name));
+    }
+    if (Array.isArray(schema.allOf)) {
+      for (const subSchema of schema.allOf) {
+        collectProperties(subSchema);
+      }
+    }
+  }
+
+  collectProperties(input);
+
+  if (propertyNames.size === 0) {
+    return [];
+  }
+
+  required.forEach((name, index) => {
+    if (!propertyNames.has(name)) {
+      errors.push({
+        message: `\`${name}\` is listed in \`required\` but does not exist in \`properties\`.`,
+        path: [...context.path, 'required', index],
+      });
+    }
+  });
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-functions/verifyRequiredPropertiesExist.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyRequiredPropertiesExist.js
@@ -38,7 +38,7 @@ module.exports = (input, _opts, context) => {
   required.forEach((name, index) => {
     if (!propertyNames.has(name)) {
       errors.push({
-        message: `\`${name}\` is listed in \`required\` but does not exist in \`properties\`.`,
+        message: `\`${name}\` is listed in \`required\` but does not exist in \`properties\` or \`allOf\` compositions.`,
         path: [...context.path, 'required', index],
       });
     }


### PR DESCRIPTION
## Description

This adds a Spectral rule that enforces that properties specified in the `required` array exist in the schema. 

This is not caught by Spectral's `oas3-schema` validation. 

I have caught two bugs with this already: 

1. A typo that I made in the required array entry name (this is what motivated me to validate that our linting catches this). 
2. After running this rule on main, a defect in the spec introduced where the property in the `required` array simply did not exist. (I patched it and tagged the schema author for review).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46272
