### PR TITLE
[Backport stable/8.9] feat(c8run): add a link to the OC MCP server on startup

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -17,6 +17,9 @@ API endpoints:
 - Zeebe API (gRPC):           {{.ZeebeAPI}}
 - Camunda metrics:            {{.CamundaMetrics}}
 
+MCP servers:
+- Orchestration Cluster:      {{.OrchestrationMCP}}
+
 Note: When using the Desktop Modeler, Authentication may be set to None.
 
 Next steps:
@@ -24,6 +27,7 @@ Next steps:
 2. View your process in Operate
 3. Run a job worker via Java/Node SDK
 4. Build your first AI agent
+5. Connect any AI agent to the Orchestration API MCP Server and chat with your processes
 
 Need guidance?
 - Quickstart:       {{.QuickstartURL}}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -41,6 +41,7 @@ type StartupSummary struct {
 	Username             string
 	Password             string
 	OrchestrationAPI     string
+	OrchestrationMCP     string
 	InboundConnectorsAPI string
 	ZeebeAPI             string
 	CamundaMetrics       string
@@ -142,6 +143,7 @@ func PrintStatus(settings types.C8RunSettings) error {
 		Username:             username,
 		Password:             password,
 		OrchestrationAPI:     fmt.Sprintf("%s://localhost:%d/v2/", protocol, camundaPort),
+		OrchestrationMCP:     fmt.Sprintf("%s://localhost:%d/mcp/cluster", protocol, camundaPort),
 		InboundConnectorsAPI: fmt.Sprintf("http://localhost:%d/", inboundConnectorsPort),
 		ZeebeAPI:             zeebeAPIURL,
 		CamundaMetrics:       camundaMetricsURL,


### PR DESCRIPTION
# Description
Backport of #46302 to `stable/8.9`.

relates to camunda/camunda#46292