### PR TITLE
fix: only override ES retention to 1d when Operate is included in load tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -384,12 +384,12 @@ jobs:
           --set zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
-          --set zeebe.retention.minimumAge=1d
           -f https://raw.githubusercontent.com/camunda/camunda/${{ github.ref }}/zeebe/benchmarks/camunda-platform-values.yaml
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/setup/default/values-stable.yaml', github.ref) || '' }}
           ${{ inputs.operate-included && format('-f https://raw.githubusercontent.com/camunda/camunda/{0}/zeebe/benchmarks/camunda-platform-operate-values.yaml', github.ref) || '' }}
           ${{ inputs.operate-included && format('--set operate.image.tag={0}', needs.calculate-image-tag.outputs.image-tag) || '' }}
+          ${{ inputs.operate-included && '--set zeebe.retention.minimumAge=1d' || '' }}
           ${{ inputs.platform-helm-values }}
 
       - name: Summarize deployment


### PR DESCRIPTION
The retention override `zeebe.retention.minimumAge=1d` was added unconditionally in 258cb67938c, causing all load tests on stable/8.7 to use 1-day retention instead of the 10m configured in the values file. The 1d override is only needed when Operate is enabled, so it has enough time to consume exported data before ILM deletes it.