### PR TITLE
feat: Add token renewal logic avoiding token expiration

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -317,6 +317,36 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
+
+      # This step is required to be able to push changes in the next steps,
+      # as the GitHub App token generated in the beginning of the job expires after 1 hour, and the maven release steps can take longer than that.
+      # By regenerating a fresh token after the potentially long-running maven release steps,
+      # we ensure that we have a valid token for pushing changes in the next steps.
+      - name: Regenerate GitHub App token
+        if: ${{ !inputs.dryRun }}
+        id: github-token-fresh
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      # As the checkout step uses the initial token, we need to override the git auth with the renewed token in order to be able to push changes in the next steps.
+      # checkout step is using extraheader for authentication, so we need to override the extraheader with the renewed token as well.
+      - name: Override git auth with renewed token (extraheader)
+        if: ${{ !inputs.dryRun }}
+        env:
+          FRESH_TOKEN: ${{ steps.github-token-fresh.outputs.token }}
+        run: |
+          echo "::add-mask::$FRESH_TOKEN"
+          AUTH_HEADER=$(printf "x-access-token:%s" "$FRESH_TOKEN" | base64 | tr -d '\n')
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $AUTH_HEADER"
+
       - name: Debug Optimize Versions
         if: ${{ inputs.includeOptimize && inputs.dryRun }}
         run: |


### PR DESCRIPTION
## Description

There was in issue, when the [release pipeline failed because the maven release step took almost an hour to be completed](https://github.com/camunda/camunda/actions/runs/22185761643/job/64170090127#step:18:29), so the initially retrieved GITHUB_TOKEN got expired. It was initially solved with a bigger runner, but it costs more and the we won only 10 minutes, so in time this issue can rise again

As the initial hotfix was to increase the runner from `cp-core-16-release` to `cp-core-32-release` was a quick solution, a proper check was needed to investigate the utilization of the given runner. 

Based on the utilization the results are the following:

## Original `gcp-core-16-release` for the [timed-out run](https://github.com/camunda/camunda/actions/runs/22185761643):
<img width="1146" height="1194" alt="image" src="https://github.com/user-attachments/assets/259e2bcd-4b70-4d47-99f8-e359dab1157a" />

[dashboard url](https://dashboard.int.camunda.com/d/zojn2gs/e274781?orgId=1&from=2026-02-19T15:38:04.403Z&to=2026-02-19T17:01:06.898Z&timezone=utc&var-cluster=camunda-ci-kubernetes-pods&var-namespace=camunda&var-runner=camunda-gcp-core-16-release&var-job=release)

## Updated `gcp-core-32-release` for the [succesful run:](https://github.com/camunda/camunda/actions/runs/22221625831)
<img width="947" height="1219" alt="image" src="https://github.com/user-attachments/assets/9c4b28a2-2192-4f2d-a6c3-f1cff415dbd8" />

[dashboard url](https://dashboard.int.camunda.com/d/zojn2gs/e274781?orgId=1&from=2026-02-20T10:37:22.753Z&to=2026-02-20T12:36:57.671Z&timezone=utc&var-cluster=camunda-ci-kubernetes-pods&var-namespace=camunda&var-runner=camunda-gcp-core-32-release&var-job=release)

## Changes:
- `Regenerate GitHub App token` and `Override git auth with renewed token (extraheader)` steps are added to regenerate and override the initial token, avoiding failure because of expiration.

### Test
[Test workflow](https://github.com/camunda/camunda/actions/runs/22226373843/job/64294013381)

## Related issues

closes #
