### PR TITLE
feat: introduce audit log cleanup ES/OS export handler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -95,6 +95,7 @@ import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandl
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -488,7 +489,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
 
   private void addAuditLogHandlers(final AuditLogConfiguration auditLog, final int partitionId) {
     final var indexName = (indexDescriptors.get(AuditLogTemplate.class).getFullQualifiedName());
-    final var auditLogBuilder = AuditLogHandler.builder(indexName, auditLog);
+    final var auditLogCleanupIndexName =
+        (indexDescriptors.get(AuditLogCleanupIndex.class).getFullQualifiedName());
+    final var auditLogBuilder =
+        AuditLogHandler.builder(indexName, auditLogCleanupIndexName, auditLog);
 
     if (partitionId == PROCESS_DEFINITION_PARTITION) {
       AuditLogTransformerRegistry.createPartitionSpecificTransformers()


### PR DESCRIPTION
## Description

- Filter cleanup handlers in resource provider
- Add tests for `AuditLogCleanupHandler` and update resource provider filtering logic
- Introduce audit log cleanup ES/OS export handler

## Related issues

closes https://github.com/camunda/camunda/issues/46200
