### PR TITLE
test: fix test to work with RDBMS

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
@@ -53,8 +53,14 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
         body,
       );
       expect(body.items.length).toBe(2);
-      expect(body.items[0].elementId).toBe('StartEvent');
-      expect(body.items[1].elementId).toBe('EndEvent');
+      // Sort by elementId before asserting — the API does not guarantee
+      // a specific ordering of element instance statistics.
+      const sorted = [...body.items].sort(
+        (a: Record<string, string>, b: Record<string, string>) =>
+          a.elementId.localeCompare(b.elementId),
+      );
+      expect(sorted[0].elementId).toBe('EndEvent');
+      expect(sorted[1].elementId).toBe('StartEvent');
       body.items.forEach((item: Record<string, number>) => {
         expect(item.incidents).toBe(0);
         expect(item.active).toBe(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
@@ -55,9 +55,8 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
       expect(body.items.length).toBe(2);
       // Sort by elementId before asserting — the API does not guarantee
       // a specific ordering of element instance statistics.
-      const sorted = [...body.items].sort(
-        (a: Record<string, string>, b: Record<string, string>) =>
-          a.elementId.localeCompare(b.elementId),
+      const sorted = [...body.items].sort((a, b) =>
+        a.elementId.localeCompare(b.elementId),
       );
       expect(sorted[0].elementId).toBe('EndEvent');
       expect(sorted[1].elementId).toBe('StartEvent');


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes a test assumption on the ordering of the elements. Turns out that RDBMS returns a different order, and the test expectation is hardcoded to the ES ordering. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46402
