### PR TITLE
fix: Possible fix for missing docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,8 @@ jobs:
           CLIENT="':zeebe-client-java',':camunda-client-java'"
 
           # General UT configuration
-          GENERAL_UT_EXTRA_SKIP="camunda-exporter rdbms-exporter"
+          ## Temprarly added camunda-process-test-java camunda-process-test-spring to extra skip list as they require a docker image not present yet.
+          GENERAL_UT_EXTRA_SKIP="camunda-exporter rdbms-exporter camunda-process-test-java camunda-process-test-spring"
           GENERAL_UT_DO_NOT_SKIP="zeebe-bom zeebe-build-tools zeebe-parent zeebe-qa zeebe-qa-util zeebe-qa-integration-tests zeebe-qa-update-tests zeebe-root operate-qa operate-qa-util operate-qa-data-generator operate-qa-it-tests operate-qa-backup-restore-tests tasklist-qa tasklist-qa-util tasklist-it-tests tasklist-qa-backup-restore-tests tasklist-test-coverage"
 
           # ============================================================================


### PR DESCRIPTION
## Description

As the new `stable/8.9` branch was created, the [tests running on this branch looking for docker image](https://github.com/camunda/camunda/actions/runs/22235892895/job/64327346428) `8.9-SNAPSHOT`, but as its not present yet, they fail.
This PR aims to skip those modules for once to create the docker image needed for the integration tests.
After the snapshot is created, this needs to be reverted



