### PR TITLE
fix: provide IO hint for checkpoint scheduler

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
@@ -108,9 +109,9 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   @Override
   protected void onActorStarted() {
     if (checkpointScheduler != null && shouldStartSchedulers()) {
-      actorScheduler.submitActor(checkpointScheduler);
+      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.IO_BOUND);
       if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob);
+        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.IO_BOUND);
       }
     }
   }
@@ -162,9 +163,9 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
 
   private void checkedStartScheduler() {
     if (shouldStartSchedulers() && isSchedulerInactive()) {
-      actorScheduler.submitActor(checkpointScheduler);
+      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.IO_BOUND);
       if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob);
+        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.IO_BOUND);
       }
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -108,12 +108,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
 
   @Override
   protected void onActorStarted() {
-    if (checkpointScheduler != null && shouldStartSchedulers()) {
-      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.IO_BOUND);
-      if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.IO_BOUND);
-      }
-    }
+    checkedStartScheduler();
   }
 
   @Override
@@ -163,9 +158,9 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
 
   private void checkedStartScheduler() {
     if (shouldStartSchedulers() && isSchedulerInactive()) {
-      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.IO_BOUND);
+      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.ioBound());
       if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.IO_BOUND);
+        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.ioBound());
       }
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStore
 import io.camunda.zeebe.broker.system.configuration.backup.BackupSchedulerRetentionCfg;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
@@ -119,9 +120,14 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
 
-    verify(scheduler, times(1)).submitActor(argThat(BackupRetention.class::isInstance));
+    verify(scheduler, times(1))
+        .submitActor(
+            argThat(BackupRetention.class::isInstance),
+            argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
   }
 
   @Test
@@ -139,8 +145,8 @@ public class CheckpointSchedulerServiceTest {
         new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_REMOVED, member3));
 
     // then
-    verify(scheduler, times(0)).submitActor(argThat(CheckpointScheduler.class::isInstance));
-    verify(scheduler, times(0)).submitActor(argThat(BackupRetention.class::isInstance));
+    verify(scheduler, times(0)).submitActor(argThat(CheckpointScheduler.class::isInstance), any());
+    verify(scheduler, times(0)).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
   @Test
@@ -162,8 +168,13 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
-    verify(scheduler, times(1)).submitActor(argThat(BackupRetention.class::isInstance));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
+    verify(scheduler, times(1))
+        .submitActor(
+            argThat(BackupRetention.class::isInstance),
+            argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
   }
 
   @Test
@@ -185,8 +196,13 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
-    verify(scheduler, times(1)).submitActor(argThat(BackupRetention.class::isInstance));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
+    verify(scheduler, times(1))
+        .submitActor(
+            argThat(BackupRetention.class::isInstance),
+            argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
   }
 
   @Test
@@ -204,8 +220,8 @@ public class CheckpointSchedulerServiceTest {
     schedulingService.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, member2));
 
     // then
-    verify(scheduler, times(0)).submitActor(argThat(CheckpointScheduler.class::isInstance));
-    verify(scheduler, times(0)).submitActor(argThat(BackupRetention.class::isInstance));
+    verify(scheduler, times(0)).submitActor(argThat(CheckpointScheduler.class::isInstance), any());
+    verify(scheduler, times(0)).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
   @Test
@@ -216,7 +232,10 @@ public class CheckpointSchedulerServiceTest {
     doReturn(Set.of(member2, member3)).when(membershipService).getMembers();
     schedulingService.onActorStarting();
     schedulingService.onActorStarted();
-    verify(scheduler, times(1)).submitActor(argThat(CheckpointScheduler.class::isInstance));
+    verify(scheduler, times(1))
+        .submitActor(
+            argThat(CheckpointScheduler.class::isInstance),
+            argThat(arg -> arg.equals(SchedulingHints.IO_BOUND)));
     final var checkpointCreatorSpy = getCheckpointCreator(schedulingService);
     final var retentionJobSpy = getRetentionJob(schedulingService);
 
@@ -249,7 +268,9 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
     assertThat(getSchedule(schedulingService, "checkpointSchedule")).isNotNull();
     assertThat(getSchedule(schedulingService, "backupSchedule")).isNull();
   }
@@ -283,7 +304,9 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
 
     assertThat(getSchedule(schedulingService, "checkpointSchedule")).isNotNull();
     assertThat(getSchedule(schedulingService, "backupSchedule")).isNull();
@@ -310,7 +333,9 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
     assertThat(getSchedule(schedulingService, "checkpointSchedule")).isNull();
     assertThat(getSchedule(schedulingService, "backupSchedule")).isNotNull();
   }
@@ -334,9 +359,11 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
 
-    verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance));
+    verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
   @Test
@@ -358,9 +385,11 @@ public class CheckpointSchedulerServiceTest {
         .untilAsserted(
             () ->
                 verify(scheduler, times(1))
-                    .submitActor(argThat(CheckpointScheduler.class::isInstance)));
+                    .submitActor(
+                        argThat(CheckpointScheduler.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
 
-    verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance));
+    verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
   private CheckpointScheduler getCheckpointCreator(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Provide scheduling hints for both Checkpoint and Retention scheduled jobs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
