### PR TITLE
fix: Possible fix for the token timeout, making build faster

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -89,7 +89,7 @@ jobs:
   # - When both flags are active, dryRun takes precedence over releaseProcessDryRun
   release:
     name: Maven Release
-    runs-on: gcp-core-16-release
+    runs-on: gcp-core-32-release
     outputs:
       releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}


### PR DESCRIPTION
## Description

Possible quick fix for the [build running too long](https://github.com/camunda/camunda/actions/runs/22185761643/job/64170090127#step:18:1), causing the [token to be expired](https://github.com/actions/create-github-app-token/issues/121) and failing the release process

