### PR TITLE
[Backport stable/8.9] feat: support tenant filter in streaming commands metrics

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/StreamJobsCommandImpl.java
@@ -66,7 +66,9 @@ public final class StreamJobsCommandImpl
     this.asyncStub = asyncStub;
     this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
-    builder = StreamActivatedJobsRequest.newBuilder();
+    builder =
+        StreamActivatedJobsRequest.newBuilder()
+            .setTenantFilter(GatewayOuterClass.TenantFilter.PROVIDED);
 
     timeout(config.getDefaultJobTimeout());
     workerName(config.getDefaultJobWorkerName());
@@ -84,10 +86,12 @@ public final class StreamJobsCommandImpl
   @Override
   public CamundaFuture<StreamJobsResponse> send() {
     builder.clearTenantIds();
-    if (customTenantIds.isEmpty()) {
-      builder.addAllTenantIds(defaultTenantIds);
-    } else {
-      builder.addAllTenantIds(customTenantIds);
+    if (builder.getTenantFilter() == GatewayOuterClass.TenantFilter.PROVIDED) {
+      if (customTenantIds.isEmpty()) {
+        builder.addAllTenantIds(defaultTenantIds);
+      } else {
+        builder.addAllTenantIds(customTenantIds);
+      }
     }
 
     final StreamActivatedJobsRequest request = builder.build();
@@ -169,7 +173,7 @@ public final class StreamJobsCommandImpl
 
   @Override
   public StreamJobsCommandStep3 tenantFilter(final TenantFilter tenantFilter) {
-    // TODO: https://github.com/camunda/camunda/issues/45356
+    builder.setTenantFilter(GatewayOuterClass.TenantFilter.valueOf(tenantFilter.name()));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.worker;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.StreamJobsResponse;
 import io.camunda.client.api.worker.BackoffSupplier;
@@ -48,6 +49,7 @@ final class JobStreamerImpl implements JobStreamer {
   private final Duration timeout;
   private final List<String> fetchVariables;
   private final List<String> tenantIds;
+  private final TenantFilter tenantFilter;
   private final Duration streamTimeout;
   private final BackoffSupplier backoffSupplier;
   private final ScheduledExecutorService executor;
@@ -75,6 +77,7 @@ final class JobStreamerImpl implements JobStreamer {
       final Duration timeout,
       final List<String> fetchVariables,
       final List<String> tenantIds,
+      final TenantFilter tenantFilter,
       final Duration streamTimeout,
       final BackoffSupplier backoffSupplier,
       final ScheduledExecutorService executor) {
@@ -84,6 +87,7 @@ final class JobStreamerImpl implements JobStreamer {
     this.timeout = timeout;
     this.fetchVariables = fetchVariables;
     this.tenantIds = tenantIds;
+    this.tenantFilter = tenantFilter;
     this.streamTimeout = streamTimeout;
     this.backoffSupplier = backoffSupplier;
     this.executor = executor;
@@ -164,6 +168,7 @@ final class JobStreamerImpl implements JobStreamer {
             .consumer(jobConsumer)
             .workerName(workerName)
             .tenantIds(tenantIds)
+            .tenantFilter(tenantFilter)
             .timeout(timeout);
 
     if (fetchVariables != null) {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -88,9 +88,9 @@ public final class JobWorkerBuilderImpl
     requestTimeout = configuration.getDefaultRequestTimeout();
     enableStreaming = configuration.getDefaultJobWorkerStreamEnabled();
     defaultTenantIds = configuration.getDefaultJobWorkerTenantIds();
+    tenantFilter = configuration.getDefaultJobWorkerTenantFilter();
     jobExceptionHandler = configuration.getDefaultJobWorkerExceptionHandler();
     customTenantIds = new ArrayList<>();
-    tenantFilter = configuration.getDefaultJobWorkerTenantFilter();
     backoffSupplier = DEFAULT_BACKOFF_SUPPLIER;
     streamNoJobsBackoffSupplier = DEFAULT_STREAM_NO_JOBS_BACKOFF_SUPPLIER;
     streamingTimeout = DEFAULT_STREAMING_TIMEOUT;
@@ -234,6 +234,7 @@ public final class JobWorkerBuilderImpl
               timeout,
               fetchVariables,
               getTenantIds(),
+              tenantFilter,
               streamingTimeout,
               backoffSupplier,
               scheduledExecutor);

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.worker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
@@ -207,6 +208,7 @@ final class JobStreamImplTest {
         Duration.ofSeconds(10),
         Arrays.asList("foo", "bar"),
         Arrays.asList("test-tenant"),
+        TenantFilter.PROVIDED,
         streamingTimeout,
         ignored -> 10_000L,
         scheduler);

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -30,6 +30,7 @@ import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
 import io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3;
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
@@ -148,6 +149,7 @@ class JobWorkerBuilderImplTest {
     Mockito.when(jobClient.newStreamJobsCommand().jobType(anyString()).consumer(any()))
         .thenReturn(lastStep);
     Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
     Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
 
     // when
@@ -238,6 +240,7 @@ class JobWorkerBuilderImplTest {
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<List<String>> tenantIdCaptor = ArgumentCaptor.forClass(List.class);
     Mockito.when(lastStep.tenantIds(tenantIdCaptor.capture())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
     Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
 
     // when
@@ -266,6 +269,7 @@ class JobWorkerBuilderImplTest {
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<List<String>> tenantIdCaptor = ArgumentCaptor.forClass(List.class);
     Mockito.when(lastStep.tenantIds(tenantIdCaptor.capture())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
     Mockito.when(lastStep.send()).thenReturn(Mockito.mock());
 
     // when

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -127,7 +128,8 @@ public final class JobStreamEndpoint {
         BufferUtil.bufferAsString(properties.worker()),
         Duration.ofMillis(properties.timeout()),
         properties.fetchVariables().stream().map(BufferUtil::bufferAsString).toList(),
-        properties.tenantIds());
+        properties.tenantIds(),
+        properties.tenantFilter());
   }
 
   /** View model for the combined list of all remote and client job streams. */
@@ -152,7 +154,8 @@ public final class JobStreamEndpoint {
       String worker,
       Duration timeout,
       Collection<String> fetchVariables,
-      Collection<String> tenantIds) {}
+      Collection<String> tenantIds,
+      TenantFilter tenantFilter) {}
 
   /** View model for a remote job stream ID */
   public record RemoteStreamId(UUID id, String receiver) {}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/JobStreamLifecycleIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/JobStreamLifecycleIT.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.it.cluster.clustering;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -371,125 +370,6 @@ final class JobStreamLifecycleIT {
                   JobStreamActuatorAssert.assertThat(actuator)
                       .remoteStreams()
                       .doNotHaveJobType(jobType));
-    }
-  }
-
-  @Test
-  void shouldReportDefaultTenantFilterAsProvided() {
-    // given — a stream with no explicit tenant filter (default should be PROVIDED)
-    final var command =
-        client
-            .newStreamJobsCommand()
-            .jobType(jobType)
-            .consumer(ignored -> {})
-            .workerName("default");
-
-    // when
-    command.send();
-
-    // then — the actuator should report the tenant filter as PROVIDED
-    Awaitility.await("until stream is registered")
-        .untilAsserted(
-            () ->
-                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
-                    .clientStreams()
-                    .haveExactlyAll(
-                        1,
-                        AbstractJobStreamsAssert.hasJobType(jobType),
-                        AbstractJobStreamsAssert.hasTenantFilter(
-                            io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
-    for (int nodeId = 0; nodeId < 2; nodeId++) {
-      final var actuator = brokerActuator(nodeId);
-      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
-          .untilAsserted(
-              () ->
-                  JobStreamActuatorAssert.assertThat(actuator)
-                      .remoteStreams()
-                      .haveExactlyAll(
-                          1,
-                          AbstractJobStreamsAssert.hasJobType(jobType),
-                          AbstractJobStreamsAssert.hasTenantFilter(
-                              io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
-    }
-  }
-
-  @Test
-  void shouldReportProvidedTenantFilterOnActuator() {
-    // given — a stream with an explicit PROVIDED tenant filter
-    final var command =
-        client
-            .newStreamJobsCommand()
-            .jobType(jobType)
-            .consumer(ignored -> {})
-            .workerName("provided")
-            .tenantFilter(TenantFilter.PROVIDED);
-
-    // when
-    command.send();
-
-    // then
-    Awaitility.await("until stream is registered")
-        .untilAsserted(
-            () ->
-                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
-                    .clientStreams()
-                    .haveExactlyAll(
-                        1,
-                        AbstractJobStreamsAssert.hasJobType(jobType),
-                        AbstractJobStreamsAssert.hasTenantFilter(
-                            io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
-    for (int nodeId = 0; nodeId < 2; nodeId++) {
-      final var actuator = brokerActuator(nodeId);
-      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
-          .untilAsserted(
-              () ->
-                  JobStreamActuatorAssert.assertThat(actuator)
-                      .remoteStreams()
-                      .haveExactlyAll(
-                          1,
-                          AbstractJobStreamsAssert.hasJobType(jobType),
-                          AbstractJobStreamsAssert.hasTenantFilter(
-                              io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
-    }
-  }
-
-  @Test
-  void shouldReportAssignedTenantFilterOnActuator() {
-    // given — a stream with ASSIGNED tenant filter
-    final var command =
-        client
-            .newStreamJobsCommand()
-            .jobType(jobType)
-            .consumer(ignored -> {})
-            .workerName("assigned")
-            .tenantFilter(TenantFilter.ASSIGNED);
-
-    // when
-    command.send();
-
-    // then
-    Awaitility.await("until stream is registered")
-        .untilAsserted(
-            () ->
-                JobStreamActuatorAssert.assertThat(JobStreamActuator.of(gateway))
-                    .clientStreams()
-                    .haveExactlyAll(
-                        1,
-                        AbstractJobStreamsAssert.hasJobType(jobType),
-                        AbstractJobStreamsAssert.hasTenantFilter(
-                            io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED)));
-    for (int nodeId = 0; nodeId < 2; nodeId++) {
-      final var actuator = brokerActuator(nodeId);
-      Awaitility.await("until stream is registered on broker '%d'".formatted(nodeId))
-          .untilAsserted(
-              () ->
-                  JobStreamActuatorAssert.assertThat(actuator)
-                      .remoteStreams()
-                      .haveExactlyAll(
-                          1,
-                          AbstractJobStreamsAssert.hasJobType(jobType),
-                          AbstractJobStreamsAssert.hasTenantFilter(
-                              io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED)));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/JobStreamEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/JobStreamEndpointIT.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.it.cluster.management;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.enums.TenantFilter;
+import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
@@ -16,7 +18,9 @@ import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
 import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert.RemoteJobStreamsAssert;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
+import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -179,5 +183,116 @@ final class JobStreamEndpointIT {
                         RemoteJobStreamsAssert.hasWorker("bar"),
                         RemoteJobStreamsAssert.hasTimeout(250L),
                         RemoteJobStreamsAssert.hasFetchVariables("bar", "barz")));
+  }
+
+  @Test
+  void shouldListTenantFilterOnRemoteStreams() {
+    // given — two workers with different tenant filters, each with a unique job type so
+    // haveExactlyAll(1, ...) assertions are independent of each other
+    final var providedJobType = Strings.newRandomValidBpmnId();
+    final var assignedJobType = Strings.newRandomValidBpmnId();
+
+    final JobWorker providedWorker =
+        client
+            .newWorker()
+            .jobType(providedJobType)
+            .handler((c, j) -> {})
+            .name("providedWorker")
+            .timeout(Duration.ofMillis(500))
+            .tenantFilter(TenantFilter.PROVIDED)
+            .streamEnabled(true)
+            .open();
+    final JobWorker assignedWorker =
+        client
+            .newWorker()
+            .jobType(assignedJobType)
+            .handler((c, j) -> {})
+            .name("assignedWorker")
+            .timeout(Duration.ofMillis(500))
+            .tenantFilter(TenantFilter.ASSIGNED)
+            .streamEnabled(true)
+            .open();
+
+    // then — the broker's remote streams expose the correct tenantFilter for each worker
+    final var brokerActuator = JobStreamActuator.of(cluster.brokers().get(MemberId.from("0")));
+    Awaitility.await("until PROVIDED stream is registered on broker")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType(providedJobType),
+                        RemoteJobStreamsAssert.hasWorker("providedWorker"),
+                        RemoteJobStreamsAssert.hasTenantFilter(
+                            io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
+    Awaitility.await("until ASSIGNED stream is registered on broker")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(brokerActuator)
+                    .remoteStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType(assignedJobType),
+                        RemoteJobStreamsAssert.hasWorker("assignedWorker"),
+                        RemoteJobStreamsAssert.hasTenantFilter(
+                            io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED)));
+
+    CloseHelper.quietCloseAll(providedWorker, assignedWorker);
+  }
+
+  @Test
+  void shouldListTenantFilterOnClientStreams() {
+    // given — two workers with different tenant filters, each with a unique job type
+    final var providedJobType = Strings.newRandomValidBpmnId();
+    final var assignedJobType = Strings.newRandomValidBpmnId();
+
+    final JobWorker providedWorker =
+        client
+            .newWorker()
+            .jobType(providedJobType)
+            .handler((c, j) -> {})
+            .name("providedWorker")
+            .timeout(Duration.ofMillis(500))
+            .tenantFilter(TenantFilter.PROVIDED)
+            .streamEnabled(true)
+            .open();
+    final JobWorker assignedWorker =
+        client
+            .newWorker()
+            .jobType(assignedJobType)
+            .handler((c, j) -> {})
+            .name("assignedWorker")
+            .timeout(Duration.ofMillis(500))
+            .tenantFilter(TenantFilter.ASSIGNED)
+            .streamEnabled(true)
+            .open();
+
+    // then — the gateway's client streams expose the correct tenantFilter for each worker
+    final var gatewayActuator = JobStreamActuator.of(gateway);
+    Awaitility.await("until PROVIDED stream is registered on gateway")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(gatewayActuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType(providedJobType),
+                        RemoteJobStreamsAssert.hasWorker("providedWorker"),
+                        RemoteJobStreamsAssert.hasTenantFilter(
+                            io.camunda.zeebe.protocol.record.value.TenantFilter.PROVIDED)));
+    Awaitility.await("until ASSIGNED stream is registered on gateway")
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(gatewayActuator)
+                    .clientStreams()
+                    .haveExactlyAll(
+                        1,
+                        RemoteJobStreamsAssert.hasJobType(assignedJobType),
+                        RemoteJobStreamsAssert.hasWorker("assignedWorker"),
+                        RemoteJobStreamsAssert.hasTenantFilter(
+                            io.camunda.zeebe.protocol.record.value.TenantFilter.ASSIGNED)));
+
+    CloseHelper.quietCloseAll(providedWorker, assignedWorker);
   }
 }

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/jobstream/AbstractJobStreamsAssert.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.qa.util.jobstream;
 
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.ClientJobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.JobStream;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint.RemoteJobStream;
@@ -135,6 +136,15 @@ public abstract class AbstractJobStreamsAssert<
                 && stream.metadata().fetchVariables().size() == expectedVariables.size(),
         "a stream with fetch variables %s".formatted(Arrays.toString(variables)),
         stream -> " but actual variables is %s".formatted(stream.metadata().fetchVariables()));
+  }
+
+  /** Returns a condition which checks that a stream has the given tenant filter. */
+  public static <T extends JobStream> Condition<T> hasTenantFilter(
+      final TenantFilter tenantFilter) {
+    return VerboseCondition.verboseCondition(
+        stream -> stream.metadata().tenantFilter() == tenantFilter,
+        "a stream with tenant filter '%s'".formatted(tenantFilter),
+        stream -> " but actual tenant filter is '%s'".formatted(stream.metadata().tenantFilter()));
   }
 
   /** Returns a condition which checks that a stream has the expected amount of consumers. */


### PR DESCRIPTION
# Description
Backport of #46324 to `stable/8.9`.

relates to camunda/camunda#45358