### PR TITLE
[Backport stable/8.9] fix: correctly pass and validate the gatewayId for the `TestStandaloneGateway`

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -278,7 +278,7 @@ public class Cluster implements Cloneable {
         gatewayId,
         String.class,
         UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(legacyPropertiesMap.get("gatewayId")));
+        Set.of(LEGACY_GATEWAY_PROPERTIES.get("gatewayId")));
   }
 
   public void setGatewayId(final String gatewayId) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -372,24 +372,23 @@ public final class TestClusterBuilder {
     for (int i = 0; i < gatewaysCount; i++) {
       final var id = "gateway-" + i;
       final var memberId = MemberId.from(id);
-      final var gateway = createGateway(id);
+      final var gateway = createGateway(id, i);
 
       applyConfigFunctions(memberId, gateway);
       gateways.put(memberId, gateway);
     }
   }
 
-  private TestStandaloneGateway createGateway(final String id) {
-    final TestStandaloneGateway gateway =
-        new TestStandaloneGateway()
-            .withUnifiedConfig(
-                uc -> {
-                  final var cluster = uc.getCluster();
-                  cluster.setName(name);
-                  cluster.setInitialContactPoints(getInitialContactPoints());
-                })
-            .withProperty("zeebe.gateway.cluster.memberId", id);
-    return gateway;
+  private TestStandaloneGateway createGateway(final String id, final int index) {
+    return new TestStandaloneGateway()
+        .withUnifiedConfig(
+            uc -> {
+              final var cluster = uc.getCluster();
+              cluster.setNodeId(index);
+              cluster.setGatewayId(id);
+              cluster.setName(name);
+              cluster.setInitialContactPoints(getInitialContactPoints());
+            });
   }
 
   private List<String> getInitialContactPoints() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -88,7 +88,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
   @Override
   public MemberId nodeId() {
     // Gateway member ID via property
-    return MemberId.from(property("zeebe.gateway.cluster.memberId", String.class, "gateway"));
+    return MemberId.from(unifiedConfig.getCluster().getGatewayId());
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #46342 to `stable/8.9`.

relates to 