### PR TITLE
perf: when multiple appends are received by a follower perform a single flush

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -44,21 +44,21 @@ import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.AbstractRaftRequest;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
-import io.atomix.raft.protocol.InternalAppendRequest;
-import io.atomix.raft.protocol.ProtocolVersionHandler;
-import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Builder;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.roles.ActiveRole;
 import io.atomix.raft.roles.CandidateRole;
@@ -407,43 +407,39 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * append requests are batched together and processed with a single flush for better throughput.
    */
   private void processRequestQueue() {
-    try {
-      final QueuedRequest first = requestQueue.poll();
-      if (first == null) {
-        return;
-      }
+    final QueuedRequest first = requestQueue.poll();
+    if (first == null) {
+      return;
+    }
 
-      if (!isAppendRequest(first.request)) {
-        // Non-append request: process immediately
-        processQueuedRequest(first);
-        if (!requestQueue.isEmpty()) {
-          threadContext.execute(this::processRequestQueue);
-        }
-        return;
-      }
-
-      // First request is an append -- drain consecutive appends from the queue
-      final var appends = new ArrayList<QueuedRequest>(6);
-      appends.add(first);
-      QueuedRequest peeked = requestQueue.peek();
-      while (peeked != null && isAppendRequest(peeked.request)) {
-        appends.add(requestQueue.poll());
-        peeked = requestQueue.peek();
-      }
-      processQueuedAppends(appends);
-
-      // Give priority to a non-append request that may be waiting behind the appends
-      final QueuedRequest next = requestQueue.peek();
-      if (next != null && !isAppendRequest(next.request)) {
-        processQueuedRequest(requestQueue.poll());
-      }
-
-      // Schedule another drain if there are more items in the queue
+    if (!isAppendRequest(first.request)) {
+      // Non-append request: process immediately
+      processQueuedRequest(first);
       if (!requestQueue.isEmpty()) {
         threadContext.execute(this::processRequestQueue);
       }
-    } catch (final Exception e) {
-      LOGGER.debug("Request queue processing error", e);
+      return;
+    }
+
+    // First request is an append -- drain consecutive appends from the queue
+    final var appends = new ArrayList<QueuedRequest>(6);
+    appends.add(first);
+    QueuedRequest peeked = requestQueue.peek();
+    while (peeked != null && isAppendRequest(peeked.request)) {
+      appends.add(requestQueue.poll());
+      peeked = requestQueue.peek();
+    }
+    processQueuedAppends(appends);
+
+    // Give priority to a non-append request that may be waiting behind the appends
+    final QueuedRequest next = requestQueue.peek();
+    if (next != null && !isAppendRequest(next.request)) {
+      processQueuedRequest(requestQueue.poll());
+    }
+
+    // Schedule another drain if there are more items in the queue
+    if (!requestQueue.isEmpty()) {
+      threadContext.execute(this::processRequestQueue);
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -484,7 +484,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private void processQueuedAppends(final List<QueuedRequest> appends) {
     if (appends.size() == 1) {
       // Single append: use the standard path (no batching overhead)
-      processQueuedRequest(appends.get(0));
+      processQueuedRequest(appends.getFirst());
       return;
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -26,6 +26,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
 import io.atomix.raft.RaftCommitListener;
+import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftException.CommitFailedException;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer.Role;
@@ -40,15 +41,18 @@ import io.atomix.raft.metrics.RaftRoleMetrics;
 import io.atomix.raft.metrics.RaftServiceMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.AbstractRaftRequest;
+import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.protocol.InternalAppendRequest;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollResponse;
-import io.atomix.raft.protocol.ProtocolVersionHandler;
-import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Builder;
 import io.atomix.raft.protocol.RaftResponse.Status;
@@ -84,9 +88,13 @@ import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
@@ -113,7 +121,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private static final long NO_CONFIGURATION_INDEX = -1L;
 
   private static final String RAFT_ROLE_KEY = "raft-role";
-
+  // Queue for incoming raft requests to enable batch processing in the future
+  private static final int REQUEST_QUEUE_CAPACITY = 1000;
   protected final String name;
   protected final ThreadContext threadContext;
   protected final ClusterMembershipService membershipService;
@@ -152,7 +161,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final Random random;
   private PersistedSnapshot currentSnapshot;
   private final int snapshotChunkSize;
-
   private boolean ongoingTransition = false;
   // Keeps track of snapshot replication to notify new listeners about missed events
   private MissedSnapshotReplicationEvents missedSnapshotReplicationEvents =
@@ -165,9 +173,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final RaftPartitionConfig partitionConfig;
   private final int partitionId;
   private final MeterRegistry meterRegistry;
-
   // after firstCommitIndex is set it will be null
   private AwaitingReadyCommitListener awaitingReadyCommitListener;
+  private final BlockingQueue<QueuedRequest> requestQueue =
+      new ArrayBlockingQueue<>(REQUEST_QUEUE_CAPACITY);
 
   public RaftContext(
       final String name,
@@ -257,6 +266,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // Register protocol listeners.
     registerHandlers(protocol);
+
     started = true;
 
     if (meta.hasCommitIndex()) {
@@ -341,81 +351,171 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   /** Registers server handlers on the configured protocol. */
   private void registerHandlers(final RaftServerProtocol protocol) {
     protocol.registerConfigureHandler(
-        request ->
-            handleRequestOnContext(
-                request, () -> role.onConfigure(request), ConfigureResponse::builder));
+        request -> handleRequestOnContext(request, ConfigureResponse::builder));
     protocol.registerInstallHandler(
-        request ->
-            handleRequestOnContext(
-                request, () -> role.onInstall(request), InstallResponse::builder));
+        request -> handleRequestOnContext(request, InstallResponse::builder));
     protocol.registerReconfigureHandler(
-        request ->
-            handleRequestOnContext(
-                request, () -> role.onReconfigure(request), ReconfigureResponse::builder));
+        request -> handleRequestOnContext(request, ReconfigureResponse::builder));
     protocol.registerForceConfigureHandler(
-        request ->
-            handleRequestOnContext(
-                request, () -> role.onForceConfigure(request), ForceConfigureResponse::builder));
-    protocol.registerJoinHandler(
-        request ->
-            handleRequestOnContext(request, () -> role.onJoin(request), JoinResponse::builder));
+        request -> handleRequestOnContext(request, ForceConfigureResponse::builder));
+    protocol.registerJoinHandler(request -> handleRequestOnContext(request, JoinResponse::builder));
     protocol.registerLeaveHandler(
-        request ->
-            handleRequestOnContext(request, () -> role.onLeave(request), LeaveResponse::builder));
+        request -> handleRequestOnContext(request, LeaveResponse::builder));
     protocol.registerTransferHandler(
-        request ->
-            handleRequestOnContext(
-                request, () -> role.onTransfer(request), TransferResponse::builder));
+        request -> handleRequestOnContext(request, TransferResponse::builder));
     protocol.registerAppendV1Handler(
-        request ->
-            handleRequestOnContext(
-                request,
-                () -> role.onAppend(ProtocolVersionHandler.transform(request)),
-                AppendResponse::builder));
+        request -> handleRequestOnContext(request, AppendResponse::builder));
     protocol.registerAppendV2Handler(
-        request ->
-            handleRequestOnContext(
-                request,
-                () -> role.onAppend(ProtocolVersionHandler.transform(request)),
-                AppendResponse::builder));
-    protocol.registerPollHandler(
-        request ->
-            handleRequestOnContext(request, () -> role.onPoll(request), PollResponse::builder));
-    protocol.registerVoteHandler(
-        request ->
-            handleRequestOnContext(request, () -> role.onVote(request), VoteResponse::builder));
+        request -> handleRequestOnContext(request, AppendResponse::builder));
+    protocol.registerPollHandler(request -> handleRequestOnContext(request, PollResponse::builder));
+    protocol.registerVoteHandler(request -> handleRequestOnContext(request, VoteResponse::builder));
   }
 
+  @SuppressWarnings("unchecked")
   private <T extends Builder<T, R>, R extends RaftResponse>
       CompletableFuture<R> handleRequestOnContext(
-          final RaftRequest request,
-          final Supplier<CompletableFuture<R>> function,
+          final AbstractRaftRequest request,
           final Supplier<RaftResponse.Builder<T, R>> responseBuilder) {
 
-    final CompletableFuture<R> future = new CompletableFuture<>();
-    threadContext.execute(
-        () ->
-            role.shouldAcceptRequest(request)
-                .ifRightOrLeft(
-                    ignore ->
-                        function
-                            .get()
-                            .whenComplete(
-                                (response, error) -> {
-                                  if (error == null) {
-                                    future.complete(response);
-                                  } else {
-                                    future.completeExceptionally(error);
-                                  }
-                                }),
-                    error -> {
-                      final R response =
-                          responseBuilder.get().withStatus(Status.ERROR).withError(error).build();
-                      LOGGER.trace("Sending {}", response);
-                      future.complete(response);
-                    }));
+    // Preallocate the CompletableFuture that will be completed async by the context
+    final CompletableFuture<RaftResponse> future = new CompletableFuture<>();
 
-    return future;
+    // Create a queued request wrapper
+    final QueuedRequest queuedRequest = new QueuedRequest(request, future, responseBuilder);
+
+    // Enqueue the request instead of directly scheduling it
+    if (!requestQueue.offer(queuedRequest)) {
+      // Queue is full - reject the request immediately
+      final R response =
+          responseBuilder
+              .get()
+              .withStatus(Status.ERROR)
+              .withError(RaftError.Type.ILLEGAL_MEMBER_STATE, "Request queue is full")
+              .build();
+      future.complete(response);
+      LOGGER.warn("Request queue is full, rejecting request: {}", request);
+    } else {
+      threadContext.execute(this::processRequestQueue);
+    }
+
+    // Safe cast: the future will be completed with an instance of R
+    return (CompletableFuture<R>) (CompletableFuture<?>) future;
+  }
+
+  /**
+   * Processes requests from the queue. Non-append requests are processed immediately. Consecutive
+   * append requests are batched together and processed with a single flush for better throughput.
+   */
+  private void processRequestQueue() {
+    try {
+      final QueuedRequest first = requestQueue.poll();
+      if (first == null) {
+        return;
+      }
+
+      if (!isAppendRequest(first.request)) {
+        // Non-append request: process immediately
+        processQueuedRequest(first);
+        if (!requestQueue.isEmpty()) {
+          threadContext.execute(this::processRequestQueue);
+        }
+        return;
+      }
+
+      // First request is an append -- drain consecutive appends from the queue
+      final var appends = new ArrayList<QueuedRequest>(6);
+      appends.add(first);
+      QueuedRequest peeked = requestQueue.peek();
+      while (peeked != null && isAppendRequest(peeked.request)) {
+        appends.add(requestQueue.poll());
+        peeked = requestQueue.peek();
+      }
+      processQueuedAppends(appends);
+
+      // Give priority to a non-append request that may be waiting behind the appends
+      final QueuedRequest next = requestQueue.peek();
+      if (next != null && !isAppendRequest(next.request)) {
+        processQueuedRequest(requestQueue.poll());
+      }
+
+      // Schedule another drain if there are more items in the queue
+      if (!requestQueue.isEmpty()) {
+        threadContext.execute(this::processRequestQueue);
+      }
+    } catch (final Exception e) {
+      LOGGER.debug("Request queue processing error", e);
+    }
+  }
+
+  private static boolean isAppendRequest(final AbstractRaftRequest request) {
+    return request instanceof AppendRequest || request instanceof VersionedAppendRequest;
+  }
+
+  /**
+   * Processes a single queued request.
+   *
+   * @param queuedRequest the request to process
+   */
+  private void processQueuedRequest(final QueuedRequest queuedRequest) {
+    role.shouldAcceptRequest(queuedRequest.request)
+        .ifRightOrLeft(
+            ignore ->
+                role.onRaftRequest(queuedRequest.request)
+                    .whenComplete(
+                        (response, error) -> {
+                          if (error == null) {
+                            queuedRequest.future.complete(response);
+                          } else {
+                            queuedRequest.future.completeExceptionally(error);
+                          }
+                        }),
+            error -> rejectRequest(queuedRequest, error));
+  }
+
+  private static void rejectRequest(final QueuedRequest queuedRequest, final RaftError error) {
+    @SuppressWarnings("unchecked")
+    final RaftResponse.Builder<?, RaftResponse> builder =
+        (RaftResponse.Builder<?, RaftResponse>) queuedRequest.responseBuilder.get();
+    final var response = builder.withStatus(Status.ERROR).withError(error).build();
+    LOGGER.trace("Sending {}", response);
+    queuedRequest.future.complete(response);
+  }
+
+  private void processQueuedAppends(final List<QueuedRequest> appends) {
+    if (appends.size() == 1) {
+      // Single append: use the standard path (no batching overhead)
+      processQueuedRequest(appends.get(0));
+      return;
+    }
+
+    // Multiple appends: validate each, then delegate to role.onBatchAppend()
+    final var batch = new ArrayList<RaftRole.BatchedAppend>(appends.size());
+    for (final QueuedRequest queuedRequest : appends) {
+      final var accepted = role.shouldAcceptRequest(queuedRequest.request);
+      if (accepted.isRight()) {
+        final InternalAppendRequest internalRequest = transformToInternal(queuedRequest.request);
+        @SuppressWarnings("unchecked")
+        final CompletableFuture<AppendResponse> appendFuture =
+            (CompletableFuture<AppendResponse>) (CompletableFuture<?>) queuedRequest.future;
+        batch.add(new RaftRole.BatchedAppend(internalRequest, appendFuture));
+      } else {
+        rejectRequest(queuedRequest, accepted.getLeft());
+      }
+    }
+
+    if (!batch.isEmpty()) {
+      role.onBatchAppend(batch);
+    }
+  }
+
+  private static InternalAppendRequest transformToInternal(final AbstractRaftRequest request) {
+    if (request instanceof final AppendRequest appendRequest) {
+      return ProtocolVersionHandler.transform(appendRequest);
+    } else if (request instanceof final VersionedAppendRequest versionedRequest) {
+      return ProtocolVersionHandler.transform(versionedRequest);
+    } else {
+      throw new IllegalArgumentException("Not an append request: " + request.getClass());
+    }
   }
 
   public int getMaxAppendBatchSize() {
@@ -1329,6 +1429,22 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
           fut.complete(segments);
         });
     return fut;
+  }
+
+  /** Wrapper for a raft request with its preallocated CompletableFuture and processing logic. */
+  private static class QueuedRequest {
+    final AbstractRaftRequest request;
+    final CompletableFuture<RaftResponse> future;
+    final Supplier<? extends RaftResponse.Builder<?, ?>> responseBuilder;
+
+    QueuedRequest(
+        final AbstractRaftRequest request,
+        final CompletableFuture<RaftResponse> future,
+        final Supplier<? extends RaftResponse.Builder<?, ?>> responseBuilder) {
+      this.request = request;
+      this.future = future;
+      this.responseBuilder = responseBuilder;
+    }
   }
 
   /** Raft server state. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/AbstractRaftRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/AbstractRaftRequest.java
@@ -19,7 +19,18 @@ package io.atomix.raft.protocol;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /** Base request for all client requests. */
-public abstract class AbstractRaftRequest implements RaftRequest {
+public abstract sealed class AbstractRaftRequest implements RaftRequest
+    permits AppendRequest,
+        ConfigureRequest,
+        ForceConfigureRequest,
+        InstallRequest,
+        JoinRequest,
+        LeaveRequest,
+        PollRequest,
+        ReconfigureRequest,
+        TransferRequest,
+        VersionedAppendRequest,
+        VoteRequest {
 
   /**
    * Abstract request builder.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * requests to followers to replicate and commit log entries, and followers sent append requests to
  * passive members to replicate committed log entries.
  */
-public class AppendRequest extends AbstractRaftRequest {
+public final class AppendRequest extends AbstractRaftRequest {
 
   private final long term;
   private final String leader;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * member to a passive or reserve member, the active member must update the passive/reserve member's
  * configuration to ensure it is in the expected state.
  */
-public class ConfigureRequest extends AbstractRaftRequest {
+public final class ConfigureRequest extends AbstractRaftRequest {
 
   private final long term;
   private final String leader;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * configuration is requested typically to remove a set of (unavailable) members when a quorum is
  * not possible without them.
  */
-public class ForceConfigureRequest extends AbstractRaftRequest {
+public final class ForceConfigureRequest extends AbstractRaftRequest {
 
   private final long term;
   private final long index;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * and other metadata. The last install request will be sent with {@link #complete()} being {@code
  * true} to indicate that all chunks of the snapshot have been sent.
  */
-public class InstallRequest extends AbstractRaftRequest {
+public final class InstallRequest extends AbstractRaftRequest {
 
   // the term of the node sending the install request
   private final long currentTerm;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/PollRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/PollRequest.java
@@ -30,7 +30,7 @@ import io.atomix.cluster.MemberId;
  * that servers that can't win elections do not disrupt existing leaders when e.g. rejoining the
  * cluster after a partition.
  */
-public class PollRequest extends AbstractRaftRequest {
+public final class PollRequest extends AbstractRaftRequest {
 
   private final long term;
   private final String candidate;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReconfigureRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReconfigureRequest.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /** Request a change of members. Members can change type, be removed or added. */
-public class ReconfigureRequest extends AbstractRaftRequest {
+public final class ReconfigureRequest extends AbstractRaftRequest {
 
   private final long index;
   private final long term;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TransferRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TransferRequest.java
@@ -23,7 +23,7 @@ import io.atomix.cluster.MemberId;
 import java.util.Objects;
 
 /** Leadership transfer request. */
-public class TransferRequest extends AbstractRaftRequest {
+public final class TransferRequest extends AbstractRaftRequest {
 
   protected final MemberId member;
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -30,7 +30,7 @@ import java.util.List;
  * requests to followers to replicate and commit log entries, and followers sent append requests to
  * passive members to replicate committed log entries.
  */
-public class VersionedAppendRequest extends AbstractRaftRequest {
+public final class VersionedAppendRequest extends AbstractRaftRequest {
 
   private static final int CURRENT_VERSION = 2;
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/VoteRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/VoteRequest.java
@@ -30,7 +30,7 @@ import io.atomix.cluster.MemberId;
  * followers to determine whether a candidate should receive their vote based on log and other
  * information.
  */
-public class VoteRequest extends AbstractRaftRequest {
+public final class VoteRequest extends AbstractRaftRequest {
 
   private final long term;
   private final String candidate;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -27,6 +27,7 @@ import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /** Abstract active state. */
@@ -59,6 +60,23 @@ public abstract class ActiveRole extends PassiveRole {
       raft.transition(RaftServer.Role.FOLLOWER);
     }
     return future;
+  }
+
+  @Override
+  public void onBatchAppend(final List<BatchedAppend> batch) {
+    raft.checkThread();
+
+    boolean transition = false;
+    for (final var item : batch) {
+      logRequest(item.request());
+      transition |= updateTermAndLeader(item.request().term(), item.request().leader());
+    }
+
+    handleBatchAppend(batch);
+
+    if (transition) {
+      raft.transition(RaftServer.Role.FOLLOWER);
+    }
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -196,7 +196,7 @@ public final class FollowerRole extends ActiveRole {
     super.onBatchAppend(batch);
     // Reset heartbeat once at the end for the whole batch
     if (!batch.isEmpty()) {
-      final var lastRequest = batch.get(batch.size() - 1).request();
+      final var lastRequest = batch.getLast().request();
       if (isRequestFromCurrentLeader(lastRequest.term(), lastRequest.leader())) {
         onHeartbeatFromLeader();
       }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -37,6 +37,7 @@ import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -188,6 +189,18 @@ public final class FollowerRole extends ActiveRole {
       onHeartbeatFromLeader();
     }
     return future;
+  }
+
+  @Override
+  public void onBatchAppend(final List<BatchedAppend> batch) {
+    super.onBatchAppend(batch);
+    // Reset heartbeat once at the end for the whole batch
+    if (!batch.isEmpty()) {
+      final var lastRequest = batch.get(batch.size() - 1).request();
+      if (isRequestFromCurrentLeader(lastRequest.term(), lastRequest.leader())) {
+        onHeartbeatFromLeader();
+      }
+    }
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -602,8 +602,8 @@ public class PassiveRole extends InactiveRole {
     }
 
     // Phase 2: Single flush for all appended entries
-    final long maxLastLogIndex = pending.get(pending.size() - 1).lastLogIndex;
-    final long minPrevLogIndex = pending.get(0).prevLogIndex;
+    final long maxLastLogIndex = pending.getLast().lastLogIndex;
+    final long minPrevLogIndex = pending.getFirst().prevLogIndex;
     try {
       flush(maxLastLogIndex, minPrevLogIndex);
     } catch (final Exception e) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -588,12 +588,17 @@ public class PassiveRole extends InactiveRole {
       }
 
       final var result = appendEntriesNoFlush(item.request(), item.future());
-      if (result != null) {
-        pending.add(result);
-      } else {
-        // Validation or append failed -- future already completed with error.
+      if (result == null) {
+        // Validation failed -- future already completed with error.
         // Cascade-fail all remaining requests.
         cascadeFailed = true;
+      } else if (!result.succeeded) {
+        // Append failed mid-iteration -- future already completed with error.
+        // Include this result so its entries get flushed, then cascade-fail the rest.
+        pending.add(result);
+        cascadeFailed = true;
+      } else {
+        pending.add(result);
       }
     }
 
@@ -617,8 +622,13 @@ public class PassiveRole extends InactiveRole {
       return;
     }
 
-    // Phase 3: Complete futures -- update commit index and succeed
+    // Phase 3: Complete futures -- update commit index and succeed (only for successful results)
     for (final var result : pending) {
+      if (!result.succeeded) {
+        // This result's future was already completed with error by appendEntriesNoFlush;
+        // we only included it in pending so its entries would be flushed.
+        continue;
+      }
       raft.setFirstCommitIndex(result.request.commitIndex(), result.lastLogIndex);
       final long previousCommitIndex = raft.setCommitIndex(result.commitIndex);
       if (previousCommitIndex < result.commitIndex) {
@@ -663,7 +673,10 @@ public class PassiveRole extends InactiveRole {
         final IndexedRaftLogEntry lastEntry = raft.getLog().getLastEntry();
         final boolean failedToAppend = tryToAppend(future, entry, index, lastEntry);
         if (failedToAppend) {
-          return null;
+          // Return a failed result so the caller can still flush entries appended before
+          // the failure. lastLogIndex - 1 is the last successfully appended entry index.
+          return new PendingAppendResult(
+              request, future, lastLogIndex - 1, commitIndex, request.prevLogIndex(), false);
         }
         if (!role().active() && index == commitIndex) {
           break;
@@ -671,7 +684,8 @@ public class PassiveRole extends InactiveRole {
       }
     }
 
-    return new PendingAppendResult(request, future, lastLogIndex, commitIndex, request.prevLogIndex());
+    return new PendingAppendResult(
+        request, future, lastLogIndex, commitIndex, request.prevLogIndex(), true);
   }
 
   private record PendingAppendResult(
@@ -679,29 +693,56 @@ public class PassiveRole extends InactiveRole {
       CompletableFuture<AppendResponse> future,
       long lastLogIndex,
       long commitIndex,
-      long prevLogIndex) {}
+      long prevLogIndex,
+      boolean succeeded) {}
 
   /** Handles an AppendRequest. */
   protected CompletableFuture<AppendResponse> handleAppend(final InternalAppendRequest request) {
     final CompletableFuture<AppendResponse> future = new CompletableFuture<>();
 
-    // Check that there is a configuration and reject the request if there isn't.
-    if (!checkConfiguration(request, future)) {
+    final PendingAppendResult result = appendEntriesNoFlush(request, future);
+    if (result == null) {
+      // Validation failed before any entries were appended; future already completed with error.
       return future;
     }
 
-    // Check that the term of the given request matches the local term or update the term.
-    if (!checkTerm(request, future)) {
+    if (!result.succeeded) {
+      // Append failed mid-iteration; future already completed with error.
+      // Best-effort flush of any entries written before the failure.
+      try {
+        flush(result.lastLogIndex, result.prevLogIndex);
+      } catch (final Exception e) {
+        log.warn(
+            "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
+            result.lastLogIndex,
+            result.prevLogIndex);
+      }
       return future;
     }
 
-    // Check that the previous index/term matches the local log's last entry.
-    if (!checkPreviousEntry(request, future)) {
+    // Set the first commit index.
+    raft.setFirstCommitIndex(request.commitIndex(), result.lastLogIndex);
+
+    try {
+      // Make sure all entries are flushed before ack to ensure we have persisted what we
+      // acknowledge
+      flush(result.lastLogIndex, result.prevLogIndex);
+    } catch (final Exception e) {
+      log.warn(
+          "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
+          e);
+      failAppend(request.prevLogIndex(), future);
       return future;
     }
 
-    // Append the entries to the log.
-    appendEntries(request, future);
+    // Update the context commit and global indices.
+    final long previousCommitIndex = raft.setCommitIndex(result.commitIndex);
+    if (previousCommitIndex < result.commitIndex) {
+      log.trace("Committed entries up to index {}", result.commitIndex);
+    }
+
+    // Return a successful append response.
+    succeedAppend(result.lastLogIndex, future);
 
     // If the request contains entries, abort any in-progress snapshot replication. The follower
     // is now receiving log entries and must not continue waiting for snapshot chunks. We skip this
@@ -827,82 +868,6 @@ public class PassiveRole extends InactiveRole {
       return failAppend(request.prevLogIndex() - 1, future);
     }
     return true;
-  }
-
-  /** Appends entries from the given AppendRequest. */
-  protected void appendEntries(
-      final InternalAppendRequest request, final CompletableFuture<AppendResponse> future) {
-    // Compute the last entry index from the previous log index and request entry count.
-    final long lastEntryIndex = request.prevLogIndex() + request.entries().size();
-
-    // Ensure the commitIndex is not increased beyond the index of the last entry in the request.
-    final long commitIndex = Math.min(request.commitIndex(), lastEntryIndex);
-
-    // Track the last log index while entries are appended.
-    long lastLogIndex = request.prevLogIndex();
-
-    if (!request.entries().isEmpty()) {
-
-      // If the previous term is zero, that indicates the previous index represents the beginning of
-      // the log.
-      // Reset the log to the previous index plus one.
-      if (request.prevLogTerm() == 0) {
-        log.debug("Reset first index to {}", request.prevLogIndex() + 1);
-        raft.getLog().reset(request.prevLogIndex() + 1);
-      }
-
-      // Iterate through entries and append them.
-      for (final ReplicatableRaftRecord entry : request.entries()) {
-        final long index = ++lastLogIndex;
-
-        // Get the last entry written to the log by the writer.
-        final IndexedRaftLogEntry lastEntry = raft.getLog().getLastEntry();
-
-        final boolean failedToAppend = tryToAppend(future, entry, index, lastEntry);
-        if (failedToAppend) {
-          try {
-            flush(lastLogIndex - 1, request.prevLogIndex());
-          } catch (final Exception e) {
-            log.warn(
-                "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
-                lastLogIndex - 1,
-                request.prevLogIndex());
-          }
-          return;
-        }
-
-        // If the last log index meets the commitIndex, break the append loop to avoid appending
-        // uncommitted entries.
-        if (!role().active() && index == commitIndex) {
-          break;
-        }
-      }
-    }
-
-    // Set the first commit index.
-    raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
-
-    try {
-      //     Make sure all entries are flushed before ack to ensure we have persisted what we
-      //     acknowledge
-      flush(lastLogIndex, request.prevLogIndex());
-    } catch (final Exception e) {
-      log.warn(
-          "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
-          e);
-      // Flush failed, return error to the leader so we can retry.
-      failAppend(request.prevLogIndex(), future);
-      return;
-    }
-
-    // Update the context commit and global indices.
-    final long previousCommitIndex = raft.setCommitIndex(commitIndex);
-    if (previousCommitIndex < commitIndex) {
-      log.trace("Committed entries up to index {}", commitIndex);
-    }
-
-    // Return a successful append response.
-    succeedAppend(lastLogIndex, future);
   }
 
   private void flush(final long lastFlushedIndex, final long previousEntryIndex)

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -688,14 +688,6 @@ public class PassiveRole extends InactiveRole {
         request, future, lastLogIndex, commitIndex, request.prevLogIndex(), true);
   }
 
-  private record PendingAppendResult(
-      InternalAppendRequest request,
-      CompletableFuture<AppendResponse> future,
-      long lastLogIndex,
-      long commitIndex,
-      long prevLogIndex,
-      boolean succeeded) {}
-
   /** Handles an AppendRequest. */
   protected CompletableFuture<AppendResponse> handleAppend(final InternalAppendRequest request) {
     final CompletableFuture<AppendResponse> future = new CompletableFuture<>();
@@ -1073,4 +1065,12 @@ public class PassiveRole extends InactiveRole {
         snapshotIndex + 1);
     raftLog.reset(snapshotIndex + 1);
   }
+
+  private record PendingAppendResult(
+      InternalAppendRequest request,
+      CompletableFuture<AppendResponse> future,
+      long lastLogIndex,
+      long commitIndex,
+      long prevLogIndex,
+      boolean succeeded) {}
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -569,6 +570,116 @@ public class PassiveRole extends InactiveRole {
       onSnapshotReceiveCompletedOrAborted();
     }
   }
+
+  /**
+   * Handles a batch of append requests with a single flush. Each request is validated and entries
+   * are appended (cheap mmap writes) without flushing. A single flush is performed at the end. If
+   * any request fails validation, it and all subsequent requests in the batch are failed.
+   */
+  protected void handleBatchAppend(final List<BatchedAppend> batch) {
+    // Phase 1: Validate and append entries without flushing
+    final var pending = new ArrayList<PendingAppendResult>(batch.size());
+    boolean cascadeFailed = false;
+
+    for (final var item : batch) {
+      if (cascadeFailed) {
+        failAppend(raft.getLog().getLastIndex(), item.future());
+        continue;
+      }
+
+      final var result = appendEntriesNoFlush(item.request(), item.future());
+      if (result != null) {
+        pending.add(result);
+      } else {
+        // Validation or append failed -- future already completed with error.
+        // Cascade-fail all remaining requests.
+        cascadeFailed = true;
+      }
+    }
+
+    if (pending.isEmpty()) {
+      return;
+    }
+
+    // Phase 2: Single flush for all appended entries
+    final long maxLastLogIndex = pending.get(pending.size() - 1).lastLogIndex;
+    final long minPrevLogIndex = pending.get(0).prevLogIndex;
+    try {
+      flush(maxLastLogIndex, minPrevLogIndex);
+    } catch (final Exception e) {
+      log.warn(
+          "Failed to flush batched appended entries, cannot guarantee durability; leader will retry",
+          e);
+      // Flush failed -- fail ALL pending requests
+      for (final var result : pending) {
+        failAppend(result.request.prevLogIndex(), result.future);
+      }
+      return;
+    }
+
+    // Phase 3: Complete futures -- update commit index and succeed
+    for (final var result : pending) {
+      raft.setFirstCommitIndex(result.request.commitIndex(), result.lastLogIndex);
+      final long previousCommitIndex = raft.setCommitIndex(result.commitIndex);
+      if (previousCommitIndex < result.commitIndex) {
+        log.trace("Committed entries up to index {}", result.commitIndex);
+      }
+      succeedAppend(result.lastLogIndex, result.future);
+    }
+
+    // Abort pending snapshots once for the batch
+    abortPendingSnapshots();
+  }
+
+  /**
+   * Appends entries from the request without flushing. Returns a PendingAppendResult on success, or
+   * null if validation/append failed (the future is already completed with an error in that case).
+   */
+  private PendingAppendResult appendEntriesNoFlush(
+      final InternalAppendRequest request, final CompletableFuture<AppendResponse> future) {
+
+    if (!checkConfiguration(request, future)) {
+      return null;
+    }
+    if (!checkTerm(request, future)) {
+      return null;
+    }
+    if (!checkPreviousEntry(request, future)) {
+      return null;
+    }
+
+    final long lastEntryIndex = request.prevLogIndex() + request.entries().size();
+    final long commitIndex = Math.min(request.commitIndex(), lastEntryIndex);
+    long lastLogIndex = request.prevLogIndex();
+
+    if (!request.entries().isEmpty()) {
+      if (request.prevLogTerm() == 0) {
+        log.debug("Reset first index to {}", request.prevLogIndex() + 1);
+        raft.getLog().reset(request.prevLogIndex() + 1);
+      }
+
+      for (final ReplicatableRaftRecord entry : request.entries()) {
+        final long index = ++lastLogIndex;
+        final IndexedRaftLogEntry lastEntry = raft.getLog().getLastEntry();
+        final boolean failedToAppend = tryToAppend(future, entry, index, lastEntry);
+        if (failedToAppend) {
+          return null;
+        }
+        if (!role().active() && index == commitIndex) {
+          break;
+        }
+      }
+    }
+
+    return new PendingAppendResult(request, future, lastLogIndex, commitIndex, request.prevLogIndex());
+  }
+
+  private record PendingAppendResult(
+      InternalAppendRequest request,
+      CompletableFuture<AppendResponse> future,
+      long lastLogIndex,
+      long commitIndex,
+      long prevLogIndex) {}
 
   /** Handles an AppendRequest. */
   protected CompletableFuture<AppendResponse> handleAppend(final InternalAppendRequest request) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -129,9 +129,6 @@ public interface RaftRole extends Managed<RaftRole> {
 
   Either<RaftError, Void> shouldAcceptRequest(RaftRequest request);
 
-  /** A batched append request paired with its response future. */
-  record BatchedAppend(InternalAppendRequest request, CompletableFuture<AppendResponse> future) {}
-
   /**
    * Handles a batch of append requests. The default implementation processes each request
    * individually. Subclasses can override this to batch multiple appends with a single flush.
@@ -170,4 +167,7 @@ public interface RaftRole extends Managed<RaftRole> {
       case final VoteRequest voteRequest -> onVote(voteRequest);
     };
   }
+
+  /** A batched append request paired with its response future. */
+  record BatchedAppend(InternalAppendRequest request, CompletableFuture<AppendResponse> future) {}
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -17,7 +17,9 @@
 package io.atomix.raft.roles;
 
 import io.atomix.raft.RaftError;
-import io.atomix.raft.RaftServer;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.protocol.AbstractRaftRequest;
+import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
@@ -32,15 +34,19 @@ import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.ProtocolVersionHandler;
 import io.atomix.raft.protocol.RaftRequest;
+import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.Managed;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /** Raft role interface. */
@@ -51,7 +57,7 @@ public interface RaftRole extends Managed<RaftRole> {
    *
    * @return The server state type.
    */
-  RaftServer.Role role();
+  Role role();
 
   /**
    * Handles a configure request.
@@ -122,4 +128,46 @@ public interface RaftRole extends Managed<RaftRole> {
   CompletableFuture<VoteResponse> onVote(VoteRequest request);
 
   Either<RaftError, Void> shouldAcceptRequest(RaftRequest request);
+
+  /** A batched append request paired with its response future. */
+  record BatchedAppend(InternalAppendRequest request, CompletableFuture<AppendResponse> future) {}
+
+  /**
+   * Handles a batch of append requests. The default implementation processes each request
+   * individually. Subclasses can override this to batch multiple appends with a single flush.
+   */
+  default void onBatchAppend(final List<BatchedAppend> batch) {
+    for (final var item : batch) {
+      onAppend(item.request())
+          .whenComplete(
+              (response, error) -> {
+                if (error == null) {
+                  item.future().complete(response);
+                } else {
+                  item.future().completeExceptionally(error);
+                }
+              });
+    }
+  }
+
+  default CompletableFuture<? extends RaftResponse> onRaftRequest(
+      final AbstractRaftRequest request) {
+    return switch (request) {
+      case null -> CompletableFuture.failedFuture(new NullPointerException("Request is null"));
+      case final PollRequest pollRequest -> onPoll(pollRequest);
+      case final InstallRequest installRequest -> onInstall(installRequest);
+      case final AppendRequest appendRequest ->
+          onAppend(ProtocolVersionHandler.transform(appendRequest));
+      case final VersionedAppendRequest versionedAppendRequest ->
+          onAppend(ProtocolVersionHandler.transform(versionedAppendRequest));
+      case final TransferRequest transferRequest -> onTransfer(transferRequest);
+      case final LeaveRequest leaveRequest -> onLeave(leaveRequest);
+      case final JoinRequest joinRequest -> onJoin(joinRequest);
+      case final ForceConfigureRequest forceConfigureRequest ->
+          onForceConfigure(forceConfigureRequest);
+      case final ConfigureRequest configureRequest -> onConfigure(configureRequest);
+      case final ReconfigureRequest reconfigureRequest -> onReconfigure(reconfigureRequest);
+      case final VoteRequest voteRequest -> onVote(voteRequest);
+    };
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
@@ -92,11 +93,14 @@ public final class ControllableRaftContexts {
 
   private final int nodeCount;
   private final Map<MemberId, RaftContext> raftServers = new HashMap<>();
+  private final Map<MemberId, Function<RaftStorage.Builder, RaftStorage.Builder>>
+      storageConfigurators = new HashMap<>();
   private final Map<MemberId, TestFileBasedSnapshotStore> snapshotStores = new HashMap<>();
   private final Map<MemberId, MeterRegistry> meterRegistries = new HashMap<>();
   private Duration electionTimeout;
   private Duration heartbeatTimeout;
   private int nextEntry = 0;
+  private RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
 
   // Used only for verification. Map[term -> leader]
   private final NavigableMap<Long, MemberId> leadersAtTerms = new TreeMap<>();
@@ -108,8 +112,27 @@ public final class ControllableRaftContexts {
     this.nodeCount = nodeCount;
   }
 
+  public ControllableRaftContexts withStorageConfigurator(
+      final MemberId memberId,
+      final Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
+    storageConfigurators.put(memberId, configurator);
+    return this;
+  }
+
+  public ControllableRaftContexts withPartitionConfig(final RaftPartitionConfig config) {
+    partitionConfig = config;
+    return this;
+  }
+
   public Map<MemberId, RaftContext> getRaftServers() {
     return raftServers;
+  }
+
+  public List<MemberId> getMembersWithRole(final RaftServer.Role role) {
+    return raftServers.entrySet().stream()
+        .filter(e -> e.getValue().getRole() == role)
+        .map(Map.Entry::getKey)
+        .toList();
   }
 
   public RaftContext getRaftContext(final int memberId) {
@@ -211,9 +234,14 @@ public final class ControllableRaftContexts {
             new TestConcurrencyControl(),
             meterRegistries.computeIfAbsent(memberId, this::meterRegistryForMember));
     snapshotStores.put(memberId, snapshotStore);
+    final Function<RaftStorage.Builder, RaftStorage.Builder> extraConfigurator =
+        storageConfigurators.getOrDefault(memberId, Function.identity());
     final RaftContext raftContext =
         createRaftContext(
-            memberId, random, createStorage(memberId, cfg -> cfg.withSnapshotStore(snapshotStore)));
+            memberId,
+            random,
+            createStorage(
+                memberId, cfg -> extraConfigurator.apply(cfg.withSnapshotStore(snapshotStore))));
     raftServers.put(memberId, raftContext);
     return raftContext;
   }
@@ -231,7 +259,7 @@ public final class ControllableRaftContexts {
             getRaftThreadContextFactory(memberId),
             () -> random,
             RaftElectionConfig.ofPriorityElection(nodeCount, Integer.parseInt(memberId.id()) + 1),
-            new RaftPartitionConfig(),
+            partitionConfig,
             meterRegistries.computeIfAbsent(memberId, this::meterRegistryForMember));
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;
@@ -472,6 +500,24 @@ public final class ControllableRaftContexts {
 
     // Wait until member has recovered lost data and have caught up with the leader
     waitUntilMembersIsReadyIn(newContext, 100);
+  }
+
+  public void awaitClusterReady() {
+    int steps = 500;
+    while (steps-- > 0) {
+      tickHeartbeatTimeout();
+      processAllMessage();
+      runUntilDone();
+      if (hasLeaderAtTheLatestTerm() && hasReplicatedAllEntries()) {
+        // One more round to ensure the leader has received all responses
+        // (which sets appendSucceeded=true, enabling append pipelining)
+        processAllMessage();
+        runUntilDone();
+        return;
+      }
+    }
+    assertThat(hasLeaderAtTheLatestTerm()).describedAs("Cluster should have a leader").isTrue();
+    assertThat(hasReplicatedAllEntries()).describedAs("All entries should be replicated").isTrue();
   }
 
   private void waitUntilThereIsAnotherLeader(final MemberId memberId) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftBatchAppendTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftBatchAppendTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.roles.LeaderRole;
+import io.atomix.raft.storage.log.RaftLogFlusher;
+import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.Journal;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RaftBatchAppendTest {
+
+  @AutoClose("shutdown")
+  private ControllableRaftContexts raftContexts;
+
+  private final Map<MemberId, CountingFlusher> flushers = new HashMap<>();
+  private MemberId leaderId;
+  private List<MemberId> followerIds;
+  private int nextEntry = 0;
+
+  @TempDir private Path raftDataDirectory;
+
+  @BeforeEach
+  void before() throws Exception {
+    final var config = new RaftPartitionConfig();
+    config.setMaxAppendsPerFollower(8);
+    raftContexts = new ControllableRaftContexts(3);
+    raftContexts.withPartitionConfig(config);
+
+    for (int i = 0; i < 3; i++) {
+      final var memberId = MemberId.from(String.valueOf(i));
+      final var flusher = new CountingFlusher();
+      flushers.put(memberId, flusher);
+      raftContexts.withStorageConfigurator(
+          memberId, builder -> builder.withFlusherFactory(ignored -> flusher));
+    }
+
+    raftContexts.setup(raftDataDirectory, new Random(1));
+    raftContexts.awaitClusterReady();
+
+    final var leaders = raftContexts.getMembersWithRole(RaftServer.Role.LEADER);
+    assertThat(leaders).hasSize(1);
+    leaderId = leaders.getFirst();
+
+    followerIds = raftContexts.getMembersWithRole(RaftServer.Role.FOLLOWER);
+    assertThat(followerIds).hasSize(2);
+  }
+
+  @Test
+  void shouldFlushOnceWhenBatchingMultipleAppends() {
+    // given - append 5 entries on the leader
+    final long logBefore = getLogLastIndex(leaderId);
+    appendEntriesOnLeader(5);
+    raftContexts.getDeterministicScheduler(leaderId).runUntilIdle();
+    assertThat(getLogLastIndex(leaderId)).isEqualTo(logBefore + 5);
+
+    // when - deliver and process all messages on each follower
+    for (final var followerId : followerIds) {
+      raftContexts.getServerProtocol(followerId).receiveAll();
+      flushers.get(followerId).reset();
+      raftContexts.getDeterministicScheduler(followerId).runUntilIdle();
+    }
+
+    // then - each follower replicated all entries with a single flush
+    for (final var followerId : followerIds) {
+      assertLogMatchesLeader(followerId);
+      assertFlushCount(followerId, 1);
+    }
+  }
+
+  private void appendEntriesOnLeader(final int count) {
+    final var leaderRole = (LeaderRole) raftContexts.getRaftContext(leaderId).getRaftRole();
+    final var listener = mock(AppendListener.class);
+    for (int i = 0; i < count; i++) {
+      final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, nextEntry++);
+      leaderRole.appendEntry(nextEntry, nextEntry, data, listener);
+    }
+  }
+
+  private long getLogLastIndex(final MemberId memberId) {
+    return raftContexts.getRaftContext(memberId).getLog().getLastIndex();
+  }
+
+  private void assertLogMatchesLeader(final MemberId followerId) {
+    assertThat(getLogLastIndex(followerId))
+        .describedAs("Follower %s should have replicated all entries", followerId)
+        .isEqualTo(getLogLastIndex(leaderId));
+  }
+
+  private void assertFlushCount(final MemberId followerId, final int expected) {
+    assertThat(flushers.get(followerId).flushCount())
+        .describedAs(
+            "Follower %s: batched appends should result in %d flush(es)", followerId, expected)
+        .isEqualTo(expected);
+  }
+
+  static class CountingFlusher implements RaftLogFlusher {
+
+    private final AtomicInteger count = new AtomicInteger();
+
+    @Override
+    public void flush(final Journal journal) throws FlushException {
+      count.incrementAndGet();
+      journal.flush();
+    }
+
+    @Override
+    public boolean isDirect() {
+      return true;
+    }
+
+    int flushCount() {
+      return count.get();
+    }
+
+    void reset() {
+      count.set(0);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  - **Batch follower append requests for single flush**: RAFT replication uses pipelining (~5-6 concurrent append requests from leader to follower). Previously, each append triggered
  an individual synchronous flush (`MappedByteBuffer.force()` + metastore DSYNC), each costing ~2ms with outliers reaching 100-200ms. With pipelining, queued requests accumulated
  latency waiting for previous flushes. This PR batches consecutive append requests into a single flush — entries are appended to the journal (cheap memory-mapped writes) without
  flushing, then a single flush is issued for the entire batch.
  - **Request queue with priority handling**: Incoming RAFT requests are enqueued in a `BlockingQueue` and processed on the raft thread context. Non-append requests (configure,
  install, vote, poll) get priority over appends — they are processed immediately, even if they arrive behind a batch of appends.
  - **Seal `AbstractRaftRequest`** for exhaustive pattern matching in the request dispatcher.

  ## Key design decisions

  - **Three-phase batch processing** in `PassiveRole.handleBatchAppend()`: (1) validate + append entries without flush, (2) single flush, (3) complete futures. If flush fails, all
  requests in the batch fail. If validation/append fails on request N, requests 1..N-1 are flushed and succeed, N+1..M cascade-fail.
  - **Single-request fast path**: When only one append is in the queue, it goes through the standard `processQueuedRequest()` path with no batching overhead.
  - **DRY append logic**: `handleAppend()` (single request path) reuses `appendEntriesNoFlush()` instead of duplicating the entry iteration logic.

  ## Test plan

  - [x] All existing raft tests pass (343 tests, including `RaftCorruptedDataTest`, `PassiveRoleTest`, `RaftAppendTest`, `RaftReplicationTest`, `RandomizedRaftTest`)
  - [ ] Performance validation with pipelined appends to measure flush reduction

