### PR TITLE
[Backport stable/8.8] fix: add elementInstanceState filter to API requests

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.test.ts
@@ -33,6 +33,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2']},
       },
@@ -49,6 +50,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$notIn: ['3', '4']},
       },
@@ -65,6 +67,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2'], $notIn: ['3']},
       },
@@ -81,6 +84,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['only'], $notIn: ['x']},
       },
@@ -97,6 +101,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -116,6 +121,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         $or: [{hasIncident: true}, {state: {$eq: 'ACTIVE'}}],
       },
     });
@@ -135,6 +141,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -154,6 +161,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         state: {$eq: 'ACTIVE'},
       },
     });
@@ -177,6 +185,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         errorMessage: 'some error',
         tenantId: 'tenant-xyz',
         batchOperationKey: 'batch-123',
@@ -201,6 +210,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         processDefinitionKey: {$in: ['p1', 'p2']},
       },
     });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/buildMutationRequestBody.ts
@@ -55,6 +55,10 @@ const buildMutationRequestBody = ({
     requestBody.filter.state = {$eq: 'TERMINATED'};
   }
 
+  if (baseFilter.activityId) {
+    requestBody.filter.elementInstanceState = {$eq: 'ACTIVE'};
+  }
+
   if (
     Array.isArray(baseFilter.processIds) &&
     baseFilter.processIds.length > 0

--- a/operate/client/src/modules/utils/buildMutationRequestBody.test.ts
+++ b/operate/client/src/modules/utils/buildMutationRequestBody.test.ts
@@ -33,6 +33,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2']},
       },
@@ -49,6 +50,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$notIn: ['3', '4']},
       },
@@ -65,6 +67,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['1', '2'], $notIn: ['3']},
       },
@@ -81,6 +84,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
         processInstanceKey: {$in: ['only'], $notIn: ['x']},
       },
@@ -97,6 +101,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -116,6 +121,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         $or: [{hasIncident: true}, {state: {$eq: 'ACTIVE'}}],
       },
     });
@@ -135,6 +141,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         hasIncident: true,
       },
     });
@@ -154,6 +161,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         state: {$eq: 'ACTIVE'},
       },
     });
@@ -177,6 +185,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         errorMessage: 'some error',
         tenantId: 'tenant-xyz',
         batchOperationKey: 'batch-123',
@@ -201,6 +210,7 @@ describe('buildMutationRequestBody', () => {
     expect(body).toEqual({
       filter: {
         elementId: 'taskA',
+        elementInstanceState: {$eq: 'ACTIVE'},
         processDefinitionKey: {$in: ['p1', 'p2']},
       },
     });

--- a/operate/client/src/modules/utils/buildMutationRequestBody.ts
+++ b/operate/client/src/modules/utils/buildMutationRequestBody.ts
@@ -57,6 +57,10 @@ const buildMutationRequestBody = ({
     requestBody.filter.state = {$eq: 'TERMINATED'};
   }
 
+  if (baseFilter.activityId) {
+    requestBody.filter.elementInstanceState = {$eq: 'ACTIVE'};
+  }
+
   if (
     Array.isArray(baseFilter.processIds) &&
     baseFilter.processIds.length > 0 &&


### PR DESCRIPTION
# Description
Backport of #46129 to `stable/8.8`.

Implementation is different from 8.9, so requesting a separate review.

Note: It's not necessary to add it to the process instances search, because in 8.8 we still use the Operate internal v1 API, which returns the correct results already.

closes #43728