### PR TITLE
[Backport stable/8.9] refactor: avoid using zeebe-util Tuple in camunda-search-client

### DIFF
--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -30,11 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -106,8 +106,8 @@ import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.ResourceAccessController;
 import io.camunda.security.reader.TenantCheck;
-import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -519,8 +519,8 @@ public class CamundaSearchClients implements SearchClientsProxy {
                 entityByMultipleIdsNotFoundException(
                     "Global Listener",
                     List.of(
-                        Tuple.of("listenerId", listenerId),
-                        Tuple.of("listenerType", listenerType.name()))));
+                        Map.entry("listenerId", listenerId),
+                        Map.entry("listenerType", listenerType.name()))));
   }
 
   @Override
@@ -649,10 +649,10 @@ public class CamundaSearchClients implements SearchClientsProxy {
   }
 
   private CamundaSearchException entityByMultipleIdsNotFoundException(
-      final String entityType, final List<Tuple<String, String>> idTypesAndValues) {
+      final String entityType, final List<Map.Entry<String, String>> idTypesAndValues) {
     final String formattedIds =
         idTypesAndValues.stream()
-            .map(e -> "%s '%s'".formatted(e.getLeft(), e.getRight()))
+            .map(e -> "%s '%s'".formatted(e.getKey(), e.getValue()))
             .collect(Collectors.joining(", "));
     return new CamundaSearchException(
         ERROR_ENTITY_BY_MULTIPLE_IDS_NOT_FOUND.formatted(entityType, formattedIds),


### PR DESCRIPTION
# Description
Backport of #46360 to `stable/8.9`.

relates to 