### PR TITLE
refactor: replace filled icons with outline variants in operations lo…

### DIFF
--- a/identity/client/src/pages/operations-log/components/styled.tsx
+++ b/identity/client/src/pages/operations-log/components/styled.tsx
@@ -8,8 +8,8 @@
 
 import styled from "styled-components";
 import {
-  CheckmarkFilled as BaseCheckmarkFilled,
-  ErrorFilled as BaseErrorFilled,
+  CheckmarkOutline as BaseCheckmarkOutline,
+  ErrorOutline as BaseErrorOutline,
 } from "@carbon/react/icons";
 import { Column, Grid as CarbonGrid } from "@carbon/react";
 import { styles } from "@carbon/elements";
@@ -20,11 +20,11 @@ const OperationLogName = styled.div`
   gap: var(--cds-spacing-02);
 `;
 
-const SuccessIcon = styled(BaseCheckmarkFilled)`
+const SuccessIcon = styled(BaseCheckmarkOutline)`
   fill: var(--cds-support-success);
 `;
 
-const ErrorIcon = styled(BaseErrorFilled)`
+const ErrorIcon = styled(BaseErrorOutline)`
   fill: var(--cds-support-error);
 `;
 

--- a/operate/client/src/modules/components/OperationsLogStateIcon/index.tsx
+++ b/operate/client/src/modules/components/OperationsLogStateIcon/index.tsx
@@ -8,11 +8,11 @@
 
 import React from 'react';
 import {type AuditLogResult} from '@camunda/camunda-api-zod-schemas/8.9/audit-log';
-import {CheckmarkFilled, ErrorFilled} from './styled';
+import {CheckmarkOutline, ErrorOutline} from './styled';
 
 const stateIconsMap = {
-  FAIL: ErrorFilled,
-  SUCCESS: CheckmarkFilled,
+  FAIL: ErrorOutline,
+  SUCCESS: CheckmarkOutline,
 } as const;
 
 type Props = {

--- a/operate/client/src/modules/components/OperationsLogStateIcon/styled.tsx
+++ b/operate/client/src/modules/components/OperationsLogStateIcon/styled.tsx
@@ -8,16 +8,16 @@
 
 import styled from 'styled-components';
 import {
-  CheckmarkFilled as BaseCheckmarkFilled,
-  ErrorFilled as BaseErrorFilled,
+  CheckmarkOutline as BaseCheckmarkOutline,
+  ErrorOutline as BaseErrorOutline,
 } from '@carbon/react/icons';
 
-const CheckmarkFilled = styled(BaseCheckmarkFilled)`
+const CheckmarkOutline = styled(BaseCheckmarkOutline)`
   fill: var(--cds-support-success);
 `;
 
-const ErrorFilled = styled(BaseErrorFilled)`
+const ErrorOutline = styled(BaseErrorOutline)`
   fill: var(--cds-support-error);
 `;
 
-export {CheckmarkFilled, ErrorFilled};
+export {CheckmarkOutline, ErrorOutline};


### PR DESCRIPTION
## Description

Replace filled icons with outline variants

## Related issues

related to https://github.com/camunda/camunda/issues/46246
