### PR TITLE
feat: treat expired leases as gracefully released after threshold

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -105,7 +105,9 @@ public class NodeIdProvider {
 
     /**
      * If a lease has been expired for longer than this threshold, treat it as if the previous node
-     * gracefully shut down.
+     * gracefully shut down. This timeout avoid copying the data folder from the previous version,
+     * reducing I/O and making the startup faster. However, it should be high enough so that the
+     * previous node is terminated or removed from the RAFT replication group.
      */
     private Duration expiredLeaseThreshold = Duration.ofMinutes(2);
 

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -104,6 +104,12 @@ public class NodeIdProvider {
     private Duration readinessCheckTimeout = Duration.ofMinutes(2);
 
     /**
+     * If a lease has been expired for longer than this threshold, treat it as if the previous node
+     * gracefully shut down.
+     */
+    private Duration expiredLeaseThreshold = Duration.ofMinutes(2);
+
+    /**
      * Name of the bucket where the leases will be stored. The bucket must be already created. The
      * bucket must not be shared with other zeebe clusters. bucketName must not be empty.
      */
@@ -246,6 +252,15 @@ public class NodeIdProvider {
     public void setReadinessCheckTimeout(final Duration readinessCheckTimeout) {
       this.readinessCheckTimeout =
           Objects.requireNonNull(readinessCheckTimeout, "readinessCheckTimeout cannot be null");
+    }
+
+    public Duration getExpiredLeaseThreshold() {
+      return expiredLeaseThreshold;
+    }
+
+    public void setExpiredLeaseThreshold(final Duration expiredLeaseThreshold) {
+      this.expiredLeaseThreshold =
+          Objects.requireNonNull(expiredLeaseThreshold, "expiredLeaseThreshold cannot be null");
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -45,7 +45,8 @@ public class ClusterNodeIdProviderTest {
         assertThat(cluster.getNodeIdProvider()).returns(Type.S3, NodeIdProvider::getType);
         assertThat(cluster.getNodeIdProvider().s3())
             .returns("bucketExample", S3::getBucketName)
-            .returns(Duration.ofSeconds(10), S3::getLeaseDuration);
+            .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
+            .returns(Duration.ofMinutes(2), S3::getExpiredLeaseThreshold);
       }
     }
 
@@ -60,6 +61,7 @@ public class ClusterNodeIdProviderTest {
           "camunda.cluster.node-id-provider.s3.region=us-east-1",
           "camunda.cluster.node-id-provider.s3.accessKey=myAccessKey",
           "camunda.cluster.node-id-provider.s3.secretKey=mySecretKey",
+          "camunda.cluster.node-id-provider.s3.expired-lease-threshold=PT5m",
         })
     class WithAllProperties {
 
@@ -80,7 +82,8 @@ public class ClusterNodeIdProviderTest {
             .returns(Optional.of("https://s3.example.com"), S3::getEndpoint)
             .returns(Optional.of("us-east-1"), S3::getRegion)
             .returns(Optional.of("myAccessKey"), S3::getAccessKey)
-            .returns(Optional.of("mySecretKey"), S3::getSecretKey);
+            .returns(Optional.of("mySecretKey"), S3::getSecretKey)
+            .returns(Duration.ofMinutes(5), S3::getExpiredLeaseThreshold);
 
         assertThatThrownBy(cluster::getNodeId).isInstanceOf(IllegalStateException.class);
       }

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
@@ -72,6 +72,7 @@ public class NodeIProviderConfigurationUtils {
                 config.getLeaseDuration(),
                 config.getLeaseAcquireMaxDelay(),
                 config.getReadinessCheckTimeout(),
+                config.getExpiredLeaseThreshold(),
                 taskId,
                 () -> {
                   log.warn("NodeIdProvider terminating the process");

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -93,6 +93,10 @@ public record Lease(
     return now <= timestamp;
   }
 
+  public boolean isExpiredBeyondThreshold(final long now, final Duration threshold) {
+    return !isStillValid(now) && (now - timestamp) >= threshold.toMillis();
+  }
+
   public Lease renew(
       final long now, final Duration leaseDuration, final VersionMappings knownVersionMappings) {
     if (!isStillValid(now)) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/Lease.java
@@ -93,8 +93,9 @@ public record Lease(
     return now <= timestamp;
   }
 
-  public boolean isExpiredBeyondThreshold(final long now, final Duration threshold) {
-    return !isStillValid(now) && (now - timestamp) >= threshold.toMillis();
+  public boolean isExpiredBeyondThreshold(final Instant now, final Duration threshold) {
+    final var nowMillis = now.toEpochMilli();
+    return !isStillValid(nowMillis) && (nowMillis - timestamp) >= threshold.toMillis();
   }
 
   public Lease renew(

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -41,6 +41,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   private volatile StoredLease.Initialized currentLease;
   private final Duration leaseDuration;
   private final Duration readinessCheckTimeout;
+  private final Duration expiredLeaseThreshold;
   private final String taskId;
   private final Runnable onLeaseFailure;
   private final ScheduledExecutorService executor;
@@ -60,6 +61,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
       final Duration expiryDuration,
       final Duration leaseAcquireMaxDelay,
       final Duration readinessCheckTimeout,
+      final Duration expiredLeaseThreshold,
       final String taskId,
       final Runnable onLeaseFailure) {
     this.nodeIdRepository =
@@ -68,6 +70,8 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     leaseDuration = Objects.requireNonNull(expiryDuration, "expiryDuration cannot be null");
     this.readinessCheckTimeout =
         Objects.requireNonNull(readinessCheckTimeout, "readinessCheckTimeout cannot be null");
+    this.expiredLeaseThreshold =
+        Objects.requireNonNull(expiredLeaseThreshold, "expiredLeaseThreshold cannot be null");
     this.taskId = Objects.requireNonNull(taskId, "taskId cannot be null");
     this.onLeaseFailure = Objects.requireNonNull(onLeaseFailure, "onLeaseFailure cannot be null");
     backoff = new ExponentialBackoffRetryDelay(leaseAcquireMaxDelay, Duration.ofSeconds(1));
@@ -260,7 +264,15 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
           "Acquired lease w/ nodeId={}.  {}", currentLease.lease().nodeInstance(), currentLease);
       // storedLease should always be non-null as currentLease is not null.
       if (storedLease != null) {
-        previousNodeGracefullyShutdown.complete(!storedLease.isInitialized());
+        final var gracefullyShutdown =
+            switch (storedLease) {
+              case StoredLease.Uninitialized u -> true;
+              case StoredLease.Initialized initialized ->
+                  initialized
+                      .lease()
+                      .isExpiredBeyondThreshold(clock.millis(), expiredLeaseThreshold);
+            };
+        previousNodeGracefullyShutdown.complete(gracefullyShutdown);
       }
       backoff.reset();
     } else {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -270,7 +270,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
               case StoredLease.Initialized initialized ->
                   initialized
                       .lease()
-                      .isExpiredBeyondThreshold(clock.millis(), expiredLeaseThreshold);
+                      .isExpiredBeyondThreshold(clock.instant(), expiredLeaseThreshold);
             };
         previousNodeGracefullyShutdown.complete(gracefullyShutdown);
       }

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/LeaseTest.java
@@ -68,6 +68,32 @@ public class LeaseTest {
   }
 
   @Test
+  public void shouldReturnIsExpiredBeyondThreshold() {
+    final var threshold = Duration.ofSeconds(10);
+
+    // lease is still valid
+    assertThat(lease.isExpiredBeyondThreshold(Instant.ofEpochMilli(originalTimestamp), threshold))
+        .isFalse();
+
+    // lease just expired, within threshold
+    assertThat(
+            lease.isExpiredBeyondThreshold(Instant.ofEpochMilli(originalTimestamp + 1), threshold))
+        .isFalse();
+
+    // lease expired exactly at threshold boundary
+    assertThat(
+            lease.isExpiredBeyondThreshold(
+                Instant.ofEpochMilli(originalTimestamp + threshold.toMillis()), threshold))
+        .isTrue();
+
+    // lease expired beyond threshold
+    assertThat(
+            lease.isExpiredBeyondThreshold(
+                Instant.ofEpochMilli(originalTimestamp + threshold.toMillis() + 1), threshold))
+        .isTrue();
+  }
+
+  @Test
   public void shouldSerializeDeserializeToJson() {
     // when
     final var serialized = lease.toJson(OBJECT_MAPPER);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderIT.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 class RepositoryNodeIdProviderIT {
 
   private static final Duration EXPIRY_DURATION = Duration.ofSeconds(5);
+  private static final Duration EXPIRED_LEASE_THRESHOLD = Duration.ofMinutes(2);
 
   @Container
   private static final LocalStackContainer S3 =
@@ -416,6 +417,28 @@ class RepositoryNodeIdProviderIT {
   }
 
   @Test
+  public void shouldReturnTrueWhenPreviousLeaseExpiredBeyondThreshold() {
+    // given
+    clusterSize = 3;
+    repository.initialize(clusterSize);
+
+    // Acquire a lease that will expire
+    createExpiredLeaseForNodeId(0);
+
+    // Advance clock beyond the expired lease threshold
+    clock.advance(EXPIRED_LEASE_THRESHOLD);
+
+    // when - new provider acquires the expired lease
+    nodeIdProvider = ofSize(clusterSize);
+    assertLeaseIsReady();
+
+    // then - lease expired beyond threshold, treat as gracefully released
+    assertThat(nodeIdProvider.previousNodeGracefullyShutdown())
+        .succeedsWithin(Duration.ofSeconds(1))
+        .isEqualTo(true);
+  }
+
+  @Test
   void shouldMarkReadyIfPreviousLeaseWasGracefullyReleased() {
     // given
     clusterSize = 3;
@@ -477,6 +500,13 @@ class RepositoryNodeIdProviderIT {
   }
 
   RepositoryNodeIdProvider ofSize(final int clusterSize, final boolean awaitInitialization) {
+    return ofSize(clusterSize, awaitInitialization, EXPIRED_LEASE_THRESHOLD);
+  }
+
+  RepositoryNodeIdProvider ofSize(
+      final int clusterSize,
+      final boolean awaitInitialization,
+      final Duration expiredLeaseThreshold) {
     final var provider =
         new RepositoryNodeIdProvider(
             repository,
@@ -484,6 +514,7 @@ class RepositoryNodeIdProviderIT {
             EXPIRY_DURATION,
             Duration.ofSeconds(30),
             Duration.ofSeconds(60),
+            expiredLeaseThreshold,
             taskId,
             () -> leaseFailed = true);
     resourcesToClose.add(provider);

--- a/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderTest.java
+++ b/zeebe/dynamic-node-id-provider/src/test/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProviderTest.java
@@ -55,6 +55,7 @@ class RepositoryNodeIdProviderTest {
             EXPIRY_DURATION,
             Duration.ofSeconds(30),
             Duration.ofSeconds(60),
+            Duration.ofSeconds(12),
             TASK_ID,
             () -> leaseFailedFlag.set(true));
   }


### PR DESCRIPTION
## Description
When a lease is not released gracefully but has been expired for longer than a configurable threshold (default 2 minutes), consider it as gracefully released. This allows hard-linking segment files instead of copying them, reducing IOPS and disk usage.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
closes #46291
