### PR TITLE
fix: change links from wiki to camunda.github.io

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -85,7 +85,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!subteam^S07D6C6B18T|monorepo-ci-medic> please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>.\n For how to investigate, see <https://github.com/camunda/camunda/wiki/CI-Runbooks#camunda-helm-chart-integration-test-failure|Runbook - Camunda Helm Chart Integration Test>."
+                    "text": "<!subteam^S07D6C6B18T|monorepo-ci-medic> please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>.\n For how to investigate, see <https://camunda.github.io/camunda/ci-runbooks/#camunda-helm-chart-integration-test-failure|Runbook - Camunda Helm Chart Integration Test>."
                   }
                 }
               ]

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -290,7 +290,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!subteam^S07D6C6B18T|monorepo-ci-medic> please check <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|workflow run>\n<https://github.com/camunda/camunda/wiki/CI-Runbooks#preview-environment-smoke-test-failure|Runbook>"
+                    "text": "<!subteam^S07D6C6B18T|monorepo-ci-medic> please check <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|workflow run>\n<https://camunda.github.io/camunda/ci-runbooks/#preview-environment-smoke-test-failure|Runbook>"
                   }
                 }
               ]


### PR DESCRIPTION
## Description

This pull request updates references to runbook documentation URLs in two GitHub Actions workflow files. The changes ensure that Slack notifications now point to the new location of the runbooks on the `camunda.github.io` site instead of the old GitHub wiki pages. Related to: https://github.com/camunda/camunda/issues/36946?reload=1

**Workflow notification updates:**

* Updated the runbook link in the Slack notification of the Camunda Helm Chart Integration workflow to use the new `camunda.github.io` documentation URL.
* Updated the runbook link in the Slack notification of the Preview Environment Smoke Test workflow to use the new `camunda.github.io` documentation URL.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
