### PR TITLE
refactor: make items required in ElementInstanceSearchQueryResult. fixes #46318

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -375,6 +375,8 @@ components:
 
     ElementInstanceSearchQueryResult:
       type: object
+      required: 
+        - items
       allOf:
         - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
       properties:


### PR DESCRIPTION
## Description

Restores required on array of items in ElementInstanceSearchQueryResult.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates https://github.com/camunda/camunda/issues/46165#issuecomment-3927091411
