### PR TITLE
feat: add audit log smaller design changes

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -210,26 +210,28 @@ const EntityList = <D extends EntityData>({
       {({ rows, getHeaderProps, getToolbarProps, getTableProps }) => (
         <StyledTableContainer {...tableContainerProps}>
           <>
-            <TableToolbar {...getToolbarProps()}>
-              <TableToolbarContent>
-                {searchKey && (
-                  <SearchBar
-                    searchKey={searchKey}
-                    searchPlaceholder={searchPlaceholder}
-                    onSearch={setSearch}
-                  />
-                )}
-                {addEntityLabel && (
-                  <Button
-                    renderIcon={Add}
-                    onClick={onAddEntity}
-                    disabled={addEntityDisabled}
-                  >
-                    {addEntityLabel}
-                  </Button>
-                )}
-              </TableToolbarContent>
-            </TableToolbar>
+            {(searchKey || addEntityLabel) && (
+              <TableToolbar {...getToolbarProps()}>
+                <TableToolbarContent>
+                  {searchKey && (
+                    <SearchBar
+                      searchKey={searchKey}
+                      searchPlaceholder={searchPlaceholder}
+                      onSearch={setSearch}
+                    />
+                  )}
+                  {addEntityLabel && (
+                    <Button
+                      renderIcon={Add}
+                      onClick={onAddEntity}
+                      disabled={addEntityDisabled}
+                    >
+                      {addEntityLabel}
+                    </Button>
+                  )}
+                </TableToolbarContent>
+              </TableToolbar>
+            )}
             {loading && (
               <DataTableSkeleton
                 columnCount={headers.length}

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -111,6 +111,7 @@ type EntityListProps<D extends EntityData> = {
   maxDisplayCellLength?: number;
   setPageNumber?: (page: number) => void;
   setPageSize?: (pageSize: number) => void;
+  pageSizes?: number[];
   page?:
     | ({ pageNumber: number; pageSize: number } & Partial<PageResult>)
     | undefined;
@@ -140,6 +141,7 @@ const EntityList = <D extends EntityData>({
   maxDisplayCellLength = 50,
   setPageNumber = () => {},
   setPageSize = () => {},
+  pageSizes = PAGESIZES,
   page: pageData,
   setSort = () => {},
   setSearch = () => {},
@@ -428,7 +430,7 @@ const EntityList = <D extends EntityData>({
             )}
           </>
           {!!pageData?.totalItems &&
-            pageData.totalItems > Math.min(...PAGESIZES) && (
+            pageData.totalItems > Math.min(...pageSizes) && (
               <Pagination
                 backwardText={t("Previous page")}
                 forwardText={t("Next page")}
@@ -436,7 +438,7 @@ const EntityList = <D extends EntityData>({
                 page={pageData.pageNumber}
                 pageNumberText={t("Page Number")}
                 pageSize={pageData.pageSize}
-                pageSizes={PAGESIZES}
+                pageSizes={pageSizes}
                 totalItems={pageData.totalItems}
                 onChange={({
                   page,

--- a/identity/client/src/pages/operations-log/CellProperty.tsx
+++ b/identity/client/src/pages/operations-log/CellProperty.tsx
@@ -43,9 +43,7 @@ const CellProperty: React.FC<Props> = ({ item }) => {
           {item.relatedEntityType
             ? spaceAndCapitalize(item.relatedEntityType)
             : "-"}{" "}
-          <CodeSnippet type="inline" hideCopyButton>
-            {item.relatedEntityKey}
-          </CodeSnippet>
+          <CodeSnippet type="inline">{item.relatedEntityKey}</CodeSnippet>
         </OwnerInfo>
       </div>
     );

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -115,7 +115,10 @@ const List: FC = () => {
     setPageNumber,
     setPageSize,
     setSort: setPaginationSort,
-  } = usePagination();
+  } = usePagination({
+    pageNumber: 1,
+    pageSize: 50,
+  });
 
   const transformedSort = useMemo((): AuditLogSort[] => {
     if (!pageParams.sort || pageParams.sort.length === 0) {

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -359,6 +359,7 @@ const List: FC = () => {
             loading={loading}
             setSort={handleSort}
             page={{ ...page, ...auditLogs?.page }}
+            pageSizes={[50, 100, 200]}
             setPageNumber={setPageNumber}
             setPageSize={setPageSize}
           />

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -25,6 +25,7 @@ import {
 } from "./components/styled";
 import {
   Button,
+  CodeSnippet,
   Column,
   DatePicker,
   DatePickerInput,
@@ -331,7 +332,9 @@ const List: FC = () => {
                   </OperationLogName>
                 ),
                 entityType: spaceAndCapitalize(log.entityType),
-                reference: log.entityKey,
+                reference: (
+                  <CodeSnippet type="inline">{log.entityKey}</CodeSnippet>
+                ),
                 property: <CellProperty item={log} />,
                 actorId: log.actorId ? (
                   <OperationLogName>

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/OperationsLog/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/OperationsLog/index.tsx
@@ -264,6 +264,7 @@ const OperationsLog: React.FC<Props> = observer(({isVisible}) => {
           fetchPreviousPage,
           fetchNextPage,
         }}
+        stickyHeader
       />
       {detailsModal.auditLog && (
         <DetailsModal


### PR DESCRIPTION
## Description

- Conditionally render `TableToolbar` in `EntityList` component
- Set default page size 50 for identity OperationsLog table
- Enable sticky header for OperationsLog table

## Related issues

related to https://github.com/camunda/camunda/issues/46246
