### PR TITLE
feat/rdbms limit total count

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -63,6 +63,8 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   @NestedConfigurationProperty
   private RdbmsInsertBatching insertBatching = new RdbmsInsertBatching();
 
+  @NestedConfigurationProperty private RdbmsQuery query = new RdbmsQuery();
+
   public Boolean getAutoDdl() {
     return autoDdl;
   }
@@ -165,5 +167,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setInsertBatching(final RdbmsInsertBatching insertBatching) {
     this.insertBatching = insertBatching;
+  }
+
+  public RdbmsQuery getQuery() {
+    return query;
+  }
+
+  public void setQuery(final RdbmsQuery query) {
+    this.query = query;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/RdbmsQuery.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsQuery.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+
+public class RdbmsQuery {
+
+  /** The maximum number of total hits to return in search results. */
+  private int maxTotalHits = RdbmsReaderConfig.DEFAULT_MAX_TOTAL_HITS;
+
+  public int getMaxTotalHits() {
+    return maxTotalHits;
+  }
+
+  public void setMaxTotalHits(final int maxTotalHits) {
+    this.maxTotalHits = maxTotalHits;
+  }
+
+  public RdbmsReaderConfig toReaderConfig() {
+    return RdbmsReaderConfig.builder().maxTotalHits(maxTotalHits).build();
+  }
+}

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/h2.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/h2.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
+count.limit=LIMIT #{page.maxTotalHits}
 userCharColumn.size=400
 variableValue.previewSize=8191
 errorMessage.size=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mariadb.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mariadb.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
+count.limit=LIMIT #{page.maxTotalHits}
 userCharColumn.size=400
 variableValue.previewSize=8191
 errorMessage.size=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mssql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mssql.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=OFFSET 0 ROWS FETCH NEXT #{page.size} ROWS ONLY
+count.limit=ORDER BY col OFFSET 0 ROWS FETCH NEXT #{page.maxTotalHits} ROWS ONLY
 userCharColumn.size=400
 variableValue.previewSize=8191
 errorMessage.size=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/mysql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/mysql.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
+count.limit=LIMIT #{page.maxTotalHits}
 userCharColumn.size=400
 variableValue.previewSize=8191
 treePath.size=8191

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/oracle.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
+count.limit=FETCH NEXT #{page.maxTotalHits} ROWS ONLY
 userCharColumn.size=400
 charColumn.maxBytes=4000
 variableValue.previewSize=4000

--- a/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms-schema/src/main/resources/db/vendor-properties/postgresql.properties
@@ -8,6 +8,7 @@
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
+count.limit=LIMIT #{page.maxTotalHits}
 userCharColumn.size=400
 variableValue.previewSize=8191
 errorMessage.size=4000

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsReaderConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsReaderConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read;
+
+import io.camunda.util.ObjectBuilder;
+
+public record RdbmsReaderConfig(
+    /*
+     * The maximum number of total hits to return in search results.
+     * This is used to limit the total hits count to prevent performance issues.
+     */
+    int maxTotalHits) {
+
+  public static final int DEFAULT_MAX_TOTAL_HITS = 10000;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder implements ObjectBuilder<RdbmsReaderConfig> {
+
+    private int maxTotalHits = DEFAULT_MAX_TOTAL_HITS;
+
+    public Builder maxTotalHits(final int maxTotalHits) {
+      this.maxTotalHits = maxTotalHits;
+      return this;
+    }
+
+    @Override
+    public RdbmsReaderConfig build() {
+      return new RdbmsReaderConfig(maxTotalHits);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -10,7 +10,8 @@ package io.camunda.db.rdbms.read.domain;
 import io.camunda.search.sort.SortOrder;
 import java.util.List;
 
-public record DbQueryPage(Integer size, Integer from, List<KeySetPagination> keySetPagination) {
+public record DbQueryPage(
+    Integer size, Integer from, Integer maxTotalHits, List<KeySetPagination> keySetPagination) {
 
   public record KeySetPagination(List<KeySetPaginationFieldEntry> entries) {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import static io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry.determineOperator;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
@@ -37,14 +38,17 @@ abstract class AbstractEntityReader<T> {
 
   private static final SearchColumn<?>[] EMPTY_SEARCHABLE_COLUMNS = new SearchColumn[0];
   private final Map<String, SearchColumn<T>> columns;
+  private final RdbmsReaderConfig readerConfig;
 
-  public AbstractEntityReader(final SearchColumn<T>[] searchableColumns) {
+  public AbstractEntityReader(
+      final SearchColumn<T>[] searchableColumns, final RdbmsReaderConfig readerConfig) {
     final var searchColumns =
         Objects.requireNonNullElse(searchableColumns, (SearchColumn<T>[]) EMPTY_SEARCHABLE_COLUMNS);
 
     columns =
         Stream.of(searchColumns)
             .collect(Collectors.toMap(SearchColumn::property, Function.identity()));
+    this.readerConfig = readerConfig;
   }
 
   private SearchColumn<T> getSearchColumn(final String property) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.AuditLogAuthorizationFilter;
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
 import io.camunda.db.rdbms.read.mapper.AuditLogEntityMapper;
@@ -29,8 +30,9 @@ public class AuditLogDbReader extends AbstractEntityReader<AuditLogEntity>
 
   private final AuditLogMapper auditLogMapper;
 
-  public AuditLogDbReader(final AuditLogMapper auditLogMapper) {
-    super(AuditLogSearchColumn.values());
+  public AuditLogDbReader(
+      final AuditLogMapper auditLogMapper, final RdbmsReaderConfig readerConfig) {
+    super(AuditLogSearchColumn.values(), readerConfig);
     this.auditLogMapper = auditLogMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.AuthorizationDbQuery;
 import io.camunda.db.rdbms.read.mapper.AuthorizationEntityMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
@@ -30,8 +31,9 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
 
   private final AuthorizationMapper authorizationMapper;
 
-  public AuthorizationDbReader(final AuthorizationMapper authorizationMapper) {
-    super(AuthorizationSearchColumn.values());
+  public AuthorizationDbReader(
+      final AuthorizationMapper authorizationMapper, final RdbmsReaderConfig readerConfig) {
+    super(AuthorizationSearchColumn.values(), readerConfig);
     this.authorizationMapper = authorizationMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
+import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.mapper.BatchOperationEntityMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.columns.BatchOperationSearchColumn;
@@ -29,8 +31,9 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
 
   private final BatchOperationMapper batchOperationMapper;
 
-  public BatchOperationDbReader(final BatchOperationMapper batchOperationMapper) {
-    super(BatchOperationSearchColumn.values());
+  public BatchOperationDbReader(
+      final BatchOperationMapper batchOperationMapper, final RdbmsReaderConfig readerConfig) {
+    super(BatchOperationSearchColumn.values(), readerConfig);
     this.batchOperationMapper = batchOperationMapper;
   }
 
@@ -71,7 +74,7 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
                     .sort(dbSort)
                     .page(dbPage));
 
-    LOG.trace("[RDBMS DB] Search for batch operations with filter {}", dbQuery);
+    LOG.debug("[RDBMS DB] Search for batch operations with filter {}", dbQuery);
     final var totalHits = batchOperationMapper.count(dbQuery);
 
     if (shouldReturnEmptyPage(dbPage, totalHits)) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -41,6 +41,7 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
     final var query =
         new BatchOperationDbQuery.Builder()
             .filter(b -> b.batchOperationKeys(batchOperationKey))
+            .page(new DbQueryPage(1, 0, 1, List.of()))
             .build();
 
     return batchOperationMapper.count(query) == 1;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -75,7 +75,7 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
                     .sort(dbSort)
                     .page(dbPage));
 
-    LOG.debug("[RDBMS DB] Search for batch operations with filter {}", dbQuery);
+    LOG.trace("[RDBMS DB] Search for batch operations with filter {}", dbQuery);
     final var totalHits = batchOperationMapper.count(dbQuery);
 
     if (shouldReturnEmptyPage(dbPage, totalHits)) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.BatchOperationItemDbQuery;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.columns.BatchOperationItemSearchColumn;
@@ -26,8 +27,9 @@ public class BatchOperationItemDbReader extends AbstractEntityReader<BatchOperat
 
   private final BatchOperationMapper batchOperationMapper;
 
-  public BatchOperationItemDbReader(final BatchOperationMapper batchOperationMapper) {
-    super(BatchOperationItemSearchColumn.values());
+  public BatchOperationItemDbReader(
+      final BatchOperationMapper batchOperationMapper, final RdbmsReaderConfig readerConfig) {
+    super(BatchOperationItemSearchColumn.values(), readerConfig);
     this.batchOperationMapper = batchOperationMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery;
 import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.columns.ClusterVariableSearchColumn;
@@ -29,8 +30,9 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
 
   private final ClusterVariableMapper clusterVariableMapper;
 
-  public ClusterVariableDbReader(final ClusterVariableMapper clusterVariableMapper) {
-    super(ClusterVariableSearchColumn.values());
+  public ClusterVariableDbReader(
+      final ClusterVariableMapper clusterVariableMapper, final RdbmsReaderConfig readerConfig) {
+    super(ClusterVariableSearchColumn.values(), readerConfig);
     this.clusterVariableMapper = clusterVariableMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/CorrelatedMessageSubscriptionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/CorrelatedMessageSubscriptionDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.CorrelatedMessageSubscriptionDbQuery;
 import io.camunda.db.rdbms.read.mapper.CorrelatedMessageSubscriptionEntityMapper;
 import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
@@ -31,8 +32,9 @@ public class CorrelatedMessageSubscriptionDbReader
 
   private final CorrelatedMessageSubscriptionMapper mapper;
 
-  public CorrelatedMessageSubscriptionDbReader(final CorrelatedMessageSubscriptionMapper mapper) {
-    super(CorrelatedMessageSubscriptionSearchColumn.values());
+  public CorrelatedMessageSubscriptionDbReader(
+      final CorrelatedMessageSubscriptionMapper mapper, final RdbmsReaderConfig readerConfig) {
+    super(CorrelatedMessageSubscriptionSearchColumn.values(), readerConfig);
     this.mapper = mapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.DecisionDefinitionSearchColumn;
@@ -28,8 +29,10 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
 
   private final DecisionDefinitionMapper decisionDefinitionMapper;
 
-  public DecisionDefinitionDbReader(final DecisionDefinitionMapper decisionDefinitionMapper) {
-    super(DecisionDefinitionSearchColumn.values());
+  public DecisionDefinitionDbReader(
+      final DecisionDefinitionMapper decisionDefinitionMapper,
+      final RdbmsReaderConfig readerConfig) {
+    super(DecisionDefinitionSearchColumn.values(), readerConfig);
     this.decisionDefinitionMapper = decisionDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DecisionInstanceDbQuery;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.columns.DecisionInstanceSearchColumn;
@@ -36,8 +37,9 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
 
   private final DecisionInstanceMapper decisionInstanceMapper;
 
-  public DecisionInstanceDbReader(final DecisionInstanceMapper decisionInstanceMapper) {
-    super(DecisionInstanceSearchColumn.values());
+  public DecisionInstanceDbReader(
+      final DecisionInstanceMapper decisionInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    super(DecisionInstanceSearchColumn.values(), readerConfig);
     this.decisionInstanceMapper = decisionInstanceMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.columns.DecisionRequirementsSearchColumn;
@@ -28,8 +29,10 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
 
   private final DecisionRequirementsMapper decisionRequirementsMapper;
 
-  public DecisionRequirementsDbReader(final DecisionRequirementsMapper decisionRequirementsMapper) {
-    super(DecisionRequirementsSearchColumn.values());
+  public DecisionRequirementsDbReader(
+      final DecisionRequirementsMapper decisionRequirementsMapper,
+      final RdbmsReaderConfig readerConfig) {
+    super(DecisionRequirementsSearchColumn.values(), readerConfig);
     this.decisionRequirementsMapper = decisionRequirementsMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.mapper.FlowNodeInstanceEntityMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -29,8 +30,9 @@ public class FlowNodeInstanceDbReader extends AbstractEntityReader<FlowNodeInsta
 
   private final FlowNodeInstanceMapper flowNodeInstanceMapper;
 
-  public FlowNodeInstanceDbReader(final FlowNodeInstanceMapper flowNodeInstanceMapper) {
-    super(FlowNodeInstanceSearchColumn.values());
+  public FlowNodeInstanceDbReader(
+      final FlowNodeInstanceMapper flowNodeInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    super(FlowNodeInstanceSearchColumn.values(), readerConfig);
     this.flowNodeInstanceMapper = flowNodeInstanceMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.FormDbQuery;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.columns.FormSearchColumn;
@@ -26,8 +27,8 @@ public class FormDbReader extends AbstractEntityReader<FormEntity> implements Fo
 
   private final FormMapper formMapper;
 
-  public FormDbReader(final FormMapper formMapper) {
-    super(FormSearchColumn.values());
+  public FormDbReader(final FormMapper formMapper, final RdbmsReaderConfig readerConfig) {
+    super(FormSearchColumn.values(), readerConfig);
     this.formMapper = formMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GlobalListenerDbQuery;
 import io.camunda.db.rdbms.read.mapper.GlobalListenerEntityMapper;
 import io.camunda.db.rdbms.sql.GlobalListenerMapper;
@@ -29,8 +30,9 @@ public class GlobalListenerDbReader extends AbstractEntityReader<GlobalListenerE
 
   private final GlobalListenerMapper globalListenerMapper;
 
-  public GlobalListenerDbReader(final GlobalListenerMapper globalListenerMapper) {
-    super(GlobalListenerSearchColumn.values());
+  public GlobalListenerDbReader(
+      final GlobalListenerMapper globalListenerMapper, final RdbmsReaderConfig rdbmsReaderConfig) {
+    super(GlobalListenerSearchColumn.values(), rdbmsReaderConfig);
     this.globalListenerMapper = globalListenerMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GroupDbQuery;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.columns.GroupSearchColumn;
@@ -29,8 +30,8 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
 
   private final GroupMapper groupMapper;
 
-  public GroupDbReader(final GroupMapper groupMapper) {
-    super(GroupSearchColumn.values());
+  public GroupDbReader(final GroupMapper groupMapper, final RdbmsReaderConfig readerConfig) {
+    super(GroupSearchColumn.values(), readerConfig);
     this.groupMapper = groupMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupMemberDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupMemberDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GroupMemberDbQuery;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.columns.GroupMemberSearchColumn;
@@ -29,8 +30,8 @@ public class GroupMemberDbReader extends AbstractEntityReader<GroupMemberEntity>
 
   private final GroupMapper groupMapper;
 
-  public GroupMemberDbReader(final GroupMapper groupMapper) {
-    super(GroupMemberSearchColumn.values());
+  public GroupMemberDbReader(final GroupMapper groupMapper, final RdbmsReaderConfig readerConfig) {
+    super(GroupMemberSearchColumn.values(), readerConfig);
     this.groupMapper = groupMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.IncidentDbQuery;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.columns.IncidentSearchColumn;
@@ -28,8 +29,9 @@ public class IncidentDbReader extends AbstractEntityReader<IncidentEntity>
 
   private final IncidentMapper incidentMapper;
 
-  public IncidentDbReader(final IncidentMapper incidentMapper) {
-    super(IncidentSearchColumn.values());
+  public IncidentDbReader(
+      final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    super(IncidentSearchColumn.values(), readerConfig);
     this.incidentMapper = incidentMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByDefinitionDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.columns.IncidentProcessInstanceStatisticsByDefinitionSearchColumn;
@@ -30,8 +31,8 @@ public class IncidentProcessInstanceStatisticsByDefinitionDbReader
   private final IncidentMapper incidentMapper;
 
   public IncidentProcessInstanceStatisticsByDefinitionDbReader(
-      final IncidentMapper incidentMapper) {
-    super(IncidentProcessInstanceStatisticsByDefinitionSearchColumn.values());
+      final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    super(IncidentProcessInstanceStatisticsByDefinitionSearchColumn.values(), readerConfig);
     this.incidentMapper = incidentMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.IncidentProcessInstanceStatisticsByErrorDbQuery;
 import io.camunda.db.rdbms.sql.IncidentMapper;
 import io.camunda.db.rdbms.sql.columns.IncidentProcessInstanceStatisticsByErrorSearchColumn;
@@ -29,8 +30,9 @@ public class IncidentProcessInstanceStatisticsByErrorDbReader
 
   private final IncidentMapper incidentMapper;
 
-  public IncidentProcessInstanceStatisticsByErrorDbReader(final IncidentMapper incidentMapper) {
-    super(IncidentProcessInstanceStatisticsByErrorSearchColumn.values());
+  public IncidentProcessInstanceStatisticsByErrorDbReader(
+      final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    super(IncidentProcessInstanceStatisticsByErrorSearchColumn.values(), readerConfig);
     this.incidentMapper = incidentMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.JobDbQuery;
 import io.camunda.db.rdbms.read.mapper.JobEntityMapper;
 import io.camunda.db.rdbms.sql.JobMapper;
@@ -28,8 +29,8 @@ public class JobDbReader extends AbstractEntityReader<JobEntity> implements JobR
 
   private final JobMapper jobMapper;
 
-  public JobDbReader(final JobMapper jobMapper) {
-    super(JobSearchColumn.values());
+  public JobDbReader(final JobMapper jobMapper, final RdbmsReaderConfig readerConfig) {
+    super(JobSearchColumn.values(), readerConfig);
     this.jobMapper = jobMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import static java.util.Optional.ofNullable;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
@@ -40,8 +41,9 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
 
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
-  public JobMetricsBatchDbReader(final JobMetricsBatchMapper jobMetricsBatchMapper) {
-    super(JobTypeStatisticsColumn.values());
+  public JobMetricsBatchDbReader(
+      final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
+    super(JobTypeStatisticsColumn.values(), readerConfig);
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.MappingRuleDbQuery;
 import io.camunda.db.rdbms.sql.MappingRuleMapper;
 import io.camunda.db.rdbms.sql.columns.MappingRuleSearchColumn;
@@ -29,8 +30,9 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
 
   private final MappingRuleMapper mappingRuleMapper;
 
-  public MappingRuleDbReader(final MappingRuleMapper mappingRuleMapper) {
-    super(MappingRuleSearchColumn.values());
+  public MappingRuleDbReader(
+      final MappingRuleMapper mappingRuleMapper, final RdbmsReaderConfig readerConfig) {
+    super(MappingRuleSearchColumn.values(), readerConfig);
     this.mappingRuleMapper = mappingRuleMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.MessageSubscriptionDbQuery;
 import io.camunda.db.rdbms.read.mapper.MessageSubscriptionEntityMapper;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
@@ -29,8 +30,9 @@ public class MessageSubscriptionDbReader extends AbstractEntityReader<MessageSub
 
   private final MessageSubscriptionMapper mapper;
 
-  public MessageSubscriptionDbReader(final MessageSubscriptionMapper mapper) {
-    super(MessageSubscriptionColumn.values());
+  public MessageSubscriptionDbReader(
+      final MessageSubscriptionMapper mapper, final RdbmsReaderConfig readerConfig) {
+    super(MessageSubscriptionColumn.values(), readerConfig);
     this.mapper = mapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.ProcessDefinitionSearchColumn;
@@ -28,8 +29,9 @@ public class ProcessDefinitionDbReader extends AbstractEntityReader<ProcessDefin
 
   private final ProcessDefinitionMapper processDefinitionMapper;
 
-  public ProcessDefinitionDbReader(final ProcessDefinitionMapper processDefinitionMapper) {
-    super(ProcessDefinitionSearchColumn.values());
+  public ProcessDefinitionDbReader(
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    super(ProcessDefinitionSearchColumn.values(), readerConfig);
     this.processDefinitionMapper = processDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceStatisticsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.ProcessDefinitionInstanceStatisticsSearchColumn;
@@ -30,8 +31,8 @@ public class ProcessDefinitionInstanceStatisticsDbReader
   private final ProcessDefinitionMapper processDefinitionMapper;
 
   public ProcessDefinitionInstanceStatisticsDbReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    super(ProcessDefinitionInstanceStatisticsSearchColumn.values());
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    super(ProcessDefinitionInstanceStatisticsSearchColumn.values(), readerConfig);
     this.processDefinitionMapper = processDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionInstanceVersionStatisticsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionInstanceVersionStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.columns.ProcessDefinitionInstanceVersionStatisticsSearchColumn;
@@ -30,8 +31,8 @@ public class ProcessDefinitionInstanceVersionStatisticsDbReader
   private final ProcessDefinitionMapper processDefinitionMapper;
 
   public ProcessDefinitionInstanceVersionStatisticsDbReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    super(ProcessDefinitionInstanceVersionStatisticsSearchColumn.values());
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    super(ProcessDefinitionInstanceVersionStatisticsSearchColumn.values(), readerConfig);
     this.processDefinitionMapper = processDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionMessageSubscriptionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionMessageSubscriptionStatisticsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionMessageSubscriptionStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.columns.ProcessDefinitionMessageSubscriptionStatisticsColumn;
@@ -35,8 +36,8 @@ public class ProcessDefinitionMessageSubscriptionStatisticsDbReader
   private final MessageSubscriptionMapper mapper;
 
   public ProcessDefinitionMessageSubscriptionStatisticsDbReader(
-      final MessageSubscriptionMapper mapper) {
-    super(ProcessDefinitionMessageSubscriptionStatisticsColumn.values());
+      final MessageSubscriptionMapper mapper, final RdbmsReaderConfig readerConfig) {
+    super(ProcessDefinitionMessageSubscriptionStatisticsColumn.values(), readerConfig);
     this.mapper = mapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.search.clients.reader.ProcessDefinitionStatisticsReader;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
@@ -26,8 +27,8 @@ public class ProcessDefinitionStatisticsDbReader
   private final ProcessDefinitionMapper processDefinitionMapper;
 
   public ProcessDefinitionStatisticsDbReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    super(null);
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    super(null, readerConfig);
     this.processDefinitionMapper = processDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
@@ -31,8 +32,9 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
 
   private final ProcessInstanceMapper processInstanceMapper;
 
-  public ProcessInstanceDbReader(final ProcessInstanceMapper processInstanceMapper) {
-    super(ProcessInstanceSearchColumn.values());
+  public ProcessInstanceDbReader(
+      final ProcessInstanceMapper processInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    super(ProcessInstanceSearchColumn.values(), readerConfig);
     this.processInstanceMapper = processInstanceMapper;
   }
 
@@ -89,6 +91,6 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
       final int partitionId, final OffsetDateTime cleanupDate, final int limit) {
     return processInstanceMapper.selectExpiredRootProcessInstances(
         new SelectExpiredRootProcessInstancesDto(
-            partitionId, cleanupDate, new DbQueryPage(limit, null, null)));
+            partitionId, cleanupDate, new DbQueryPage(limit, null, null, null)));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceStatisticsDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.search.clients.reader.ProcessInstanceStatisticsReader;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
@@ -25,8 +26,9 @@ public class ProcessInstanceStatisticsDbReader
 
   private final ProcessInstanceMapper processInstanceMapper;
 
-  public ProcessInstanceStatisticsDbReader(final ProcessInstanceMapper processInstanceMapper) {
-    super(null);
+  public ProcessInstanceStatisticsDbReader(
+      final ProcessInstanceMapper processInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    super(null, readerConfig);
     this.processInstanceMapper = processInstanceMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.RoleDbQuery;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.columns.RoleSearchColumn;
@@ -29,8 +30,8 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
 
   private final RoleMapper roleMapper;
 
-  public RoleDbReader(final RoleMapper roleMapper) {
-    super(RoleSearchColumn.values());
+  public RoleDbReader(final RoleMapper roleMapper, final RdbmsReaderConfig readerConfig) {
+    super(RoleSearchColumn.values(), readerConfig);
     this.roleMapper = roleMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleMemberDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleMemberDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.RoleMemberDbQuery;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.columns.RoleMemberSearchColumn;
@@ -29,8 +30,8 @@ public class RoleMemberDbReader extends AbstractEntityReader<RoleMemberEntity>
 
   private final RoleMapper roleMapper;
 
-  public RoleMemberDbReader(final RoleMapper roleMapper) {
-    super(RoleMemberSearchColumn.values());
+  public RoleMemberDbReader(final RoleMapper roleMapper, final RdbmsReaderConfig readerConfig) {
+    super(RoleMemberSearchColumn.values(), readerConfig);
     this.roleMapper = roleMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SequenceFlowDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SequenceFlowDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.SequenceFlowDbQuery;
 import io.camunda.db.rdbms.read.mapper.SequenceFlowEntityMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
@@ -27,8 +28,9 @@ public class SequenceFlowDbReader extends AbstractEntityReader<SequenceFlowEntit
 
   private final SequenceFlowMapper sequenceFlowMapper;
 
-  public SequenceFlowDbReader(final SequenceFlowMapper sequenceFlowMapper) {
-    super(null);
+  public SequenceFlowDbReader(
+      final SequenceFlowMapper sequenceFlowMapper, final RdbmsReaderConfig readerConfig) {
+    super(null, readerConfig);
     this.sequenceFlowMapper = sequenceFlowMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.TenantDbQuery;
 import io.camunda.db.rdbms.sql.TenantMapper;
 import io.camunda.db.rdbms.sql.columns.TenantSearchColumn;
@@ -29,8 +30,8 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
 
   private final TenantMapper tenantMapper;
 
-  public TenantDbReader(final TenantMapper tenantMapper) {
-    super(TenantSearchColumn.values());
+  public TenantDbReader(final TenantMapper tenantMapper, final RdbmsReaderConfig readerConfig) {
+    super(TenantSearchColumn.values(), readerConfig);
     this.tenantMapper = tenantMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantMemberDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantMemberDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.TenantMemberDbQuery;
 import io.camunda.db.rdbms.sql.TenantMapper;
 import io.camunda.db.rdbms.sql.columns.TenantMemberSearchColumn;
@@ -28,8 +29,9 @@ public class TenantMemberDbReader extends AbstractEntityReader<TenantMemberEntit
 
   private final TenantMapper tenantMapper;
 
-  public TenantMemberDbReader(final TenantMapper tenantMapper) {
-    super(TenantMemberSearchColumn.values());
+  public TenantMemberDbReader(
+      final TenantMapper tenantMapper, final RdbmsReaderConfig readerConfig) {
+    super(TenantMemberSearchColumn.values(), readerConfig);
     this.tenantMapper = tenantMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.UserDbQuery;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.columns.UserSearchColumn;
@@ -27,8 +28,8 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
 
   private final UserMapper userMapper;
 
-  public UserDbReader(final UserMapper userMapper) {
-    super(UserSearchColumn.values());
+  public UserDbReader(final UserMapper userMapper, final RdbmsReaderConfig readerConfig) {
+    super(UserSearchColumn.values(), readerConfig);
     this.userMapper = userMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.read.service;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.UserTaskDbQuery;
 import io.camunda.db.rdbms.read.domain.UserTaskDbQuery.UserTaskAuthorizationProperties;
 import io.camunda.db.rdbms.read.mapper.UserTaskEntityMapper;
@@ -36,8 +37,9 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
 
   private final UserTaskMapper userTaskMapper;
 
-  public UserTaskDbReader(final UserTaskMapper userTaskMapper) {
-    super(UserTaskSearchColumn.values());
+  public UserTaskDbReader(
+      final UserTaskMapper userTaskMapper, final RdbmsReaderConfig readerConfig) {
+    super(UserTaskSearchColumn.values(), readerConfig);
     this.userTaskMapper = userTaskMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.VariableDbQuery;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.columns.VariableSearchColumn;
@@ -30,8 +31,9 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
 
   private final VariableMapper variableMapper;
 
-  public VariableDbReader(final VariableMapper variableMapper) {
-    super(VariableSearchColumn.values());
+  public VariableDbReader(
+      final VariableMapper variableMapper, final RdbmsReaderConfig readerConfig) {
+    super(VariableSearchColumn.values(), readerConfig);
     this.variableMapper = variableMapper;
   }
 

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.AuditLogMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}AUDIT_LOG
-    <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.searchFilter" />
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}AUDIT_LOG
+      <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.searchFilter" />
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search"

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -12,9 +12,12 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.AuthorizationDbQuery">
     SELECT COUNT(*) FROM (
-    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME
+    SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME,
+                    <!-- MSSQL needs a sort column -->
+                    NULL as col
     FROM ${prefix}AUTHORIZATIONS a
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
+    ${count.limit}
     ) t
   </select>
 

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -14,7 +14,7 @@
     SELECT COUNT(*) FROM (
     SELECT DISTINCT AUTHORIZATION_KEY, OWNER_ID, OWNER_TYPE, RESOURCE_TYPE, RESOURCE_MATCHER, RESOURCE_ID, RESOURCE_PROPERTY_NAME,
                     <!-- MSSQL needs a sort column -->
-                    NULL as col
+                    1 as col
     FROM ${prefix}AUTHORIZATIONS a
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
     ${count.limit}

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -252,9 +252,12 @@
   </update>
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}BATCH_OPERATION
-    <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}BATCH_OPERATION
+      <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search"
@@ -346,10 +349,13 @@
   </sql>
 
   <select id="countItems" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}BATCH_OPERATION_ITEM bi
-    JOIN ${prefix}BATCH_OPERATION bo ON (bi.batch_operation_key = bo.batch_operation_key)
-    <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.itemSearchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}BATCH_OPERATION_ITEM bi
+      JOIN ${prefix}BATCH_OPERATION bo ON (bi.batch_operation_key = bo.batch_operation_key)
+      <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.itemSearchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="searchItems"

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -23,9 +23,12 @@
   </resultMap>
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}CLUSTER_VARIABLE
-    <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}CLUSTER_VARIABLE
+      <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery"

--- a/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/CorrelatedMessageSubscriptionMapper.xml
@@ -67,9 +67,12 @@
   </insert>
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.CorrelatedMessageSubscriptionDbQuery" resultType="long">
-    SELECT COUNT(*)
-    FROM ${prefix}CORRELATED_MESSAGE_SUBSCRIPTION
-    <include refid="io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper.searchAndAuthFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}CORRELATED_MESSAGE_SUBSCRIPTION
+      <include refid="io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper.searchAndAuthFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -11,10 +11,13 @@
 <mapper namespace="io.camunda.db.rdbms.sql.DecisionDefinitionMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}DECISION_DEFINITION t
-    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.maxVersionFilter"/>
-    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}DECISION_DEFINITION t
+      <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.maxVersionFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery"

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -11,11 +11,14 @@
 <mapper namespace="io.camunda.db.rdbms.sql.DecisionInstanceMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}DECISION_INSTANCE di
-    LEFT JOIN ${prefix}DECISION_DEFINITION dd ON (di.DECISION_DEFINITION_KEY =
-    dd.DECISION_DEFINITION_KEY)
-    <include refid="io.camunda.db.rdbms.sql.DecisionInstanceMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}DECISION_INSTANCE di
+      LEFT JOIN ${prefix}DECISION_DEFINITION dd ON (di.DECISION_DEFINITION_KEY =
+      dd.DECISION_DEFINITION_KEY)
+      <include refid="io.camunda.db.rdbms.sql.DecisionInstanceMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.DecisionRequirementsMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}DECISION_REQUIREMENTS
-    <include refid="io.camunda.db.rdbms.sql.DecisionRequirementsMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}DECISION_REQUIREMENTS
+      <include refid="io.camunda.db.rdbms.sql.DecisionRequirementsMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery"

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}FLOW_NODE_INSTANCE fni
-    <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}FLOW_NODE_INSTANCE fni
+      <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/FormMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FormMapper.xml
@@ -38,9 +38,12 @@
   </update>
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.FormDbQuery" resultType="long">
-    SELECT COUNT(*)
-    FROM ${prefix}FORM
-    <include refid="io.camunda.db.rdbms.sql.FormMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}FORM
+      <include refid="io.camunda.db.rdbms.sql.FormMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.FormDbQuery"

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -127,9 +127,12 @@
   </select>
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}GLOBAL_LISTENER gl
-    <include refid="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}GLOBAL_LISTENER gl
+      <include refid="io.camunda.db.rdbms.sql.GlobalListenerMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <sql id="searchFilter">

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.GroupMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}GROUP_ g
-    <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}GROUP_ g
+      <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery"

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.IncidentMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}INCIDENT i
-    <include refid="io.camunda.db.rdbms.sql.IncidentMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}INCIDENT i
+      <include refid="io.camunda.db.rdbms.sql.IncidentMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -13,9 +13,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.JobMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}JOB
-    <include refid="io.camunda.db.rdbms.sql.JobMapper.searchFilter" />
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}JOB
+      <include refid="io.camunda.db.rdbms.sql.JobMapper.searchFilter" />
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -43,9 +43,12 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.MappingRuleDbQuery"
     resultType="long">
-    SELECT COUNT(*)
-    FROM ${prefix}MAPPING_RULES m
-    <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}MAPPING_RULES m
+      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.MappingRuleDbQuery"

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -13,9 +13,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.MessageSubscriptionMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}MESSAGE_SUBSCRIPTION
-    <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchAndAuthFilter" />
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}MESSAGE_SUBSCRIPTION
+      <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchAndAuthFilter" />
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -11,10 +11,13 @@
 <mapper namespace="io.camunda.db.rdbms.sql.ProcessDefinitionMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}PROCESS_DEFINITION t
-    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.maxVersionFilter"/>
-    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}PROCESS_DEFINITION t
+      <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.maxVersionFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery"
@@ -347,10 +350,11 @@
     resultType="long">
     SELECT COUNT(*)
     FROM (
-      SELECT pi.PROCESS_DEFINITION_ID
-      FROM ${prefix}PROCESS_INSTANCE pi
+      SELECT 1 as col
+    FROM ${prefix}PROCESS_INSTANCE pi
     <include refid="processInstanceStatisticsWhere"/>
     <include refid="processInstanceStatisticsGroupBy"/>
+    ${count.limit}
     ) t
   </select>
 
@@ -424,12 +428,13 @@
     SELECT COUNT(*)
     FROM
     (SELECT
-    pi.PROCESS_DEFINITION_KEY
+    1 as col
     FROM ${prefix}PROCESS_INSTANCE pi
     JOIN ${prefix}PROCESS_DEFINITION pd
     ON pd.PROCESS_DEFINITION_KEY = pi.PROCESS_DEFINITION_KEY
     <include refid="processInstanceVersionStatisticsWhere"/>
     <include refid="processInstanceVersionStatisticsGroupBy"/>
+    ${count.limit}
     ) t
   </select>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -37,11 +37,15 @@
   </select>
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}PROCESS_INSTANCE pi
-    <!-- TODO: only when definition filters are active -->
-    LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
-    <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchAndAuthFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}PROCESS_INSTANCE pi
+      <!-- TODO: only when definition filters are active -->
+      LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY =
+      pd.PROCESS_DEFINITION_KEY)
+      <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchAndAuthFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -11,16 +11,22 @@
 <mapper namespace="io.camunda.db.rdbms.sql.RoleMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}ROLES r
-    <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}ROLES r
+      <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="countMembers" parameterType="io.camunda.db.rdbms.read.domain.RoleMemberDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}ROLE_MEMBER rm
-    JOIN ${prefix}ROLES r ON r.ROLE_ID = rm.ROLE_ID
-    <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchMemberFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}ROLE_MEMBER rm
+      JOIN ${prefix}ROLES r ON r.ROLE_ID = rm.ROLE_ID
+      <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchMemberFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery"

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -11,9 +11,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.TenantMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.TenantDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}TENANT t
-    <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}TENANT t
+      <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.TenantDbQuery"
@@ -33,10 +36,13 @@
   </select>
 
   <select id="countMembers" parameterType="io.camunda.db.rdbms.read.domain.TenantMemberDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}TENANT_MEMBER tm
-    JOIN ${prefix}TENANT t ON t.TENANT_ID = tm.TENANT_ID
-    <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchMemberFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}TENANT_MEMBER tm
+      JOIN ${prefix}TENANT t ON t.TENANT_ID = tm.TENANT_ID
+      <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchMemberFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="searchMembers" parameterType="io.camunda.db.rdbms.read.domain.TenantMemberDbQuery"

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -11,17 +11,20 @@
 <mapper namespace="io.camunda.db.rdbms.sql.UserMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.UserDbQuery">
-    SELECT COUNT(*)
-    FROM ${prefix}USER_ t
-    <if test="filter.groupId != null">
-      JOIN ${prefix}GROUP_MEMBER gm ON t.USERNAME = gm.ENTITY_ID
-      AND gm.ENTITY_TYPE = 'USER'
-    </if>
-    <if test="filter.roleId != null">
-      JOIN ${prefix}ROLE_MEMBER rm ON t.USERNAME = rm.ENTITY_ID
-      AND rm.ENTITY_TYPE = 'USER'
-    </if>
-      <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}USER_ t
+      <if test="filter.groupId != null">
+        JOIN ${prefix}GROUP_MEMBER gm ON t.USERNAME = gm.ENTITY_ID
+        AND gm.ENTITY_TYPE = 'USER'
+      </if>
+      <if test="filter.roleId != null">
+        JOIN ${prefix}ROLE_MEMBER rm ON t.USERNAME = rm.ENTITY_ID
+        AND rm.ENTITY_TYPE = 'USER'
+      </if>
+        <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.UserDbQuery"

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -138,9 +138,12 @@
   </select>
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}USER_TASK ut
-    <include refid="io.camunda.db.rdbms.sql.UserTaskMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}USER_TASK ut
+      <include refid="io.camunda.db.rdbms.sql.UserTaskMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <sql id="searchFilter">

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -10,9 +10,12 @@
 <mapper namespace="io.camunda.db.rdbms.sql.VariableMapper">
 
   <select id="count" resultType="java.lang.Long">
-    SELECT COUNT(*)
-    FROM ${prefix}VARIABLE
-    <include refid="io.camunda.db.rdbms.sql.VariableMapper.searchFilter"/>
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}VARIABLE
+      <include refid="io.camunda.db.rdbms.sql.VariableMapper.searchFilter"/>
+      ${count.limit}
+    ) t
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.read.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
@@ -27,11 +28,13 @@ import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
 class AbstractEntityReaderTest {
-  final AbstractEntityReader<ProcessInstanceEntity> reader = new ProcessInstanceDbReader(null);
+  public static final RdbmsReaderConfig TEST_CONFIG = RdbmsReaderConfig.builder().build();
+  final AbstractEntityReader<ProcessInstanceEntity> reader =
+      new ProcessInstanceDbReader(null, TEST_CONFIG);
 
   @Test
   void shouldConvertSort() {
-    final var reader = new ProcessInstanceDbReader(null);
+    final var reader = new ProcessInstanceDbReader(null, TEST_CONFIG);
 
     final var convertedSort =
         reader.convertSort(
@@ -48,7 +51,7 @@ class AbstractEntityReaderTest {
 
   @Test
   void shouldThrowOnUnknownSortColumn() {
-    final var reader = new ProcessInstanceDbReader(null);
+    final var reader = new ProcessInstanceDbReader(null, TEST_CONFIG);
 
     assertThatThrownBy(
             () ->

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuditLogDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuditLogDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class AuditLogDbReaderTest {
   private final AuditLogMapper auditLogMapper = mock(AuditLogMapper.class);
-  private final AuditLogDbReader auditLogDbReader = new AuditLogDbReader(auditLogMapper);
+  private final AuditLogDbReader auditLogDbReader =
+      new AuditLogDbReader(auditLogMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuthorizationDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuthorizationDbReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class AuthorizationDbReaderTest {
   private final AuthorizationMapper authorizationMapper = mock(AuthorizationMapper.class);
   private final AuthorizationDbReader authorizationDbReader =
-      new AuthorizationDbReader(authorizationMapper);
+      new AuthorizationDbReader(authorizationMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/BatchOperationDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/BatchOperationDbReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class BatchOperationDbReaderTest {
   private final BatchOperationMapper batchOperationMapper = mock(BatchOperationMapper.class);
   private final BatchOperationDbReader batchOperationDbReader =
-      new BatchOperationDbReader(batchOperationMapper);
+      new BatchOperationDbReader(batchOperationMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/BatchOperationItemDbReaderTest.java
@@ -25,7 +25,7 @@ class BatchOperationItemDbReaderTest {
 
   private final BatchOperationMapper batchOperationMapper = mock(BatchOperationMapper.class);
   private final BatchOperationItemDbReader batchOperationItemDbReader =
-      new BatchOperationItemDbReader(batchOperationMapper);
+      new BatchOperationItemDbReader(batchOperationMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyPageWhenPageSizeIsZero() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReaderTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 class ClusterVariableDbReaderTest {
   private final ClusterVariableMapper clusterVariableMapper = mock(ClusterVariableMapper.class);
   private final ClusterVariableDbReader clusterVariableDbReader =
-      new ClusterVariableDbReader(clusterVariableMapper);
+      new ClusterVariableDbReader(clusterVariableMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CorrelatedMessageSubscriptionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/CorrelatedMessageSubscriptionDbReaderTest.java
@@ -27,7 +27,8 @@ class CorrelatedMessageSubscriptionDbReaderTest {
   private final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper =
       mock(CorrelatedMessageSubscriptionMapper.class);
   private final CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionDbReader =
-      new CorrelatedMessageSubscriptionDbReader(correlatedMessageSubscriptionMapper);
+      new CorrelatedMessageSubscriptionDbReader(
+          correlatedMessageSubscriptionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReaderTest.java
@@ -27,7 +27,8 @@ class DecisionDefinitionDbReaderTest {
   private final DecisionDefinitionMapper decisionDefinitionMapper =
       mock(DecisionDefinitionMapper.class);
   private final DecisionDefinitionDbReader decisionDefinitionDbReader =
-      new DecisionDefinitionDbReader(decisionDefinitionMapper);
+      new DecisionDefinitionDbReader(
+          decisionDefinitionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReaderTest.java
@@ -25,7 +25,7 @@ class DecisionInstanceDbReaderTest {
 
   private final DecisionInstanceMapper decisionInstanceMapper = mock(DecisionInstanceMapper.class);
   private final DecisionInstanceDbReader decisionInstanceDbReader =
-      new DecisionInstanceDbReader(decisionInstanceMapper);
+      new DecisionInstanceDbReader(decisionInstanceMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyPageWhenPageSizeIsZero() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReaderTest.java
@@ -27,7 +27,8 @@ class DecisionRequirementsDbReaderTest {
   private final DecisionRequirementsMapper decisionRequirementsMapper =
       mock(DecisionRequirementsMapper.class);
   private final DecisionRequirementsDbReader decisionRequirementsDbReader =
-      new DecisionRequirementsDbReader(decisionRequirementsMapper);
+      new DecisionRequirementsDbReader(
+          decisionRequirementsMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class FlowNodeInstanceDbReaderTest {
   private final FlowNodeInstanceMapper flowNodeInstanceMapper = mock(FlowNodeInstanceMapper.class);
   private final FlowNodeInstanceDbReader flowNodeInstanceDbReader =
-      new FlowNodeInstanceDbReader(flowNodeInstanceMapper);
+      new FlowNodeInstanceDbReader(flowNodeInstanceMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/FormDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/FormDbReaderTest.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
 class FormDbReaderTest {
 
   private final FormMapper formMapper = mock(FormMapper.class);
-  private final FormDbReader formDbReader = new FormDbReader(formMapper);
+  private final FormDbReader formDbReader =
+      new FormDbReader(formMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyPageWhenPageSizeIsZero() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReaderTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class GlobalListenerDbReaderTest {
   private final GlobalListenerMapper globalListenerMapper = mock(GlobalListenerMapper.class);
   private final GlobalListenerDbReader globalListenerDbReader =
-      new GlobalListenerDbReader(globalListenerMapper);
+      new GlobalListenerDbReader(globalListenerMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupDbReaderTest.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 class GroupDbReaderTest {
 
   private final GroupMapper mapper = mock(GroupMapper.class);
-  private final GroupDbReader reader = new GroupDbReader(mapper);
+  private final GroupDbReader reader =
+      new GroupDbReader(mapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldImmediatelyReturnEmptyResultWhenMemberIdsFilterIsEmpty() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupMemberDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/GroupMemberDbReaderTest.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
 class GroupMemberDbReaderTest {
 
   private final GroupMapper groupMapper = mock(GroupMapper.class);
-  private final GroupMemberDbReader groupMemberDbReader = new GroupMemberDbReader(groupMapper);
+  private final GroupMemberDbReader groupMemberDbReader =
+      new GroupMemberDbReader(groupMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyPageWhenPageSizeIsZero() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class IncidentDbReaderTest {
   private final IncidentMapper incidentMapper = mock(IncidentMapper.class);
-  private final IncidentDbReader incidentDbReader = new IncidentDbReader(incidentMapper);
+  private final IncidentDbReader incidentDbReader =
+      new IncidentDbReader(incidentMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByDefinitionDbReaderTest.java
@@ -28,7 +28,8 @@ class IncidentProcessInstanceStatisticsByDefinitionDbReaderTest {
 
   private final IncidentMapper incidentMapper = mock(IncidentMapper.class);
   private final IncidentProcessInstanceStatisticsByDefinitionDbReader reader =
-      new IncidentProcessInstanceStatisticsByDefinitionDbReader(incidentMapper);
+      new IncidentProcessInstanceStatisticsByDefinitionDbReader(
+          incidentMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/IncidentProcessInstanceStatisticsByErrorDbReaderTest.java
@@ -28,7 +28,8 @@ class IncidentProcessInstanceStatisticsByErrorDbReaderTest {
 
   private final IncidentMapper incidentMapper = mock(IncidentMapper.class);
   private final IncidentProcessInstanceStatisticsByErrorDbReader reader =
-      new IncidentProcessInstanceStatisticsByErrorDbReader(incidentMapper);
+      new IncidentProcessInstanceStatisticsByErrorDbReader(
+          incidentMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class JobDbReaderTest {
   private final JobMapper jobMapper = mock(JobMapper.class);
-  private final JobDbReader jobDbReader = new JobDbReader(jobMapper);
+  private final JobDbReader jobDbReader =
+      new JobDbReader(jobMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class JobMetricsBatchDbReaderTest {
   private final JobMetricsBatchMapper jobMetricsBatchMapper = mock(JobMetricsBatchMapper.class);
   private final JobMetricsBatchDbReader jobMetricsBatchDbReader =
-      new JobMetricsBatchDbReader(jobMetricsBatchMapper);
+      new JobMetricsBatchDbReader(jobMetricsBatchMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyGlobalJobStatisticsWhenTenantCheckEnabledButNoTenants() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/MappingRuleDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/MappingRuleDbReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class MappingRuleDbReaderTest {
   private final MappingRuleMapper mappingRuleMapper = mock(MappingRuleMapper.class);
   private final MappingRuleDbReader mappingRuleDbReader =
-      new MappingRuleDbReader(mappingRuleMapper);
+      new MappingRuleDbReader(mappingRuleMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReaderTest.java
@@ -27,7 +27,8 @@ class MessageSubscriptionDbReaderTest {
   private final MessageSubscriptionMapper messageSubscriptionMapper =
       mock(MessageSubscriptionMapper.class);
   private final MessageSubscriptionDbReader messageSubscriptionDbReader =
-      new MessageSubscriptionDbReader(messageSubscriptionMapper);
+      new MessageSubscriptionDbReader(
+          messageSubscriptionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReaderTest.java
@@ -27,7 +27,7 @@ class ProcessDefinitionDbReaderTest {
   private final ProcessDefinitionMapper processDefinitionMapper =
       mock(ProcessDefinitionMapper.class);
   private final ProcessDefinitionDbReader processDefinitionDbReader =
-      new ProcessDefinitionDbReader(processDefinitionMapper);
+      new ProcessDefinitionDbReader(processDefinitionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessDefinitionStatisticsDbReaderTest.java
@@ -24,7 +24,8 @@ class ProcessDefinitionStatisticsDbReaderTest {
   private final ProcessDefinitionMapper processDefinitionMapper =
       mock(ProcessDefinitionMapper.class);
   private final ProcessDefinitionStatisticsDbReader reader =
-      new ProcessDefinitionStatisticsDbReader(processDefinitionMapper);
+      new ProcessDefinitionStatisticsDbReader(
+          processDefinitionMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnStatistics() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class ProcessInstanceDbReaderTest {
   private final ProcessInstanceMapper processInstanceMapper = mock(ProcessInstanceMapper.class);
   private final ProcessInstanceDbReader processInstanceDbReader =
-      new ProcessInstanceDbReader(processInstanceMapper);
+      new ProcessInstanceDbReader(processInstanceMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessInstanceStatisticsDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/ProcessInstanceStatisticsDbReaderTest.java
@@ -22,7 +22,8 @@ import org.junit.jupiter.api.Test;
 class ProcessInstanceStatisticsDbReaderTest {
   private final ProcessInstanceMapper processInstanceMapper = mock(ProcessInstanceMapper.class);
   private final ProcessInstanceStatisticsDbReader reader =
-      new ProcessInstanceStatisticsDbReader(processInstanceMapper);
+      new ProcessInstanceStatisticsDbReader(
+          processInstanceMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnStatistics() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class RoleDbReaderTest {
   private final RoleMapper roleMapper = mock(RoleMapper.class);
-  private final RoleDbReader roleDbReader = new RoleDbReader(roleMapper);
+  private final RoleDbReader roleDbReader =
+      new RoleDbReader(roleMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleMemberDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/RoleMemberDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class RoleMemberDbReaderTest {
   private final RoleMapper roleMapper = mock(RoleMapper.class);
-  private final RoleMemberDbReader roleMemberDbReader = new RoleMemberDbReader(roleMapper);
+  private final RoleMemberDbReader roleMemberDbReader =
+      new RoleMemberDbReader(roleMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/SequenceFlowDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/SequenceFlowDbReaderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 class SequenceFlowDbReaderTest {
   private final SequenceFlowMapper sequenceFlowMapper = mock(SequenceFlowMapper.class);
   private final SequenceFlowDbReader sequenceFlowDbReader =
-      new SequenceFlowDbReader(sequenceFlowMapper);
+      new SequenceFlowDbReader(sequenceFlowMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantDbReaderTest.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 class TenantDbReaderTest {
 
   private final TenantMapper mapper = mock(TenantMapper.class);
-  private final TenantDbReader reader = new TenantDbReader(mapper);
+  private final TenantDbReader reader =
+      new TenantDbReader(mapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldImmediatelyReturnEmptyResultWhenMemberIdsFilterIsEmpty() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantMemberDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/TenantMemberDbReaderTest.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
 class TenantMemberDbReaderTest {
 
   private final TenantMapper tenantMapper = mock(TenantMapper.class);
-  private final TenantMemberDbReader tenantMemberDbReader = new TenantMemberDbReader(tenantMapper);
+  private final TenantMemberDbReader tenantMemberDbReader =
+      new TenantMemberDbReader(tenantMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyPageWhenPageSizeIsZero() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UserDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UserDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class UserDbReaderTest {
   private final UserMapper userMapper = mock(UserMapper.class);
-  private final UserDbReader userDbReader = new UserDbReader(userMapper);
+  private final UserDbReader userDbReader =
+      new UserDbReader(userMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UserTaskDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/UserTaskDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class UserTaskDbReaderTest {
   private final UserTaskMapper userTaskMapper = mock(UserTaskMapper.class);
-  private final UserTaskDbReader userTaskDbReader = new UserTaskDbReader(userTaskMapper);
+  private final UserTaskDbReader userTaskDbReader =
+      new UserTaskDbReader(userTaskMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class VariableDbReaderTest {
   private final VariableMapper variableMapper = mock(VariableMapper.class);
-  private final VariableDbReader variableDbReader = new VariableDbReader(variableMapper);
+  private final VariableDbReader variableDbReader =
+      new VariableDbReader(variableMapper, AbstractEntityReaderTest.TEST_CONFIG);
 
   @Test
   void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNull() {

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -12,6 +12,7 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
@@ -110,157 +111,182 @@ public class RdbmsConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsConfiguration.class);
 
   @Bean
-  public VariableDbReader variableRdbmsReader(final VariableMapper variableMapper) {
-    return new VariableDbReader(variableMapper);
+  public RdbmsReaderConfig rdbmsReaderConfig(final Camunda configuration) {
+    return configuration.getData().getSecondaryStorage().getRdbms().getQuery().toReaderConfig();
+  }
+
+  @Bean
+  public VariableDbReader variableRdbmsReader(
+      final VariableMapper variableMapper, final RdbmsReaderConfig readerConfig) {
+    return new VariableDbReader(variableMapper, readerConfig);
   }
 
   @Bean
   public ClusterVariableDbReader clusterVariableRdbmsReader(
-      final ClusterVariableMapper clusterVariableMapper) {
-    return new ClusterVariableDbReader(clusterVariableMapper);
+      final ClusterVariableMapper clusterVariableMapper, final RdbmsReaderConfig readerConfig) {
+    return new ClusterVariableDbReader(clusterVariableMapper, readerConfig);
   }
 
   @Bean
-  public AuthorizationDbReader authorizationReader(final AuthorizationMapper authorizationMapper) {
-    return new AuthorizationDbReader(authorizationMapper);
+  public AuthorizationDbReader authorizationReader(
+      final AuthorizationMapper authorizationMapper, final RdbmsReaderConfig readerConfig) {
+    return new AuthorizationDbReader(authorizationMapper, readerConfig);
   }
 
   @Bean
-  public AuditLogDbReader auditLogReader(final AuditLogMapper auditLogMapper) {
-    return new AuditLogDbReader(auditLogMapper);
+  public AuditLogDbReader auditLogReader(
+      final AuditLogMapper auditLogMapper, final RdbmsReaderConfig readerConfig) {
+    return new AuditLogDbReader(auditLogMapper, readerConfig);
   }
 
   @Bean
   public DecisionDefinitionDbReader decisionDefinitionReader(
-      final DecisionDefinitionMapper decisionDefinitionMapper) {
-    return new DecisionDefinitionDbReader(decisionDefinitionMapper);
+      final DecisionDefinitionMapper decisionDefinitionMapper,
+      final RdbmsReaderConfig readerConfig) {
+    return new DecisionDefinitionDbReader(decisionDefinitionMapper, readerConfig);
   }
 
   @Bean
   public DecisionInstanceDbReader decisionInstanceReader(
-      final DecisionInstanceMapper decisionInstanceMapper) {
-    return new DecisionInstanceDbReader(decisionInstanceMapper);
+      final DecisionInstanceMapper decisionInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    return new DecisionInstanceDbReader(decisionInstanceMapper, readerConfig);
   }
 
   @Bean
   public DecisionRequirementsDbReader decisionRequirementsReader(
-      final DecisionRequirementsMapper decisionRequirementsMapper) {
-    return new DecisionRequirementsDbReader(decisionRequirementsMapper);
+      final DecisionRequirementsMapper decisionRequirementsMapper,
+      final RdbmsReaderConfig readerConfig) {
+    return new DecisionRequirementsDbReader(decisionRequirementsMapper, readerConfig);
   }
 
   @Bean
   public FlowNodeInstanceDbReader flowNodeInstanceReader(
-      final FlowNodeInstanceMapper flowNodeInstanceMapper) {
-    return new FlowNodeInstanceDbReader(flowNodeInstanceMapper);
+      final FlowNodeInstanceMapper flowNodeInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    return new FlowNodeInstanceDbReader(flowNodeInstanceMapper, readerConfig);
   }
 
   @Bean
-  public GroupDbReader groupReader(final GroupMapper groupMapper) {
-    return new GroupDbReader(groupMapper);
+  public GroupDbReader groupReader(
+      final GroupMapper groupMapper, final RdbmsReaderConfig readerConfig) {
+    return new GroupDbReader(groupMapper, readerConfig);
   }
 
   @Bean
-  public GroupMemberDbReader groupMemberReader(final GroupMapper groupMapper) {
-    return new GroupMemberDbReader(groupMapper);
+  public GroupMemberDbReader groupMemberReader(
+      final GroupMapper groupMapper, final RdbmsReaderConfig readerConfig) {
+    return new GroupMemberDbReader(groupMapper, readerConfig);
   }
 
   @Bean
-  public IncidentDbReader incidentReader(final IncidentMapper incidentMapper) {
-    return new IncidentDbReader(incidentMapper);
+  public IncidentDbReader incidentReader(
+      final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    return new IncidentDbReader(incidentMapper, readerConfig);
   }
 
   @Bean
   public ProcessDefinitionDbReader processDefinitionReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    return new ProcessDefinitionDbReader(processDefinitionMapper);
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionDbReader(processDefinitionMapper, readerConfig);
   }
 
   @Bean
   public ProcessDefinitionStatisticsDbReader processDefinitionStatisticsReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    return new ProcessDefinitionStatisticsDbReader(processDefinitionMapper);
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionStatisticsDbReader(processDefinitionMapper, readerConfig);
   }
 
   @Bean
   public ProcessInstanceDbReader processInstanceReader(
-      final ProcessInstanceMapper processInstanceMapper) {
-    return new ProcessInstanceDbReader(processInstanceMapper);
+      final ProcessInstanceMapper processInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    return new ProcessInstanceDbReader(processInstanceMapper, readerConfig);
   }
 
   @Bean
   public ProcessInstanceStatisticsDbReader processInstanceStatisticsReader(
-      final ProcessInstanceMapper processInstanceMapper) {
-    return new ProcessInstanceStatisticsDbReader(processInstanceMapper);
+      final ProcessInstanceMapper processInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    return new ProcessInstanceStatisticsDbReader(processInstanceMapper, readerConfig);
   }
 
   @Bean
-  public TenantDbReader tenantReader(final TenantMapper tenantMapper) {
-    return new TenantDbReader(tenantMapper);
+  public TenantDbReader tenantReader(
+      final TenantMapper tenantMapper, final RdbmsReaderConfig readerConfig) {
+    return new TenantDbReader(tenantMapper, readerConfig);
   }
 
   @Bean
-  public TenantMemberDbReader tenantMemberReader(final TenantMapper tenantMapper) {
-    return new TenantMemberDbReader(tenantMapper);
+  public TenantMemberDbReader tenantMemberReader(
+      final TenantMapper tenantMapper, final RdbmsReaderConfig readerConfig) {
+    return new TenantMemberDbReader(tenantMapper, readerConfig);
   }
 
   @Bean
-  public UserDbReader userReader(final UserMapper userTaskMapper) {
-    return new UserDbReader(userTaskMapper);
+  public UserDbReader userReader(
+      final UserMapper userTaskMapper, final RdbmsReaderConfig readerConfig) {
+    return new UserDbReader(userTaskMapper, readerConfig);
   }
 
   @Bean
-  public RoleDbReader roleReader(final RoleMapper roleMapper) {
-    return new RoleDbReader(roleMapper);
+  public RoleDbReader roleReader(
+      final RoleMapper roleMapper, final RdbmsReaderConfig readerConfig) {
+    return new RoleDbReader(roleMapper, readerConfig);
   }
 
   @Bean
-  public RoleMemberDbReader roleMemberReader(final RoleMapper roleMapper) {
-    return new RoleMemberDbReader(roleMapper);
+  public RoleMemberDbReader roleMemberReader(
+      final RoleMapper roleMapper, final RdbmsReaderConfig readerConfig) {
+    return new RoleMemberDbReader(roleMapper, readerConfig);
   }
 
   @Bean
-  public UserTaskDbReader userTaskReader(final UserTaskMapper userTaskMapper) {
-    return new UserTaskDbReader(userTaskMapper);
+  public UserTaskDbReader userTaskReader(
+      final UserTaskMapper userTaskMapper, final RdbmsReaderConfig readerConfig) {
+    return new UserTaskDbReader(userTaskMapper, readerConfig);
   }
 
   @Bean
-  public FormDbReader formReader(final FormMapper formMapper) {
-    return new FormDbReader(formMapper);
+  public FormDbReader formReader(
+      final FormMapper formMapper, final RdbmsReaderConfig readerConfig) {
+    return new FormDbReader(formMapper, readerConfig);
   }
 
   @Bean
-  public MappingRuleDbReader mappingReader(final MappingRuleMapper mappingMapper) {
-    return new MappingRuleDbReader(mappingMapper);
+  public MappingRuleDbReader mappingReader(
+      final MappingRuleMapper mappingMapper, final RdbmsReaderConfig readerConfig) {
+    return new MappingRuleDbReader(mappingMapper, readerConfig);
   }
 
   @Bean
   public MessageSubscriptionDbReader messageSubscriptionDbReader(
-      final MessageSubscriptionMapper messageSubscriptionMapper) {
-    return new MessageSubscriptionDbReader(messageSubscriptionMapper);
+      final MessageSubscriptionMapper messageSubscriptionMapper,
+      final RdbmsReaderConfig readerConfig) {
+    return new MessageSubscriptionDbReader(messageSubscriptionMapper, readerConfig);
   }
 
   @Bean
   public ProcessDefinitionMessageSubscriptionStatisticsDbReader
       processDefinitionMessageSubscriptionStatisticsDbReader(
-          final MessageSubscriptionMapper messageSubscriptionMapper) {
-    return new ProcessDefinitionMessageSubscriptionStatisticsDbReader(messageSubscriptionMapper);
+          final MessageSubscriptionMapper messageSubscriptionMapper,
+          final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionMessageSubscriptionStatisticsDbReader(
+        messageSubscriptionMapper, readerConfig);
   }
 
   @Bean
   public BatchOperationDbReader batchOperationReader(
-      final BatchOperationMapper batchOperationMapper) {
-    return new BatchOperationDbReader(batchOperationMapper);
+      final BatchOperationMapper batchOperationMapper, final RdbmsReaderConfig readerConfig) {
+    return new BatchOperationDbReader(batchOperationMapper, readerConfig);
   }
 
   @Bean
-  public SequenceFlowDbReader sequenceFlowReader(final SequenceFlowMapper sequenceFlowMapper) {
-    return new SequenceFlowDbReader(sequenceFlowMapper);
+  public SequenceFlowDbReader sequenceFlowReader(
+      final SequenceFlowMapper sequenceFlowMapper, final RdbmsReaderConfig readerConfig) {
+    return new SequenceFlowDbReader(sequenceFlowMapper, readerConfig);
   }
 
   @Bean
   public BatchOperationItemDbReader batchOperationItemReader(
-      final BatchOperationMapper batchOperationMapper) {
-    return new BatchOperationItemDbReader(batchOperationMapper);
+      final BatchOperationMapper batchOperationMapper, final RdbmsReaderConfig readerConfig) {
+    return new BatchOperationItemDbReader(batchOperationMapper, readerConfig);
   }
 
   @Bean
@@ -270,8 +296,8 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public JobDbReader jobReader(final JobMapper jobMapper) {
-    return new JobDbReader(jobMapper);
+  public JobDbReader jobReader(final JobMapper jobMapper, final RdbmsReaderConfig readerConfig) {
+    return new JobDbReader(jobMapper, readerConfig);
   }
 
   @Bean
@@ -286,22 +312,26 @@ public class RdbmsConfiguration {
 
   @Bean
   public ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsReader(
-      final ProcessDefinitionMapper processDefinitionMapper) {
-    return new ProcessDefinitionInstanceStatisticsDbReader(processDefinitionMapper);
+      final ProcessDefinitionMapper processDefinitionMapper, final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionInstanceStatisticsDbReader(processDefinitionMapper, readerConfig);
   }
 
   @Bean
   public ProcessDefinitionMessageSubscriptionStatisticsReader
       processDefinitionMessageSubscriptionStatisticsReader(
-          final MessageSubscriptionMapper messageSubscriptionMapper) {
-    return new ProcessDefinitionMessageSubscriptionStatisticsDbReader(messageSubscriptionMapper);
+          final MessageSubscriptionMapper messageSubscriptionMapper,
+          final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionMessageSubscriptionStatisticsDbReader(
+        messageSubscriptionMapper, readerConfig);
   }
 
   @Bean
   public ProcessDefinitionInstanceVersionStatisticsDbReader
       processDefinitionInstanceVersionStatisticsReader(
-          final ProcessDefinitionMapper processDefinitionMapper) {
-    return new ProcessDefinitionInstanceVersionStatisticsDbReader(processDefinitionMapper);
+          final ProcessDefinitionMapper processDefinitionMapper,
+          final RdbmsReaderConfig readerConfig) {
+    return new ProcessDefinitionInstanceVersionStatisticsDbReader(
+        processDefinitionMapper, readerConfig);
   }
 
   @Bean
@@ -312,8 +342,9 @@ public class RdbmsConfiguration {
 
   @Bean
   public IncidentProcessInstanceStatisticsByErrorDbReader
-      incidentProcessInstanceStatisticsByErrorReader(final IncidentMapper incidentMapper) {
-    return new IncidentProcessInstanceStatisticsByErrorDbReader(incidentMapper);
+      incidentProcessInstanceStatisticsByErrorReader(
+          final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    return new IncidentProcessInstanceStatisticsByErrorDbReader(incidentMapper, readerConfig);
   }
 
   @Bean
@@ -326,14 +357,17 @@ public class RdbmsConfiguration {
 
   @Bean
   public CorrelatedMessageSubscriptionDbReader correlatedMessageSubscriptionReader(
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper) {
-    return new CorrelatedMessageSubscriptionDbReader(correlatedMessageSubscriptionMapper);
+      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
+      final RdbmsReaderConfig readerConfig) {
+    return new CorrelatedMessageSubscriptionDbReader(
+        correlatedMessageSubscriptionMapper, readerConfig);
   }
 
   @Bean
   public IncidentProcessInstanceStatisticsByDefinitionDbReader
-      incidentProcessInstanceStatisticsByDefinitionReader(final IncidentMapper incidentMapper) {
-    return new IncidentProcessInstanceStatisticsByDefinitionDbReader(incidentMapper);
+      incidentProcessInstanceStatisticsByDefinitionReader(
+          final IncidentMapper incidentMapper, final RdbmsReaderConfig readerConfig) {
+    return new IncidentProcessInstanceStatisticsByDefinitionDbReader(incidentMapper, readerConfig);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -384,8 +384,8 @@ public class RdbmsConfiguration {
 
   @Bean
   public GlobalListenerDbReader globalListenerRdbmsReader(
-      final GlobalListenerMapper globalListenerMapper) {
-    return new GlobalListenerDbReader(globalListenerMapper);
+      final GlobalListenerMapper globalListenerMapper, final RdbmsReaderConfig readerConfig) {
+    return new GlobalListenerDbReader(globalListenerMapper, readerConfig);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -291,8 +291,8 @@ public class RdbmsConfiguration {
 
   @Bean
   public JobMetricsBatchDbReader jobMetricsBatchReader(
-      final JobMetricsBatchMapper jobMetricsBatchMapper) {
-    return new JobMetricsBatchDbReader(jobMetricsBatchMapper);
+      final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
+    return new JobMetricsBatchDbReader(jobMetricsBatchMapper, readerConfig);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -135,6 +135,30 @@ public class AuditLogIT {
   }
 
   @TestTemplate
+  public void shouldFindAllAuditLogsPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
+
+    final Long processInstanceKey = nextKey();
+    createAndSaveRandomAuditLogs(rdbmsWriters, 120, b -> b.processInstanceKey(processInstanceKey));
+
+    final var searchResult =
+        auditLogReader.search(
+            AuditLogQuery.of(
+                b ->
+                    b.filter(f -> f.processInstanceKeys(processInstanceKey))
+                        .sort(s -> s.timestamp().asc().entityType().asc())
+                        .page(p -> p.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindAuditLogWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -238,7 +238,9 @@ public class AuditLogIT {
                                     AuditLogOperationCategory.USER_TASKS.name())))),
             TenantCheck.disabled());
 
-    final var searchResult = auditLogReader.search(AuditLogQuery.of(b -> b), resourceAccessChecks);
+    final var searchResult =
+        auditLogReader.search(
+            AuditLogQuery.of(b -> b.page(p -> p.size(1000))), resourceAccessChecks);
 
     assertThat(searchResult.items())
         .extracting(AuditLogEntity::auditLogKey)
@@ -332,7 +334,9 @@ public class AuditLogIT {
                             .resourceIds(List.of("*")))),
             TenantCheck.disabled());
 
-    final var searchResult = auditLogReader.search(AuditLogQuery.of(b -> b), resourceAccessChecks);
+    final var searchResult =
+        auditLogReader.search(
+            AuditLogQuery.of(b -> b.page(p -> p.size(1000))), resourceAccessChecks);
 
     // Should return all logs that have a process definition ID (including USER_TASKS)
     assertThat(searchResult.items())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -186,6 +186,27 @@ public class AuthorizationIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final AuthorizationDbReader authorizationReader = rdbmsService.getAuthorizationReader();
+
+    createAndSaveRandomAuthorizations(rdbmsWriters, 120, b -> b.ownerType("TEST_MORE"));
+
+    final var searchResult =
+        authorizationReader.search(
+            new AuthorizationQuery(
+                new AuthorizationFilter.Builder().ownerType("TEST_MORE").build(),
+                AuthorizationSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -182,6 +182,33 @@ public class ClusterVariableIT {
   }
 
   @TestTemplate
+  public void shouldFindAllTenantClusterVariablesPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String tenantId = CommonFixtures.nextStringId();
+    ClusterVariableFixtures.createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(
+        rdbmsService, 120, tenantId);
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes("TENANT")
+                        .tenantIds(tenantId)
+                        .build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindAllTenantClusterVariablesPageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -185,6 +185,32 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionDbReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    final String decisionDefinitionId = DecisionDefinitionFixtures.nextStringId();
+    createAndSaveRandomDecisionDefinitions(
+        rdbmsWriters, 120, b -> b.decisionDefinitionId(decisionDefinitionId));
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                new DecisionDefinitionFilter.Builder()
+                    .decisionDefinitionIds(decisionDefinitionId)
+                    .build(),
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindAllPageValuesAreNull(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -187,6 +187,33 @@ public class DecisionRequirementsIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsDbReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    final String decisionRequirementsId = DecisionRequirementsFixtures.nextStringId();
+    createAndSaveRandomDecisionRequirements(
+        rdbmsWriters, 120, b -> b.decisionRequirementsId(decisionRequirementsId));
+
+    final var searchResult =
+        decisionRequirementsReader.search(
+            new DecisionRequirementsQuery(
+                new DecisionRequirementsFilter.Builder()
+                    .decisionRequirementsIds(decisionRequirementsId)
+                    .build(),
+                DecisionRequirementsSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5)),
+                null));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuditLogFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuditLogFixtures.java
@@ -109,7 +109,14 @@ public final class AuditLogFixtures extends CommonFixtures {
   public static void createAndSaveRandomAuditLogs(
       final RdbmsWriters rdbmsWriters,
       final Function<AuditLogDbModel.Builder, AuditLogDbModel.Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomAuditLogs(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomAuditLogs(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<AuditLogDbModel.Builder, AuditLogDbModel.Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getAuditLogWriter().create(AuditLogFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
@@ -60,7 +60,14 @@ public final class AuthorizationFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomAuthorizations(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomAuthorizations(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomAuthorizations(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getAuthorizationWriter()
           .createAuthorization(AuthorizationFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -49,8 +49,15 @@ public final class BatchOperationFixtures {
 
   public static List<BatchOperationDbModel> createAndSaveRandomBatchOperations(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
+    return createAndSaveRandomBatchOperations(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static List<BatchOperationDbModel> createAndSaveRandomBatchOperations(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
     final List<BatchOperationDbModel> models =
-        IntStream.range(0, 20)
+        IntStream.range(0, numberOfInstances)
             .mapToObj(i -> createRandomized(builderFunction))
             .peek(rdbmsWriters.getBatchOperationWriter()::createIfNotAlreadyExists)
             .collect(Collectors.toList());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ClusterVariableFixtures.java
@@ -59,9 +59,14 @@ public final class ClusterVariableFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(
       final RdbmsService rdbmsService, final String tenantId) {
+    createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(rdbmsService, 20, tenantId);
+  }
+
+  public static void createAndSaveRandomsTenantClusterVariablesWithFixedTenantId(
+      final RdbmsService rdbmsService, final int numberOfInstances, final String tenantId) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0L);
 
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < numberOfInstances; i++) {
       final ClusterVariableDbModel randomized =
           createRandomizedTenantClusterVariable(b -> b.tenantId(tenantId));
       rdbmsWriters.getClusterVariableWriter().create(randomized);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CorrelatedMessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CorrelatedMessageSubscriptionFixtures.java
@@ -52,7 +52,17 @@ public final class CorrelatedMessageSubscriptionFixtures extends CommonFixtures 
               CorrelatedMessageSubscriptionDbModel.Builder,
               CorrelatedMessageSubscriptionDbModel.Builder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomCorrelatedMessageSubscriptions(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomCorrelatedMessageSubscriptions(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<
+              CorrelatedMessageSubscriptionDbModel.Builder,
+              CorrelatedMessageSubscriptionDbModel.Builder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getCorrelatedMessageSubscriptionWriter()
           .create(createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
@@ -58,7 +58,15 @@ public final class DecisionDefinitionFixtures extends CommonFixtures {
       final RdbmsWriters rdbmsWriters,
       final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomDecisionDefinitions(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomDecisionDefinitions(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getDecisionDefinitionWriter()
           .create(DecisionDefinitionFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
@@ -89,7 +89,15 @@ public final class DecisionInstanceFixtures extends CommonFixtures {
       final RdbmsWriters rdbmsWriters,
       final Function<DecisionInstanceDbModel.Builder, DecisionInstanceDbModel.Builder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomDecisionInstances(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomDecisionInstances(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<DecisionInstanceDbModel.Builder, DecisionInstanceDbModel.Builder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getDecisionInstanceWriter()
           .create(DecisionInstanceFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionRequirementsFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionRequirementsFixtures.java
@@ -41,7 +41,14 @@ public final class DecisionRequirementsFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomDecisionRequirements(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomDecisionRequirements(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomDecisionRequirements(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getDecisionRequirementsWriter()
           .create(DecisionRequirementsFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FlowNodeInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FlowNodeInstanceFixtures.java
@@ -51,7 +51,15 @@ public final class FlowNodeInstanceFixtures extends CommonFixtures {
       final RdbmsWriters rdbmsWriters,
       final Function<FlowNodeInstanceDbModelBuilder, FlowNodeInstanceDbModelBuilder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomFlowNodeInstances(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomFlowNodeInstances(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<FlowNodeInstanceDbModelBuilder, FlowNodeInstanceDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getFlowNodeInstanceWriter()
           .create(FlowNodeInstanceFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FormFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/FormFixtures.java
@@ -45,8 +45,15 @@ public final class FormFixtures extends CommonFixtures {
   public static void createAndSaveRandomForms(
       final RdbmsService rdbmsService,
       final Function<FormDbModelBuilder, FormDbModelBuilder> builderFunction) {
+    createAndSaveRandomForms(rdbmsService, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomForms(
+      final RdbmsService rdbmsService,
+      final int numberOfInstances,
+      final Function<FormDbModelBuilder, FormDbModelBuilder> builderFunction) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(1L);
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getFormWriter().create(FormFixtures.createRandomized(builderFunction));
     }
     rdbmsWriters.flush();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
@@ -45,7 +45,14 @@ public final class GroupFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomGroups(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomGroups(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomGroups(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getGroupWriter().create(GroupFixtures.createRandomized(builderFunction));
     }
 
@@ -55,7 +62,14 @@ public final class GroupFixtures extends CommonFixtures {
   public static void createAndSaveRandomGroupsWithMembers(
       final RdbmsWriters rdbmsWriters,
       final Function<GroupDbModel.Builder, GroupDbModel.Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomGroupsWithMembers(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomGroupsWithMembers(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<GroupDbModel.Builder, GroupDbModel.Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       final var group = GroupFixtures.createRandomized(builderFunction);
       rdbmsWriters.getGroupWriter().create(group);
       GroupMemberFixtures.createAndSaveRandomGroupMembers(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/IncidentFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/IncidentFixtures.java
@@ -50,7 +50,14 @@ public final class IncidentFixtures extends CommonFixtures {
   public static void createAndSaveRandomIncidents(
       final RdbmsWriters rdbmsWriters,
       final Function<IncidentDbModel.Builder, IncidentDbModel.Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomIncidents(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomIncidents(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<IncidentDbModel.Builder, IncidentDbModel.Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getIncidentWriter().create(IncidentFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
@@ -56,7 +56,14 @@ public final class JobFixtures extends CommonFixtures {
   public static void createAndSaveRandomJobs(
       final RdbmsWriters rdbmsWriters,
       final Function<JobDbModel.Builder, JobDbModel.Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomJobs(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomJobs(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<JobDbModel.Builder, JobDbModel.Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getJobWriter().create(JobFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingRuleFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingRuleFixtures.java
@@ -39,7 +39,14 @@ public final class MappingRuleFixtures extends CommonFixtures {
   public static void createAndSaveRandomMappingRules(
       final RdbmsWriters rdbmsWriters,
       final Function<MappingRuleDbModelBuilder, MappingRuleDbModelBuilder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomMappingRules(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomMappingRules(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<MappingRuleDbModelBuilder, MappingRuleDbModelBuilder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getMappingRuleWriter()
           .create(MappingRuleFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
@@ -52,7 +52,14 @@ public final class MessageSubscriptionFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomMessageSubscriptions(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomMessageSubscriptions(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomMessageSubscriptions(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getMessageSubscriptionWriter()
           .create(MessageSubscriptionFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessDefinitionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessDefinitionFixtures.java
@@ -56,7 +56,15 @@ public final class ProcessDefinitionFixtures extends CommonFixtures {
       final RdbmsWriters rdbmsWriters,
       final Function<ProcessDefinitionDbModelBuilder, ProcessDefinitionDbModelBuilder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomProcessDefinitions(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomProcessDefinitions(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<ProcessDefinitionDbModelBuilder, ProcessDefinitionDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getProcessDefinitionWriter()
           .create(ProcessDefinitionFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
@@ -48,7 +48,15 @@ public final class ProcessInstanceFixtures extends CommonFixtures {
       final RdbmsWriters rdbmsWriters,
       final Function<ProcessInstanceDbModelBuilder, ProcessInstanceDbModelBuilder>
           builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomProcessInstances(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomProcessInstances(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<ProcessInstanceDbModelBuilder, ProcessInstanceDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters
           .getProcessInstanceWriter()
           .create(ProcessInstanceFixtures.createRandomized(builderFunction));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/RoleFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/RoleFixtures.java
@@ -44,7 +44,14 @@ public final class RoleFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomRoles(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomRoles(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomRoles(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getRoleWriter().create(RoleFixtures.createRandomized(builderFunction));
     }
 
@@ -57,7 +64,14 @@ public final class RoleFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomRolesWithMembers(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomRolesWithMembers(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomRolesWithMembers(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       final var role = RoleFixtures.createRandomized(builderFunction);
       rdbmsWriters.getRoleWriter().create(role);
       RoleMemberFixtures.createAndSaveRandomRoleMembers(rdbmsWriters, b -> b.roleId(role.roleId()));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/TenantFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/TenantFixtures.java
@@ -30,7 +30,14 @@ public final class TenantFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomTenants(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomTenants(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomTenants(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getTenantWriter().create(TenantFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserFixtures.java
@@ -44,7 +44,14 @@ public final class UserFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomUsers(
       final RdbmsWriters rdbmsWriters, final Function<Builder, Builder> builderFunction) {
-    for (int i = 0; i < 20; i++) {
+    createAndSaveRandomUsers(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomUsers(
+      final RdbmsWriters rdbmsWriters,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getUserWriter().create(UserFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
@@ -60,8 +60,15 @@ public final class UserTaskFixtures extends CommonFixtures {
 
   public static void createAndSaveRandomUserTasks(
       final RdbmsService rdbmsService, final Function<Builder, Builder> builderFunction) {
+    createAndSaveRandomUserTasks(rdbmsService, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomUserTasks(
+      final RdbmsService rdbmsService,
+      final int numberOfInstances,
+      final Function<Builder, Builder> builderFunction) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0L);
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < numberOfInstances; i++) {
       rdbmsWriters.getUserTaskWriter().create(UserTaskFixtures.createRandomized(builderFunction));
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/VariableFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/VariableFixtures.java
@@ -76,10 +76,17 @@ public final class VariableFixtures extends CommonFixtures {
   public static List<VariableDbModel> createAndSaveRandomVariables(
       final RdbmsService rdbmsService,
       final Function<VariableDbModelBuilder, VariableDbModelBuilder> builderFunction) {
+    return createAndSaveRandomVariables(rdbmsService, 20, builderFunction);
+  }
+
+  public static List<VariableDbModel> createAndSaveRandomVariables(
+      final RdbmsService rdbmsService,
+      final int numberOfInstances,
+      final Function<VariableDbModelBuilder, VariableDbModelBuilder> builderFunction) {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(0L);
 
     final List<VariableDbModel> models = new ArrayList<>();
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < numberOfInstances; i++) {
       final VariableDbModel randomized = createRandomized(builderFunction);
       models.add(randomized);
       rdbmsWriters.getVariableWriter().create(randomized);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
@@ -123,6 +123,29 @@ public class FormIT {
   }
 
   @TestTemplate
+  public void shouldFindAllFormsPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String id = FormFixtures.nextStringId();
+    createAndSaveRandomForms(rdbmsService, 120, b -> b.formId(id));
+
+    final var searchResult =
+        rdbmsService
+            .getFormReader()
+            .search(
+                new FormQuery(
+                    new FormFilter.Builder().formIds(id).build(),
+                    FormSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindFormWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final FormDbReader formReader = rdbmsService.getFormReader();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerIT.java
@@ -83,6 +83,33 @@ public class GlobalListenerIT {
   }
 
   @TestTemplate
+  public void shouldFindAllGlobalListenersPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String testIdentifier = nextStringId();
+
+    // given more than 100 global listeners with the same type
+    createAndSaveRandomGlobalListeners(testApplication, 120, b -> b.type(testIdentifier));
+
+    // when searching with paging
+    final var searchResult =
+        testApplication
+            .getRdbmsService()
+            .getGlobalListenerDbReader()
+            .search(
+                new GlobalListenerQuery(
+                    new GlobalListenerFilter.Builder().types(testIdentifier).build(),
+                    GlobalListenerSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))),
+                ResourceAccessChecks.disabled());
+
+    // then hasMoreTotalItems is true
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldUpdateGlobalListener(final CamundaRdbmsTestApplication testApplication) {
     // given an existing global listener
     final GlobalListenerDbModel globalListener =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -181,6 +181,27 @@ public class GroupIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final GroupDbReader groupReader = rdbmsService.getGroupReader();
+
+    createAndSaveRandomGroupsWithMembers(rdbmsWriters, 120, b -> b.name("Jane More"));
+
+    final var searchResult =
+        groupReader.search(
+            new GroupQuery(
+                new GroupFilter.Builder().name("Jane More").build(),
+                GroupSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
@@ -225,6 +225,30 @@ public class MappingRuleIT {
   }
 
   @TestTemplate
+  public void shouldFindAllMappingRulesPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+
+    final String claimName = "claimName-" + MappingRuleFixtures.nextStringId();
+    createAndSaveRandomMappingRules(rdbmsWriters, 120, b -> b.claimName(claimName));
+
+    final var searchResult =
+        rdbmsService
+            .getMappingRuleReader()
+            .search(
+                new MappingRuleQuery(
+                    new MappingRuleFilter.Builder().claimName(claimName).build(),
+                    MappingRuleSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindMappingRuleWithFullFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -344,7 +344,6 @@ public class ProcessDefinitionIT {
                         f -> f.processDefinitionIds(processDefinition.processDefinitionId()))));
 
     assertThat(searchResult).isNotNull();
-    assertThat(searchResult.items()).hasSize(3);
     final var statistics =
         searchResult.items().stream()
             .filter(f -> "proc-1-id".equals(f.processDefinitionId()))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -135,6 +135,27 @@ public class RoleIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final RoleDbReader roleReader = rdbmsService.getRoleReader();
+
+    createAndSaveRandomRolesWithMembers(rdbmsWriters, 120, b -> b.name("Jane More"));
+
+    final var searchResult =
+        roleReader.search(
+            new RoleQuery(
+                new RoleFilter.Builder().name("Jane More").build(),
+                RoleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -157,6 +157,28 @@ public class TenantIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final TenantDbReader reader = rdbmsService.getTenantReader();
+
+    final var tenantName = "tenant-more-" + nextStringId();
+    createAndSaveRandomTenants(rdbmsWriters, 120, b -> b.name(tenantName));
+
+    final var searchResult =
+        reader.search(
+            new TenantQuery(
+                new TenantFilter.Builder().name(tenantName).build(),
+                TenantSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -168,6 +168,27 @@ public class UserIT {
   }
 
   @TestTemplate
+  public void shouldFindAllPagedWithHasMoreHits(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final UserDbReader userReader = rdbmsService.getUserReader();
+
+    createAndSaveRandomUsers(rdbmsWriters, 120, b -> b.name("Jane More"));
+
+    final var searchResult =
+        userReader.search(
+            new UserQuery(
+                new UserFilter.Builder().names("Jane More").build(),
+                UserSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -179,6 +179,30 @@ public class UserTaskIT {
   }
 
   @TestTemplate
+  public void shouldFindAllUserTasksPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String processDefinitionId = UUID.randomUUID().toString();
+    createAndSaveRandomUserTasks(
+        rdbmsService, 120, b -> b.processDefinitionId(processDefinitionId));
+
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder().bpmnProcessIds(processDefinitionId).build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindUserTaskByProcessInstanceKey(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -165,5 +165,6 @@ public final class CamundaRdbmsTestApplication
         .getSecondaryStorage()
         .getRdbms()
         .setPassword(TestSearchContainers.CAMUNDA_PASSWORD);
+    unifiedConfig.getData().getSecondaryStorage().getRdbms().getQuery().setMaxTotalHits(100);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.db.util;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.configuration.Camunda;
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import javax.sql.DataSource;
 import org.mockito.Mockito;
@@ -36,6 +37,10 @@ public class RdbmsTestConfiguration {
 
   @Bean
   public Camunda camunda() {
-    return Mockito.mock(Camunda.class, Mockito.RETURNS_DEEP_STUBS);
+    final var camundaConfig = Mockito.mock(Camunda.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(
+            camundaConfig.getData().getSecondaryStorage().getRdbms().getQuery().toReaderConfig())
+        .thenReturn(RdbmsReaderConfig.builder().maxTotalHits(100).build());
+    return camundaConfig;
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -219,6 +219,29 @@ public class VariableIT {
   }
 
   @TestTemplate
+  public void shouldFindAllVariablesPagedWithHasMoreHits(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String varName = "var-name-" + nextStringId();
+    VariableFixtures.createAndSaveRandomVariables(rdbmsService, 120, b -> b.name(varName));
+
+    final var searchResult =
+        rdbmsService
+            .getVariableReader()
+            .search(
+                new VariableQuery(
+                    new VariableFilter.Builder().names(varName).build(),
+                    VariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(100);
+    assertThat(searchResult.hasMoreTotalItems()).isEqualTo(true);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
   public void shouldFindAllVariablesPageValuesAreNull(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsTestConfiguration.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsTestConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.it.rdbms.exporter;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.configuration.Camunda;
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -26,6 +27,10 @@ public class RdbmsTestConfiguration {
 
   @Bean
   public Camunda camunda() {
-    return Mockito.mock(Camunda.class, Mockito.RETURNS_DEEP_STUBS);
+    final var camundaConfig = Mockito.mock(Camunda.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(
+            camundaConfig.getData().getSecondaryStorage().getRdbms().getQuery().toReaderConfig())
+        .thenReturn(RdbmsReaderConfig.builder().maxTotalHits(100).build());
+    return camundaConfig;
   }
 }


### PR DESCRIPTION
## Description

This change limits the totalResults of each count() in RDBMS to a max of 10,000 (configurable). This will speed up the count() when the filter has a bad selectivity and would find more than 10,000 results.

In refactoring, this changes/adds:
- a new property `camunda.data.secondaryStorage.rdbms.query.maxTotalResults` with default 10,000
- a new `RdbmsReaderConfig` containing the new property
- use the config in AbstractEntityReader (this caused a lot of refactoring in subclasses to add the constructor parameter)
- introduce a new DB vendor property `count.limit` for the vendor specific COUNT(*) limitation
- change all `count` SQL statements to use the nested SQL count with the new limit
- add an integration test to every EntityIT class (this also caused a change of the Fixture classes)

## Related issues

closes #46341 
