### PR TITLE
45176 align date time picker between identity operate

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -13,6 +13,7 @@
         "@carbon/elements": "^11.57.0",
         "@carbon/react": "1.100.0",
         "@monaco-editor/react": "4.7.0",
+        "date-fns": "^4.1.0",
         "fuse.js": "7.1.0",
         "i18next": "25.8.11",
         "mobx-react-lite": "4.1.1",
@@ -3530,6 +3531,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -23,6 +23,7 @@
     "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.100.0",
     "@monaco-editor/react": "4.7.0",
+    "date-fns": "^4.1.0",
     "fuse.js": "7.1.0",
     "i18next": "25.8.11",
     "mobx-react-lite": "4.1.1",

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/DateInput/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/DateInput/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { forwardRef } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { DatePickerInput } from "@carbon/react";
+
+type Props = {
+  type: "from" | "to";
+  id: string;
+  labelText: string;
+  onChange?: () => void;
+  autoFocus?: boolean;
+};
+
+export const DateInput = forwardRef<HTMLDivElement, Props>(
+  ({ type, onChange, ...props }, ref) => {
+    const { control } = useFormContext();
+
+    const fieldName = `${type}Date` as const;
+
+    return (
+      <Controller
+        name={fieldName}
+        control={control}
+        render={({ field }) => (
+          <DatePickerInput
+            {...props}
+            size="sm"
+            value={field.value ?? ""}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+              field.onChange(event.target.value);
+              onChange?.();
+            }}
+            ref={ref}
+            placeholder="YYYY-MM-DD"
+            // @ts-expect-error - Carbon types are wrong
+            pattern="\\d{4}-\\d{1,2}-\\d{1,2}"
+            maxLength={10}
+            autoComplete="off"
+          />
+        )}
+      />
+    );
+  },
+);

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/DateInput/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/DateInput/index.tsx
@@ -49,3 +49,5 @@ export const DateInput = forwardRef<HTMLDivElement, Props>(
     );
   },
 );
+
+DateInput.displayName = "DateInput";

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { TextInput } from "@carbon/react";
+import {
+  validateTimeCharacters,
+  validateTimeComplete,
+  validateTimeRange,
+} from "src/components/form/DateRangeField/validators.ts";
+import { Controller, useFormContext } from "react-hook-form";
+
+type Props = {
+  type: "from" | "to";
+  labelText: string;
+  onChange?: () => void;
+};
+
+type DateFieldName = `${"from" | "to"}Time`;
+
+export type FormValues = {
+  fromDate: string;
+  toDate: string;
+  fromTime: string;
+  toTime: string;
+};
+
+const TimeInput: React.FC<Props> = ({ type, labelText, onChange }) => {
+  const { control, getValues } = useFormContext<FormValues>();
+
+  const fieldName: DateFieldName = `${type}Time`;
+
+  return (
+    <Controller
+      name={fieldName}
+      control={control}
+      rules={{
+        validate: {
+          complete: validateTimeComplete,
+          characters: validateTimeCharacters,
+          range: validateTimeRange(getValues),
+        },
+      }}
+      render={({ field, fieldState }) => (
+        <TextInput
+          {...field}
+          id="time-picker"
+          labelText={labelText}
+          size="sm"
+          placeholder="hh:mm:ss"
+          data-testid={fieldName}
+          maxLength={8}
+          autoComplete="off"
+          invalid={!!fieldState.error}
+          invalidText={fieldState.error?.message}
+          onChange={(event) => {
+            field.onChange(event.target.value);
+            onChange?.();
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export { TimeInput };

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
@@ -30,7 +30,7 @@ export type FormValues = {
 };
 
 const TimeInput: React.FC<Props> = ({ type, labelText, onChange }) => {
-  const { control, getValues } = useFormContext<FormValues>();
+  const { control } = useFormContext<FormValues>();
 
   const fieldName: DateFieldName = `${type}Time`;
 
@@ -42,7 +42,7 @@ const TimeInput: React.FC<Props> = ({ type, labelText, onChange }) => {
         validate: {
           complete: validateTimeComplete,
           characters: validateTimeCharacters,
-          range: validateTimeRange(getValues),
+          range: validateTimeRange,
         },
       }}
       render={({ field, fieldState }) => (

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/TimeInput/index.tsx
@@ -11,8 +11,9 @@ import {
   validateTimeCharacters,
   validateTimeComplete,
   validateTimeRange,
-} from "src/components/form/DateRangeField/validators.ts";
+} from "src/components/form/DateRangeField/validators";
 import { Controller, useFormContext } from "react-hook-form";
+import { FormValues } from "src/components/form/DateRangeField/DateRangeModal";
 
 type Props = {
   type: "from" | "to";
@@ -21,13 +22,6 @@ type Props = {
 };
 
 type DateFieldName = `${"from" | "to"}Time`;
-
-export type FormValues = {
-  fromDate: string;
-  toDate: string;
-  fromTime: string;
-  toTime: string;
-};
 
 const TimeInput: React.FC<Props> = ({ type, labelText, onChange }) => {
   const { control } = useFormContext<FormValues>();
@@ -48,7 +42,7 @@ const TimeInput: React.FC<Props> = ({ type, labelText, onChange }) => {
       render={({ field, fieldState }) => (
         <TextInput
           {...field}
-          id="time-picker"
+          id={`${type}-time-picker`}
           labelText={labelText}
           size="sm"
           placeholder="hh:mm:ss"

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { DatePicker, Layer, Modal, Stack } from "@carbon/react";
+import { formatDate } from "../formatDate";
+import { DateInput } from "./DateInput";
+import { TimeInput } from "./TimeInput";
+import { TimeInputStack } from "./styled";
+import { createPortal } from "react-dom";
+import { FormProvider, useForm } from "react-hook-form";
+
+const defaultTime = {
+  from: "00:00:00",
+  to: "23:59:59",
+};
+
+type FormValues = {
+  fromDate: string;
+  fromTime: string;
+  toDate: string;
+  toTime: string;
+};
+
+type Props = {
+  title: string;
+  onCancel: () => void;
+  onApply: ({
+    fromDateTime,
+    toDateTime,
+  }: {
+    fromDateTime: Date;
+    toDateTime: Date;
+  }) => void;
+  defaultValues: FormValues;
+  isModalOpen: boolean;
+};
+
+const DateRangeModal: React.FC<Props> = ({
+  defaultValues,
+  onApply,
+  onCancel,
+  title,
+  isModalOpen,
+}) => {
+  const handleApply = ({
+    fromDate,
+    fromTime,
+    toDate,
+    toTime,
+  }: {
+    fromDate?: string;
+    fromTime?: string;
+    toDate?: string;
+    toTime?: string;
+  }) => {
+    if (
+      fromDate !== undefined &&
+      fromTime !== undefined &&
+      toDate !== undefined &&
+      toTime !== undefined
+    ) {
+      try {
+        onApply({
+          fromDateTime: new Date(`${fromDate} ${fromTime}`),
+          toDateTime: new Date(`${toDate} ${toTime}`),
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  const methods = useForm<FormValues>({
+    defaultValues,
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <Layer level={0}>
+          <>
+            {createPortal(
+              <Modal
+                data-testid="date-range-modal"
+                open={isModalOpen}
+                size="xs"
+                modalHeading={title}
+                primaryButtonText="Apply"
+                secondaryButtonText="Cancel"
+                onRequestClose={onCancel}
+                onRequestSubmit={methods.handleSubmit(handleApply)}
+                primaryButtonDisabled={!methods.formState.isValid}
+              >
+                <Stack gap={6}>
+                  <div>
+                    <DatePicker
+                      datePickerType="range"
+                      onChange={(event) => {
+                        const [fromDateTime, toDateTime] = event;
+                        if (fromDateTime !== undefined) {
+                          methods.setValue(
+                            "fromDate",
+                            formatDate(fromDateTime),
+                          );
+                          if (methods.getValues("fromTime") === "") {
+                            methods.setValue("fromTime", defaultTime.from);
+                          }
+                        }
+                        if (toDateTime !== undefined) {
+                          methods.setValue("toDate", formatDate(toDateTime));
+                          if (methods.getValues("toTime") === "") {
+                            methods.setValue("toTime", defaultTime.to);
+                          }
+                        }
+                      }}
+                      dateFormat="Y-m-d"
+                      short
+                    >
+                      <DateInput
+                        id="date-picker-input-id-start"
+                        type="from"
+                        labelText="From date"
+                      />
+                      <DateInput
+                        id="date-picker-input-id-finish"
+                        type="to"
+                        labelText="To date"
+                      />
+                    </DatePicker>
+                  </div>
+                  <TimeInputStack orientation="horizontal">
+                    <TimeInput type="from" labelText="From time" />
+                    <TimeInput type="to" labelText="To time" />
+                  </TimeInputStack>
+                </Stack>
+              </Modal>,
+              document.body,
+            )}
+          </>
+        </Layer>
+      </form>
+    </FormProvider>
+  );
+};
+
+export { DateRangeModal };

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
@@ -77,6 +77,8 @@ const DateRangeModal: React.FC<Props> = ({
 
   const methods = useForm<FormValues>({
     defaultValues,
+    mode: "onChange",
+    reValidateMode: "onChange",
   });
 
   return (

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/index.tsx
@@ -19,10 +19,10 @@ const defaultTime = {
   to: "23:59:59",
 };
 
-type FormValues = {
+export type FormValues = {
   fromDate: string;
-  fromTime: string;
   toDate: string;
+  fromTime: string;
   toTime: string;
 };
 
@@ -108,15 +108,22 @@ const DateRangeModal: React.FC<Props> = ({
                           methods.setValue(
                             "fromDate",
                             formatDate(fromDateTime),
+                            { shouldValidate: true },
                           );
                           if (methods.getValues("fromTime") === "") {
-                            methods.setValue("fromTime", defaultTime.from);
+                            methods.setValue("fromTime", defaultTime.from, {
+                              shouldValidate: true,
+                            });
                           }
                         }
                         if (toDateTime !== undefined) {
-                          methods.setValue("toDate", formatDate(toDateTime));
+                          methods.setValue("toDate", formatDate(toDateTime), {
+                            shouldValidate: true,
+                          });
                           if (methods.getValues("toTime") === "") {
-                            methods.setValue("toTime", defaultTime.to);
+                            methods.setValue("toTime", defaultTime.to, {
+                              shouldValidate: true,
+                            });
                           }
                         }
                       }}

--- a/identity/client/src/components/form/DateRangeField/DateRangeModal/styled.tsx
+++ b/identity/client/src/components/form/DateRangeField/DateRangeModal/styled.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { Stack } from "@carbon/react";
+import styled from "styled-components";
+
+const TimeInputStack = styled(Stack)`
+  width: 289px;
+  --cds-stack-gap: 1px;
+`;
+
+export { TimeInputStack };

--- a/identity/client/src/components/form/DateRangeField/README.md
+++ b/identity/client/src/components/form/DateRangeField/README.md
@@ -1,0 +1,72 @@
+# Date Range Field (React Hook Form version)
+
+This component and its related validators are inspired by the original
+`DateRangeField` implementation used in Operate:
+
+https://github.com/camunda/camunda/tree/main/operate/client/src/modules/components/DateRangeField
+
+The original implementation is built on top of **react-final-form**.
+This version adapts the same behavior and validation logic to work with
+**react-hook-form**.
+
+## What’s Included
+
+- `DateInput`
+- `TimeInput`
+- Time and range validators (`validateTimeCharacters`, `validateTimeComplete`, `validateTimeRange`)
+- Integration via `Controller` from `react-hook-form`
+
+The goal was to preserve:
+
+- UX behavior
+- Validation semantics
+- Error messaging
+- Edge case handling
+
+while aligning with the form architecture used in Identity.
+
+---
+
+## Differences from the Operate Version
+
+- Uses `react-hook-form` instead of `react-final-form`
+- Validators follow the RHF validation contract:
+  - `true` → valid
+  - `string` → error message
+  - `Promise<true | string>` → async validation
+- No dependency on `FieldValidator` or final-form types
+
+---
+
+## Long-Term Direction
+
+Ideally, we want to:
+
+1. Extract a **form-library-agnostic DateRange component**
+2. Move shared logic (parsing, validation, formatting) into a common package
+3. Standardize the validation layer
+4. Replace both the Operate and Identity implementations with the generic version
+
+The long-term goal is to:
+
+- Avoid duplication
+- Ensure consistent UX across applications
+- Decouple design components from specific form libraries
+- Keep validation logic reusable and framework-agnostic
+
+---
+
+## Architectural Intent
+
+Short term:
+
+- Keep compatibility with the current form setup (RHF in Identity, final-form in Operate).
+- Offering the same user experience and validation behavior in both applications without forcing a major refactor.
+
+Long term:
+
+- Introduce a shared, form-library-agnostic component in a common package
+  (e.g., `composite-components`).
+- Provide thin adapters per form library if needed.
+
+This implementation is therefore a transitional step toward a unified solution.

--- a/identity/client/src/components/form/DateRangeField/formatDate.ts
+++ b/identity/client/src/components/form/DateRangeField/formatDate.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { format } from "date-fns";
+
+const formatDate = (date: Date) => {
+  return format(date, "yyyy-MM-dd");
+};
+
+const formatTime = (date: Date) => {
+  return format(date, "HH:mm:ss");
+};
+
+const formatISODate = (date: Date) => {
+  return format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxx");
+};
+
+export { formatDate, formatISODate, formatTime };

--- a/identity/client/src/components/form/DateRangeField/formatDate.ts
+++ b/identity/client/src/components/form/DateRangeField/formatDate.ts
@@ -16,8 +16,4 @@ const formatTime = (date: Date) => {
   return format(date, "HH:mm:ss");
 };
 
-const formatISODate = (date: Date) => {
-  return format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxx");
-};
-
-export { formatDate, formatISODate, formatTime };
+export { formatDate, formatTime };

--- a/identity/client/src/components/form/DateRangeField/index.tsx
+++ b/identity/client/src/components/form/DateRangeField/index.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useRef } from "react";
+import { formatDate, formatTime } from "./formatDate";
+import { Calendar } from "@carbon/react/icons";
+import { DateRangeModal } from "./DateRangeModal";
+import { IconTextInput } from "../IconInput";
+
+type Props = {
+  popoverTitle: string;
+  label: string;
+  isModalOpen: boolean;
+  onModalClose: () => void;
+  onClick: () => void;
+  value: { from: string; to: string };
+  onChange: ([fromDateTime, toDateTime]: [Date, Date]) => void;
+};
+
+const formatInputValue = (fromDateTime?: Date, toDateTime?: Date) => {
+  if (fromDateTime === undefined || toDateTime === undefined) {
+    return "";
+  }
+  return `${formatDate(fromDateTime)} ${formatTime(
+    fromDateTime,
+  )} - ${formatDate(toDateTime)} ${formatTime(toDateTime)}`;
+};
+
+const DateRangeField: React.FC<Props> = ({
+  popoverTitle,
+  label,
+  isModalOpen,
+  onModalClose,
+  onClick,
+  onChange,
+  value,
+}) => {
+  const textFieldRef = useRef<HTMLDivElement>(null);
+
+  const getInputValue = () => {
+    if (isModalOpen) {
+      return "Custom";
+    }
+    if (value.from !== "" && value.to !== "") {
+      return formatInputValue(new Date(value.from), new Date(value.to));
+    }
+    return "";
+  };
+
+  const handleClick = () => {
+    if (!isModalOpen) {
+      onClick();
+    }
+  };
+
+  return (
+    <>
+      <div ref={textFieldRef}>
+        <IconTextInput
+          Icon={Calendar}
+          id={`optional-filter-timestamp`}
+          labelText={label}
+          value={getInputValue()}
+          title={getInputValue()}
+          placeholder="Enter date range"
+          size="sm"
+          buttonLabel="Open date range modal"
+          onIconClick={handleClick}
+          onClick={handleClick}
+        />
+      </div>
+
+      {isModalOpen ? (
+        <DateRangeModal
+          isModalOpen={isModalOpen}
+          title={popoverTitle}
+          onCancel={onModalClose}
+          onApply={({ fromDateTime, toDateTime }) => {
+            onModalClose();
+            onChange([fromDateTime, toDateTime]);
+          }}
+          defaultValues={{
+            fromDate: value.from === "" ? "" : formatDate(new Date(value.from)),
+            fromTime: value.from === "" ? "" : formatTime(new Date(value.from)),
+            toDate: value.to === "" ? "" : formatDate(new Date(value.to)),
+            toTime: value.to === "" ? "" : formatTime(new Date(value.to)),
+          }}
+          key={`date-range-modal-${isModalOpen ? "open" : "closed"}`}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export { DateRangeField };

--- a/identity/client/src/components/form/DateRangeField/validators.ts
+++ b/identity/client/src/components/form/DateRangeField/validators.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { isValid, parse, parseISO } from "date-fns";
+import { FieldValidator } from "final-form";
+import { FieldValues, UseFormGetValues } from "react-hook-form";
+import { FormValues } from "src/components/form/DateRangeField/DateRangeModal/TimeInput";
+
+const VALIDATION_TIMEOUT = 750;
+const TIME_ERROR = "Time has to be in the format hh:mm:ss";
+const TIME_RANGE_ERROR = '"From time" is after "To time"';
+
+function parseDate(dateString: string | Date) {
+  return typeof dateString === "string" ? parseISO(dateString) : dateString;
+}
+
+function parseFilterTime(value: string) {
+  const HOUR_MINUTES_PATTERN = /^[0-9]{2}:[0-9]{2}$/;
+  const HOUR_MINUTES_SECONDS_PATTERN = /^[0-9]{2}:[0-9]{2}:[0-9]{2}$/;
+
+  if (HOUR_MINUTES_PATTERN.test(value)) {
+    const parsedDate = parse(value, "HH:mm", new Date());
+    return isValid(parsedDate) ? parsedDate : undefined;
+  }
+
+  if (HOUR_MINUTES_SECONDS_PATTERN.test(value)) {
+    const parsedDate = parse(value, "HH:mm:ss", new Date());
+    return isValid(parsedDate) ? parsedDate : undefined;
+  }
+}
+
+export const validateTimeComplete = async (
+  value: string | undefined,
+): Promise<true | string> => {
+  if (value && value !== "" && !isValid(parseFilterTime(value.trim()))) {
+    await new Promise((r) => setTimeout(r, VALIDATION_TIMEOUT));
+    return TIME_ERROR;
+  }
+
+  return true;
+};
+
+export const validateTimeRange =
+  (getValues: UseFormGetValues<FormValues>) => (): true | string => {
+    const { fromDate, toDate, fromTime, toTime } = getValues();
+
+    if (!fromDate || !toDate || !fromTime || !toTime) {
+      return true;
+    }
+
+    const parsedFromDate = parseDate(fromDate).getTime();
+    const parsedToDate = parseDate(toDate).getTime();
+    const parsedFromTime = parseFilterTime(fromTime.trim())?.getTime() ?? 0;
+    const parsedToTime = parseFilterTime(toTime.trim())?.getTime() ?? 0;
+
+    if (parsedFromDate === parsedToDate && parsedFromTime > parsedToTime) {
+      return TIME_RANGE_ERROR;
+    }
+
+    return true;
+  };
+
+export const validateTimeCharacters = (value: string): true | string => {
+  if (value !== "" && value.replace(/[0-9]|:/g, "") !== "") {
+    return TIME_ERROR;
+  }
+  return true;
+};
+
+const isPromise = (value: unknown): value is Promise<unknown> => {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "then" in value &&
+    typeof (value as { then: unknown }).then === "function",
+  );
+};
+
+export const mergeValidators = (
+  ...validators: Array<FieldValidator<string | undefined>>
+): FieldValidator<string | undefined> => {
+  return (
+    ...validateParams: Parameters<FieldValidator<string | undefined>>
+  ) => {
+    const executedValidators = validators.map((validator) =>
+      validator(...validateParams),
+    );
+    const syncValidators = executedValidators.filter(
+      (validator) => !isPromise(validator),
+    );
+    const asyncValidators = executedValidators.filter((validator) =>
+      isPromise(validator),
+    );
+
+    const immediateError = syncValidators.reduce(
+      (error, result) => error ?? result,
+      undefined,
+    );
+
+    if (immediateError !== undefined) {
+      return immediateError;
+    }
+
+    if (asyncValidators.length === 0) {
+      return undefined;
+    }
+
+    return new Promise((resolve) => {
+      asyncValidators.forEach((result) => resolve(result));
+    });
+  };
+};

--- a/identity/client/src/components/form/DateRangeField/validators.ts
+++ b/identity/client/src/components/form/DateRangeField/validators.ts
@@ -7,7 +7,7 @@
  */
 
 import { isValid, parse, parseISO } from "date-fns";
-import { FormValues } from "src/components/form/DateRangeField/DateRangeModal/TimeInput";
+import { FormValues } from "src/components/form/DateRangeField/DateRangeModal";
 
 const VALIDATION_TIMEOUT = 750;
 const TIME_ERROR = "Time has to be in the format hh:mm:ss";

--- a/identity/client/src/components/form/DateRangeField/validators.ts
+++ b/identity/client/src/components/form/DateRangeField/validators.ts
@@ -7,8 +7,6 @@
  */
 
 import { isValid, parse, parseISO } from "date-fns";
-import { FieldValidator } from "final-form";
-import { FieldValues, UseFormGetValues } from "react-hook-form";
 import { FormValues } from "src/components/form/DateRangeField/DateRangeModal/TimeInput";
 
 const VALIDATION_TIMEOUT = 750;
@@ -45,73 +43,29 @@ export const validateTimeComplete = async (
   return true;
 };
 
-export const validateTimeRange =
-  (getValues: UseFormGetValues<FormValues>) => (): true | string => {
-    const { fromDate, toDate, fromTime, toTime } = getValues();
-
-    if (!fromDate || !toDate || !fromTime || !toTime) {
-      return true;
-    }
-
-    const parsedFromDate = parseDate(fromDate).getTime();
-    const parsedToDate = parseDate(toDate).getTime();
-    const parsedFromTime = parseFilterTime(fromTime.trim())?.getTime() ?? 0;
-    const parsedToTime = parseFilterTime(toTime.trim())?.getTime() ?? 0;
-
-    if (parsedFromDate === parsedToDate && parsedFromTime > parsedToTime) {
-      return TIME_RANGE_ERROR;
-    }
-
+export const validateTimeRange = (
+  _: string,
+  { fromDate, fromTime, toDate, toTime }: FormValues,
+): true | string => {
+  if (!fromDate || !toDate || !fromTime || !toTime) {
     return true;
-  };
+  }
+
+  const parsedFromDate = parseDate(fromDate).getTime();
+  const parsedToDate = parseDate(toDate).getTime();
+  const parsedFromTime = parseFilterTime(fromTime.trim())?.getTime() ?? 0;
+  const parsedToTime = parseFilterTime(toTime.trim())?.getTime() ?? 0;
+
+  if (parsedFromDate === parsedToDate && parsedFromTime > parsedToTime) {
+    return TIME_RANGE_ERROR;
+  }
+
+  return true;
+};
 
 export const validateTimeCharacters = (value: string): true | string => {
   if (value !== "" && value.replace(/[0-9]|:/g, "") !== "") {
     return TIME_ERROR;
   }
   return true;
-};
-
-const isPromise = (value: unknown): value is Promise<unknown> => {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    "then" in value &&
-    typeof (value as { then: unknown }).then === "function",
-  );
-};
-
-export const mergeValidators = (
-  ...validators: Array<FieldValidator<string | undefined>>
-): FieldValidator<string | undefined> => {
-  return (
-    ...validateParams: Parameters<FieldValidator<string | undefined>>
-  ) => {
-    const executedValidators = validators.map((validator) =>
-      validator(...validateParams),
-    );
-    const syncValidators = executedValidators.filter(
-      (validator) => !isPromise(validator),
-    );
-    const asyncValidators = executedValidators.filter((validator) =>
-      isPromise(validator),
-    );
-
-    const immediateError = syncValidators.reduce(
-      (error, result) => error ?? result,
-      undefined,
-    );
-
-    if (immediateError !== undefined) {
-      return immediateError;
-    }
-
-    if (asyncValidators.length === 0) {
-      return undefined;
-    }
-
-    return new Promise((resolve) => {
-      asyncValidators.forEach((result) => resolve(result));
-    });
-  };
 };

--- a/identity/client/src/components/form/IconInput/IconTextArea.tsx
+++ b/identity/client/src/components/form/IconInput/IconTextArea.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  TextArea as BaseTextArea,
+  IconButton as BaseIconButton,
+} from "@carbon/react";
+import type { CarbonIconType } from "@carbon/react/icons";
+import { Container, IconContainer, TextArea, IconButton } from "./styled";
+
+interface Props extends React.ComponentProps<typeof BaseTextArea> {
+  Icon: CarbonIconType;
+  invalid?: boolean;
+  onIconClick: () => void;
+  buttonLabel: string;
+  tooltipPosition?: React.ComponentProps<typeof BaseIconButton>["align"];
+}
+
+const IconTextArea: React.FC<Props> = ({
+  Icon,
+  invalid,
+  onIconClick,
+  buttonLabel,
+  tooltipPosition = "top-end",
+  ...props
+}) => {
+  return (
+    <Container $isInvalid={invalid}>
+      <TextArea invalid={invalid} {...props} />
+      <IconContainer $isTextArea $isInvalid={invalid}>
+        <IconButton
+          kind="ghost"
+          size="sm"
+          onClick={onIconClick}
+          label={buttonLabel}
+          aria-label={buttonLabel}
+          align={tooltipPosition}
+        >
+          <Icon />
+        </IconButton>
+      </IconContainer>
+    </Container>
+  );
+};
+
+export { IconTextArea };

--- a/identity/client/src/components/form/IconInput/IconTextInput.tsx
+++ b/identity/client/src/components/form/IconInput/IconTextInput.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { type CarbonIconType } from "@carbon/react/icons";
+import {
+  TextInput as BaseTextInput,
+  IconButton as BaseIconButton,
+} from "@carbon/react";
+import { Container, IconContainer, TextInput, IconButton } from "./styled";
+
+interface Props extends React.ComponentProps<typeof BaseTextInput> {
+  Icon: CarbonIconType;
+  invalid?: boolean;
+  onIconClick: () => void;
+  buttonLabel: string;
+  tooltipPosition?: React.ComponentProps<typeof BaseIconButton>["align"];
+}
+
+const IconTextInput: React.FC<Props> = ({
+  Icon,
+  invalid,
+  onIconClick,
+  buttonLabel,
+  tooltipPosition = "top-end",
+  ...props
+}) => {
+  return (
+    <Container $isInvalid={invalid}>
+      <TextInput invalid={invalid} {...props} />
+      <IconContainer>
+        <IconButton
+          kind="ghost"
+          size="sm"
+          onClick={onIconClick}
+          label={buttonLabel}
+          aria-label={buttonLabel}
+          align={tooltipPosition}
+        >
+          <Icon />
+        </IconButton>
+      </IconContainer>
+    </Container>
+  );
+};
+
+export { IconTextInput };

--- a/identity/client/src/components/form/IconInput/index.tsx
+++ b/identity/client/src/components/form/IconInput/index.tsx
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { IconTextArea } from "./IconTextArea";
+export { IconTextInput } from "./IconTextInput";

--- a/identity/client/src/components/form/IconInput/styled.tsx
+++ b/identity/client/src/components/form/IconInput/styled.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, { css } from "styled-components";
+import {
+  TextInput as BaseTextInput,
+  TextArea as BaseTextArea,
+  IconButton as BaseIconButton,
+} from "@carbon/react";
+
+const SCROLLBAR_WIDTH = 5;
+const ICON_WIDTH = 32;
+const RIGHT_SPACING = 8;
+
+const IconButton = styled(BaseIconButton)`
+  min-height: calc(2rem - 4px);
+  margin: 2px 0;
+`;
+
+const IconContainer = styled.div<{
+  $isTextArea?: boolean;
+  $isInvalid?: boolean;
+}>`
+  position: absolute;
+
+  ${({ $isTextArea }) =>
+    $isTextArea
+      ? css`
+          top: 26px;
+        `
+      : css`
+          bottom: 0;
+        `}
+
+  ${({ $isTextArea, $isInvalid }) => {
+    if ($isTextArea) {
+      return $isInvalid
+        ? css`
+            right: ${SCROLLBAR_WIDTH}px;
+          `
+        : css`
+            right: calc(${RIGHT_SPACING}px + ${SCROLLBAR_WIDTH}px);
+          `;
+    } else {
+      return css`
+        right: 0;
+      `;
+    }
+  }}
+`;
+
+const TextInput: typeof BaseTextInput = styled(BaseTextInput)`
+  input {
+    ${({ invalid }) =>
+      invalid
+        ? // padding for warning icon, icon button
+          css`
+            padding-right: calc(
+              ${ICON_WIDTH}px + ${ICON_WIDTH}px + ${RIGHT_SPACING}px
+            );
+          `
+        : // padding for icon button
+          css`
+            padding-right: ${ICON_WIDTH}px;
+          `}
+  }
+`;
+const TextArea: typeof BaseTextArea = styled(BaseTextArea)`
+  textarea {
+    ${({ invalid }) =>
+      invalid
+        ? // padding for warning icon, icon button and scrollbar
+          css`
+            padding-right: calc(
+              ${ICON_WIDTH}px + ${ICON_WIDTH}px + ${SCROLLBAR_WIDTH}px
+            );
+          `
+        : // padding for icon button and scrollbar
+          css`
+            padding-right: calc(
+              ${ICON_WIDTH}px + ${SCROLLBAR_WIDTH}px + ${RIGHT_SPACING}px
+            );
+          `}
+  }
+`;
+
+const Container = styled.div<{ $isInvalid?: boolean }>`
+  position: relative;
+
+  ${IconContainer} {
+    ${({ $isInvalid }) =>
+      $isInvalid &&
+      css`
+        bottom: 20px;
+        right: var(--cds-spacing-08);
+      `}}
+  }
+`;
+
+export { Container, TextInput, TextArea, IconContainer, IconButton };

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -21,16 +21,12 @@ import {
   Grid,
   ColumnRightPadding,
   CenteredRow,
-  DatePickerWrapper,
 } from "./components/styled";
 import {
   Button,
   CodeSnippet,
   Column,
-  DatePicker,
-  DatePickerInput,
   Dropdown,
-  FormLabel,
   Heading,
   MultiSelect,
   Section,

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -47,6 +47,7 @@ import useDebounce from "react-debounced";
 import { useForm } from "react-hook-form";
 import { CellProperty } from "src/pages/operations-log/CellProperty";
 import { User } from "@carbon/react/icons";
+import { DateRangeField } from "src/components/form/DateRangeField";
 
 type AuditLogSort = { field: string; order: "asc" | "desc" };
 
@@ -109,6 +110,9 @@ const List: FC = () => {
 
   const debounce = useDebounce();
   const [debouncedActor, setDebouncedActor] = useState<string>();
+
+  const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
+    useState<boolean>(false);
 
   const {
     pageParams,
@@ -251,40 +255,24 @@ const List: FC = () => {
                 }}
                 size="sm"
               />
-              <FormLabel>{t("date")}</FormLabel>
-              <DatePickerWrapper>
-                <DatePicker
-                  datePickerType="range"
-                  dateFormat="Y-m-d"
-                  value={[timestampRange.from ?? "", timestampRange.to ?? ""]}
-                  onChange={(dates) => {
-                    const [from, to] = dates;
-                    setValue("timestampRange", {
-                      from: from ? from.toISOString() : undefined,
-                      to: to ? to.toISOString() : undefined,
-                    });
-                  }}
-                >
-                  <DatePickerInput
-                    id="date-picker1"
-                    labelText="From"
-                    placeholder="YYYY-MM-DD"
-                    hideLabel
-                    size="sm"
-                    // @ts-expect-error - autoComplete is not in type definition but supported by underlying input
-                    autoComplete="off"
-                  />
-                  <DatePickerInput
-                    id="date-picker2"
-                    labelText="To"
-                    placeholder="YYYY-MM-DD"
-                    hideLabel
-                    size="sm"
-                    // @ts-expect-error - autoComplete is not in type definition but supported by underlying input
-                    autoComplete="off"
-                  />
-                </DatePicker>
-              </DatePickerWrapper>
+              <DateRangeField
+                isModalOpen={isDateRangeModalOpen}
+                onModalClose={() => setIsDateRangeModalOpen(false)}
+                onClick={() => setIsDateRangeModalOpen(true)}
+                value={{
+                  from: timestampRange.from ?? "",
+                  to: timestampRange.to ?? "",
+                }}
+                onChange={(dates) => {
+                  const [from, to] = dates;
+                  setValue("timestampRange", {
+                    from: from ? from.toISOString() : undefined,
+                    to: to ? to.toISOString() : undefined,
+                  });
+                }}
+                popoverTitle="Filter by timestamp date range"
+                label={t("date")}
+              />
               <CenteredRow>
                 <Button
                   kind="ghost"

--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -263,8 +263,7 @@ const List: FC = () => {
                   from: timestampRange.from ?? "",
                   to: timestampRange.to ?? "",
                 }}
-                onChange={(dates) => {
-                  const [from, to] = dates;
+                onChange={([from, to]) => {
                   setValue("timestampRange", {
                     from: from ? from.toISOString() : undefined,
                     to: to ? to.toISOString() : undefined,

--- a/identity/client/src/pages/operations-log/components/styled.tsx
+++ b/identity/client/src/pages/operations-log/components/styled.tsx
@@ -42,27 +42,6 @@ const CenteredRow = styled.div`
   width: 100%;
 `;
 
-const DatePickerWrapper = styled.div`
-  .cds--date-picker {
-    width: 100%;
-  }
-
-  .cds--date-picker-container {
-    width: 100%;
-    max-width: 100%;
-  }
-
-  .cds--date-picker-input__wrapper {
-    display: contents;
-    width: 100%;
-  }
-
-  input.cds--date-picker__input {
-    width: 100%;
-    max-width: 100%;
-  }
-`;
-
 const PropertyText = styled.div`
   ${styles.caption01}
 `;
@@ -78,7 +57,6 @@ export {
   Grid,
   ColumnRightPadding,
   CenteredRow,
-  DatePickerWrapper,
   PropertyText,
   OwnerInfo,
 };


### PR DESCRIPTION
## Description

Adapt Identity date-time picker to the Operate one. 

As of now the component is duplicated with the main difference being the form-library that each uses. Long-term we'll replace both implementations with a generic shared component as mentioned in the component README file

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45176 
