### PR TITLE
refactor: avoid using zeebe-util Tuple in camunda-search-client

### DIFF
--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -30,11 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -106,8 +106,8 @@ import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.TenantCheck;
-import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -519,8 +519,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
                 entityByMultipleIdsNotFoundException(
                     "Global Listener",
                     List.of(
-                        Tuple.of("listenerId", listenerId),
-                        Tuple.of("listenerType", listenerType.name()))));
+                        Map.entry("listenerId", listenerId),
+                        Map.entry("listenerType", listenerType.name()))));
   }
 
   @Override
@@ -649,10 +649,10 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   private CamundaSearchException entityByMultipleIdsNotFoundException(
-      final String entityType, final List<Tuple<String, String>> idTypesAndValues) {
+      final String entityType, final List<Map.Entry<String, String>> idTypesAndValues) {
     final String formattedIds =
         idTypesAndValues.stream()
-            .map(e -> "%s '%s'".formatted(e.getLeft(), e.getRight()))
+            .map(e -> "%s '%s'".formatted(e.getKey(), e.getValue()))
             .collect(Collectors.joining(", "));
     return new CamundaSearchException(
         ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND.formatted(entityType, formattedIds),


### PR DESCRIPTION
Having the zeebe-util dependency in camunda-search-client creates a FOSSA cycle, making the CI fail (see https://camunda.slack.com/archives/C071KP5BTHB/p1771601443548359)

This pull request removes the dependency on `zeebe-util` and updates the code to use standard Java types instead of the `Tuple` class from that library. The changes focus on improving maintainability by reducing external dependencies and simplifying the code.

Dependency removal and code simplification:

* Removed the `zeebe-util` dependency from `search/search-client/pom.xml`, reducing reliance on external libraries.
* Replaced usage of `Tuple` with `Map.Entry` in method signatures and implementations in `CamundaSearchClients.java`, specifically for handling multiple ID-value pairs.
* Updated imports in `CamundaSearchClients.java` to remove `Tuple` and add `Map`.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).