### PR TITLE
Add missing history deletion ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionRequirementsHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteDecisionRequirementsHistoryIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.historydeletion;
+
+import static io.camunda.it.util.DmnBuilderHelper.getDmnModelInstance;
+import static io.camunda.it.util.TestHelper.deployDmnModel;
+import static io.camunda.it.util.TestHelper.evaluateDecision;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForDecisionInstanceCount;
+import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Decision;
+import io.camunda.client.api.response.DeleteResourceResponse;
+import io.camunda.configuration.HistoryDeletion;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class DeleteDecisionRequirementsHistoryIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withProcessingConfig(
+              config ->
+                  config
+                      .getEngine()
+                      .getBatchOperations()
+                      .setSchedulerInterval(Duration.ofMillis(100)))
+          .withDataConfig(
+              config -> {
+                final var historyDeletionConfig = new HistoryDeletion();
+                historyDeletionConfig.setDelayBetweenRuns(Duration.ofMillis(100));
+                historyDeletionConfig.setMaxDelayBetweenRuns(Duration.ofMillis(100));
+                config.setHistoryDeletion(historyDeletionConfig);
+              });
+
+  private static final Duration DELETION_TIMEOUT = Duration.ofSeconds(30);
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldDeleteDecisionRequirementsWithHistory() {
+    // given
+    final var decisionId = Strings.newRandomValidBpmnId();
+    final var dmnModel = getDmnModelInstance(decisionId);
+    final Decision decision = deployDmnModel(camundaClient, dmnModel, decisionId);
+    waitForDecisionsToBeDeployed(
+        camundaClient, decision.getDecisionKey(), decision.getDecisionRequirementsKey(), 1, 1);
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    waitForDecisionInstanceCount(camundaClient, f -> f.decisionDefinitionId(decisionId), 1);
+
+    // when
+    final DeleteResourceResponse result =
+        camundaClient
+            .newDeleteResourceCommand(decision.getDecisionRequirementsKey())
+            .deleteHistory(true)
+            .send()
+            .join();
+
+    // then
+    final var batchOperationKey = result.getCreateBatchOperationResponse().getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 1);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    assertDecisionInstancesDeleted(camundaClient, decisionId);
+    assertDecisionDefinitionsDeleted(camundaClient, decision.getDecisionRequirementsKey());
+    assertDecisionRequirementsDeleted(camundaClient, decision.getDecisionRequirementsKey());
+  }
+
+  @Test
+  void shouldDeleteDecisionRequirementsWithMultipleEvaluatedDecisionInstances() {
+    // given
+    final var decisionId = Strings.newRandomValidBpmnId();
+    final var dmnModel = getDmnModelInstance(decisionId);
+    final Decision decision = deployDmnModel(camundaClient, dmnModel, decisionId);
+    waitForDecisionsToBeDeployed(
+        camundaClient, decision.getDecisionKey(), decision.getDecisionRequirementsKey(), 1, 1);
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    waitForDecisionInstanceCount(camundaClient, f -> f.decisionDefinitionId(decisionId), 3);
+
+    // when
+    final DeleteResourceResponse result =
+        camundaClient
+            .newDeleteResourceCommand(decision.getDecisionRequirementsKey())
+            .deleteHistory(true)
+            .send()
+            .join();
+
+    // then
+    final var batchOperationKey = result.getCreateBatchOperationResponse().getBatchOperationKey();
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 3);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 3, 0);
+    assertDecisionInstancesDeleted(camundaClient, decisionId);
+    assertDecisionDefinitionsDeleted(camundaClient, decision.getDecisionRequirementsKey());
+    assertDecisionRequirementsDeleted(camundaClient, decision.getDecisionRequirementsKey());
+  }
+
+  @Test
+  void shouldDeleteDecisionRequirementsWithoutHistory() {
+    // given
+    final var decisionId = Strings.newRandomValidBpmnId();
+    final var dmnModel = getDmnModelInstance(decisionId);
+    final Decision decision = deployDmnModel(camundaClient, dmnModel, decisionId);
+    waitForDecisionsToBeDeployed(
+        camundaClient, decision.getDecisionKey(), decision.getDecisionRequirementsKey(), 1, 1);
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    waitForDecisionInstanceCount(camundaClient, f -> f.decisionDefinitionId(decisionId), 2);
+
+    // when
+    final DeleteResourceResponse result =
+        camundaClient
+            .newDeleteResourceCommand(decision.getDecisionRequirementsKey())
+            .deleteHistory(false)
+            .send()
+            .join();
+
+    // then - deletion without history should not create a batch operation
+    assertThat(result.getCreateBatchOperationResponse()).isNull();
+    // and - decision instances should still exist
+    waitForDecisionInstanceCount(camundaClient, f -> f.decisionDefinitionId(decisionId), 2);
+    // and - decision definitions and decision requirements should still exist
+    waitForDecisionsToBeDeployed(
+        camundaClient, decision.getDecisionKey(), decision.getDecisionRequirementsKey(), 1, 1);
+  }
+
+  /** Asserts that all decision instances for a given decision definition ID have been deleted. */
+  private void assertDecisionInstancesDeleted(final CamundaClient client, final String decisionId) {
+    Awaitility.await("Decision instances should be deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var decisionInstances =
+                  client
+                      .newDecisionInstanceSearchRequest()
+                      .filter(f -> f.decisionDefinitionId(decisionId))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(decisionInstances).isEmpty();
+            });
+  }
+
+  /**
+   * Asserts that all decision definitions for a given decision requirements key have been deleted.
+   */
+  private void assertDecisionDefinitionsDeleted(
+      final CamundaClient client, final long decisionRequirementsKey) {
+    Awaitility.await("Decision definitions should be deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var decisionDefinitions =
+                  client
+                      .newDecisionDefinitionSearchRequest()
+                      .filter(f -> f.decisionRequirementsKey(decisionRequirementsKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(decisionDefinitions).isEmpty();
+            });
+  }
+
+  /** Asserts that the decision requirements have been deleted from secondary storage. */
+  private void assertDecisionRequirementsDeleted(
+      final CamundaClient client, final long decisionRequirementsKey) {
+    Awaitility.await("Decision requirements should be deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var decisionRequirements =
+                  client
+                      .newDecisionRequirementsSearchRequest()
+                      .filter(f -> f.decisionRequirementsKey(decisionRequirementsKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(decisionRequirements).isEmpty();
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -15,8 +15,10 @@ import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTota
 import static io.camunda.it.util.TestHelper.waitForProcessInstances;
 import static io.camunda.it.util.TestHelper.waitForProcesses;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DeleteResourceResponse;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.HistoryDeletion;
@@ -196,6 +198,50 @@ public class DeleteProcessDefinitionHistoryIT {
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey1);
     assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey2);
     assertProcessDefinitionDeleted(camundaClient, processDefinitionKey);
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenDeletingProcessDefinitionWithHistoryTwice() {
+    // given - a deployed process with a completed instance, deleted with history
+    final var processId = Strings.newRandomValidBpmnId();
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(),
+            processId + ".bpmn");
+    final var processDefinitionKey = process.getProcessDefinitionKey();
+    final long piKey = startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionId(processId).state(ProcessInstanceState.COMPLETED),
+        1);
+
+    final DeleteResourceResponse firstResult =
+        camundaClient
+            .newDeleteResourceCommand(processDefinitionKey)
+            .deleteHistory(true)
+            .send()
+            .join();
+    final var batchOperationKey =
+        firstResult.getCreateBatchOperationResponse().getBatchOperationKey();
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
+    assertProcessDefinitionDeleted(camundaClient, processDefinitionKey);
+
+    // when / then - a second delete with history should return not found
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () ->
+                camundaClient
+                    .newDeleteResourceCommand(processDefinitionKey)
+                    .deleteHistory(true)
+                    .send()
+                    .join())
+        .satisfies(
+            exception -> {
+              assertThat(exception.code()).isEqualTo(404);
+              assertThat(exception.details().getDetail()).containsIgnoringCase("NOT_FOUND");
+            });
   }
 
   /** Asserts that a process definition has been deleted from secondary storage. */

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class DeleteProcessDefinitionIT {
+public class DeleteProcessDefinitionHistoryIT {
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We were missing some scenarios:
1. We didn't verify DRG deletion at all
2. We didn't verify historic data deletion after the resource was already deleted without historic data.

This PR adds both. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to #41189 and #44627 
