### PR TITLE
fix: allow scale up after scale down when using dynamic node id

### DIFF
--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -266,11 +266,14 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
       if (storedLease != null) {
         final var gracefullyShutdown =
             switch (storedLease) {
-              case StoredLease.Uninitialized u -> true;
-              case StoredLease.Initialized initialized ->
+              case final StoredLease.Uninitialized u -> true;
+              case final StoredLease.Initialized initialized ->
                   initialized
                       .lease()
                       .isExpiredBeyondThreshold(clock.instant(), expiredLeaseThreshold);
+              // the following scenario won't happen because the currentLease will be null. We are
+              // adding it for completeness, but it won't have any effect on the outcome.
+              case final StoredLease.Unusable u -> true;
             };
         previousNodeGracefullyShutdown.complete(gracefullyShutdown);
       }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -13,10 +13,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-public record Metadata(Optional<String> task, Version version) {
+public record Metadata(Optional<String> task, Version version, boolean acquirable) {
   // KEYS MUST BE LOWERCASE
   private static final String TASK_ID_KEY = "taskid";
   private static final String VERSION_KEY = "version";
+  private static final String ACQUIRABLE_KEY = "acquirable";
 
   public Metadata {
     Objects.requireNonNull(task, "task cannot be null");
@@ -26,16 +27,31 @@ public record Metadata(Optional<String> task, Version version) {
     Objects.requireNonNull(version, "version cannot be null");
   }
 
+  public Metadata(final Optional<String> task, final Version version) {
+    this(task, version, true);
+  }
+
   public Metadata forRelease() {
-    return new Metadata(Optional.empty(), version);
+    return new Metadata(Optional.empty(), version, true);
+  }
+
+  public Metadata forUnusable() {
+    return new Metadata(Optional.empty(), version, false);
+  }
+
+  public Metadata forAcquirable() {
+    return new Metadata(Optional.empty(), version, true);
   }
 
   public static Metadata fromLease(final Lease lease) {
-    return new Metadata(Optional.of(lease.taskId()), lease.nodeInstance().version());
+    return new Metadata(Optional.of(lease.taskId()), lease.nodeInstance().version(), true);
   }
 
   public Map<String, String> asMap() {
-    return Map.of(TASK_ID_KEY, task.orElse(""), VERSION_KEY, Long.toString(version.version()));
+    return Map.of(
+        TASK_ID_KEY, task.orElse(""),
+        VERSION_KEY, Long.toString(version.version()),
+        ACQUIRABLE_KEY, Boolean.toString(acquirable));
   }
 
   public static Metadata fromMap(final Map<String, String> map) {
@@ -47,7 +63,10 @@ public record Metadata(Optional<String> task, Version version) {
       final Optional<String> taskId =
           taskIdOpt != null && !taskIdOpt.isEmpty() ? Optional.of(taskIdOpt) : Optional.empty();
       final var version = new Version(Long.parseLong(map.get(VERSION_KEY)));
-      return new Metadata(taskId, version);
+      final var acquirableStr = map.get(ACQUIRABLE_KEY);
+      // Default to true for backwards compatibility with existing leases
+      final var acquirable = acquirableStr == null || Boolean.parseBoolean(acquirableStr);
+      return new Metadata(taskId, version, acquirable);
     } catch (final Exception e) {
       throw new IllegalArgumentException("Failed to deserialize metadata, map is " + map, e);
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -99,6 +99,8 @@ public interface NodeIdRepository extends AutoCloseable {
    *   <li>{@link Initialized} when it's held by another node. Note that Initialized does not
    *       guarantee validity, since a node can expire. This can happen if the lease is failed to be
    *       renewed in time, either due to the node crashing or failing in some way.
+   *   <li>{@link Unusable} when the lease has been marked as not acquirable, for example during
+   *       scale down operations.
    * </ul>
    */
   sealed interface StoredLease {
@@ -114,6 +116,15 @@ public interface NodeIdRepository extends AutoCloseable {
       return switch (this) {
         case final Uninitialized u -> false;
         case final Initialized i -> true;
+        case final Unusable u -> false;
+      };
+    }
+
+    default boolean isAcquirable() {
+      return switch (this) {
+        case final Uninitialized u -> true;
+        case final Initialized i -> true;
+        case final Unusable u -> false;
       };
     }
 
@@ -121,6 +132,7 @@ public interface NodeIdRepository extends AutoCloseable {
       return switch (this) {
         case final Uninitialized u -> false;
         case final Initialized i -> i.lease().isStillValid(now);
+        case final Unusable u -> false;
       };
     }
 
@@ -132,7 +144,7 @@ public interface NodeIdRepository extends AutoCloseable {
      */
     default Optional<Lease> acquireInitialLease(
         final String taskId, final InstantSource clock, final Duration leaseDuration) {
-      if (isStillValid(clock.millis())) {
+      if (!isAcquirable() || isStillValid(clock.millis())) {
         return Optional.empty();
       } else {
         return Optional.of(
@@ -144,6 +156,9 @@ public interface NodeIdRepository extends AutoCloseable {
         final int nodeId, final Lease lease, final Metadata metadata, final String eTag) {
       if (eTag == null || eTag.isEmpty()) {
         throw new IllegalArgumentException("eTag cannot be null or empty:" + eTag);
+      }
+      if (metadata != null && !metadata.acquirable()) {
+        return new StoredLease.Unusable(new NodeInstance(nodeId, metadata.version()), eTag);
       }
       if (lease == null) {
         final var version =
@@ -195,6 +210,16 @@ public interface NodeIdRepository extends AutoCloseable {
       @Override
       public NodeInstance node() {
         return lease.nodeInstance();
+      }
+    }
+
+    record Unusable(NodeInstance node, String eTag) implements StoredLease {
+      public Unusable {
+        Objects.requireNonNull(node, "node cannot be null");
+        Objects.requireNonNull(eTag, "eTag cannot be null");
+        if (eTag.isEmpty()) {
+          throw new IllegalArgumentException("eTag cannot be empty");
+        }
       }
     }
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -94,7 +94,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
     final var totalLeaseCount = getTotalLeaseCount();
     if (newCount > availableLeaseCount) {
       // scale up => first make existing unusable leases acquirable, then add new leases if needed
-      for (int nodeId = getAvailableLeaseCount();
+      for (int nodeId = availableLeaseCount;
           nodeId < totalLeaseCount && nodeId < newCount;
           nodeId++) {
         makeLeaseAcquirable(nodeId);
@@ -229,11 +229,15 @@ public class S3NodeIdRepository implements NodeIdRepository {
         getNodeIdLeaseKeys().stream()
             .filter(
                 key -> {
-                  final var nodeId = Integer.parseInt(key.replace(".json", ""));
+                  final var nodeId = parseNodeIdFromKey(key);
                   final var storedLease = getLeaseIncludingUnusable(nodeId);
                   return storedLease.isAcquirable();
                 })
             .count();
+  }
+
+  private static int parseNodeIdFromKey(final String key) {
+    return Integer.parseInt(key.replace(".json", ""));
   }
 
   private void markLeaseAsUnusable(final int nodeId) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
@@ -31,11 +32,11 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 public class S3NodeIdRepository implements NodeIdRepository {
 
@@ -88,50 +89,34 @@ public class S3NodeIdRepository implements NodeIdRepository {
     if (newCount <= 0) {
       throw new IllegalArgumentException("newCount must be greater than 0");
     }
-    // Keep it simple for now by just creating new leases for new nodes and deleting leases for
-    // removed nodes. We can improve it later by making the leases non-acquirable. This would let
-    // graceful shutdown of tasks that are still holding those leases.
-    final var oldCount = getAvailableLeaseCount();
-    if (newCount > oldCount) {
-      // scale up => add new leases
-      IntStream.range(oldCount, newCount).forEach(this::initializeForNode);
+    // Get the total number of leases in the repository (both acquirable and unusable)
+    final var availableLeaseCount = getAvailableLeaseCount();
+    final var totalLeaseCount = getTotalLeaseCount();
+    if (newCount > availableLeaseCount) {
+      // scale up => first make existing unusable leases acquirable, then add new leases if needed
+      for (int nodeId = getAvailableLeaseCount();
+          nodeId < totalLeaseCount && nodeId < newCount;
+          nodeId++) {
+        makeLeaseAcquirable(nodeId);
+      }
+      // Add new leases if we need more than total existing
+      IntStream.range(totalLeaseCount, newCount).forEach(this::initializeForNode);
     } else {
-      // scale down =>  delete extra leases
-      // Delete in reverse order so that retry after failure will correctly delete remaining node
-      // ids
-      for (int nodeId = oldCount - 1; nodeId >= newCount; nodeId--) {
-        final var request =
-            DeleteObjectRequest.builder().bucket(config.bucketName).key(objectKey(nodeId)).build();
-        try {
-          client.deleteObject(request);
-        } catch (final S3Exception e) {
-          if (e.statusCode() == 404) {
-            LOG.debug("Lease for nodeId {} does not exist, likely already deleted.", nodeId);
-          } else {
-            LOG.warn("Failed to delete lease object for node {} ", nodeId, e);
-            throw e;
-          }
-        }
+      // scale down => mark extra leases as not acquirable
+      // Mark in reverse order so that retry after failure will correctly mark remaining node ids
+      for (int nodeId = totalLeaseCount - 1; nodeId >= newCount; nodeId--) {
+        markLeaseAsUnusable(nodeId);
       }
     }
   }
 
   @Override
   public StoredLease getLease(final int nodeId) {
-    final var request =
-        GetObjectRequest.builder().bucket(config.bucketName).key(objectKey(nodeId)).build();
-    final var response = client.getObject(request);
-    try {
-      final var bytes = response.readAllBytes();
-      final var lease = bytes.length > 0 ? Lease.fromJsonBytes(OBJECT_MAPPER, bytes) : null;
-      final var metadata = Metadata.fromMap(response.response().metadata());
-      final var eTag = response.response().eTag();
-      final var storedLease = StoredLease.of(nodeId, lease, metadata, eTag);
-      LOG.trace("Lease for object {} is {}", nodeId, storedLease);
-      return storedLease;
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+    final var storedLease = getLeaseIncludingUnusable(nodeId);
+    if (!storedLease.isAcquirable()) {
+      throw new IllegalStateException("Lease for nodeId " + nodeId + " is not acquirable");
     }
+    return storedLease;
   }
 
   @Override
@@ -140,6 +125,13 @@ public class S3NodeIdRepository implements NodeIdRepository {
       throw new IllegalArgumentException("lease is null");
     }
     final var nodeId = lease.nodeInstance().id();
+
+    // Verify the lease is acquirable before attempting to acquire
+    final var currentLease = getLeaseIncludingUnusable(nodeId);
+    if (!currentLease.isAcquirable()) {
+      throw new IllegalStateException("Lease for nodeId " + nodeId + " is not acquirable");
+    }
+
     final var metadata = Metadata.fromLease(lease);
     final PutObjectRequest putRequest =
         createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(previousETag)).build();
@@ -233,13 +225,102 @@ public class S3NodeIdRepository implements NodeIdRepository {
 
   @Override
   public int getAvailableLeaseCount() {
+    return (int)
+        getNodeIdLeaseKeys().stream()
+            .filter(
+                key -> {
+                  final var nodeId = Integer.parseInt(key.replace(".json", ""));
+                  final var storedLease = getLeaseIncludingUnusable(nodeId);
+                  return storedLease.isAcquirable();
+                })
+            .count();
+  }
+
+  private void markLeaseAsUnusable(final int nodeId) {
+    try {
+      final var currentLease = getLeaseIncludingUnusable(nodeId);
+      if (!currentLease.isAcquirable()) {
+        LOG.debug("Lease for nodeId {} is already unusable, skipping", nodeId);
+        return;
+      }
+      final var metadata = new Metadata(Optional.empty(), currentLease.version()).forUnusable();
+      // Use null etag as we do not want to fail due to concurrent updates.
+      final PutObjectRequest putRequest =
+          createPutObjectRequest(nodeId, Optional.of(metadata), Optional.empty()).build();
+      LOG.debug("Marking lease for nodeId {} as unusable", nodeId);
+      client.putObject(putRequest, RequestBody.empty());
+      LOG.debug("Lease for nodeId {} marked as unusable", nodeId);
+    } catch (final S3Exception e) {
+      if (e.statusCode() == 404) {
+        LOG.debug("Lease for nodeId {} does not exist, likely already deleted.", nodeId);
+      } else {
+        LOG.warn("Failed to mark lease for node {} as unusable", nodeId, e);
+        throw e;
+      }
+    }
+  }
+
+  private void makeLeaseAcquirable(final int nodeId) {
+    try {
+      final var currentLease = getLeaseIncludingUnusable(nodeId);
+      if (currentLease.isAcquirable()) {
+        LOG.debug("Lease for nodeId {} is already acquirable, skipping", nodeId);
+        return;
+      }
+      final var metadata = new Metadata(Optional.empty(), currentLease.version()).forAcquirable();
+      final PutObjectRequest putRequest =
+          createPutObjectRequest(nodeId, Optional.of(metadata), Optional.of(currentLease.eTag()))
+              .build();
+      LOG.debug("Making lease for nodeId {} acquirable", nodeId);
+      client.putObject(putRequest, RequestBody.empty());
+      LOG.debug("Lease for nodeId {} is now acquirable", nodeId);
+    } catch (final S3Exception e) {
+      LOG.warn("Failed to make lease for node {} acquirable", nodeId, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Get a lease regardless of whether it is acquirable. This is used internally for scale
+   * operations.
+   */
+  private StoredLease getLeaseIncludingUnusable(final int nodeId) {
+    final var request =
+        GetObjectRequest.builder().bucket(config.bucketName).key(objectKey(nodeId)).build();
+    final var response = client.getObject(request);
+    try {
+      final var bytes = response.readAllBytes();
+      final var lease = bytes.length > 0 ? Lease.fromJsonBytes(OBJECT_MAPPER, bytes) : null;
+      final var metadata = Metadata.fromMap(response.response().metadata());
+      final var eTag = response.response().eTag();
+      final var storedLease = StoredLease.of(nodeId, lease, metadata, eTag);
+      LOG.trace("Lease for object {} is {}", nodeId, storedLease);
+      return storedLease;
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get the total number of leases in the repository, including both acquirable and unusable
+   * leases.
+   */
+  private int getTotalLeaseCount() {
+    return getNodeIdLeaseKeys().size();
+  }
+
+  /** Get all node ID lease object keys from the bucket. */
+  private java.util.List<String> getNodeIdLeaseKeys() {
     final var request = ListObjectsV2Request.builder().bucket(config.bucketName).build();
     try {
       final var response = client.listObjectsV2(request);
       if (response.hasContents() && !response.contents().isEmpty()) {
-        return (int) response.contents().stream().filter(o -> isNodeIdLease(o.key())).count();
+        return response.contents().stream()
+            .map(S3Object::key)
+            .filter(this::isNodeIdLease)
+            .collect(java.util.stream.Collectors.toList());
       }
-      return 0;
+      return Collections.emptyList();
     } catch (final S3Exception e) {
       if (e.statusCode() == 404) {
         LOG.warn("Bucket {} does not exist", config.bucketName);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/StoredLeaseTest.java
@@ -31,6 +31,54 @@ public class StoredLeaseTest {
   }
 
   @Nested
+  class FactoryMethod {
+    @Test
+    void shouldReturnUnusableWhenMetadataIsNotAcquirable() {
+      // given
+      final var metadata = new Metadata(Optional.empty(), Version.of(1), false);
+
+      // when
+      final var stored = StoredLease.of(2, null, metadata, "eTag");
+
+      // then
+      assertThat(stored).isInstanceOf(StoredLease.Unusable.class);
+      assertThat(stored.node().id()).isEqualTo(2);
+      assertThat(stored.version()).isEqualTo(Version.of(1));
+      assertThat(stored.isAcquirable()).isFalse();
+    }
+
+    @Test
+    void shouldReturnUninitializedWhenLeaseIsNullAndMetadataIsAcquirable() {
+      // given
+      final var metadata = new Metadata(Optional.empty(), Version.of(1), true);
+
+      // when
+      final var stored = StoredLease.of(2, null, metadata, "eTag");
+
+      // then
+      assertThat(stored).isInstanceOf(StoredLease.Uninitialized.class);
+      assertThat(stored.node().id()).isEqualTo(2);
+      assertThat(stored.version()).isEqualTo(Version.of(1));
+      assertThat(stored.isAcquirable()).isTrue();
+    }
+
+    @Test
+    void shouldReturnInitializedWhenLeaseIsNotNull() {
+      // given
+      final var lease =
+          new Lease(taskId, expiryFromNow(), nodeInstance, VersionMappings.of(nodeInstance));
+      final var metadata = new Metadata(Optional.of(taskId), nodeInstance.version(), true);
+
+      // when
+      final var stored = StoredLease.of(nodeInstance.id(), lease, metadata, "eTag");
+
+      // then
+      assertThat(stored).isInstanceOf(StoredLease.Initialized.class);
+      assertThat(stored.isAcquirable()).isTrue();
+    }
+  }
+
+  @Nested
   class Uninitialized {
     @Test
     void shouldAlwaysContainNodeId() {
@@ -142,6 +190,51 @@ public class StoredLeaseTest {
                           VersionMappings.of(nodeInstance.nextVersion()),
                           Lease::knownVersionMappings)
                       .returns(expiryFromNow(), Lease::timestamp));
+    }
+  }
+
+  @Nested
+  class Unusable {
+    @Test
+    void shouldAlwaysContainNodeId() {
+      assertThatThrownBy(() -> new StoredLease.Unusable(null, "asdasd"))
+          .hasMessageContaining("node cannot be null");
+    }
+
+    @Test
+    void shouldAlwaysContainETag() {
+      assertThatThrownBy(() -> new StoredLease.Unusable(nodeInstance, ""))
+          .hasMessageContaining("eTag cannot be empty");
+      assertThatThrownBy(() -> new StoredLease.Unusable(nodeInstance, null))
+          .hasMessageContaining("eTag cannot be null");
+    }
+
+    @Test
+    void shouldNotBeAcquirable() {
+      // given
+      final var stored = new StoredLease.Unusable(nodeInstance, "eTagExample");
+
+      // when/then
+      assertThat(stored.isAcquirable()).isFalse();
+      assertThat(stored.acquireInitialLease(taskId, clock, expiryDuration)).isEmpty();
+    }
+
+    @Test
+    void shouldNotBeInitialized() {
+      // given
+      final var stored = new StoredLease.Unusable(nodeInstance, "eTagExample");
+
+      // when/then
+      assertThat(stored.isInitialized()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeValid() {
+      // given
+      final var stored = new StoredLease.Unusable(nodeInstance, "eTagExample");
+
+      // when/then
+      assertThat(stored.isStillValid(clock.millis())).isFalse();
     }
   }
 }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepositoryIT.java
@@ -173,7 +173,7 @@ class S3NodeIdRepositoryIT {
     }
 
     @Test
-    void shouldRemoveNodesWhenScalingDown() {
+    void shouldMarkLeaseUnusableWhenScalingDown() {
       // given
       repository = fixed(Clock.systemUTC().millis());
       repository.initialize(4);
@@ -189,13 +189,13 @@ class S3NodeIdRepositoryIT {
 
       assertThatException()
           .isThrownBy(() -> repository.getLease(3))
-          .isInstanceOf(NoSuchKeyException.class)
-          .withMessageContaining("The specified key does not exist");
+          .isInstanceOf(IllegalStateException.class)
+          .withMessageContaining("not acquirable");
 
       assertThatException()
           .isThrownBy(() -> repository.getLease(2))
-          .isInstanceOf(NoSuchKeyException.class)
-          .withMessageContaining("The specified key does not exist");
+          .isInstanceOf(IllegalStateException.class)
+          .withMessageContaining("not acquirable");
     }
 
     @Test
@@ -230,7 +230,7 @@ class S3NodeIdRepositoryIT {
     }
 
     @Test
-    void shouldRemoveActiveLeasesWhenScalingDown() {
+    void shouldMarkActiveLeasesAsUnusableWhenScalingDown() {
       // given
       repository = fixed(Clock.systemUTC().millis());
       repository.initialize(4);
@@ -245,8 +245,109 @@ class S3NodeIdRepositoryIT {
       // then
       assertThatException()
           .isThrownBy(() -> repository.getLease(2))
-          .isInstanceOf(NoSuchKeyException.class)
-          .withMessageContaining("The specified key does not exist");
+          .isInstanceOf(IllegalStateException.class)
+          .withMessageContaining("not acquirable");
+    }
+
+    @Test
+    void shouldMakeUnusableLeasesAcquirableWhenScalingUp() {
+      // given
+      repository = fixed(Clock.systemUTC().millis());
+      repository.initialize(4);
+      repository.scale(2);
+
+      // verify leases 2 and 3 are not acquirable
+      assertThatException()
+          .isThrownBy(() -> repository.getLease(2))
+          .isInstanceOf(IllegalStateException.class);
+      assertThatException()
+          .isThrownBy(() -> repository.getLease(3))
+          .isInstanceOf(IllegalStateException.class);
+
+      // when
+      repository.scale(4);
+
+      // then - all leases should be acquirable again
+      for (int i = 0; i < 4; i++) {
+        final var lease = repository.getLease(i);
+        assertThat(lease.isAcquirable()).isTrue();
+      }
+    }
+
+    @Test
+    void shouldPreserveVersionWhenScalingDownAndBackUp() {
+      // given
+      repository = fixed(Clock.systemUTC().millis());
+      repository.initialize(3);
+
+      // Acquire lease 2 to increment its version
+      final var lease2 = repository.getLease(2);
+      final var toAcquire = lease2.acquireInitialLease(taskId, clock, EXPIRY_DURATION).get();
+      final var acquired = repository.acquire(toAcquire, lease2.eTag());
+      assertThat(acquired.node().version()).isEqualTo(Version.of(1));
+
+      // Release the lease
+      repository.release(acquired);
+      final var released = repository.getLease(2);
+      assertThat(released.version()).isEqualTo(Version.of(1));
+
+      // Scale down to 2 nodes
+      repository.scale(2);
+
+      // when - scale back up
+      repository.scale(3);
+
+      // then - version should be preserved
+      final var leaseAfterScaleUp = repository.getLease(2);
+      assertThat(leaseAfterScaleUp.version()).isEqualTo(Version.of(1));
+    }
+
+    @Test
+    void shouldReturnOnlyAcquirableLeasesInGetAvailableLeaseCount() {
+      // given
+      repository = fixed(Clock.systemUTC().millis());
+      repository.initialize(4);
+      assertThat(repository.getAvailableLeaseCount()).isEqualTo(4);
+
+      // when - scale down
+      repository.scale(2);
+
+      // then - only 2 leases should be available
+      assertThat(repository.getAvailableLeaseCount()).isEqualTo(2);
+
+      // when - scale back up
+      repository.scale(4);
+
+      // then - all 4 leases should be available
+      assertThat(repository.getAvailableLeaseCount()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldFailAcquireOnUnusableLease() {
+      // given
+      repository = fixed(Clock.systemUTC().millis());
+      repository.initialize(3);
+
+      // Get lease 2 before scaling down to get its eTag
+      final var lease2 = repository.getLease(2);
+      final var eTag = lease2.eTag();
+
+      // Scale down to make lease 2 unusable
+      repository.scale(2);
+
+      // Create a lease to acquire
+      final var leaseToAcquire =
+          new Lease(
+              taskId,
+              clock.millis() + EXPIRY_DURATION.toMillis(),
+              new NodeInstance(2, Version.of(1)),
+              VersionMappings.of(new NodeInstance(2, Version.of(1))));
+
+      // when/then - should fail to acquire
+      assertThatException()
+          .isThrownBy(() -> repository.acquire(leaseToAcquire, eTag))
+          .isInstanceOf(IllegalStateException.class)
+          .withMessageContaining("not acquirable");
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/dynamicnodeid/DynamicNodeIdScalingIT.java
@@ -15,7 +15,6 @@ import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository;
 import io.camunda.zeebe.dynamic.nodeid.repository.s3.S3NodeIdRepository.S3ClientConfig;
-import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
@@ -46,7 +45,6 @@ import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
 @Testcontainers
 @ZeebeIntegration
@@ -114,12 +112,19 @@ public class DynamicNodeIdScalingIT {
     s3.setSecretKey(S3.getSecretKey());
   }
 
-  private int getLeasesCount() {
-    return (int)
-        s3Client.listObjects(b -> b.bucket(bucketName)).contents().stream()
-            .map(S3Object::key)
-            .filter(key -> key.matches("\\d+\\.json"))
-            .count();
+  private void assertConfigurationChangeCompleted(
+      final ClusterActuator clusterActuator, final int targetClusterSize) {
+    final var topology = clusterActuator.getTopology();
+
+    // verify no pending changes
+    assertThat(topology.getPendingChange()).isNull();
+
+    // verify remaining broker is active
+    final var activeBrokers =
+        topology.getBrokers().stream()
+            .filter(b -> b.getState() == BrokerStateCode.ACTIVE)
+            .collect(Collectors.toList());
+    assertThat(activeBrokers).hasSize(targetClusterSize);
   }
 
   @Nested
@@ -148,11 +153,6 @@ public class DynamicNodeIdScalingIT {
       final var firstBroker = testCluster.brokers().values().iterator().next();
       final var initialContactPoint = firstBroker.address(TestZeebePort.CLUSTER);
 
-      // verify initial state - one lease object
-      Awaitility.await("Until initial broker has a valid lease")
-          .atMost(Duration.ofSeconds(10))
-          .untilAsserted(() -> assertThat(getLeasesCount()).isEqualTo(1));
-
       // when - start two new brokers with contact point to first broker
       final var secondBroker = getAdditionalBroker(initialContactPoint);
       final var thirdBroker = getAdditionalBroker(initialContactPoint);
@@ -171,35 +171,12 @@ public class DynamicNodeIdScalingIT {
 
       clusterActuator.patchCluster(scaleRequest, false, false);
 
-      // verify second broker has acquired a lease
-      Awaitility.await("Until new brokers has a valid lease")
-          .atMost(Duration.ofSeconds(30))
-          .untilAsserted(() -> assertThat(getLeasesCount()).isEqualTo(TARGET_CLUSTER_SIZE));
-
       // then - verify scale operation completes
       Awaitility.await("Until scale operation completes")
           .atMost(Duration.ofMinutes(2))
           .pollInterval(Duration.ofSeconds(2))
           .untilAsserted(
-              () -> {
-                final var topology = clusterActuator.getTopology();
-                assertThat(topology.getBrokers()).hasSize(TARGET_CLUSTER_SIZE);
-
-                // verify no pending changes
-                assertThat(topology.getPendingChange()).isNull();
-
-                // verify all brokers are active
-                final var activeBrokers =
-                    topology.getBrokers().stream()
-                        .filter(b -> b.getState() == BrokerStateCode.ACTIVE)
-                        .collect(Collectors.toList());
-                assertThat(activeBrokers).hasSize(TARGET_CLUSTER_SIZE);
-
-                // verify partitions are distributed
-                for (final BrokerState broker : topology.getBrokers()) {
-                  assertThat(broker.getPartitions()).isNotEmpty();
-                }
-              });
+              () -> assertConfigurationChangeCompleted(clusterActuator, TARGET_CLUSTER_SIZE));
 
       Awaitility.await("Start up of new brokers completes")
           .untilAsserted(
@@ -268,12 +245,6 @@ public class DynamicNodeIdScalingIT {
 
       final var clusterActuator = ClusterActuator.of(testCluster.anyGateway());
 
-      // verify initial state - three lease objects and three active brokers
-      Awaitility.await("Until all brokers have valid leases")
-          .atMost(Duration.ofSeconds(30))
-          .untilAsserted(
-              () -> assertThat(getLeasesCount()).isEqualTo(SCALE_DOWN_INITIAL_CLUSTER_SIZE));
-
       // when - send scale down request
       final var scaleDownRequest =
           new ClusterConfigPatchRequest()
@@ -287,31 +258,9 @@ public class DynamicNodeIdScalingIT {
           .atMost(Duration.ofMinutes(2))
           .pollInterval(Duration.ofSeconds(2))
           .untilAsserted(
-              () -> {
-                final var topology = clusterActuator.getTopology();
-                assertThat(topology.getBrokers()).hasSize(SCALE_DOWN_TARGET_CLUSTER_SIZE);
-
-                // verify no pending changes
-                assertThat(topology.getPendingChange()).isNull();
-
-                // verify remaining broker is active
-                final var activeBrokers =
-                    topology.getBrokers().stream()
-                        .filter(b -> b.getState() == BrokerStateCode.ACTIVE)
-                        .collect(Collectors.toList());
-                assertThat(activeBrokers).hasSize(SCALE_DOWN_TARGET_CLUSTER_SIZE);
-
-                // verify remaining broker has all partitions
-                for (final BrokerState broker : topology.getBrokers()) {
-                  assertThat(broker.getPartitions()).hasSize(PARTITIONS_COUNT);
-                }
-              });
-
-      // verify leases are released for removed brokers
-      Awaitility.await("Until leases are released for removed brokers")
-          .atMost(LEASE_DURATION.multipliedBy(2))
-          .untilAsserted(
-              () -> assertThat(getLeasesCount()).isEqualTo(SCALE_DOWN_TARGET_CLUSTER_SIZE));
+              () ->
+                  assertConfigurationChangeCompleted(
+                      clusterActuator, SCALE_DOWN_TARGET_CLUSTER_SIZE));
 
       Awaitility.await("Scaled down brokers are shutdown")
           .atMost(Duration.ofMinutes(1))
@@ -322,6 +271,37 @@ public class DynamicNodeIdScalingIT {
                               .filter(TestSpringApplication::isStarted)
                               .count())
                       .isEqualTo(1));
+    }
+
+    @Test
+    void shouldScaleUpAgainAfterScaleDown() {
+      // given
+      shouldScaleDownClusterFromThreeToOneBroker();
+      testCluster.awaitCompleteTopology(
+          SCALE_DOWN_TARGET_CLUSTER_SIZE, PARTITIONS_COUNT, 1, Duration.ofSeconds(10));
+
+      // when
+      final var clusterActuator = ClusterActuator.of(testCluster.anyGateway());
+      testCluster.brokers().values().stream()
+          .filter(b -> !b.isStarted())
+          .forEach(b -> Thread.ofVirtual().start(b::start));
+
+      final var scaleUpRequest =
+          new ClusterConfigPatchRequest()
+              .brokers(
+                  new ClusterConfigPatchRequestBrokers().count(SCALE_DOWN_INITIAL_CLUSTER_SIZE));
+
+      clusterActuator.patchCluster(scaleUpRequest, false, false);
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(1))
+          .untilAsserted(
+              () ->
+                  assertConfigurationChangeCompleted(
+                      clusterActuator, SCALE_DOWN_INITIAL_CLUSTER_SIZE));
+      testCluster.awaitCompleteTopology(
+          SCALE_DOWN_INITIAL_CLUSTER_SIZE, PARTITIONS_COUNT, 1, Duration.ofSeconds(10));
     }
   }
 }


### PR DESCRIPTION
## Description

The new leases created after scaling down followed by a scaleup would restart the version from 0. This can create issues if the data directory for older versions are not deleted, because on startup old version directories might already exists. 

In this PR, to allow scaling up after scaling down, instead of deleting the leases we mark it as unusable. The unusable leases will be marked as usable again when scaling up. 

In addition, we can delete the directories post scale down as well. This can be done in a follow up. This would not cause issues, but deleting directories would help free up disk space especially when we are keeping more then one previous version.

## Related issues

closes #47335
