### PR TITLE
ci: use the built Tasklist image in docker tests

### DIFF
--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -376,6 +376,8 @@ jobs:
     env:
       TEST_TYPE: Integration
       TEST_OWNER: Core Features
+      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
+      TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
     services:
       registry:
         image: registry:3
@@ -402,13 +404,23 @@ jobs:
           maven-extra-args: -D skip.fe.build -D skipOptimize
       - uses: ./.github/actions/build-platform-docker
         with:
-          repository: localhost:5000/camunda/tasklist
-          version: current-test
+          repository: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
+          version: ${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }}
           push: true
           distball: ${{ steps.build-backend.outputs.distball }}
           dockerfile: tasklist.Dockerfile
       - name: Run Docker tests
-        run: ./mvnw --no-snapshot-updates -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+        run: |
+          ./mvnw \
+            --no-snapshot-updates \
+            -pl tasklist/qa/integration-tests \
+            -DskipChecks \
+            -Dtest=StartupIT \
+            -Dsurefire.failIfNoSpecifiedTests=false \
+            -Dspring.profiles.active=docker-test \
+            -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }} \
+            -Dtasklist.currentVersion.docker.repo=${{ env.TASKLIST_TEST_DOCKER_IMAGE }} \
+            test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -20,6 +20,9 @@ jobs:
         image: registry:3
         ports:
           - 5000:5000
+    env:
+      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
+      TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
     steps:
       - uses: actions/checkout@v6
       - uses: hadolint/hadolint-action@v3.3.0
@@ -39,13 +42,23 @@ jobs:
           maven-extra-args: -D skip.fe.build -D skipOptimize
       - uses: ./.github/actions/build-platform-docker
         with:
-          repository: localhost:5000/camunda/tasklist
-          version: current-test
+          repository: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
+          version: ${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }}
           push: true
           distball: ${{ steps.build-backend.outputs.distball }}
           dockerfile: tasklist.Dockerfile
       - name: Run Docker tests
-        run: ./mvnw --no-snapshot-updates -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+        run: |
+          ./mvnw \
+            --no-snapshot-updates \
+            -pl tasklist/qa/integration-tests \
+            -DskipChecks \
+            -Dtest=StartupIT \
+            -Dsurefire.failIfNoSpecifiedTests=false \
+            -Dspring.profiles.active=docker-test \
+            -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }} \
+            -Dtasklist.currentVersion.docker.repo=${{ env.TASKLIST_TEST_DOCKER_IMAGE }} \
+            test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The test was using the SNAPSHOT image instead of the built image

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
