### PR TITLE
43069 client layer

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -175,6 +175,7 @@ import io.camunda.client.api.search.request.VariableSearchRequest;
 import io.camunda.client.api.statistics.request.GlobalJobStatisticsRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByErrorRequest;
+import io.camunda.client.api.statistics.request.JobTypeStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionElementStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
@@ -999,6 +1000,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the global job statistics request
    */
   GlobalJobStatisticsRequest newGlobalJobStatisticsRequest(
+      final OffsetDateTime from, final OffsetDateTime to);
+
+  /**
+   * Executes a request to query job statistics grouped by job type.
+   *
+   * <pre>
+   * camundaClient
+   *  .newJobTypeStatisticsRequest(OffsetDateTime.now().minusDays(1), OffsetDateTime.now())
+   *  .filter(f -&gt; f.jobType(jt -&gt; jt.like("fetch-*")))
+   *  .send();
+   * </pre>
+   *
+   * @param from the start of the time range (inclusive)
+   * @param to the end of the time range (inclusive)
+   * @return a builder for the job type statistics request
+   */
+  JobTypeStatisticsRequest newJobTypeStatisticsRequest(
       final OffsetDateTime from, final OffsetDateTime to);
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/JobTypeStatisticsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/JobTypeStatisticsFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+/** Filter for job type statistics queries. */
+public interface JobTypeStatisticsFilter extends SearchRequestFilter {
+
+  /**
+   * Filter by exact job type match.
+   *
+   * <pre>
+   * filter(f -&gt; f.jobType("myJobType"))
+   * </pre>
+   *
+   * @param jobType the job type to filter by
+   * @return the updated filter
+   */
+  JobTypeStatisticsFilter jobType(String jobType);
+
+  /**
+   * Filter by job type using advanced string filtering capabilities.
+   *
+   * <p>Supports: eq, neq, like, in, notIn, exists
+   *
+   * <pre>
+   * filter(f -&gt; f.jobType(jt -&gt; jt.like("fetch-*")))
+   * filter(f -&gt; f.jobType(jt -&gt; jt.in("type1", "type2")))
+   * </pre>
+   *
+   * @param fn the job type {@link StringProperty} consumer
+   * @return the updated filter
+   */
+  JobTypeStatisticsFilter jobType(Consumer<StringProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -28,6 +28,7 @@ import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.JobFilter;
+import io.camunda.client.api.search.filter.JobTypeStatisticsFilter;
 import io.camunda.client.api.search.filter.MappingRuleFilter;
 import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
@@ -123,6 +124,7 @@ import io.camunda.client.impl.search.sort.TenantUserSortImpl;
 import io.camunda.client.impl.search.sort.UserSortImpl;
 import io.camunda.client.impl.search.sort.UserTaskSortImpl;
 import io.camunda.client.impl.search.sort.VariableSortImpl;
+import io.camunda.client.impl.statistics.filter.JobTypeStatisticsFilterImpl;
 import io.camunda.client.impl.statistics.filter.ProcessDefinitionStatisticsFilterImpl;
 import java.util.function.Consumer;
 
@@ -282,6 +284,13 @@ public final class SearchRequestBuilders {
   public static ProcessDefinitionStatisticsFilter processDefinitionStatisticsFilter(
       final Consumer<ProcessDefinitionStatisticsFilter> fn) {
     final ProcessDefinitionStatisticsFilter filter = new ProcessDefinitionStatisticsFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static JobTypeStatisticsFilter jobTypeStatisticsFilter(
+      final Consumer<JobTypeStatisticsFilter> fn) {
+    final JobTypeStatisticsFilter filter = new JobTypeStatisticsFilterImpl();
     fn.accept(filter);
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/request/JobTypeStatisticsRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/request/JobTypeStatisticsRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.request;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.filter.JobTypeStatisticsFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest;
+import io.camunda.client.api.search.request.TypedPageableRequest;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
+
+/**
+ * Request to query job statistics grouped by job type. Allows filtering by time range, job type
+ * patterns, and supports pagination.
+ */
+public interface JobTypeStatisticsRequest
+    extends FinalCommandStep<JobTypeStatistics>,
+        TypedPageableRequest<JobTypeStatisticsRequest>,
+        TypedFilterableRequest<JobTypeStatisticsFilter, JobTypeStatisticsRequest> {}

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobTypeStatistics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobTypeStatistics.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.response;
+
+import io.camunda.client.api.search.response.SearchResponse;
+
+/** Response for job type statistics query. Contains a list of statistics grouped by job type. */
+public interface JobTypeStatistics extends SearchResponse<JobTypeStatisticsItem> {}

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobTypeStatisticsItem.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobTypeStatisticsItem.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.response;
+
+/** Statistics for a specific job type. */
+public interface JobTypeStatisticsItem {
+
+  /**
+   * Returns the job type name.
+   *
+   * @return the job type
+   */
+  String getJobType();
+
+  /**
+   * Returns the metric for jobs in CREATED state.
+   *
+   * @return the created jobs metric
+   */
+  JobStatusMetric getCreated();
+
+  /**
+   * Returns the metric for jobs in COMPLETED state.
+   *
+   * @return the completed jobs metric
+   */
+  JobStatusMetric getCompleted();
+
+  /**
+   * Returns the metric for jobs in FAILED state.
+   *
+   * @return the failed jobs metric
+   */
+  JobStatusMetric getFailed();
+
+  /**
+   * Returns the number of distinct workers that have worked on this job type.
+   *
+   * @return the worker count
+   */
+  int getWorkers();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -186,6 +186,7 @@ import io.camunda.client.api.search.request.VariableSearchRequest;
 import io.camunda.client.api.statistics.request.GlobalJobStatisticsRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByErrorRequest;
+import io.camunda.client.api.statistics.request.JobTypeStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionElementStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
@@ -354,6 +355,7 @@ import io.camunda.client.impl.search.request.VariableSearchRequestImpl;
 import io.camunda.client.impl.statistics.request.GlobalJobStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequestImpl;
 import io.camunda.client.impl.statistics.request.IncidentProcessInstanceStatisticsByErrorRequestImpl;
+import io.camunda.client.impl.statistics.request.JobTypeStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionElementStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequestImpl;
@@ -923,6 +925,12 @@ public final class CamundaClientImpl implements CamundaClient {
   public GlobalJobStatisticsRequest newGlobalJobStatisticsRequest(
       final OffsetDateTime from, final OffsetDateTime to) {
     return new GlobalJobStatisticsRequestImpl(httpClient, from, to);
+  }
+
+  @Override
+  public JobTypeStatisticsRequest newJobTypeStatisticsRequest(
+      final OffsetDateTime from, final OffsetDateTime to) {
+    return new JobTypeStatisticsRequestImpl(httpClient, config.getJsonMapper(), from, to);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/JobTypeStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/JobTypeStatisticsFilterImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.filter;
+
+import io.camunda.client.api.search.filter.JobTypeStatisticsFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import java.util.function.Consumer;
+
+public class JobTypeStatisticsFilterImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.JobTypeStatisticsFilter>
+    implements JobTypeStatisticsFilter {
+
+  private final io.camunda.client.protocol.rest.JobTypeStatisticsFilter filter;
+
+  public JobTypeStatisticsFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.JobTypeStatisticsFilter();
+  }
+
+  @Override
+  public JobTypeStatisticsFilter jobType(final String jobType) {
+    jobType(b -> b.eq(jobType));
+    return this;
+  }
+
+  @Override
+  public JobTypeStatisticsFilter jobType(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setJobType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.JobTypeStatisticsFilter getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/request/JobTypeStatisticsRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/request/JobTypeStatisticsRequestImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.jobTypeStatisticsFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.filter.JobTypeStatisticsFilter;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.statistics.request.JobTypeStatisticsRequest;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.statistics.response.StatisticsResponseMapper;
+import io.camunda.client.protocol.rest.CursorForwardPagination;
+import io.camunda.client.protocol.rest.JobTypeStatisticsQuery;
+import io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult;
+import io.camunda.client.protocol.rest.SearchQueryPageRequest;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class JobTypeStatisticsRequestImpl
+    extends TypedSearchRequestPropertyProvider<JobTypeStatisticsQuery>
+    implements JobTypeStatisticsRequest {
+
+  private final JobTypeStatisticsQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public JobTypeStatisticsRequestImpl(
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper,
+      final OffsetDateTime from,
+      final OffsetDateTime to) {
+    request = new JobTypeStatisticsQuery();
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+
+    // Set the time range in the filter
+    if (request.getFilter() == null) {
+      request.setFilter(new io.camunda.client.protocol.rest.JobTypeStatisticsFilter());
+    }
+    request
+        .getFilter()
+        .from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(from))
+        .to(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(to));
+  }
+
+  @Override
+  public FinalCommandStep<JobTypeStatistics> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<JobTypeStatistics> send() {
+    final HttpCamundaFuture<JobTypeStatistics> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/jobs/statistics/by-types",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        JobTypeStatisticsQueryResult.class,
+        StatisticsResponseMapper::toJobTypeStatisticsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public JobTypeStatisticsRequest filter(final JobTypeStatisticsFilter value) {
+    final io.camunda.client.protocol.rest.JobTypeStatisticsFilter filterProperty =
+        provideSearchRequestProperty(value);
+    // Preserve the from/to that were set in the constructor
+    if (request.getFilter() != null) {
+      final String fromValue = request.getFilter().getFrom();
+      final String toValue = request.getFilter().getTo();
+      filterProperty.from(fromValue).to(toValue);
+    }
+    request.setFilter(filterProperty);
+    return this;
+  }
+
+  @Override
+  public JobTypeStatisticsRequest filter(final Consumer<JobTypeStatisticsFilter> fn) {
+    return filter(jobTypeStatisticsFilter(fn));
+  }
+
+  @Override
+  protected JobTypeStatisticsQuery getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public JobTypeStatisticsRequest page(final SearchRequestPage value) {
+    final SearchQueryPageRequest page = provideSearchRequestProperty(value);
+    request.setPage(new CursorForwardPagination().limit(page.getLimit()).after(page.getAfter()));
+    return this;
+  }
+
+  @Override
+  public JobTypeStatisticsRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.response;
+
+import io.camunda.client.api.search.response.SearchResponsePage;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
+import io.camunda.client.api.statistics.response.JobTypeStatisticsItem;
+import java.util.List;
+import java.util.Objects;
+
+public class JobTypeStatisticsImpl implements JobTypeStatistics {
+  private final List<JobTypeStatisticsItem> items;
+  private final SearchResponsePage page;
+
+  public JobTypeStatisticsImpl(
+      final List<JobTypeStatisticsItem> items, final SearchResponsePage page) {
+    this.items = items;
+    this.page = page;
+  }
+
+  @Override
+  public List<JobTypeStatisticsItem> items() {
+    return items;
+  }
+
+  @Override
+  public SearchResponsePage page() {
+    return page;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, page);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final JobTypeStatisticsImpl that = (JobTypeStatisticsImpl) obj;
+    return Objects.equals(items, that.items) && Objects.equals(page, that.page);
+  }
+
+  @Override
+  public String toString() {
+    return "JobTypeStatisticsImpl{" + "items=" + items + ", page=" + page + '}';
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsItemImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsItemImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.response;
+
+import io.camunda.client.api.statistics.response.JobStatusMetric;
+import io.camunda.client.api.statistics.response.JobTypeStatisticsItem;
+import java.util.Objects;
+
+public class JobTypeStatisticsItemImpl implements JobTypeStatisticsItem {
+
+  private final String jobType;
+  private final JobStatusMetric created;
+  private final JobStatusMetric completed;
+  private final JobStatusMetric failed;
+  private final int workers;
+
+  public JobTypeStatisticsItemImpl(
+      final String jobType,
+      final JobStatusMetric created,
+      final JobStatusMetric completed,
+      final JobStatusMetric failed,
+      final int workers) {
+    this.jobType = jobType;
+    this.created = created;
+    this.completed = completed;
+    this.failed = failed;
+    this.workers = workers;
+  }
+
+  @Override
+  public String getJobType() {
+    return jobType;
+  }
+
+  @Override
+  public JobStatusMetric getCreated() {
+    return created;
+  }
+
+  @Override
+  public JobStatusMetric getCompleted() {
+    return completed;
+  }
+
+  @Override
+  public JobStatusMetric getFailed() {
+    return failed;
+  }
+
+  @Override
+  public int getWorkers() {
+    return workers;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jobType, created, completed, failed, workers);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobTypeStatisticsItemImpl that = (JobTypeStatisticsItemImpl) o;
+    return workers == that.workers
+        && Objects.equals(jobType, that.jobType)
+        && Objects.equals(created, that.created)
+        && Objects.equals(completed, that.completed)
+        && Objects.equals(failed, that.failed);
+  }
+
+  @Override
+  public String toString() {
+    return "JobTypeStatisticsItemImpl{"
+        + "jobType='"
+        + jobType
+        + '\''
+        + ", created="
+        + created
+        + ", completed="
+        + completed
+        + ", failed="
+        + failed
+        + ", workers="
+        + workers
+        + '}';
+  }
+}
+

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsItemImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobTypeStatisticsItemImpl.java
@@ -103,4 +103,3 @@ public class JobTypeStatisticsItemImpl implements JobTypeStatisticsItem {
         + '}';
   }
 }
-

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
@@ -24,6 +24,8 @@ import io.camunda.client.api.statistics.response.GlobalJobStatistics;
 import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisticsByDefinition;
 import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisticsByError;
 import io.camunda.client.api.statistics.response.JobStatusMetric;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
+import io.camunda.client.api.statistics.response.JobTypeStatisticsItem;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceStatistics;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceVersionStatistics;
 import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
@@ -35,6 +37,7 @@ import io.camunda.client.impl.search.response.SearchResponseImpl;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.GlobalJobStatisticsQueryResult;
 import io.camunda.client.protocol.rest.IncidentProcessInstanceStatisticsByErrorQueryResult;
+import io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceVersionStatisticsQueryResult;
@@ -171,6 +174,26 @@ public class StatisticsResponseMapper {
         toJobStatusMetric(response.getCompleted()),
         toJobStatusMetric(response.getFailed()),
         response.getIsIncomplete());
+  }
+
+  public static JobTypeStatistics toJobTypeStatisticsResponse(
+      final JobTypeStatisticsQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<io.camunda.client.api.statistics.response.JobTypeStatisticsItem> items =
+        toSearchResponseInstances(
+            response.getItems(), StatisticsResponseMapper::toJobTypeStatisticsItem);
+
+    return new JobTypeStatisticsImpl(items, page);
+  }
+
+  private static JobTypeStatisticsItem toJobTypeStatisticsItem(
+      final io.camunda.client.protocol.rest.JobTypeStatisticsItem item) {
+    return new JobTypeStatisticsItemImpl(
+        item.getJobType(),
+        toJobStatusMetric(item.getCreated()),
+        toJobStatusMetric(item.getCompleted()),
+        toJobStatusMetric(item.getFailed()),
+        ofNullable(item.getWorkers()).orElse(0));
   }
 
   private static JobStatusMetric toJobStatusMetric(final StatusMetric metric) {

--- a/clients/java/src/test/java/io/camunda/client/job/JobTypeStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobTypeStatisticsTest.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
+import io.camunda.client.protocol.rest.JobTypeStatisticsFilter;
+import io.camunda.client.protocol.rest.JobTypeStatisticsItem;
+import io.camunda.client.protocol.rest.JobTypeStatisticsQuery;
+import io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.StatusMetric;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class JobTypeStatisticsTest extends ClientRestTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
+  private static final OffsetDateTime FROM = NOW.minusDays(1); // now-1day
+  private static final OffsetDateTime TO = NOW.plusDays(1); // now+1day
+
+  @Test
+  void shouldGetJobTypeStatisticsWithEmptyQuery() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getJobTypeStatisticsUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldGetJobTypeStatisticsWithFilter() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client.newJobTypeStatisticsRequest(FROM, TO).filter(f -> f.jobType("myJobType")).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/jobs/statistics/by-types");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldGetJobTypeStatisticsWithPagination() {
+    // given
+    final JobTypeStatisticsQueryResult response = createPaginatedResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .page(p -> p.limit(10).after("cursor123"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    final String body = request.getBodyAsString();
+    assertThat(body).contains("\"page\"");
+    assertThat(body).contains("\"limit\":10");
+    assertThat(body).contains("\"after\":\"cursor123\"");
+  }
+
+  @Test
+  void shouldGetJobTypeStatistics() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/jobs/statistics/by-types");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+
+    assertThat(result).isNotNull();
+    assertThat(result.items()).hasSize(2);
+
+    // Verify first job type
+    assertThat(result.items().get(0).getJobType()).isEqualTo("jobTypeA");
+    assertThat(result.items().get(0).getCreated().getCount()).isEqualTo(100L);
+    assertThat(result.items().get(0).getCompleted().getCount()).isEqualTo(80L);
+    assertThat(result.items().get(0).getFailed().getCount()).isEqualTo(5L);
+    assertThat(result.items().get(0).getWorkers()).isEqualTo(3);
+
+    // Verify second job type
+    assertThat(result.items().get(1).getJobType()).isEqualTo("jobTypeB");
+    assertThat(result.items().get(1).getCreated().getCount()).isEqualTo(50L);
+    assertThat(result.items().get(1).getCompleted().getCount()).isEqualTo(45L);
+    assertThat(result.items().get(1).getFailed().getCount()).isEqualTo(2L);
+    assertThat(result.items().get(1).getWorkers()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldSendCorrectRequestBodyWithTimeRange() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+
+    final String body = request.getBodyAsString();
+    assertThat(body)
+        .contains("\"from\":\"" + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(FROM) + "\"");
+    assertThat(body)
+        .contains("\"to\":\"" + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(TO) + "\"");
+  }
+
+  @Test
+  void shouldFilterByJobTypeExactMatch() {
+    // given
+    final JobTypeStatisticsQueryResult response = createSingleJobTypeResponse("myJobType");
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client.newJobTypeStatisticsRequest(FROM, TO).filter(f -> f.jobType("myJobType")).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    final String body = request.getBodyAsString();
+    assertThat(body).contains("\"jobType\"");
+    assertThat(body).contains("myJobType");
+  }
+
+  @Test
+  void shouldFilterByJobTypeLikePattern() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType(jt -> jt.like("fetch-*")))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    final String body = request.getBodyAsString();
+    assertThat(body).contains("\"jobType\"");
+    assertThat(body).contains("fetch-*");
+  }
+
+  @Test
+  void shouldFilterByJobTypeInList() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType(jt -> jt.in("jobTypeA", "jobTypeB")))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    final String body = request.getBodyAsString();
+    assertThat(body).contains("\"jobType\"");
+    assertThat(body).contains("jobTypeA");
+    assertThat(body).contains("jobTypeB");
+  }
+
+  @Test
+  void shouldFilterByJobTypeWithAdvancedOperations() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType(jt -> jt.eq("exactMatch")))
+        .send()
+        .join();
+
+    // then
+    final JobTypeStatisticsQuery request =
+        gatewayService.getLastRequest(JobTypeStatisticsQuery.class);
+    final JobTypeStatisticsFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getJobType().get$Eq()).isEqualTo("exactMatch");
+  }
+
+  @Test
+  void shouldFilterByJobTypeNotEquals() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType(jt -> jt.neq("excludeThis")))
+        .send()
+        .join();
+
+    // then
+    final JobTypeStatisticsQuery request =
+        gatewayService.getLastRequest(JobTypeStatisticsQuery.class);
+    final JobTypeStatisticsFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getJobType().get$Neq()).isEqualTo("excludeThis");
+  }
+
+  @Test
+  void shouldFilterByJobTypeExists() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType(jt -> jt.exists(true)))
+        .send()
+        .join();
+
+    // then
+    final JobTypeStatisticsQuery request =
+        gatewayService.getLastRequest(JobTypeStatisticsQuery.class);
+    final JobTypeStatisticsFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getJobType().get$Exists()).isTrue();
+  }
+
+  @Test
+  void shouldIncludeFilterAndPageInRequestBody() {
+    // given
+    final JobTypeStatisticsQueryResult response = createPaginatedResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    client
+        .newJobTypeStatisticsRequest(FROM, TO)
+        .filter(f -> f.jobType("testJobType"))
+        .page(p -> p.limit(5))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
+    final String requestBody = lastRequest.getBodyAsString();
+
+    assertThat(requestBody).contains("\"filter\"");
+    assertThat(requestBody).contains("\"jobType\"");
+    assertThat(requestBody).contains("testJobType");
+    assertThat(requestBody).contains("\"page\"");
+  }
+
+  @Test
+  void shouldHandleEmptyResults() {
+    // given
+    final JobTypeStatisticsQueryResult response = createEmptyResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullMetrics() {
+    // given
+    final JobTypeStatisticsQueryResult response = createResponseWithNullMetrics();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).getCreated().getCount()).isZero();
+    assertThat(result.items().get(0).getCompleted().getCount()).isZero();
+    assertThat(result.items().get(0).getFailed().getCount()).isZero();
+    assertThat(result.items().get(0).getCreated().getLastUpdatedAt()).isNull();
+  }
+
+  @Test
+  void shouldHandleJobTypeWithZeroWorkers() {
+    // given
+    final JobTypeStatisticsQueryResult response = createResponseWithZeroWorkers();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).getWorkers()).isZero();
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByJobType() {
+    // given
+    final JobTypeStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobStatisticsRequest(response);
+
+    // when
+    final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
+
+    // then - results should be sorted by jobType (from SQL ORDER BY)
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().get(0).getJobType()).isEqualTo("jobTypeA");
+    assertThat(result.items().get(1).getJobType()).isEqualTo("jobTypeB");
+  }
+
+  private JobTypeStatisticsQueryResult createTestResponse() {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(
+        Arrays.asList(
+            createJobTypeItem("jobTypeA", 100L, 80L, 5L, 3),
+            createJobTypeItem("jobTypeB", 50L, 45L, 2L, 2)));
+    return response;
+  }
+
+  private JobTypeStatisticsQueryResult createSingleJobTypeResponse(final String jobType) {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(Collections.singletonList(createJobTypeItem(jobType, 100L, 80L, 5L, 3)));
+    return response;
+  }
+
+  private JobTypeStatisticsQueryResult createPaginatedResponse() {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse().totalItems(3L).endCursor("cursor123"));
+    response.setItems(
+        Arrays.asList(
+            createJobTypeItem("jobTypeA", 100L, 80L, 5L, 3),
+            createJobTypeItem("jobTypeB", 50L, 45L, 2L, 2),
+            createJobTypeItem("jobTypeC", 30L, 25L, 1L, 1)));
+    return response;
+  }
+
+  private JobTypeStatisticsQueryResult createEmptyResponse() {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(Collections.emptyList());
+    return response;
+  }
+
+  private JobTypeStatisticsQueryResult createResponseWithNullMetrics() {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    final JobTypeStatisticsItem item = new JobTypeStatisticsItem();
+    item.setJobType("testJobType");
+    item.setWorkers(1);
+    response.setItems(Collections.singletonList(item));
+    return response;
+  }
+
+  private JobTypeStatisticsQueryResult createResponseWithZeroWorkers() {
+    final JobTypeStatisticsQueryResult response = new JobTypeStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(
+        Collections.singletonList(createJobTypeItem("noWorkersType", 10L, 5L, 1L, 0)));
+    return response;
+  }
+
+  private JobTypeStatisticsItem createJobTypeItem(
+      final String jobType,
+      final long createdCount,
+      final long completedCount,
+      final long failedCount,
+      final int workers) {
+    final JobTypeStatisticsItem item = new JobTypeStatisticsItem();
+    item.setJobType(jobType);
+    item.setCreated(createStatusMetric(createdCount));
+    item.setCompleted(createStatusMetric(completedCount));
+    item.setFailed(createStatusMetric(failedCount));
+    item.setWorkers(workers);
+    return item;
+  }
+
+  private StatusMetric createStatusMetric(final long count) {
+    final StatusMetric metric = new StatusMetric();
+    metric.setCount(count);
+    metric.setLastUpdatedAt(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.now()));
+    return metric;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/job/JobTypeStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobTypeStatisticsTest.java
@@ -46,7 +46,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldGetJobTypeStatisticsWithEmptyQuery() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client.newJobTypeStatisticsRequest(FROM, TO).send().join();
@@ -61,14 +61,14 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldGetJobTypeStatisticsWithFilter() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client.newJobTypeStatisticsRequest(FROM, TO).filter(f -> f.jobType("myJobType")).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/jobs/statistics/by-types");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getJobTypeStatisticsUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 
@@ -76,7 +76,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldGetJobTypeStatisticsWithPagination() {
     // given
     final JobTypeStatisticsQueryResult response = createPaginatedResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -97,14 +97,14 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldGetJobTypeStatistics() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/jobs/statistics/by-types");
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getJobTypeStatisticsUrl());
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
 
     assertThat(result).isNotNull();
@@ -129,7 +129,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldSendCorrectRequestBodyWithTimeRange() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client.newJobTypeStatisticsRequest(FROM, TO).send().join();
@@ -149,7 +149,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeExactMatch() {
     // given
     final JobTypeStatisticsQueryResult response = createSingleJobTypeResponse("myJobType");
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client.newJobTypeStatisticsRequest(FROM, TO).filter(f -> f.jobType("myJobType")).send().join();
@@ -165,7 +165,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeLikePattern() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -185,7 +185,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeInList() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -206,7 +206,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeWithAdvancedOperations() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -227,7 +227,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeNotEquals() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -248,7 +248,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldFilterByJobTypeExists() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -269,7 +269,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldIncludeFilterAndPageInRequestBody() {
     // given
     final JobTypeStatisticsQueryResult response = createPaginatedResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     client
@@ -293,7 +293,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldHandleEmptyResults() {
     // given
     final JobTypeStatisticsQueryResult response = createEmptyResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
@@ -306,7 +306,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldHandleNullMetrics() {
     // given
     final JobTypeStatisticsQueryResult response = createResponseWithNullMetrics();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
@@ -323,7 +323,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldHandleJobTypeWithZeroWorkers() {
     // given
     final JobTypeStatisticsQueryResult response = createResponseWithZeroWorkers();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();
@@ -337,7 +337,7 @@ public class JobTypeStatisticsTest extends ClientRestTest {
   void shouldVerifyResultsAreSortedByJobType() {
     // given
     final JobTypeStatisticsQueryResult response = createTestResponse();
-    gatewayService.onJobStatisticsRequest(response);
+    gatewayService.onJobTypeStatisticsRequest(response);
 
     // when
     final JobTypeStatistics result = client.newJobTypeStatisticsRequest(FROM, TO).send().join();

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -123,6 +123,7 @@ public class RestGatewayPaths {
   private static final String URL_INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR =
       REST_API_PATH + "/incidents/statistics/process-instances-by-error";
   private static final String URL_GLOBAL_JOB_STATISTICS = REST_API_PATH + "/jobs/statistics/global";
+  private static final String URL_JOB_TYPE_STATISTICS = REST_API_PATH + "/jobs/statistics/by-types";
 
   /**
    * @return the topology request URL
@@ -457,6 +458,10 @@ public class RestGatewayPaths {
 
   public static String getGlobalJobStatisticsUrl() {
     return URL_GLOBAL_JOB_STATISTICS;
+  }
+
+  public static String getJobTypeStatisticsUrl() {
+    return URL_JOB_TYPE_STATISTICS;
   }
 
   public static String getResourceDeletionUrl(final long resourceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -486,6 +486,13 @@ public class RestGatewayService {
         response);
   }
 
+  public void onJobStatisticsRequest(
+      final io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult response) {
+    register(
+        WireMock.post(WireMock.urlPathEqualTo(RestGatewayPaths.getJobTypeStatisticsUrl())),
+        response);
+  }
+
   public void onStatusRequestHealthy() {
     onStatusRequest(204);
   }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -486,7 +486,7 @@ public class RestGatewayService {
         response);
   }
 
-  public void onJobStatisticsRequest(
+  public void onJobTypeStatisticsRequest(
       final io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult response) {
     register(
         WireMock.post(WireMock.urlPathEqualTo(RestGatewayPaths.getJobTypeStatisticsUrl())),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
@@ -11,7 +11,6 @@ import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
 import static io.camunda.it.util.TestHelper.activateAndFailJobs;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForAll;
 import static io.camunda.it.util.TestHelper.waitForJobStatistics;
 import static io.camunda.it.util.TestHelper.waitForJobs;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,30 +23,23 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
-import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-// @DisabledIfSystemProperty(
-//    named = "test.integration.camunda.database.type",
-//    matches = "AWS_OS") // test is flaky on AWS OS
-@Disabled(
-    "Flaky test, will be fixed in the context of https://github.com/camunda/camunda/issues/42928")
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "AWS_OS") // test is flaky on AWS OS
 public class GlobalJobStatisticsIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
-  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(5);
-  public static final int MAX_WORKER_NAME_LENGTH = 10;
-  public static final int MAX_JOB_TYPE_LENGTH = 10;
-  public static final int MAX_UNIQUE_KEYS = 5;
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -56,54 +48,21 @@ public class GlobalJobStatisticsIT {
           .withAuthenticatedAccess()
           // set exportInterval via properties because it is not yet supported in unified config
           .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength",
-              MAX_WORKER_NAME_LENGTH)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxJobTypeLength", MAX_JOB_TYPE_LENGTH)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys", MAX_UNIQUE_KEYS);
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
 
   private static final String ADMIN = "admin";
   private static final String JOB_TYPE_A = "taskA";
   private static final String PROCESS_ID = "service_tasks_v1";
-  private static final String SHORT_WORKER_NAME = "shortWork"; // 9 chars, within limit
-  private static final String LONG_WORKER_NAME = "veryLongWorkerName"; // 18 chars, exceeds limit
-  private static final String LONG_JOB_TYPE = "veryLongJobType"; // 15 chars, exceeds limit of 10
+  private static final String WORKER_NAME = "testWorker";
 
   @UserDefinition
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
-
-  // Time after first batch of metrics was exported (before second batch for incomplete test)
-  private static OffsetDateTime firstBatchExportedTime;
-  // Time after second batch of metrics was exported (for long worker name test)
-  private static OffsetDateTime secondBatchExportedTime;
-  // Time after third batch of metrics was exported (for long job type test)
-  private static OffsetDateTime thirdBatchExportedTime;
-  // Time after fourth batch of metrics was exported (for max unique keys test)
-  private static OffsetDateTime fourthBatchExportedTime;
 
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
     // Deploy a process with service tasks (taskA, taskB, taskC)
     deployResource(adminClient, "process/service_tasks_v1.bpmn");
-    // Deploy a process with a job type that EXCEEDS the limit
-    final var longJobTypeProcess =
-        Bpmn.createExecutableProcess("longJobTypeProcess")
-            .startEvent()
-            .serviceTask("longTask", t -> t.zeebeJobType(LONG_JOB_TYPE))
-            .serviceTask("taskA", t -> t.zeebeJobType(JOB_TYPE_A))
-            .endEvent()
-            .done();
-    adminClient
-        .newDeployResourceCommand()
-        .addProcessModel(longJobTypeProcess, "longJobTypeProcess.bpmn")
-        .send()
-        .join();
-
-    // ========== FIRST BATCH: Normal metrics ==========
 
     // Start 2 process instances to create jobs
     startProcessInstance(adminClient, PROCESS_ID);
@@ -113,19 +72,18 @@ public class GlobalJobStatisticsIT {
     waitForJobs(adminClient, f -> f.type(JOB_TYPE_A), 2);
 
     // Complete 1 taskA job
-    activateAndCompleteJobs(adminClient, JOB_TYPE_A, SHORT_WORKER_NAME, 1);
+    activateAndCompleteJobs(adminClient, JOB_TYPE_A, WORKER_NAME, 1);
 
     // Wait for completion to be reflected
     waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).type(JOB_TYPE_A), 1);
 
     // Fail 1 taskA job (the remaining one from instance 2)
-    activateAndFailJobs(
-        adminClient, JOB_TYPE_A, SHORT_WORKER_NAME, 1, "Intentional failure for test");
+    activateAndFailJobs(adminClient, JOB_TYPE_A, WORKER_NAME, 1, "Intentional failure for test");
 
     // Wait for failure to be reflected
     waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_A), 1);
 
-    // Wait for first batch metrics to be exported
+    // Wait for metrics to be exported
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
@@ -137,129 +95,12 @@ public class GlobalJobStatisticsIT {
           assertThat(stats.getFailed().getCount()).isEqualTo(1L);
           assertThat(stats.isIncomplete()).isFalse();
         });
-
-    // Wait for export & store first batch export time
-    firstBatchExportedTime = OffsetDateTime.now();
-    Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
-
-    // ========== SECOND BATCH: Incomplete metrics (long worker name) ==========
-    // Start a new process instance to have a new taskA job available
-    startProcessInstance(adminClient, PROCESS_ID);
-
-    // Wait for the new taskA job to be available
-    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A).state(JobState.CREATED), 1);
-
-    // Activate and complete the job with a worker name that EXCEEDS the limit
-    // This should cause the statistics to be marked as incomplete
-    activateAndCompleteJobs(adminClient, JOB_TYPE_A, LONG_WORKER_NAME, 1);
-
-    // Wait for the completion to be reflected in the job search
-    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).worker(LONG_WORKER_NAME), 1);
-
-    // Wait for second batch metrics to be exported
-    waitForJobStatistics(
-        adminClient,
-        firstBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // taskA: 1 created, taskB: 1 created (after taskA completed)
-          assertThat(stats.getCreated().getCount()).isEqualTo(2L);
-          // The completed count should be 0 because the job with the long worker name
-          // should not be included in the statistics
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          // The isIncomplete flag should be true because the worker name exceeded the limit
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-
-    // Wait for export & store second batch export time
-    secondBatchExportedTime = OffsetDateTime.now();
-    Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
-
-    // ========== THIRD BATCH: Incomplete metrics (long job type) ==========
-    // Start a process instance with the long job type
-    adminClient
-        .newCreateInstanceCommand()
-        .bpmnProcessId("longJobTypeProcess")
-        .latestVersion()
-        .send()
-        .join();
-
-    // Wait for the job to be created
-    waitForJobs(adminClient, f -> f.type(LONG_JOB_TYPE).state(JobState.CREATED), 1);
-    activateAndCompleteJobs(adminClient, LONG_JOB_TYPE, SHORT_WORKER_NAME, 1);
-    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A).state(JobState.CREATED), 1);
-
-    // Wait for third batch metrics to be exported
-    waitForJobStatistics(
-        adminClient,
-        secondBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // Should have 1 valid created job (taskA), long job type not counted
-          assertThat(stats.getCreated().getCount()).isEqualTo(1L);
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-
-    // Wait for export & store third batch export time
-    thirdBatchExportedTime = OffsetDateTime.now();
-    Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
-
-    // ========== FOURTH BATCH: Incomplete metrics (max unique keys exceeded) ==========
-    // Deploy all processes first (deployments don't create job metrics)
-    final var deploymentFutures =
-        IntStream.rangeClosed(1, MAX_UNIQUE_KEYS + 1)
-            .mapToObj(
-                i -> {
-                  final String uniqueJobType = "type" + i; // type1, type2, ..., type6
-                  final var uniqueProcess =
-                      Bpmn.createExecutableProcess("uniqueProcess" + i)
-                          .startEvent()
-                          .serviceTask("task" + i, t -> t.zeebeJobType(uniqueJobType))
-                          .endEvent()
-                          .done();
-                  return adminClient
-                      .newDeployResourceCommand()
-                      .addProcessModel(uniqueProcess, "uniqueProcess" + i + ".bpmn")
-                      .send();
-                })
-            .toList();
-    waitForAll(deploymentFutures);
-
-    // Now start all instances in parallel (within one export interval)
-    // This ensures all jobs are created in the same batch
-    final var instanceFutures =
-        IntStream.rangeClosed(1, MAX_UNIQUE_KEYS + 1)
-            .mapToObj(
-                i ->
-                    adminClient
-                        .newCreateInstanceCommand()
-                        .bpmnProcessId("uniqueProcess" + i)
-                        .latestVersion()
-                        .send())
-            .toList();
-    // Wait for all instances to be created
-    waitForAll(instanceFutures);
-
-    // Wait for fourth batch metrics to be exported
-    waitForJobStatistics(
-        adminClient,
-        thirdBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // Should be incomplete because we exceeded max unique keys
-          // First MAX_UNIQUE_KEYS are tracked, the 6th is not
-          assertThat(stats.getCreated().getCount()).isEqualTo(MAX_UNIQUE_KEYS);
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-
-    fourthBatchExportedTime = OffsetDateTime.now();
   }
 
   @Test
   void shouldReturnGlobalJobStatisticsWithExpectedCounts(
       @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // We have:
     // - 2 process instances started
     // - Each process has taskA, taskB, taskC
@@ -268,7 +109,7 @@ public class GlobalJobStatisticsIT {
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(3L);
           assertThat(stats.getCompleted().getCount()).isEqualTo(1L);
@@ -280,12 +121,12 @@ public class GlobalJobStatisticsIT {
   @Test
   void shouldReturnStatisticsFilteredByJobType(
       @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // For taskA specifically: 1 completed, 1 failed, 2 created total
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
           // taskA: 2 created, 1 completed, 1 failed
@@ -302,11 +143,11 @@ public class GlobalJobStatisticsIT {
     // given
     final String nonExistentJobType = "non-existent-job-type-xyz";
 
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         nonExistentJobType,
         stats -> {
           assertThat(stats.getCreated().getCount()).isZero();
@@ -318,68 +159,18 @@ public class GlobalJobStatisticsIT {
 
   @Test
   void shouldReturnOnlyCreatedJobsForTaskB(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // taskB: 1 created (from the completed taskA flow)
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         "taskB",
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(1L);
           assertThat(stats.getCompleted().getCount()).isZero();
           assertThat(stats.getFailed().getCount()).isZero();
           assertThat(stats.isIncomplete()).isFalse();
-        });
-  }
-
-  @Test
-  void shouldReturnIncompleteWhenWorkerNameExceedsLimit(
-      @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only second batch (long worker name)
-    waitForJobStatistics(
-        adminClient,
-        firstBatchExportedTime,
-        secondBatchExportedTime,
-        stats -> {
-          // taskA: 1 created, taskB: 1 created (after taskA completed)
-          assertThat(stats.getCreated().getCount()).isEqualTo(2L);
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-  }
-
-  @Test
-  void shouldReturnIncompleteWhenJobTypeExceedsLimit(
-      @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only third batch (long job type)
-    waitForJobStatistics(
-        adminClient,
-        secondBatchExportedTime,
-        thirdBatchExportedTime,
-        stats -> {
-          // Should have 1 valid created job (taskA), long job type not counted
-          assertThat(stats.getCreated().getCount()).isEqualTo(1L);
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-  }
-
-  @Test
-  void shouldReturnIncompleteWhenMaxUniqueKeysExceeded(
-      @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only fourth batch (max unique keys exceeded)
-    waitForJobStatistics(
-        adminClient,
-        thirdBatchExportedTime,
-        fourthBatchExportedTime,
-        stats -> {
-          // We created MAX_UNIQUE_KEYS + 1 (6) unique job types
-          // Only MAX_UNIQUE_KEYS (5) should be tracked
-          assertThat(stats.getCreated().getCount()).isEqualTo(MAX_UNIQUE_KEYS);
-          assertThat(stats.isIncomplete()).isTrue();
         });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
+import static io.camunda.it.util.TestHelper.activateAndFailJobs;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForJobTypeStatistics;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.JobState;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@CompatibilityTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "AWS_OS") // test is flaky on AWS OS
+public class JobTypeStatisticsIT {
+
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthenticatedAccess()
+          // set exportInterval via properties because it is not yet supported in unified config
+          .withProperty(
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
+
+  private static final String ADMIN = "admin";
+  private static final String JOB_TYPE_A = "taskA";
+  private static final String JOB_TYPE_B = "taskB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+  private static final String WORKER_NAME = "testWorker";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @BeforeAll
+  static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws InterruptedException {
+    // Deploy a process with service tasks (taskA, taskB, taskC)
+    deployResource(adminClient, "process/service_tasks_v1.bpmn");
+
+    // Start 2 process instances to create jobs
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+
+    // Wait for the jobs to be created (2 instances x taskA = 2 taskA jobs initially)
+    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A), 2);
+
+    // Complete 1 taskA job
+    activateAndCompleteJobs(adminClient, JOB_TYPE_A, WORKER_NAME, 1);
+
+    // Wait for completion to be reflected
+    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).type(JOB_TYPE_A), 1);
+
+    // Fail 1 taskA job (the remaining one from instance 2)
+    activateAndFailJobs(adminClient, JOB_TYPE_A, WORKER_NAME, 1, "Intentional failure for test");
+
+    // Wait for failure to be reflected
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_A), 1);
+
+    // Wait for metrics to be exported
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          // We should have 2 job types: taskA and taskB
+          assertThat(stats.items()).hasSize(2);
+        });
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsWithAllJobTypes(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then
+    // We have:
+    // - taskA: 2 created, 1 completed, 1 failed
+    // - taskB: 1 created (after completing taskA in instance 1)
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          // Results should be sorted by jobType ASC
+          final var taskAStats = stats.items().get(0);
+          assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(2L);
+          assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getWorkers()).isEqualTo(1);
+
+          final var taskBStats = stats.items().get(1);
+          assertThat(taskBStats.getJobType()).isEqualTo(JOB_TYPE_B);
+          assertThat(taskBStats.getCreated().getCount()).isEqualTo(1L);
+          assertThat(taskBStats.getCompleted().getCount()).isZero();
+          assertThat(taskBStats.getFailed().getCount()).isZero();
+          assertThat(taskBStats.getWorkers()).isEqualTo(0); // no worker activated taskB yet
+        });
+  }
+
+  @Test
+  void shouldFilterJobTypeStatisticsByJobType(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by taskA only
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_A),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+
+          final var taskAStats = stats.items().get(0);
+          assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(2L);
+          assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldFilterJobTypeStatisticsByJobTypeLike(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by pattern "task*"
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(jt -> jt.like("task*")),
+        stats -> {
+          // Should match both taskA and taskB
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(1).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+
+  @Test
+  void shouldFilterJobTypeStatisticsByJobTypeIn(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by taskA and taskB
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(jt -> jt.in(JOB_TYPE_A, JOB_TYPE_B)),
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(1).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentJobType(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by non-existent job type
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType("non-existent-job-type"),
+        stats -> {
+          assertThat(stats.items()).isEmpty();
+        });
+  }
+
+  @Test
+  void shouldPaginateJobTypeStatistics(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final AtomicReference<String> endCursor = new AtomicReference<>("");
+    // when - get first page with size 1
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> {},
+        p -> p.limit(1),
+        stats -> {
+          // First page should have 1 item (taskA due to ORDER BY jobType)
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // when - get second page
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> {},
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          // Second page should have 1 item (taskB)
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTaskBStatistics(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by taskB only
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_B),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+
+          final var taskBStats = stats.items().get(0);
+          assertThat(taskBStats.getJobType()).isEqualTo(JOB_TYPE_B);
+          assertThat(taskBStats.getCreated().getCount()).isEqualTo(1L);
+          assertThat(taskBStats.getCompleted().getCount()).isZero();
+          assertThat(taskBStats.getFailed().getCount()).isZero();
+        });
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByJobType(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          // Results should be sorted by jobType in ascending order
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(1).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
@@ -28,20 +28,15 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-// @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-@Disabled(
-    "Flaky test, will be fixed in the context of https://github.com/camunda/camunda/issues/42928")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class GlobalJobStatisticsTenancyIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
-  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(10);
-  public static final int MAX_WORKER_NAME_LENGTH = 10;
-  public static final int MAX_TENANT_ID_LENGTH = 10;
-  public static final int MAX_UNIQUE_KEYS = 4;
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -51,14 +46,7 @@ public class GlobalJobStatisticsTenancyIT {
           .withAuthenticatedAccess()
           // set exportInterval via properties because it is not yet supported in unified config
           .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxWorkerNameLength",
-              MAX_WORKER_NAME_LENGTH)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxTenantIdLength", MAX_TENANT_ID_LENGTH)
-          .withProperty(
-              "zeebe.broker.experimental.engine.jobMetrics.maxUniqueKeys", MAX_UNIQUE_KEYS);
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
 
   private static final String ADMIN = "admin";
   private static final String USER_TENANT_A = "userTenantA";
@@ -68,9 +56,7 @@ public class GlobalJobStatisticsTenancyIT {
   private static final String TENANT_B = "tenantB";
   private static final String JOB_TYPE_A = "taskA";
   private static final String PROCESS_ID = "service_tasks_v1";
-  private static final String SHORT_WORKER_NAME = "shortWork"; // 9 chars, within limit
-  private static final String LONG_WORKER_NAME = "veryLongWorkerName"; // 18 chars, exceeds limit
-  private static final String LONG_TENANT_ID = "veryLongTenantId"; // 16 chars, exceeds limit of 10
+  private static final String WORKER_NAME = "testWorker";
 
   @UserDefinition
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
@@ -87,28 +73,17 @@ public class GlobalJobStatisticsTenancyIT {
   private static final TestUser USER_NO_TENANT_USER =
       new TestUser(USER_NO_TENANT, "password", List.of());
 
-  // Time after first batch of metrics was exported (before second batch for incomplete test)
-  private static OffsetDateTime firstBatchExportedTime;
-  // Time after second batch of metrics was exported (for long worker name test)
-  private static OffsetDateTime secondBatchExportedTime;
-
   @BeforeAll
   static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
       throws InterruptedException {
-    // ========== FIRST BATCH: Normal metrics ==========
     // Create tenants and assign users
     createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
     createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
-    // Create a tenant with a long ID that EXCEEDS the limit
-    createTenant(adminClient, LONG_TENANT_ID, LONG_TENANT_ID, ADMIN);
-
     // USER_NO_TENANT is not assigned to any tenant
 
     // Deploy processes for each tenant
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
     deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
-    // Deploy a process to the long tenant
-    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", LONG_TENANT_ID);
 
     // Start process instances for each tenant to create jobs
     // TENANT_A: 2 instances -> 2 taskA jobs created
@@ -122,19 +97,19 @@ public class GlobalJobStatisticsTenancyIT {
     waitForJobs(adminClient, f -> f.tenantId(TENANT_B), 1);
 
     // Complete 1 taskA job from TENANT_A
-    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_A, TENANT_A, SHORT_WORKER_NAME, 1);
+    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_A, TENANT_A, WORKER_NAME, 1);
 
     // Wait for completion to be reflected
     waitForJobs(adminClient, f -> f.state(JobState.COMPLETED), 1);
 
     // Fail 1 taskA job from TENANT_B
     activateAndFailJobsForTenant(
-        adminClient, JOB_TYPE_A, TENANT_B, SHORT_WORKER_NAME, 1, "Intentional failure for test");
+        adminClient, JOB_TYPE_A, TENANT_B, WORKER_NAME, 1, "Intentional failure for test");
 
     // Wait for failure to be reflected
     waitForJobs(adminClient, f -> f.state(JobState.FAILED), 1);
 
-    // Wait for first batch metrics to be exported
+    // Wait for metrics to be exported
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
@@ -146,70 +121,12 @@ public class GlobalJobStatisticsTenancyIT {
           assertThat(stats.getFailed().getCount()).isEqualTo(1L);
           assertThat(stats.isIncomplete()).isFalse();
         });
-
-    // Wait for export & store first batch export time
-    firstBatchExportedTime = OffsetDateTime.now();
-    Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
-
-    // ========== SECOND BATCH: Incomplete metrics (long worker name) ==========
-    // Start a new process instance in TENANT_A to have a new taskA job available
-    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
-
-    // Wait for the new taskA job to be available
-    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A).state(JobState.CREATED).tenantId(TENANT_A), 2);
-
-    // Activate and complete the job with a worker name that EXCEEDS the limit
-    // This should cause the statistics to be marked as incomplete
-    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_A, TENANT_A, LONG_WORKER_NAME, 1);
-
-    // Wait for the completion to be reflected in the job search
-    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).worker(LONG_WORKER_NAME), 1);
-
-    // Wait for second batch metrics to be exported
-    waitForJobStatistics(
-        adminClient,
-        firstBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // taskA: 1 created, taskB: 1 created (after taskA completed)
-          assertThat(stats.getCreated().getCount()).isEqualTo(2L);
-          // The completed count should be 0 because the job with the long worker name
-          // should not be included in the statistics
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          // The isIncomplete flag should be true because the worker name exceeded the limit
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-
-    // Wait for export & store second batch export time
-    secondBatchExportedTime = OffsetDateTime.now();
-    Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
-
-    // ========== THIRD BATCH: Incomplete metrics (long tenant id) ==========
-    // Start a process instance in the long tenant
-    startProcessInstanceForTenant(adminClient, PROCESS_ID, LONG_TENANT_ID);
-    // Create a valid job in TENANT_A to ensure at least one metric is recorded
-    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
-
-    // Wait for the new taskA job to be available
-    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A).tenantId(LONG_TENANT_ID), 1);
-
-    // Wait for third batch metrics to be exported
-    waitForJobStatistics(
-        adminClient,
-        secondBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // Should have 1 valid created job from TENANT_A, long tenant ID job not counted
-          assertThat(stats.getCreated().getCount()).isEqualTo(1L);
-          assertThat(stats.isIncomplete()).isTrue();
-        });
   }
 
   @Test
   void shouldReturnGlobalStatisticsForAllTenants(
       @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // Admin has access to all tenants, so should see:
     // - CREATED: 3 taskA (2 from TENANT_A + 1 from TENANT_B) + 1 taskB (from completed taskA)
     // - COMPLETED: 1 taskA
@@ -217,7 +134,7 @@ public class GlobalJobStatisticsTenancyIT {
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(4L);
           assertThat(stats.getCompleted().getCount()).isEqualTo(1L);
@@ -229,7 +146,7 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldReturnOnlyTenantAStatisticsForUserTenantA(
       @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // User assigned to TENANT_A should only see TENANT_A statistics:
     // - CREATED: 2 taskA + 1 taskB (from completed taskA)
     // - COMPLETED: 1 taskA
@@ -237,7 +154,7 @@ public class GlobalJobStatisticsTenancyIT {
     waitForJobStatistics(
         userTenantAClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(2L);
@@ -250,7 +167,7 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldReturnOnlyTenantBStatisticsForUserTenantB(
       @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // User assigned to TENANT_B should only see TENANT_B statistics:
     // - CREATED: 1 taskA
     // - COMPLETED: 0 (completed job is in TENANT_A)
@@ -258,7 +175,7 @@ public class GlobalJobStatisticsTenancyIT {
     waitForJobStatistics(
         userTenantBClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(1L);
@@ -271,12 +188,12 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldReturnZeroStatisticsForUserWithNoTenantAccess(
       @Authenticated(USER_NO_TENANT) final CamundaClient userNoTenantClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // User not assigned to any tenant should see zero statistics
     waitForJobStatistics(
         userNoTenantClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         stats -> {
           assertThat(stats.getCreated().getCount()).isZero();
           assertThat(stats.getCompleted().getCount()).isZero();
@@ -287,7 +204,7 @@ public class GlobalJobStatisticsTenancyIT {
 
   @Test
   void shouldFilterStatisticsByJobType(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // For taskA only:
     // - CREATED: 3 (2 from TENANT_A + 1 from TENANT_B)
     // - COMPLETED: 1
@@ -295,7 +212,7 @@ public class GlobalJobStatisticsTenancyIT {
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         JOB_TYPE_A,
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(3L);
@@ -308,13 +225,13 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldReturnTaskBStatisticsOnlyForTenantA(
       @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // taskB was created in TENANT_A after completing taskA
     // User in TENANT_A should see it
     waitForJobStatistics(
         userTenantAClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         "taskB",
         stats -> {
           assertThat(stats.getCreated().getCount()).isEqualTo(1L);
@@ -327,12 +244,12 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldNotSeeTaskBForUserTenantB(
       @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     // taskB was created in TENANT_A, so TENANT_B user should not see it
     waitForJobStatistics(
         userTenantBClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         "taskB",
         stats -> {
           assertThat(stats.getCreated().getCount()).isZero();
@@ -345,59 +262,17 @@ public class GlobalJobStatisticsTenancyIT {
   @Test
   void shouldReturnZeroForNonExistentJobType(
       @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only first batch (before incomplete metrics)
+    // when/then
     waitForJobStatistics(
         adminClient,
         NOW.minusDays(1),
-        firstBatchExportedTime,
+        NOW.plusDays(1),
         "non-existent-job-type",
         stats -> {
           assertThat(stats.getCreated().getCount()).isZero();
           assertThat(stats.getCompleted().getCount()).isZero();
           assertThat(stats.getFailed().getCount()).isZero();
           assertThat(stats.isIncomplete()).isFalse();
-        });
-  }
-
-  @Test
-  void shouldReturnIncompleteWhenWorkerNameExceedsLimit(
-      @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only second batch (after first batch, containing incomplete metrics)
-    // The statistics should be marked as incomplete because we used a worker name
-    // that exceeds the configured limit
-    waitForJobStatistics(
-        adminClient,
-        firstBatchExportedTime,
-        secondBatchExportedTime,
-        stats -> {
-          // taskA: 1 created, taskB: 1 created (after taskA completed)
-          assertThat(stats.getCreated().getCount()).isEqualTo(2L);
-          // The completed count should be 0 because the job with the long worker name
-          // should not be included in the statistics
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          // The isIncomplete flag should be true because the worker name exceeded the limit
-          assertThat(stats.isIncomplete()).isTrue();
-        });
-  }
-
-  @Test
-  void shouldReturnIncompleteWhenTenantIdExceedsLimit(
-      @Authenticated(ADMIN) final CamundaClient adminClient) {
-    // when/then - query only third batch (after second batch, containing incomplete metrics)
-    // The statistics should be marked as incomplete because we used a tenant ID
-    // that exceeds the configured limit
-    waitForJobStatistics(
-        adminClient,
-        secondBatchExportedTime,
-        NOW.plusDays(1),
-        stats -> {
-          // Should have 1 valid created job from TENANT_A, long tenant ID job not counted
-          assertThat(stats.getCreated().getCount()).isEqualTo(1L);
-          assertThat(stats.getCompleted().getCount()).isZero();
-          assertThat(stats.getFailed().getCount()).isZero();
-          // The isIncomplete flag should be true because the tenant ID exceeded the limit
-          assertThat(stats.isIncomplete()).isTrue();
         });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
+import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
+import static io.camunda.it.util.TestHelper.createTenant;
+import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
+import static io.camunda.it.util.TestHelper.waitForJobTypeStatistics;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.JobState;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class JobTypeStatisticsTenancyIT {
+
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess()
+          // set exportInterval via properties because it is not yet supported in unified config
+          .withProperty(
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
+
+  private static final String ADMIN = "admin";
+  private static final String USER_TENANT_A = "userTenantA";
+  private static final String USER_TENANT_B = "userTenantB";
+  private static final String USER_NO_TENANT = "userNoTenant";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String JOB_TYPE_A = "taskA";
+  private static final String JOB_TYPE_B = "taskB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+  private static final String WORKER_NAME = "testWorker";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_TENANT_A_USER =
+      new TestUser(USER_TENANT_A, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_TENANT_B_USER =
+      new TestUser(USER_TENANT_B, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_NO_TENANT_USER =
+      new TestUser(USER_NO_TENANT, "password", List.of());
+
+  @BeforeAll
+  static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws InterruptedException {
+    // Create tenants and assign users
+    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
+    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
+    // USER_NO_TENANT is not assigned to any tenant
+
+    // Deploy processes for each tenant
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+
+    // Start process instances for each tenant to create jobs
+    // TENANT_A: 2 instances -> 2 taskA jobs created
+    // TENANT_B: 1 instance -> 1 taskA job created
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_B);
+
+    // Wait for jobs to be available
+    waitForJobs(adminClient, f -> f.tenantId(TENANT_A), 2);
+    waitForJobs(adminClient, f -> f.tenantId(TENANT_B), 1);
+
+    // Complete 1 taskA job from TENANT_A
+    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_A, TENANT_A, WORKER_NAME, 1);
+
+    // Wait for completion to be reflected
+    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED), 1);
+
+    // Fail 1 taskA job from TENANT_B
+    activateAndFailJobsForTenant(
+        adminClient, JOB_TYPE_A, TENANT_B, WORKER_NAME, 1, "Intentional failure for test");
+
+    // Wait for failure to be reflected
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED), 1);
+
+    // Wait for metrics to be exported
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          // Admin should see taskA from both tenants + taskB from TENANT_A
+          assertThat(stats.items()).hasSizeGreaterThanOrEqualTo(2);
+        });
+  }
+
+  @Test
+  void shouldReturnJobTypeStatisticsForAllTenants(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then
+    // Admin has access to all tenants, so should see:
+    // - taskA: 3 created (2 TENANT_A + 1 TENANT_B), 1 completed, 1 failed
+    // - taskB: 1 created (from TENANT_A after completing taskA)
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          // Results sorted by jobType ASC
+          final var taskAStats = stats.items().get(0);
+          assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(3L);
+          assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getWorkers()).isEqualTo(1);
+
+          final var taskBStats = stats.items().get(1);
+          assertThat(taskBStats.getJobType()).isEqualTo(JOB_TYPE_B);
+          assertThat(taskBStats.getCreated().getCount()).isEqualTo(1L);
+          assertThat(taskBStats.getCompleted().getCount()).isZero();
+          assertThat(taskBStats.getFailed().getCount()).isZero();
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTenantAJobTypeStatistics(
+      @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
+    // when/then
+    // User assigned to TENANT_A should only see TENANT_A statistics:
+    // - taskA: 2 created, 1 completed, 0 failed
+    // - taskB: 1 created
+    waitForJobTypeStatistics(
+        userTenantAClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          final var taskAStats = stats.items().get(0);
+          assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(2L);
+          assertThat(taskAStats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getFailed().getCount()).isZero();
+
+          final var taskBStats = stats.items().get(1);
+          assertThat(taskBStats.getJobType()).isEqualTo(JOB_TYPE_B);
+          assertThat(taskBStats.getCreated().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTenantBJobTypeStatistics(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // when/then
+    // User assigned to TENANT_B should only see TENANT_B statistics:
+    // - taskA: 1 created, 0 completed, 1 failed
+    waitForJobTypeStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+
+          final var taskAStats = stats.items().get(0);
+          assertThat(taskAStats.getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(taskAStats.getCreated().getCount()).isEqualTo(1L);
+          assertThat(taskAStats.getCompleted().getCount()).isZero();
+          assertThat(taskAStats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyForUserWithNoTenantAccess(
+      @Authenticated(USER_NO_TENANT) final CamundaClient userNoTenantClient) {
+    // when/then
+    // User not assigned to any tenant should see no statistics
+    waitForJobTypeStatistics(
+        userNoTenantClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          assertThat(stats.items()).isEmpty();
+        });
+  }
+
+  @Test
+  void shouldFilterByJobTypeForTenantAUser(
+      @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
+    // when/then - filter by taskA only
+    waitForJobTypeStatistics(
+        userTenantAClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_A),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(0).getCreated().getCount()).isEqualTo(2L);
+        });
+  }
+
+  @Test
+  void shouldFilterByJobTypeForTenantBUser(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // when/then - filter by taskA only
+    waitForJobTypeStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_A),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(0).getCreated().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldNotSeeTenantATaskBForTenantBUser(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // when/then
+    // taskB was created in TENANT_A, so TENANT_B user should not see it
+    waitForJobTypeStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(JOB_TYPE_B),
+        stats -> {
+          assertThat(stats.items()).isEmpty();
+        });
+  }
+
+  @Test
+  void shouldPaginateJobTypeStatisticsWithTenantFiltering(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var endCursor = new AtomicReference<>("");
+    // when - get first page with size 1
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> {},
+        p -> p.limit(1),
+        stats -> {
+          // First page should have 1 item (taskA due to ORDER BY jobType)
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // when - get second page
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> {},
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          // Second page should have 1 item (taskB)
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+
+  @Test
+  void shouldFilterByJobTypeLikePatternWithTenancy(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then - filter by pattern "task*"
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType(jt -> jt.like("task*")),
+        stats -> {
+          // Should match both taskA and taskB across all tenants
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(1).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentJobTypeWithTenancy(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        f -> f.jobType("non-existent-job-type"),
+        stats -> {
+          assertThat(stats.items()).isEmpty();
+        });
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByJobTypeAcrossTenants(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // when/then
+    waitForJobTypeStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        stats -> {
+          // Results should be sorted by jobType in ascending order
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getJobType()).isEqualTo(JOB_TYPE_A);
+          assertThat(stats.items().get(1).getJobType()).isEqualTo(JOB_TYPE_B);
+        });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -34,6 +34,7 @@ import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.JobFilter;
+import io.camunda.client.api.search.filter.JobTypeStatisticsFilter;
 import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
@@ -47,6 +48,7 @@ import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.statistics.response.GlobalJobStatistics;
+import io.camunda.client.api.statistics.response.JobTypeStatistics;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -899,6 +901,73 @@ public final class TestHelper {
               if (jobType != null) {
                 request = request.jobType(jobType);
               }
+
+              assertThat(request.send().join()).satisfies(fnRequirements);
+            });
+  }
+
+  /**
+   * Waits for job type statistics to be exported and match the given requirements.
+   *
+   * @param camundaClient the Camunda client
+   * @param startTime the start time for the statistics query
+   * @param endTime the end time for the statistics query
+   * @param fnRequirements the assertions to apply to the statistics
+   */
+  public static void waitForJobTypeStatistics(
+      final CamundaClient camundaClient,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
+      final Consumer<JobTypeStatistics> fnRequirements) {
+    waitForJobTypeStatistics(camundaClient, startTime, endTime, f -> {}, p -> {}, fnRequirements);
+  }
+
+  /**
+   * Waits for job type statistics to be exported and match the given requirements, with filter.
+   *
+   * @param camundaClient the Camunda client
+   * @param startTime the start time for the statistics query
+   * @param endTime the end time for the statistics query
+   * @param filterFn the filter consumer to apply
+   * @param fnRequirements the assertions to apply to the statistics
+   */
+  public static void waitForJobTypeStatistics(
+      final CamundaClient camundaClient,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
+      final Consumer<JobTypeStatisticsFilter> filterFn,
+      final Consumer<JobTypeStatistics> fnRequirements) {
+    waitForJobTypeStatistics(camundaClient, startTime, endTime, filterFn, p -> {}, fnRequirements);
+  }
+
+  /**
+   * Waits for job type statistics to be exported and match the given requirements, with filter and
+   * pagination.
+   *
+   * @param camundaClient the Camunda client
+   * @param startTime the start time for the statistics query
+   * @param endTime the end time for the statistics query
+   * @param filterFn the filter consumer to apply
+   * @param pageFn the page consumer to apply
+   * @param fnRequirements the assertions to apply to the statistics
+   */
+  public static void waitForJobTypeStatistics(
+      final CamundaClient camundaClient,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
+      final Consumer<JobTypeStatisticsFilter> filterFn,
+      final Consumer<SearchRequestPage> pageFn,
+      final Consumer<JobTypeStatistics> fnRequirements) {
+    Awaitility.await("should export job type metrics to secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var request =
+                  camundaClient
+                      .newJobTypeStatisticsRequest(startTime, endTime)
+                      .filter(filterFn)
+                      .page(pageFn);
 
               assertThat(request.send().join()).satisfies(fnRequirements);
             });

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobTypeStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobTypeStatisticsQuery.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.query;
 
+import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.JobTypeStatisticsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -33,6 +35,11 @@ public record JobTypeStatisticsQuery(JobTypeStatisticsFilter filter, SearchQuery
   @Override
   public SortOption sort() {
     return NoSort.NO_SORT;
+  }
+
+  @Override
+  public AggregationBase aggregation() {
+    return new JobTypeStatisticsAggregation(page);
   }
 
   public static final class Builder

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
@@ -112,7 +112,7 @@ public class JobBatchMetricsExportedHandler
             jobMetrics.getStatusMetrics().get(JobMetricsExportState.CREATED.getIndex()).getCount())
         .setLastCreatedAt(getLastUpdatedAtForStatus(jobMetrics, JobMetricsExportState.CREATED))
         .setJobType(encodedStrings.get(jobMetrics.getJobTypeIndex()))
-        .setWorker(encodedStrings.get(jobMetrics.getWorkerNameIndex()));
+        .setWorker(emptyToNull(encodedStrings.get(jobMetrics.getWorkerNameIndex())));
   }
 
   @Override
@@ -124,6 +124,15 @@ public class JobBatchMetricsExportedHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  /**
+   * When a Job is activated, it has no worker name but the record contains an empty string. In that
+   * case, we want to store null in the database instead of an empty string, to be able to properly
+   * count distinct worker names.
+   */
+  private String emptyToNull(final String string) {
+    return string == null || string.isEmpty() ? null : string;
   }
 
   private OffsetDateTime getLastUpdatedAtForStatus(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobMetricsBatchExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobMetricsBatchExportHandler.java
@@ -88,9 +88,18 @@ public class JobMetricsBatchExportHandler
                     .lastCreatedAt(
                         getLastUpdatedAtForStatus(jobMetrics, JobMetricsExportState.CREATED))
                     .jobType(encodedString.get(jobMetrics.getJobTypeIndex()))
-                    .worker(encodedString.get(jobMetrics.getWorkerNameIndex()))
+                    .worker(emptyToNull(encodedString.get(jobMetrics.getWorkerNameIndex())))
                     .build())
         .toList();
+  }
+
+  /**
+   * When a Job is activated, it has no worker name but the record contains an empty string. In that
+   * case, we want to store null in the database instead of an empty string, to be able to properly
+   * count distinct worker names.
+   */
+  private String emptyToNull(final String string) {
+    return string == null || string.isEmpty() ? null : string;
   }
 
   private OffsetDateTime getLastUpdatedAtForStatus(

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -122,6 +122,7 @@ components:
           example: 145
         lastUpdatedAt:
           description: ISO 8601 timestamp of the last update for this status.
+          nullable: true
           type: string
           format: date-time
           example: "2024-07-29T15:51:28.071Z"


### PR DESCRIPTION
## Description

This pull request introduces a new feature to the Java client: the ability to query job statistics grouped by job type. It adds a new API for requesting, filtering, and handling job type statistics, including support for advanced filtering and pagination. The implementation includes new request, filter, and response classes, as well as integration into the client and supporting infrastructure.

I also enabled the ITs back, [see this incident ](https://camunda.slack.com/archives/C0AFTGHS5EV)to get a full explanation of why these tests were flaky.

**New Job Type Statistics API**

* Added the `JobTypeStatisticsRequest` interface and implementation, allowing users to query job statistics grouped by job type, with support for time range, advanced filtering, and pagination. (`JobTypeStatisticsRequest.java`, `JobTypeStatisticsRequestImpl.java`) [[1]](diffhunk://#diff-2f495dbe5cbe7ba9ee003472150ce3d1e67ca79509089932fb594fc6a01b0bc0R1-R31) [[2]](diffhunk://#diff-ee2706409ddbf3097134b391f4e7d8f5950c29ef0cad6a2c81561f74368fcddaR1-R126)
* Introduced the `JobTypeStatisticsFilter` interface and its implementation, enabling filtering by job type with exact match or advanced string operations (e.g., `like`, `in`). (`JobTypeStatisticsFilter.java`, `JobTypeStatisticsFilterImpl.java`) [[1]](diffhunk://#diff-0be5634d9192e0f77eb9161f0fd4c6ec3dfc115a9ed044a2069c8effe5a4329bR1-R51) [[2]](diffhunk://#diff-1c2b54d0b2967ba45a15eeb5b47a4dfbacfedca87d592478544e9191b7b48a62R1-R53)
* Created response interfaces and implementations for job type statistics, including `JobTypeStatistics`, `JobTypeStatisticsItem`, and their concrete classes, to represent and access grouped job statistics results. (`JobTypeStatistics.java`, `JobTypeStatisticsItem.java`, `JobTypeStatisticsImpl.java`) [[1]](diffhunk://#diff-1606178194d793d039e7a99fb7cb79fc4dbaf8381e8893beaefcc3c6511e2179R1-R21) [[2]](diffhunk://#diff-d8fb9d012a706282a15c9f9e41f98ee46ab357b05603333f5d3b0be3ba5b54f4R1-R55) [[3]](diffhunk://#diff-f13e58b069f31521e8a19921026b96744c226eab25b75246faade5e7f8ea8f7aR1-R65)

**Client Integration**

* Added the new request method `newJobTypeStatisticsRequest` to the main client interface and implementation, enabling users to construct and send job type statistics queries. (`CamundaClient.java`, `CamundaClientImpl.java`) [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR1005-R1021) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R930-R935)
* Registered new filter and request builders in `SearchRequestBuilders` to support the creation of job type statistics filters in a fluent API style. (`SearchRequestBuilders.java`) [[1]](diffhunk://#diff-feb992d8de5e76a5013e9404ba94af2bfa9dd0659b22cbc160344062499ef3dfR31) [[2]](diffhunk://#diff-feb992d8de5e76a5013e9404ba94af2bfa9dd0659b22cbc160344062499ef3dfR127) [[3]](diffhunk://#diff-feb992d8de5e76a5013e9404ba94af2bfa9dd0659b22cbc160344062499ef3dfR291-R297)

These changes collectively provide a new, flexible way to analyze job statistics by type, enhancing the observability and reporting capabilities of the client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43069
