### PR TITLE
Enable MCP gateway prompts/resources

### DIFF
--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -5,6 +5,23 @@ spring:
         enabled: true
         name: Camunda 8 Orchestration API MCP Server
         version: '${project.version}'
+        instructions: |
+          This server exposes APIs of a Camunda 8 Orchestration Cluster. All operations are
+          scoped to the permissions of the authenticated user.
+
+          Most tools return eventually consistent data. Recently written data may not appear
+          immediately in subsequent reads.
+
+          Process instances, incidents, and user tasks are related. A process instance can have
+          active incidents and user tasks. Use the process instance key to correlate across
+          domains. To understand the structure of a process, retrieve its BPMN XML.
+
+          When starting a process instance with awaitCompletion, a timeout does NOT mean the
+          process failed — the instance was created and continues running. Tag each instance
+          (e.g. "mcp-tool:<operation>-<timestamp>") so you can find it later. Poll the instance
+          state: if COMPLETED, retrieve result variables; if it has an incident, investigate
+          using the process instance key. Variables can be retrieved at any time, including
+          while the instance is still running.
         type: sync
         protocol: stateless
         annotation-scanner:

--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -13,6 +13,6 @@ spring:
           mcp-endpoint: /mcp/cluster
         capabilities:
           completion: false
-          prompt: false
-          resource: false
+          prompt: true
+          resource: true
           tool: true

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
@@ -38,14 +38,24 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
         .extracting(
             ServerCapabilities::completions,
             ServerCapabilities::experimental,
-            ServerCapabilities::logging,
-            ServerCapabilities::prompts,
-            ServerCapabilities::resources)
+            ServerCapabilities::logging)
         .allMatch(Objects::isNull);
 
     assertThat(initializeResult.capabilities().tools())
         .isNotNull()
         .satisfies(tools -> assertThat(tools.listChanged()).isFalse());
+
+    assertThat(initializeResult.capabilities().prompts())
+        .isNotNull()
+        .satisfies(prompts -> assertThat(prompts.listChanged()).isFalse());
+
+    assertThat(initializeResult.capabilities().resources())
+        .isNotNull()
+        .satisfies(
+            resources -> {
+              assertThat(resources.listChanged()).isFalse();
+              assertThat(resources.subscribe()).isFalse();
+            });
   }
 
   @Test


### PR DESCRIPTION
## Description

Enables the `prompts` and `resources` capabilities in the MCP gateway initialize response in order to avoid false positive errors caused by not registered handlers (see https://github.com/camunda/camunda/issues/44941). We can keep this as temporary measure until the underlying upstream issue is fixed.

In addition, this adds a small set of MCP server instructions to guide clients on how to work with the gateway ([might or might not be used by clients](https://blog.modelcontextprotocol.io/posts/2025-11-03-using-server-instructions/)).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

temporary fix for https://github.com/camunda/camunda/issues/44941
