### PR TITLE
[Backport stable/8.8] fix: Update runner for maven release job

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -89,7 +89,7 @@ jobs:
   # - When both flags are active, dryRun takes precedence over releaseProcessDryRun
   release:
     name: Maven Release
-    runs-on: gcp-core-16-release
+    runs-on: gcp-core-32-release
     outputs:
       releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}


### PR DESCRIPTION
# Description
Backport of #46305 to `stable/8.8`.

relates to 