### PR TITLE
ci: enable the breadth-first dependency collector in maven

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -29,6 +29,8 @@ runs:
       # `aether.enhancedLocalRepository.splitRemote` splits remote artifacts into released and snapshot
       # `aether.syncContext.*` config ensures that maven uses file locks to prevent corruption
       #      from downloading multiple artifacts at the same time.
+      # `aether.dependencyCollector.impl=bf` uses a breadth first algorithm when resolving/downloading poms.
+      #     The `bf` collector is suggested when the project contains many modules and dependencies.
       run: |
         tee .mvn/maven.config <<EOF
         --errors
@@ -43,6 +45,7 @@ runs:
         -D aether.syncContext.named.factory=file-lock
         -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
+        -D aether.dependencyCollector.impl=bf
         EOF
     - name: Get cache path and keys
       env:


### PR DESCRIPTION
## Description
This new dependency collector was added in maven 3.9.0 and it might be able to speed up the dependency resolution as we have a lot of modules. From the
[configuration](https://maven.apache.org/components/resolver/configuration.html):
> Our experience shows that existing “df” is well suited for smaller to
medium size projects, while “bf” may perform better on huge projects with many dependencies.

I noticed that the release job takes almost 1 hour, so I wonder if this change might help us make it faster.

Not sure what would be the best way to try this?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
