### PR TITLE
ci: benchmark rdbms label

### DIFF
--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -104,3 +104,49 @@ jobs:
       cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
       teleport-join-token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
 
+  delete-benchmark:
+    name: Benchmark Cleanup
+    needs: sanitize-branch-name
+    if: >
+      (github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) ||
+      (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
+          kubernetes-cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
+      - name: Delete benchmark namespace
+        if: >
+          github.event.action == 'closed' ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
+        run: |
+          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
+      - name: Delete RDBMS benchmark namespace
+        if: >
+          github.event.action == 'closed' ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark-rdbms')
+        run: |
+          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}" --ignore-not-found
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -131,13 +131,13 @@ jobs:
       - name: Delete benchmark namespace
         if: >
           github.event.action == 'closed' ||
-          (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'benchmark'))
+          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
         run: |
           kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
       - name: Delete RDBMS benchmark namespace
         if: >
           github.event.action == 'closed' ||
-          (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
+          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark-rdbms' && contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
         run: |
           kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}" --ignore-not-found
       - name: Observe build status

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -29,6 +29,8 @@ jobs:
     outputs:
       sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
       sanitized-name-rdbms: c8-${{ steps.sanitize.outputs.branch_name }}-rdbms
+      cluster: ${{ env.CLUSTER }}
+      teleport-join-token: ${{ env.TELEPORT_JOIN_TOKEN }}
     steps:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
@@ -84,6 +86,8 @@ jobs:
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
       benchmark-label: 'Elasticsearch'
+      cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
+      teleport-join-token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
 
   profile-and-comment-rdbms:
     name: Profile and Comment RDBMS
@@ -97,43 +101,6 @@ jobs:
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}
       benchmark-label: 'RDBMS'
+      cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
+      teleport-join-token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
 
-  delete-benchmark:
-    name: Benchmark Cleanup
-    needs: sanitize-branch-name
-    if: >
-      (github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) ||
-      (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms')))
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Set up Teleport
-        uses: teleport-actions/setup@v1
-        with:
-          version: 17.2.2
-
-      - name: Authenticate to Cluster using Teleport
-        uses: teleport-actions/auth-k8s@v2
-        with:
-          proxy: camunda.teleport.sh:443
-          token: ${{ env.TELEPORT_JOIN_TOKEN }}
-          kubernetes-cluster: ${{ env.CLUSTER }}
-
-      - name: Delete benchmarks
-        run: |
-          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
-          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}" --ignore-not-found
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -47,9 +47,7 @@ jobs:
   create-benchmark:
     name: Benchmark
     needs: sanitize-branch-name
-    if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+    if: contains(fromJSON('["labeled", "synchronize"]'), github.event.action) && contains(github.event.pull_request.labels.*.name, 'benchmark')
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
@@ -57,12 +55,24 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
       scenario: 'max'
 
+  create-benchmark-rdbms:
+    name: Benchmark
+    needs: sanitize-branch-name
+    if: contains(fromJSON('["labeled", "synchronize"]'), github.event.action) && contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms')
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      ref: ${{ github.event.pull_request.head.ref }}
+      scenario: 'max'
+      secondary-storage-type: 'postgresql'
+
   await-benchmark:
     name: Await Benchmark
     needs: [sanitize-branch-name, create-benchmark]
     if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+      contains(fromJSON('["labeled", "synchronize"]'), github.event.action) &&
+      (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -28,6 +28,7 @@ jobs:
     permissions: {}
     outputs:
       sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
+      sanitized-name-rdbms: c8-${{ steps.sanitize.outputs.branch_name }}-rdbms
     steps:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
@@ -66,120 +67,36 @@ jobs:
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}
       ref: ${{ github.event.pull_request.head.ref }}
       scenario: 'max'
       secondary-storage-type: 'postgresql'
 
-  await-benchmark:
-    name: Await Benchmark
-    needs: [sanitize-branch-name,create-benchmark, create-benchmark-rdbms]
+  profile-and-comment:
+    name: Profile and Comment
+    needs: [sanitize-branch-name, create-benchmark]
     if: >
       always() &&
-      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
-      (needs.create-benchmark.result == 'success' || needs.create-benchmark-rdbms.result == 'success')
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions: {}
-    steps:
-      - name: Wait for load test to stabilize
-        run: sleep 900  # 15 minutes
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  run-profiling:
-    name: Run Profiling
-    needs: [sanitize-branch-name, await-benchmark]
-    if: >
-      always() &&
-      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
-      needs.await-benchmark.result == 'success'
-    uses: ./.github/workflows/profile-load-test.yml
+      !(github.event.action == 'unlabeled' && github.event.label.name == 'benchmark') &&
+      needs.create-benchmark.result == 'success'
+    uses: ./.github/workflows/profile-benchmark.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      pod: ''
+      benchmark-label: 'Elasticsearch'
 
-  comment-pr:
-    name: Comment on PR with profiling results
-    needs: [sanitize-branch-name, run-profiling]
+  profile-and-comment-rdbms:
+    name: Profile and Comment RDBMS
+    needs: [sanitize-branch-name, create-benchmark-rdbms]
     if: >
       always() &&
-      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
-      needs.run-profiling.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: 'read'
-      pull-requests: 'write'
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-      - name: Comment PR with profiling results
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            // List all downloaded artifacts
-            const artifactPath = 'artifacts';
-            const artifacts = fs.readdirSync(artifactPath);
-
-            // Get artifact IDs from GitHub API
-            const { data: workflowArtifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-            });
-
-            let comment = '## Profiling Results\n\n';
-            comment += 'The benchmark has been profiled with the following events:\n\n';
-            comment += '| Event | Pod | Artifact |\n';
-            comment += '|-------|-----|----------|\n';
-
-            artifacts.forEach(artifact => {
-              const match = artifact.match(/flamegraph-(\w+)-(\w+-\d+)/);
-              if (match) {
-                const event = match[1];
-                const pod = match[2];
-
-                // Find the artifact ID for this artifact name
-                const artifactInfo = workflowArtifacts.artifacts.find(a => a.name === artifact);
-                if (artifactInfo) {
-                  const downloadUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${artifactInfo.id}`;
-                  comment += `| ${event} | ${pod} | [Download](${downloadUrl}) |\n`;
-                } else {
-                  comment += `| ${event} | ${pod} | N/A |\n`;
-                }
-              }
-            });
-
-            comment += '\n📊 [View all artifacts and workflow summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n';
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      !(github.event.action == 'unlabeled' && github.event.label.name == 'benchmark-rdbms') &&
+      needs.create-benchmark-rdbms.result == 'success'
+    uses: ./.github/workflows/profile-benchmark.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}
+      benchmark-label: 'RDBMS'
 
   delete-benchmark:
     name: Benchmark Cleanup
@@ -209,7 +126,8 @@ jobs:
 
       - name: Delete benchmarks
         run: |
-          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}"
+          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
+          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}" --ignore-not-found
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -85,7 +85,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      benchmark-label: 'Elasticsearch'
+      database: 'elasticsearch'
       cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
       teleport-join-token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
 
@@ -100,7 +100,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}
-      benchmark-label: 'RDBMS'
+      database: 'rdbms'
       cluster: ${{ needs.sanitize-branch-name.outputs.cluster }}
       teleport-join-token: ${{ needs.sanitize-branch-name.outputs.teleport-join-token }}
 

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -58,7 +58,7 @@ jobs:
       scenario: 'max'
 
   create-benchmark-rdbms:
-    name: Benchmark
+    name: Benchmark RDBMS
     needs: sanitize-branch-name
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark-rdbms') ||

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
           branch: ${{ github.event.pull_request.head.ref }}
-          max_length: 50  # reduced to account for load-test prefix "c8-"" and potential suffixes for uniqueness
+          max_length: 44  # reduced to account for load-test prefix "c8-"" and potential suffixes for uniqueness
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -69,7 +69,7 @@ jobs:
 
   await-benchmark:
     name: Await Benchmark
-    needs: [sanitize-branch-name, create-benchmark]
+    needs: [sanitize-branch-name, create-benchmark, create-benchmark-rdbms]
     if: >
       contains(fromJSON('["labeled", "synchronize"]'), github.event.action) &&
       (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -76,6 +76,7 @@ jobs:
     needs: [sanitize-branch-name,create-benchmark, create-benchmark-rdbms]
     if: >
       always() &&
+      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
       (needs.create-benchmark.result == 'success' || needs.create-benchmark-rdbms.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -96,7 +97,10 @@ jobs:
   run-profiling:
     name: Run Profiling
     needs: [sanitize-branch-name, await-benchmark]
-    if: always() && needs.await-benchmark.result == 'success'
+    if: >
+      always() &&
+      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
+      needs.await-benchmark.result == 'success'
     uses: ./.github/workflows/profile-load-test.yml
     secrets: inherit
     with:
@@ -106,7 +110,10 @@ jobs:
   comment-pr:
     name: Comment on PR with profiling results
     needs: [sanitize-branch-name, run-profiling]
-    if: always() && needs.run-profiling.result == 'success'
+    if: >
+      always() &&
+      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
+      needs.run-profiling.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -47,7 +47,9 @@ jobs:
   create-benchmark:
     name: Benchmark
     needs: sanitize-branch-name
-    if: contains(fromJSON('["labeled", "synchronize"]'), github.event.action) && contains(github.event.pull_request.labels.*.name, 'benchmark')
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
@@ -58,7 +60,9 @@ jobs:
   create-benchmark-rdbms:
     name: Benchmark
     needs: sanitize-branch-name
-    if: contains(fromJSON('["labeled", "synchronize"]'), github.event.action) && contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms')
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'benchmark-rdbms') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
@@ -69,11 +73,12 @@ jobs:
 
   await-benchmark:
     name: Await Benchmark
-    needs: [sanitize-branch-name, create-benchmark, create-benchmark-rdbms]
+    needs: [sanitize-branch-name,create-benchmark, create-benchmark-rdbms]
     if: >
-      contains(fromJSON('["labeled", "synchronize"]'), github.event.action) &&
-      (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
+      always() &&
+      (needs.create-benchmark.result == 'success' || needs.create-benchmark-rdbms.result == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions: {}
     steps:
       - name: Wait for load test to stabilize
@@ -91,9 +96,7 @@ jobs:
   run-profiling:
     name: Run Profiling
     needs: [sanitize-branch-name, await-benchmark]
-    if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+    if: always() && needs.await-benchmark.result == 'success'
     uses: ./.github/workflows/profile-load-test.yml
     secrets: inherit
     with:
@@ -103,9 +106,7 @@ jobs:
   comment-pr:
     name: Comment on PR with profiling results
     needs: [sanitize-branch-name, run-profiling]
-    if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+    if: always() && needs.run-profiling.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -177,8 +178,8 @@ jobs:
     name: Benchmark Cleanup
     needs: sanitize-branch-name
     if: >
-      (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark') ||
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+      (github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) ||
+      (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'benchmark') || contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms')))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -131,13 +131,13 @@ jobs:
       - name: Delete benchmark namespace
         if: >
           github.event.action == 'closed' ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
+          (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'benchmark'))
         run: |
           kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
       - name: Delete RDBMS benchmark namespace
         if: >
           github.event.action == 'closed' ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark-rdbms')
+          (github.event.action == 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'benchmark-rdbms'))
         run: |
           kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name-rdbms }}" --ignore-not-found
       - name: Observe build status

--- a/.github/workflows/profile-benchmark.yml
+++ b/.github/workflows/profile-benchmark.yml
@@ -10,8 +10,8 @@ on:
         description: 'Name of the load test (Kubernetes namespace) to profile'
         required: true
         type: string
-      benchmark-label:
-        description: 'Human-readable label for the benchmark variant shown in the PR comment header (e.g. "Benchmark" or "Benchmark RDBMS")'
+      database:
+        description: 'Database variant'
         required: true
         type: string
       cluster:
@@ -53,6 +53,7 @@ jobs:
     secrets: inherit
     with:
       name: ${{ inputs.name }}
+      database: ${{ inputs.database }}
       pod: ''
 
   comment-pr:
@@ -74,7 +75,7 @@ jobs:
       - name: Comment PR with profiling results
         uses: actions/github-script@v8
         env:
-          BENCHMARK_LABEL: ${{ inputs.benchmark-label }}
+          DATABASE: ${{ inputs.database }}
         with:
           script: |
             const fs = require('fs');
@@ -91,8 +92,8 @@ jobs:
               run_id: context.runId,
             });
 
-            const benchmarkLabel = process.env.BENCHMARK_LABEL;
-            let comment = `## Profiling Results — ${benchmarkLabel}\n\n`;
+            const database = process.env.DATABASE;
+            let comment = `## Profiling Results — ${database}\n\n`;
             comment += 'The benchmark has been profiled with the following events:\n\n';
             comment += '| Event | Pod | Artifact |\n';
             comment += '|-------|-----|----------|\n';

--- a/.github/workflows/profile-benchmark.yml
+++ b/.github/workflows/profile-benchmark.yml
@@ -98,8 +98,10 @@ jobs:
             comment += '| Event | Pod | Artifact |\n';
             comment += '|-------|-----|----------|\n';
 
+            const artifactPrefix = 'flamegraph-'+database;
+            const regex = new RegExp(artifactPrefix + '-(\\w+)-(\\w+-\\d+)');
             artifacts.forEach(artifact => {
-              const match = artifact.match(/flamegraph-(\w+)-(\w+-\d+)/);
+              const match = artifact.match(regex);
               if (match) {
                 const event = match[1];
                 const pod = match[2];

--- a/.github/workflows/profile-benchmark.yml
+++ b/.github/workflows/profile-benchmark.yml
@@ -1,0 +1,125 @@
+# description: Profiles a running benchmark load test and posts a PR comment with the flamegraph results
+# type: CI
+# owner: @camunda/reliability-testing
+name: Benchmark Profiling
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: 'Name of the load test (Kubernetes namespace) to profile'
+        required: true
+        type: string
+      benchmark-label:
+        description: 'Human-readable label for the benchmark variant shown in the PR comment header (e.g. "Benchmark" or "Benchmark RDBMS")'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  await-benchmark:
+    name: Await Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions: {}
+    steps:
+      - name: Wait for load test to stabilize
+        run: sleep 900  # 15 minutes
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  run-profiling:
+    name: Run Profiling
+    needs: await-benchmark
+    uses: ./.github/workflows/profile-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ inputs.name }}
+      pod: ''
+
+  comment-pr:
+    name: Comment on PR with profiling results
+    needs: [run-profiling]
+    if: >
+      always() &&
+      !(github.event.action == 'unlabeled' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-rdbms')) &&
+      needs.run-profiling.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+      - name: Comment PR with profiling results
+        uses: actions/github-script@v8
+        env:
+          BENCHMARK_LABEL: ${{ inputs.benchmark-label }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            // List all downloaded artifacts
+            const artifactPath = 'artifacts';
+            const artifacts = fs.readdirSync(artifactPath);
+
+            // Get artifact IDs from GitHub API
+            const { data: workflowArtifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+
+            const benchmarkLabel = process.env.BENCHMARK_LABEL;
+            let comment = `## Profiling Results — ${benchmarkLabel}\n\n`;
+            comment += 'The benchmark has been profiled with the following events:\n\n';
+            comment += '| Event | Pod | Artifact |\n';
+            comment += '|-------|-----|----------|\n';
+
+            artifacts.forEach(artifact => {
+              const match = artifact.match(/flamegraph-(\w+)-(\w+-\d+)/);
+              if (match) {
+                const event = match[1];
+                const pod = match[2];
+
+                // Find the artifact ID for this artifact name
+                const artifactInfo = workflowArtifacts.artifacts.find(a => a.name === artifact);
+                if (artifactInfo) {
+                  const downloadUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${artifactInfo.id}`;
+                  comment += `| ${event} | ${pod} | [Download](${downloadUrl}) |\n`;
+                } else {
+                  comment += `| ${event} | ${pod} | N/A |\n`;
+                }
+              }
+            });
+
+            comment += '\n📊 [View all artifacts and workflow summary](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n';
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/profile-benchmark.yml
+++ b/.github/workflows/profile-benchmark.yml
@@ -138,7 +138,7 @@ jobs:
   delete-namespace:
     name: Delete Namespace
     needs: comment-pr
-    if: always() && needs.comment-pr.result != 'skipped'
+    if: always() && needs.comment-pr.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/profile-benchmark.yml
+++ b/.github/workflows/profile-benchmark.yml
@@ -14,6 +14,14 @@ on:
         description: 'Human-readable label for the benchmark variant shown in the PR comment header (e.g. "Benchmark" or "Benchmark RDBMS")'
         required: true
         type: string
+      cluster:
+        description: 'Kubernetes cluster name to connect to via Teleport'
+        required: true
+        type: string
+      teleport-join-token:
+        description: 'Teleport join token for authenticating to the cluster'
+        required: true
+        type: string
 
 defaults:
   run:
@@ -114,6 +122,41 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  delete-namespace:
+    name: Delete Namespace
+    needs: comment-pr
+    if: always() && needs.comment-pr.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: 17.2.2
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@v2
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ inputs.teleport-join-token }}
+          kubernetes-cluster: ${{ inputs.cluster }}
+      - name: Delete namespace
+        run: |
+          kubectl delete ns "${{ inputs.name }}" --ignore-not-found
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -92,7 +92,7 @@ jobs:
           ./load-tests/docs/scripts/executeProfiling.sh ${{ matrix.pod }} ${{ matrix.event }} "${{ inputs.database }}" "${{ inputs.profiler_options }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: flamegraph-${{ matrix.event }}-${{ matrix.pod }}-${{ inputs.database }}
+          name: flamegraph-${{ inputs.database }}-${{ matrix.event }}-${{ matrix.pod }}
           path: ${{ matrix.pod }}*
       - name: Summarize profiling
         if: success()
@@ -141,7 +141,7 @@ jobs:
           ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.pod }} cpu "${{ inputs.database }}" "${{ inputs.profiler_options }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: flamegraph-cpu-${{ inputs.pod }}-${{ inputs.database }}
+          name: flamegraph-${{ inputs.database }}-cpu-${{ inputs.pod }}
           path: ${{ inputs.pod }}*
       - name: Summarize profiling
         if: success()

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -89,10 +89,10 @@ jobs:
           kubectl config set-context --current --namespace=${{ inputs.name }}
       - name: Execute profiling
         run: >
-          ./load-tests/docs/scripts/executeProfiling.sh ${{ matrix.pod }} ${{ matrix.event }} "${{ inputs.profiler_options }}"
+          ./load-tests/docs/scripts/executeProfiling.sh ${{ matrix.pod }} ${{ matrix.event }} "${{ inputs.database }}" "${{ inputs.profiler_options }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: flamegraph-${{ matrix.event }}-${{ matrix.pod }}
+          name: flamegraph-${{ matrix.event }}-${{ matrix.pod }}-${{ inputs.database }}
           path: ${{ matrix.pod }}*
       - name: Summarize profiling
         if: success()

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -16,6 +16,10 @@ on:
         description: 'Optional additional flags for async-profiler (e.g., "-t" for flamegraph format)'
         default: ''
         required: false
+      database:
+        description: 'Database variant'
+        required: true
+        type: string
   workflow_call:
     inputs:
       name:
@@ -31,6 +35,10 @@ on:
         description: 'Optional additional flags for async-profiler (e.g., "-t" for flamegraph format)'
         default: ''
         required: false
+        type: string
+      database:
+        description: 'Database variant'
+        required: true
         type: string
 
 defaults:
@@ -130,10 +138,10 @@ jobs:
           kubectl config set-context --current --namespace=${{ inputs.name }}
       - name: Execute profiling
         run: >
-          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.pod }} cpu "${{ inputs.profiler_options }}"
+          ./load-tests/docs/scripts/executeProfiling.sh ${{ inputs.pod }} cpu "${{ inputs.database }}" "${{ inputs.profiler_options }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: flamegraph-cpu-${{ inputs.pod }}
+          name: flamegraph-cpu-${{ inputs.pod }}-${{ inputs.database }}
           path: ${{ inputs.pod }}*
       - name: Summarize profiling
         if: success()

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -81,7 +81,7 @@ fi
 PID=$(kubectl exec "$node" -- ps -ax | awk '$5 ~ /java/ {print $1}')
 
 # Run profiling
-kubectl exec "$node" -- ./data/asprof -e "$profiler_event" -d 100 -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
+kubectl exec "$node" -- $containerPath/asprof -e "$profiler_event" -d 100 -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
 
 # Copy result
 kubectl cp "$node:$containerPath/$filename" "$node-$filename"

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xeu
 # Usage:
-#   ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]
+#   ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [DATABASE] [ADDITIONAL-OPTIONS]
 #
 # EVENT-TYPE can be:
 #   cpu   - CPU profiling (default)
@@ -18,7 +18,20 @@ if [ -z "$1" ]; then
 fi
 node=$1
 profiler_event=${2:-cpu}
-additional_options=${3:-}
+raw_database=${3:-}
+additional_options=${4:-}
+database=""
+
+# Validate database param — if it's not a known value, treat it as additional options
+valid_databases=("elasticsearch" "rdbms")
+
+if [[ -n "$raw_database" ]] && [[ ! " ${valid_databases[*]} " =~ " ${raw_database} " ]]; then
+  # Not a known database — treat it as additional options
+  additional_options="$raw_database ${4:-}"
+  database=""
+else
+  database="$raw_database"
+fi
 
 if [[ $profiler_event == "wall" ]]; then
   # Add -t flag for wall profiling to split threads (recommended for wall-clock profiling)
@@ -50,7 +63,11 @@ then
 fi
 
 # Run profiling
-filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S).html
+if [ -n "$database" ]; then
+  filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S)-$database.html
+else
+  filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S).html
+fi
 # Extracting the PID:
 #
 #  $ k exec camunda-0 -it -- ps -ax

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -64,7 +64,7 @@ fi
 
 # Run profiling
 if [ -n "$database" ]; then
-  filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S)-$database.html
+  filename=flamegraph-$database-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S).html
 else
   filename=flamegraph-$profiler_event-$(date +%Y-%m-%d_%H-%M-%S).html
 fi


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow running benchmark clusters against PostgreSQL using the `benchmark-rdbms` label.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
