### PR TITLE
ci: add second-pass with file glob for Spectral lint. Fixes #46274

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,14 +1302,22 @@ jobs:
       - name: Install Spectral CLI
         run: npm install -g "@stoplight/spectral-cli@${SPECTRAL_VERSION}"
         shell: bash
-      - name: Run OpenAPI Linter (Spectral)
+      - name: Run OpenAPI Linter (Structural pass)
         # Spectral provides comprehensive OpenAPI validation including:
         # - Schema structure validation (catches issues like required: false at property level)
-        # - Custom business rules (flow node terminology, key properties, descriptions)
         # - x-eventually-consistent annotation correctness (command operations must not be marked eventually consistent)
         # - Works correctly with multi-part specs using external $ref
         run: >
           spectral lint zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+          --ruleset zeebe/gateway-protocol/.spectral.yaml
+          --fail-severity error
+        shell: bash
+      - name: Run OpenAPI Linter (File-level pass)
+        # - Custom business rules (flow node terminology, key properties, descriptions)
+        # This requires a different invocation to the structural pass: glob, to run per-file. 
+        # See: https://github.com/camunda/camunda/issues/46274
+        run: >
+          spectral lint "zeebe/gateway-protocol/src/main/proto/v2/*.yaml"
           --ruleset zeebe/gateway-protocol/.spectral.yaml
           --fail-severity error
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,7 +1314,7 @@ jobs:
         shell: bash
       - name: Run OpenAPI Linter (File-level pass)
         # - Custom business rules (flow node terminology, key properties, descriptions)
-        # This requires a different invocation to the structural pass: glob, to run per-file. 
+        # This requires a different invocation to the structural pass: glob, to run per-file.
         # See: https://github.com/camunda/camunda/issues/46274
         run: >
           spectral lint "zeebe/gateway-protocol/src/main/proto/v2/*.yaml"


### PR DESCRIPTION
## Description

This PR adds a second pass of the Spectral linter over the OpenAPI spec. One pass is insufficient — it correctly traverses the schema and detects structural issues, but with a multi-part spec it does not correctly fire custom schema rules due to the schema resolution. 

Running a second pass in file glob mode doesn't do structural checking but does fire the custom rules. 

Thus: two passes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46274
