### PR TITLE
ci: add Spectral rule to enforce response schema arrays required and non-nullable

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -7,6 +7,7 @@ functions:
   - verifyKeyTypesSchemas
   - verifyEventuallyConsistent
   - verifyRequiredPropertiesExist
+  - verifyArrayPropertiesRequired
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -111,6 +112,14 @@ rules:
     given: "$.components.schemas[*]"
     then:
       function: verifyRequiredPropertiesExist
+
+  array-properties-must-be-required:
+    description: "Response array properties must be `required` and not `nullable`."
+    severity: error
+    given: "$.paths[*]"
+    message: "{{error}}"
+    then:
+      function: verifyArrayPropertiesRequired
 
   no-eventually-consistent-on-commands:
     description: "Command (mutating) operations must not have x-eventually-consistent: true."

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -159,8 +159,6 @@ spectral-tests/
 
 Tests invoke `spectral lint` on the fixture spec using the production `.spectral.yaml` ruleset, then assert on the JSON results. This ensures custom functions are tested end-to-end through Spectral's resolution and rule engine — not just in isolation.
 
-> **Note:** These tests should ideally run in CI. The `openapi-lint` job already sets up Node.js and Spectral, so adding a step to run `node --test spectral-tests/*.test.js` would be straightforward and would catch regressions automatically.
-
 ## CI Integration
 
 Spectral runs automatically in the `openapi-lint` CI job when OpenAPI files are modified. See `.github/workflows/ci.yml` for details.

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -26,7 +26,14 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
 npm install -g @stoplight/spectral-cli
 
 # Run validation from the repository root
+
+# This first pass validates schema structure
 spectral lint zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml \
+  --ruleset zeebe/gateway-protocol/.spectral.yaml \
+  --fail-severity error
+
+# This second pass is necessary for file-level analysis
+spectral lint zeebe/gateway-protocol/src/main/proto/v2/*.yaml \
   --ruleset zeebe/gateway-protocol/.spectral.yaml \
   --fail-severity error
 ```
@@ -85,6 +92,74 @@ paths:
 ```
 
 Query operations (GET requests, POST to `/search` or `/statistics` endpoints) read from eventually-consistent projections and should use `x-eventually-consistent: true`. Command operations (POST, PUT, PATCH, DELETE that create/modify/delete resources) are synchronous writes and must use `x-eventually-consistent: false`. See [#45968](https://github.com/camunda/camunda/issues/45968) for details.
+
+### Array Properties Must Be Required and Non-Nullable
+
+Response arrays must always be listed in `required` and must not be `nullable`. The gateway coerces `null` arrays to `[]`, so the spec should reflect the actual runtime behaviour.
+
+**Wrong:**
+
+```yaml
+schema:
+  properties:
+    items:
+      type: array
+      items:
+        $ref: '#/components/schemas/Thing'
+# Missing from required array
+```
+
+**Correct:**
+
+```yaml
+schema:
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      items:
+        $ref: '#/components/schemas/Thing'
+```
+
+See [#46224](https://github.com/camunda/camunda/issues/46224) for details.
+
+## Testing Custom Spectral Functions
+
+Unit tests for the custom Spectral functions live in `spectral-tests/`. Each rule has its own test file and a set of multi-part YAML fixture specs that mirror the real spec structure (entry-point `rest-api.yaml` with `$ref`s to domain and shared-model files).
+
+### Running Tests
+
+```bash
+# From zeebe/gateway-protocol/
+node --test spectral-tests/*.test.js
+
+# Run a specific rule's tests
+node --test spectral-tests/verifyArrayPropertiesRequired.test.js
+```
+
+### Structure
+
+```
+spectral-tests/
+├── helpers.js                          # Shared: lintFixture(), filterByRule(), filterByPathSegment()
+├── verifyArrayPropertiesRequired.test.js
+└── fixtures/
+    └── array-required/                 # Multi-part fixture for this rule
+        ├── rest-api.yaml               # Entry point ($ref to things.yaml)
+        ├── things.yaml                 # Paths + schemas with valid/invalid cases
+        └── search-models.yaml          # Shared SearchQueryResponse for allOf composition
+```
+
+### Adding Tests for a New Rule
+
+1. Create `spectral-tests/fixtures/<rule-name>/` with a multi-part YAML spec exercising valid and invalid cases.
+2. Create `spectral-tests/<ruleName>.test.js` using `lintFixture()` and `filterByRule()` from `helpers.js`.
+3. Run `node --test spectral-tests/<ruleName>.test.js` to verify.
+
+Tests invoke `spectral lint` on the fixture spec using the production `.spectral.yaml` ruleset, then assert on the JSON results. This ensures custom functions are tested end-to-end through Spectral's resolution and rule engine — not just in isolation.
+
+> **Note:** These tests should ideally run in CI. The `openapi-lint` job already sets up Node.js and Spectral, so adding a step to run `node --test spectral-tests/*.test.js` would be straightforward and would catch regressions automatically.
 
 ## CI Integration
 

--- a/zeebe/gateway-protocol/spectral-functions/verifyArrayPropertiesRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyArrayPropertiesRequired.js
@@ -1,0 +1,131 @@
+// Spectral custom function to verify that all array properties in response
+// schemas are both required and not nullable.
+//
+// Applied via $.paths[*] in the traversal pass (rest-api.yaml), so $refs are
+// fully resolved. The function navigates from each path item into its HTTP
+// method operations → responses → content → schema, then recursively checks
+// every nested schema for array properties (including allOf-composed schemas,
+// nested objects, and array items).
+//
+// Arrays that are optional or nullable cause SDK generators to produce
+// union types (e.g. `string[] | undefined | null`), which complicates
+// consumer code. The convention is to use an empty array as the default
+// instead of omitting or nulling the field.
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+module.exports = (input, _opts, context) => {
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+
+  const errors = [];
+  const visited = new Set();
+
+  // input is a path item; iterate over HTTP methods.
+  for (const method of HTTP_METHODS) {
+    const operation = input[method];
+    if (!operation || typeof operation !== 'object' || !operation.responses) {
+      continue;
+    }
+
+    for (const [code, response] of Object.entries(operation.responses)) {
+      if (!response || !response.content) continue;
+
+      for (const [mediaType, mediaObj] of Object.entries(response.content)) {
+        if (!mediaObj || !mediaObj.schema) continue;
+
+        const schemaPath = [
+          ...context.path,
+          method,
+          'responses',
+          code,
+          'content',
+          mediaType,
+          'schema',
+        ];
+
+        checkSchema(mediaObj.schema, schemaPath, errors, visited);
+      }
+    }
+  }
+
+  return errors;
+};
+
+// Aggregate `required` entries and `properties` from a schema and its allOf
+// members into a single view for the current schema level. Tracks the actual
+// path to each property so errors point to the right spec location.
+function collectRequiredAndProperties(
+  schema,
+  requiredSet,
+  propertyEntries,
+  basePath
+) {
+  if (!schema || typeof schema !== 'object') return;
+
+  if (Array.isArray(schema.required)) {
+    schema.required.forEach((name) => requiredSet.add(name));
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      propertyEntries.push({
+        name,
+        schema: prop,
+        path: [...basePath, 'properties', name],
+      });
+    }
+  }
+
+  if (Array.isArray(schema.allOf)) {
+    schema.allOf.forEach((sub, i) =>
+      collectRequiredAndProperties(sub, requiredSet, propertyEntries, [
+        ...basePath,
+        'allOf',
+        i,
+      ])
+    );
+  }
+}
+
+function checkSchema(schema, basePath, errors, visited) {
+  if (!schema || typeof schema !== 'object') return;
+
+  // Prevent infinite loops on circular $refs.
+  if (visited.has(schema)) return;
+  visited.add(schema);
+
+  // Aggregate required + properties across allOf at this level.
+  const requiredSet = new Set();
+  const propertyEntries = [];
+  collectRequiredAndProperties(schema, requiredSet, propertyEntries, basePath);
+
+  for (const { name, schema: propSchema, path: propPath } of propertyEntries) {
+    if (!propSchema || typeof propSchema !== 'object') continue;
+
+    if (propSchema.type === 'array') {
+      if (!requiredSet.has(name)) {
+        errors.push({
+          message: `Array property \`${name}\` must be listed in \`required\`.`,
+          path: [...propPath, 'type'],
+        });
+      }
+
+      if (propSchema.nullable === true) {
+        errors.push({
+          message: `Array property \`${name}\` must not be \`nullable\` on response schema. \`null\` coerces to \`[]\` in the gateway.`,
+          path: [...propPath, 'nullable'],
+        });
+      }
+
+      // Recurse into array items (e.g. items of a search result list).
+      if (propSchema.items && typeof propSchema.items === 'object') {
+        checkSchema(propSchema.items, [...propPath, 'items'], errors, visited);
+      }
+    } else if (propSchema.properties || propSchema.allOf) {
+      // Recurse into nested object schemas.
+      checkSchema(propSchema, propPath, errors, visited);
+    }
+  }
+}

--- a/zeebe/gateway-protocol/spectral-tests/README.md
+++ b/zeebe/gateway-protocol/spectral-tests/README.md
@@ -1,0 +1,33 @@
+# Spectral Custom Function Tests
+
+Unit tests for the custom Spectral functions in `../spectral-functions/`.
+
+## Running
+
+```bash
+cd zeebe/gateway-protocol
+node --test spectral-tests/*.test.js
+```
+
+Requires [Spectral CLI](https://docs.stoplight.io/docs/spectral/b8391e051b7d8-installation) (globally installed or via `npx`).
+
+## Structure
+
+```
+spectral-tests/
+├── helpers.js          # Shared utilities (run spectral, filter results)
+├── *.test.js           # Test files (one per custom function)
+└── fixtures/
+    └── <rule-name>/    # Multi-part YAML spec fixtures per rule
+        ├── rest-api.yaml       # Entry point (mirrors real spec structure)
+        ├── things.yaml         # Domain schemas with valid + invalid cases
+        └── search-models.yaml  # Shared models (allOf composition targets)
+```
+
+## Adding tests for a new rule
+
+1. Create a fixture directory under `fixtures/<rule-name>/` with a multi-part
+   YAML spec that exercises both valid and invalid cases.
+2. Create `<ruleName>.test.js` using the helpers from `helpers.js`.
+3. Run `node --test spectral-tests/<ruleName>.test.js` to verify.
+

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/rest-api.yaml
@@ -1,0 +1,47 @@
+# Entry point for array-required rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — array-properties-must-be-required
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  # Search result with required, non-nullable array + allOf composition
+  /valid-search/search:
+    $ref: 'things.yaml#/paths/~1valid-search~1search'
+
+  # Single-entity GET — no arrays in response
+  /valid-get/{thingKey}:
+    $ref: 'things.yaml#/paths/~1valid-get~1{thingKey}'
+
+  # Nested object with a required array
+  /valid-nested/get:
+    $ref: 'things.yaml#/paths/~1valid-nested~1get'
+
+  # allOf composition: required in one member, properties in another
+  /valid-allof-split/search:
+    $ref: 'things.yaml#/paths/~1valid-allof-split~1search'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  # Array property not listed in required
+  /invalid-not-required/search:
+    $ref: 'things.yaml#/paths/~1invalid-not-required~1search'
+
+  # Array property is nullable (but required)
+  /invalid-nullable/search:
+    $ref: 'things.yaml#/paths/~1invalid-nullable~1search'
+
+  # Array property is both not-required and nullable
+  /invalid-both/search:
+    $ref: 'things.yaml#/paths/~1invalid-both~1search'
+
+  # Nested object with a non-required array
+  /invalid-nested/get:
+    $ref: 'things.yaml#/paths/~1invalid-nested~1get'
+
+  # Array items contain an object with a non-required array (recursion test)
+  /invalid-items-recurse/search:
+    $ref: 'things.yaml#/paths/~1invalid-items-recurse~1search'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/search-models.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/search-models.yaml
@@ -1,0 +1,18 @@
+# Shared search models — simulates search-models.yaml from the real spec.
+# Provides the SearchQueryResponse base schema used in allOf compositions.
+components:
+  schemas:
+    SearchQueryResponse:
+      type: object
+      required:
+        - page
+      properties:
+        page:
+          type: object
+          description: Pagination information about the search results.
+          required:
+            - totalItems
+          properties:
+            totalItems:
+              type: integer
+              description: The total number of items matching the query.

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/array-required/things.yaml
@@ -1,0 +1,290 @@
+# Domain file with paths and schemas for testing array-properties-must-be-required.
+# Contains both valid and invalid cases, each at a distinct API path.
+
+## ─── Path definitions ──────────────────────────────────────────────────────────
+
+paths:
+
+  # ── Valid: search with required array + allOf ─────────────────────
+  /valid-search/search:
+    post:
+      tags: [Test]
+      operationId: validSearch
+      summary: Search things (valid)
+      description: Array is required and not nullable, composed via allOf with SearchQueryResponse.
+      responses:
+        "200":
+          description: The search results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidSearchResult'
+
+  # ── Valid: single entity GET, no arrays ───────────────────────────
+  /valid-get/{thingKey}:
+    get:
+      tags: [Test]
+      operationId: validGet
+      summary: Get a thing (valid)
+      description: Response has no array properties.
+      parameters:
+        - name: thingKey
+          in: path
+          required: true
+          description: The key of the thing.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThingResult'
+
+  # ── Valid: nested object with required array ──────────────────────
+  /valid-nested/get:
+    get:
+      tags: [Test]
+      operationId: validNested
+      summary: Get nested (valid)
+      description: Nested object has a required array property.
+      responses:
+        "200":
+          description: Result with nested arrays.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidNestedResult'
+
+  # ── Valid: allOf with required and properties split across members ─
+  /valid-allof-split/search:
+    post:
+      tags: [Test]
+      operationId: validAllofSplit
+      summary: Search with split allOf (valid)
+      description: required list in one allOf member, properties in another.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfSplitResult'
+
+  # ── Invalid: array not in required ────────────────────────────────
+  /invalid-not-required/search:
+    post:
+      tags: [Test]
+      operationId: invalidNotRequired
+      summary: Search (invalid - not required)
+      description: Array property is not listed in required.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotRequiredResult'
+
+  # ── Invalid: array is nullable ────────────────────────────────────
+  /invalid-nullable/search:
+    post:
+      tags: [Test]
+      operationId: invalidNullable
+      summary: Search (invalid - nullable)
+      description: Array property is required but nullable.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableResult'
+
+  # ── Invalid: array both not required and nullable ─────────────────
+  /invalid-both/search:
+    post:
+      tags: [Test]
+      operationId: invalidBoth
+      summary: Search (invalid - both)
+      description: Array property is neither required nor non-nullable.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BothResult'
+
+  # ── Invalid: nested object with non-required array ────────────────
+  /invalid-nested/get:
+    get:
+      tags: [Test]
+      operationId: invalidNested
+      summary: Get nested (invalid)
+      description: Nested object has a non-required array property.
+      responses:
+        "200":
+          description: Result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidNestedResult'
+
+  # ── Invalid: array items with non-required array (recursion) ──────
+  /invalid-items-recurse/search:
+    post:
+      tags: [Test]
+      operationId: invalidItemsRecurse
+      summary: Search with recursive items (invalid)
+      description: Array items schema contains an object with a non-required array.
+      responses:
+        "200":
+          description: Results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsRecurseResult'
+
+
+## ─── Schema definitions ────────────────────────────────────────────────────────
+
+components:
+  schemas:
+
+    # ── Shared result schema ──────────────────────────────────────────
+    ThingResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name of the thing.
+        thingKey:
+          type: string
+          description: The unique key of the thing.
+
+    # ── Valid: required array with allOf composition ──────────────────
+    ValidSearchResult:
+      required:
+        - items
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ThingResult'
+
+    # ── Invalid: array not in required ────────────────────────────────
+    NotRequiredResult:
+      type: object
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ThingResult'
+
+    # ── Invalid: array is nullable ────────────────────────────────────
+    NullableResult:
+      required:
+        - items
+      type: object
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ThingResult'
+
+    # ── Invalid: both not required and nullable ───────────────────────
+    BothResult:
+      type: object
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/ThingResult'
+
+    # ── Valid: nested object with required array ──────────────────────
+    ValidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          required:
+            - tags
+          properties:
+            tags:
+              description: Tags associated with the thing.
+              type: array
+              items:
+                type: string
+
+    # ── Invalid: nested object with non-required array ────────────────
+    InvalidNestedResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata:
+          type: object
+          description: Metadata about the thing.
+          properties:
+            tags:
+              description: Tags associated with the thing.
+              type: array
+              items:
+                type: string
+
+    # ── Valid: allOf with split required / properties ──────────────────
+    AllOfSplitResult:
+      type: object
+      allOf:
+        - type: object
+          required:
+            - items
+        - type: object
+          properties:
+            items:
+              description: The things.
+              type: array
+              items:
+                $ref: '#/components/schemas/ThingResult'
+
+    # ── Invalid: array items containing object with non-required array ─
+    ItemsRecurseResult:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          description: The matching things.
+          type: array
+          items:
+            $ref: '#/components/schemas/ThingWithBadArrayResult'
+
+    ThingWithBadArrayResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        labels:
+          description: Labels on the thing.
+          type: array
+          items:
+            type: string

--- a/zeebe/gateway-protocol/spectral-tests/helpers.js
+++ b/zeebe/gateway-protocol/spectral-tests/helpers.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+
+const GATEWAY_PROTOCOL_DIR = path.resolve(__dirname, '..');
+const RULESET_FILE = path.join(GATEWAY_PROTOCOL_DIR, '.spectral.yaml');
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+/**
+ * Runs Spectral lint on a fixture's rest-api.yaml using the production ruleset.
+ * Returns the parsed JSON results array.
+ */
+function lintFixture(fixtureName) {
+  const specFile = path.join(FIXTURES_DIR, fixtureName, 'rest-api.yaml');
+  const cmd = `spectral lint "${specFile}" --ruleset "${RULESET_FILE}" --format json`;
+
+  try {
+    const output = execSync(cmd, {
+      encoding: 'utf8',
+      cwd: GATEWAY_PROTOCOL_DIR,
+    });
+    return output.trim() ? JSON.parse(output) : [];
+  } catch (err) {
+    // Spectral exits non-zero when violations are found — stdout still has JSON.
+    if (err.stdout) {
+      return JSON.parse(err.stdout);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Filters Spectral results to only violations for a specific rule code.
+ */
+function filterByRule(results, ruleName) {
+  return results.filter((r) => r.code === ruleName);
+}
+
+/**
+ * Filters violations to those whose JSON path contains the given segment.
+ * Works with both path-level violations (path[1] = API path) and
+ * schema-level violations (path[2] = schema name) since Spectral remaps
+ * error locations back to the source file where schemas are defined.
+ */
+function filterByPathSegment(violations, segment) {
+  return violations.filter(
+    (v) => Array.isArray(v.path) && v.path.includes(segment)
+  );
+}
+
+module.exports = { lintFixture, filterByRule, filterByPathSegment };

--- a/zeebe/gateway-protocol/spectral-tests/verifyArrayPropertiesRequired.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyArrayPropertiesRequired.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule, filterByPathSegment } = require('./helpers');
+
+const RULE = 'array-properties-must-be-required';
+const FIXTURE = 'array-required';
+
+describe('verifyArrayPropertiesRequired', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: required array with allOf composition', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidSearchResult');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: response with no array properties', () => {
+    it('produces no violations', () => {
+      // ThingResult has no arrays — should never appear in violations.
+      // Exclude ThingWithBadArrayResult which also contains the substring.
+      const v = violations.filter(
+        (e) =>
+          e.path.includes('ThingResult') &&
+          !e.path.includes('ThingWithBadArrayResult')
+      );
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: nested object with required array', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'ValidNestedResult');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  describe('valid: allOf with required and properties in separate members', () => {
+    it('produces no violations', () => {
+      const v = filterByPathSegment(violations, 'AllOfSplitResult');
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: array not listed in required', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'NotRequiredResult');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'NotRequiredResult');
+      assert.match(v[0].message, /items/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: array is nullable', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'NullableResult');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = filterByPathSegment(violations, 'NullableResult');
+      assert.match(v[0].message, /items/);
+      assert.match(v[0].message, /must not be `nullable`/);
+    });
+  });
+
+  describe('invalid: array is both not required and nullable', () => {
+    it('flags two violations', () => {
+      const v = filterByPathSegment(violations, 'BothResult');
+      assert.equal(v.length, 2);
+    });
+
+    it('reports both the required and nullable messages', () => {
+      const v = filterByPathSegment(violations, 'BothResult');
+      const messages = v.map((e) => e.message);
+      assert.ok(messages.some((m) => /must be listed in `required`/.test(m)));
+      assert.ok(messages.some((m) => /must not be `nullable`/.test(m)));
+    });
+  });
+
+  describe('invalid: nested object with non-required array', () => {
+    it('flags one violation', () => {
+      const v = filterByPathSegment(violations, 'InvalidNestedResult');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByPathSegment(violations, 'InvalidNestedResult');
+      assert.match(v[0].message, /tags/);
+      assert.match(v[0].message, /must be listed in `required`/);
+    });
+  });
+
+  describe('invalid: array items with non-required nested array (recursion)', () => {
+    it('flags one violation in the item schema', () => {
+      const v = filterByPathSegment(violations, 'ThingWithBadArrayResult');
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct property name', () => {
+      const v = filterByPathSegment(violations, 'ThingWithBadArrayResult');
+      assert.match(v[0].message, /labels/);
+    });
+  });
+
+  // ── Total count ──────────────────────────────────────────────────
+
+  it('produces exactly 6 violations across all paths', () => {
+    assert.equal(violations.length, 6);
+  });
+});


### PR DESCRIPTION
## Description

Adds a custom Spectral rule (`verify-array-properties-required`) that detects when an array property in a response schema is not listed in `required` or is marked as `nullable`.

Also adds unit tests for the rule with fixture specs, a test helper library, and documentation in `OPENAPI_VALIDATION.md`.

This rule was used to discover unrequired arrays that were patched in #46392.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46224