### PR TITLE
docs: CI/CD improvement plan and testing strategy proposal

### DIFF
--- a/docs/ci-cd-consolidated.md
+++ b/docs/ci-cd-consolidated.md
@@ -1,0 +1,1218 @@
+# CI/CD Improvement Plan: Path to Continuous Delivery — Consolidated Document
+
+> This is a consolidated version of the CI/CD Improvement Plan for easier reading and import. For the structured version, see the [`docs/ci-cd/`](./ci-cd/) folder.
+
+**Repository**: `camunda/camunda` (monorepo)
+**Scope**: GitHub Actions pipelines, Maven build configuration, testing strategy, flaky test remediation, developer experience
+
+> **Phase Ordering Rationale**: Flaky test remediation (Phase 1) runs concurrently with build
+> optimization (Phase 2) — not sequentially. Quick wins (Phase 0) and the shared build artifact
+> investigation start immediately, because reducing 75 redundant builds per PR also reduces resource
+> contention that itself causes flakiness. However, reliability work (flaky test fixes, retry
+> reduction) must reach measurable milestones before enforcing strict merge queue rules or
+> restructuring the test strategy.
+
+> **Implementation Tiers**: This plan is structured as three explicit tiers with off-ramps:
+> - **Tier 1 (Must-Do, Weeks 1-8)**: Phase 0 + shared build artifacts + top flaky test fixes. Expected: ~25 min PR, -55% compute.
+> - **Tier 2 (Should-Do, Weeks 8-16)**: Flaky budget enforcement, testing manifesto adoption, parallel-tests, runner right-sizing.
+> - **Tier 3 (Aspirational, Weeks 16+)**: Contract testing, JUnit 4 migration, full CD pipeline, workflow consolidation. Only pursue with continued organizational commitment.
+
+---
+
+## Current vs. Target Metrics
+
+| Metric | Current | Phase 0+1 | Phase 2+3 | CD Target |
+|--------|---------|-----------|-----------|-----------|
+| PR wall-clock time | ~55 min | ~45 min | ~25 min | **~20 min** |
+| Compute cost per PR | Baseline | -30% | -55% | **-65%** |
+| Flaky test rate | Unknown | <10% | <5% | **<2%** |
+| CI retriggers per PR | Multiple | <1 | ~0 | **0** |
+| Local `mvn -Dquickly` | ~5-10 min | ~3-5 min | ~2-3 min | **<2 min** |
+
+## Phase Overview
+
+| Phase | Timeline | Focus | Key Impact |
+|-------|----------|-------|------------|
+| Phase 0: Quick Wins | Week 1-2 | Build config, low-hanging fruit | -30% compute |
+| Phase 1: Flaky Test Remediation | Week 2-6 | Pipeline trustworthiness | Reliable CI |
+| Phase 2: Build Artifact Sharing | Week 2-8 | Eliminate redundant builds | -55% compute |
+| Phase 3: Test Strategy | Week 8-16 | Testing pyramid, OpenAPI contract validation | Faster feedback |
+| Phase 4: Developer Experience | Week 12-20 | Local dev, JUnit migration | <5 min local tests |
+| Phase 5: Pipeline Architecture | Week 16-24 | CD-ready pipeline | ~20 min PR time |
+
+## Target Pipeline Architecture
+
+```
+PR Push
+  |
+  +- [Tier 0: ~1 min] Lint + Format
+  |
+  +- [Tier 1: ~5 min] Build Artifacts (single job, shared via artifacts)
+  |    |
+  |    +- [Tier 2: ~8 min] Unit Tests (parallel, affected modules only)
+  |    +- [Tier 2: ~8 min] Contract Tests (API compatibility)
+  |    +- [Tier 2: ~3 min] ArchUnit + Static Analysis
+  |    |
+  |    +- [Tier 3: ~15 min] Integration Tests (primary DB only)
+  |    |
+  |    +- [Gate] check-results <- All green = mergeable
+  |
+  Merge to main -> Deploy snapshots + Docker (~10 min)
+  |
+  Nightly -> Full DB matrix, cross-browser E2E, load tests
+```
+
+## Detailed Documentation
+
+| Document | Description |
+|----------|-------------|
+| Current State Assessment | Key numbers, architecture, what's done well |
+| Root Cause Analysis | Slowness, flakiness, developer CI dependency |
+| Success Metrics | Full metrics table across all phases |
+| Priority Summary | All 32 action items ranked |
+| Workflow Inventory | All GitHub Actions workflow tables |
+| Detailed Findings | Findings tables by area |
+
+## Related Documentation
+
+- Testing Strategy Manifesto — Testing practices, patterns, and policies
+- Flaky Test Policy — Budget, quarantine, runbook
+- Contract Tests — Pact consumer-driven contract testing
+- Enforcement Rules — ArchUnit, ESLint, Checkstyle
+
+---
+
+# Current State Assessment
+
+## Key Numbers
+
+| Metric | Value |
+|--------|-------|
+| GitHub Actions workflow files | 121 |
+| Maven modules (total pom.xml) | 144 (22 aggregators + 122 buildable) |
+| Top-level modules in root POM | 36 |
+| PR wall-clock CI time | ~50-55 min |
+| Main branch CI time (with deploys) | ~70-75 min |
+| Redundant full Maven builds per PR | ~75 (across 22 workflow files) |
+| Legacy duplicate workflows | 5+ (running in parallel with unified CI) |
+| Test files with `@Disabled` / `@Ignore` | 139 |
+| Tests blanket-disabled on AWS OpenSearch | 97 files |
+| `Thread.sleep()` in test code | 52 files |
+| Hardcoded Playwright `waitForTimeout` | 15 occurrences |
+| `rerunFailingTestsCount` | 2-3 retries on every test job |
+| JUnit 4 test files remaining | ~804 |
+| Maven build cache | Installed but **disabled** |
+| `.mvn/maven.config` | Does not exist |
+
+## Pipeline Architecture Overview
+
+The repository has a unified CI entry point (`ci.yml`) that fans out into component sub-workflows:
+
+```
+ci.yml (main entry point)
+  +-- detect-changes (path-based filtering)
+  +-- [Tier 0] Linting: actionlint, commitlint, spotless, openapi, renovate, protobuf
+  +-- [Tier 1] Build: build-platform-frontend
+  +-- [Tier 2] Unit Tests: general-unit-tests, zeebe-unit-tests (7x matrix)
+  +-- [Tier 2] Integration Tests: integration-tests (12x matrix), database ITs (7 variants)
+  +-- [Tier 2] Sub-workflows:
+  |   +-- ci-operate.yml (10+ jobs)
+  |   +-- ci-tasklist.yml (10+ jobs)
+  |   +-- ci-optimize.yml (4+ jobs)
+  |   +-- ci-zeebe.yml (8+ jobs)
+  |   +-- ci-client-components.yml (1 job)
+  +-- [Gate] check-results (requires ALL jobs)
+  +-- [Deploy] deploy-snapshots, deploy-docker (main/stable only)
+```
+
+**Total effective job count per full PR build: 60+ parallel/sequential jobs.**
+
+## What's Already Done Well
+
+- **Smart path-based change detection** — only affected component tests run on PRs
+- **Concurrency control** — cancels superseded PR builds, preserves main builds
+- **Flaky test observability pipeline** — BigQuery + Grafana + daily/weekly Slack + PR comments + team medic escalation (industry-leading)
+- **Maven cache** design is solid — split local repo, modifier-based keys, restore-only on PRs
+- **Playwright container images** — no browser installation overhead
+- **`-Dquickly` cascading skip system** — well-designed for local dev inner loop
+- **ChatOps `/ci-problems`** command for self-service CI failure analysis
+- **Maven Wrapper** (`mvnw`) ensures reproducible Maven versions
+
+---
+
+# Root Cause Analysis
+
+## Root Causes of Slowness
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| S1 | No shared build artifacts — every test job independently runs full `mvn install -DskipTests` | `.github/actions/build-zeebe` called ~75 times across 22 workflow files | ~200-600 runner-minutes wasted per PR |
+| S2 | Legacy workflows run in parallel with unified CI | `operate-ci.yml`, `optimize-ci-core-features.yml`, etc. | Doubles compute for Operate/Optimize PRs |
+| S3 | Frontend builds repeated — `build-platform-frontend` output never shared | `deploy-snapshots` and `deploy-docker` rebuild all 3 frontends | 18-48 min wasted in deploy jobs |
+| S4 | No Docker layer caching | `docker/build-push-action` without `cache-from`/`cache-to` | Slow Docker builds across all workflows |
+| S5 | Maven build cache disabled | `.mvn/maven-build-cache-config.xml:10` — `<enabled>false</enabled>` | No incremental build benefit |
+| S6 | No default parallel module builds | No `.mvn/maven.config` with `-T1C` | Modules build serially by default |
+| S7 | `parallel-tests` profile not activated by default | `parent/pom.xml:3114` requires explicit `-Pparallel-tests` | Tests run serially by default |
+| S8 | `useIncrementalCompilation=false` | `parent/pom.xml:2379` — stale workaround for bug fixed in compiler plugin 3.13+ | Slower recompilation |
+| S9 | Database integration tests run full matrix on every PR | 7 DB variants on every PR | Each variant takes ~20 min on gcp-perf-core-16 |
+| S10 | Node.js downloaded 4 times per build | Each frontend module independently installs Node via `frontend-maven-plugin` | ~2-4 min wasted |
+
+## Root Causes of Flakiness
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| F1 | `${env.LIMITS_CPU}` forkCount resolves to null when unset | `tasklist/pom.xml:61,74` (operate already uses `testForkCount` property but defaults to `${env.LIMITS_CPU}`) | forkCount=0 -> no test isolation -> shared JVM state pollution |
+| F2 | Retry-as-a-strategy masks flakiness | `rerunFailingTestsCount=3` on every job | Tests failing 66% of the time appear "green" |
+| F3 | `Thread.sleep()` in 52 test files | Hardcoded timing waits instead of polling | Timing-dependent failures on varying CI load |
+| F4 | Playwright `actionTimeout: 0` | `operate/client/playwright.config.ts`, `tasklist/client/playwright.config.ts` | Stuck selectors hang indefinitely |
+| F5 | 15 hardcoded `waitForTimeout()` in Playwright | All in Operate client E2E tests | Fragile timing on varying CI load |
+| F6 | `continue-on-error` in CI workflows | `ci.yml:989` is on the Hadolint SARIF upload step (not a test step); however, 26 `continue-on-error` instances in `ci.yml` and 90+ across all workflows need systematic audit | Some may mask real failures in observability/reporting steps |
+| F7 | 97 tests blanket-disabled on AWS OpenSearch | `@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")` | Entire DB backend has degraded test coverage |
+| F8 | Database cleanup ordering sensitivity | `RdbmsTableNames.java:20-23` — FK ordering is a known flakiness source | Adding a table in wrong order breaks `RdbmsPurgerIT` |
+| F9 | Race conditions in test helpers | `ElasticsearchSetupHelperTest.java:169` — explicit "race condition" comment | Non-deterministic test behavior |
+| F10 | `skip.docker` double definition | `optimize/pom.xml:86,88` — second definition always wins | Docker containers start even when `skipTests=true` |
+
+## Root Causes of Developer CI Dependency
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| D1 | Build cache disabled | `.mvn/maven-build-cache-config.xml:10` | Full rebuild every time locally |
+| D2 | No default `-T1C` parallel builds | No `.mvn/maven.config` | Serial module builds by default |
+| D3 | No JVM heap configuration | `.mvn/jvm.config` exists but only has `--add-exports`/`--add-opens` flags, no `-Xmx` | OOM during parallel builds |
+| D4 | No "PR-ready" local test profile | Only `quickly` (skips ALL tests) exists | No middle ground between "skip all" and "run all" |
+| D5 | 804 JUnit 4 test files | Can't use JUnit 5 parallel execution | Slower test execution locally |
+
+---
+
+# Phase 0: Quick Wins (Week 1-2)
+
+**Goal**: Immediate cost and time reduction with minimal risk.
+
+> **Rollback protocol**: Every Phase 0 change must have a revert trigger. If any change increases the
+> CI flaky rate by >5% within 1 week of deployment, revert immediately and investigate before re-applying.
+
+---
+
+## 3.1 Disable Legacy Duplicate Workflows
+
+**Impact**: ~30-40% compute reduction for Operate/Optimize PRs
+**Risk**: Low
+**Effort**: Low
+
+These workflows duplicate work already covered by the unified CI:
+
+| File | Name | Overlap |
+|------|------|---------|
+| `.github/workflows/operate-ci.yml` | [Legacy] Operate | `ci.yml -> ci-operate.yml` |
+| `.github/workflows/operate-docker-tests.yml` | [Legacy] Operate / Docker | `ci.yml -> docker-checks` |
+| `.github/workflows/optimize-ci-core-features.yml` | [Legacy] Optimize Core Features | `ci.yml -> ci-optimize.yml` (uses 120min timeout on 32-core runners) |
+| `.github/workflows/optimize-ci-data-layer.yml` | [Legacy] Optimize Data Layer | `ci.yml -> database-integration-tests` |
+| `.github/workflows/optimize-e2e-tests-sm.yml` | [Legacy] Optimize E2E SM | 120min timeout on ubuntu-latest |
+
+**Action**: Validate unified CI covers all scenarios, then rename to `.yml.disabled` or delete. Start by adding a condition that skips them (e.g., `if: false`) so they can be quickly re-enabled if needed.
+
+---
+
+## 3.2 Create `.mvn/maven.config`
+
+**Impact**: ~30-50% faster full builds (local and CI)
+**Risk**: Low
+**Effort**: Trivial
+
+Create `.mvn/maven.config` with:
+```
+-T1C
+--fail-at-end
+```
+
+This enables parallel module builds by default. Currently only the Tasklist Makefile uses `-T1C`.
+
+---
+
+## 3.3 Enable Maven Build Cache
+
+**Impact**: 50-80% faster incremental local builds
+**Risk**: Medium (test with a small module set first)
+**Effort**: Low
+
+At `.mvn/maven-build-cache-config.xml:10`, change:
+```xml
+<!-- Before -->
+<enabled>false</enabled>
+
+<!-- After -->
+<enabled>true</enabled>
+```
+
+The configuration (xxHash, glob patterns, `maxBuildsCached=5`) is already well-designed. Start with local development only, expand to CI incrementally.
+
+---
+
+## 3.4 Fix `${env.LIMITS_CPU}` forkCount
+
+**Impact**: Eliminates a class of flaky tests caused by missing test isolation
+**Risk**: Low
+**Effort**: Low
+
+**Note**: `operate/pom.xml` already uses the `testForkCount` property indirection, but the default value still resolves to `${env.LIMITS_CPU}`. In `tasklist/pom.xml:61,74`, the forkCount is set directly in the plugin config.
+
+**Fix for both modules**: Ensure the `testForkCount` property defaults to `1` (not `${env.LIMITS_CPU}`):
+```xml
+<!-- In <properties> -->
+<testForkCount>1</testForkCount>
+
+<!-- In surefire/failsafe config -->
+<forkCount>${testForkCount}</forkCount>
+```
+
+CI overrides via `-DtestForkCount=${LIMITS_CPU}`.
+
+**Rollback**: Revert the property default if test isolation causes unexpected failures.
+
+---
+
+## 3.5 Fix Playwright `actionTimeout: 0`
+
+**Impact**: Prevents indefinite hangs in E2E tests
+**Risk**: Low
+**Effort**: Trivial
+
+In `operate/client/playwright.config.ts` and `tasklist/client/playwright.config.ts`, change:
+```typescript
+// Before — unlimited, hangs forever on stuck selectors
+actionTimeout: 0,
+
+// After — 10 seconds, matching the C8 orchestration suite
+actionTimeout: 10_000,
+```
+
+---
+
+## 3.6 Fix `skip.docker` Double Definition
+
+**Impact**: Prevents unnecessary Docker operations when tests are skipped
+**Risk**: Low
+**Effort**: Trivial
+
+In `optimize/pom.xml`, remove the duplicate at line 88:
+```xml
+<!-- Remove line 88, keep line 86 -->
+<skip.docker>${skipTests}</skip.docker>    <!-- line 86: correct -->
+<!-- <skip.docker>false</skip.docker> -->  <!-- line 88: overwrites, always false — REMOVE -->
+```
+
+---
+
+## 3.7 Add JVM Heap Configuration
+
+**Impact**: Prevents OOM during parallel builds
+**Risk**: Low
+**Effort**: Trivial
+
+The file `.mvn/jvm.config` already exists with `--add-exports`/`--add-opens` flags for Java module access, but has no heap settings. Append:
+```
+-Xmx4g -Xms1g
+```
+
+**Rollback**: Remove the heap flags if they cause issues on machines with <8 GB RAM.
+
+---
+
+## 3.8 Re-enable Incremental Compilation
+
+**Impact**: Faster recompilation during local development
+**Risk**: Low (bug was fixed in maven-compiler-plugin 3.13+, project uses 3.15.0)
+**Effort**: Trivial
+
+In `parent/pom.xml:2379`, change:
+```xml
+<!-- Before -->
+<useIncrementalCompilation>false</useIncrementalCompilation>
+
+<!-- After: remove the line entirely, or set to true -->
+<useIncrementalCompilation>true</useIncrementalCompilation>
+```
+
+---
+
+# Phase 1: Flaky Test Remediation (Week 2-6)
+
+**Goal**: Make the pipeline trustworthy. Stop masking flakiness, start fixing it. Engineers should never need to retrigger a passing build.
+
+> **Why this is Phase 1**: The pipeline currently fails due to flaky tests and engineers retrigger
+> until it passes. This is the #1 source of developer frustration and wasted compute. No amount of
+> build optimization matters if developers don't trust the results. A reliable pipeline is the
+> prerequisite for everything that follows.
+
+---
+
+## 4.1 Establish a Flaky Test Budget
+
+**Impact**: Cultural shift from "tolerate" to "fix"
+**Risk**: Medium (requires team buy-in)
+**Effort**: Low (policy change)
+
+For the full flaky test policy including budget, quarantine process, runbook, and root cause table, see Flaky Test Policy.
+
+Summary:
+- **Tiered targets**: <10% by end of Phase 1, <5% by end of Phase 3, <2% as CD stretch goal
+- **Metric definition**: Flaky rate = (test methods that flaked at least once in a week) / (total distinct test methods executed that week). Secondary metric: CI pipeline flake rate = (pipeline runs failed due to flakes) / (total pipeline runs)
+- **Quarantine threshold**: Flake rate >5% for tests run 10+ times/week, OR 3+ flakes for tests run <10 times/week
+- **Quarantine mechanism**: Use JUnit 5 `@Tag("quarantine")` with Surefire `<excludedGroups>quarantine</excludedGroups>` to exclude from PR runs; create GitHub issue with `kind/flake` label; escalate to team medic
+- **Fix SLA**: Quarantined tests must be fixed or deleted within 2 sprints
+- **Enforcement**: Block PR merge if flaky test count exceeds budget
+
+---
+
+## 4.2 Replace `Thread.sleep()` with Awaitility
+
+**Impact**: Eliminates timing-dependent flakiness in 52 files
+**Risk**: Low
+**Effort**: Medium
+
+Awaitility is already a dependency (200+ files use it). Expand adoption to the remaining 52 files. For the rule and examples, see Prohibited Patterns.
+
+**Tier the 52 files before starting:**
+
+| Tier | Count | Description | Timeline |
+|------|-------|-------------|----------|
+| **(a) Trivial** | ~30 | Sleep precedes a simple assertion — direct 1:1 replacement | Week 3-4 |
+| **(b) Moderate** | ~15 | Requires custom polling logic or condition identification | Week 5-6 |
+| **(c) Hard** | ~7 | Test architecture needs restructuring (e.g., Raft, SWIM protocol) | Defer to Phase 4 |
+
+Priority files (highest flakiness risk):
+- `qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java` (3 occurrences)
+- `qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java` (2 occurrences)
+- `dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java` (explicit "can be flaky" comment)
+- `zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java`
+- `zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java`
+
+---
+
+## 4.3 Replace Playwright `waitForTimeout` with Proper Assertions
+
+**Impact**: Eliminates 15 timing-dependent E2E flakiness sources
+**Risk**: Low
+**Effort**: Low
+
+For the rule, see Prohibited Patterns.
+
+All 15 occurrences in the Operate client E2E tests:
+
+| File | Occurrences | Current Wait |
+|------|------------|-------------|
+| `operate/client/e2e-playwright/visual/processInstance.spec.ts` | 6 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/visual/decisionInstance.spec.ts` | 1 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts` | 3 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts` | 1 | `waitForTimeout(1000)` |
+| `operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts` | 1 | `waitForTimeout(2000)` |
+| `operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts` | 3 | `waitForTimeout(1000)` |
+
+---
+
+## 4.4 Reduce `rerunFailingTestsCount` Progressively
+
+**Impact**: Surfaces real flakiness instead of masking it
+**Risk**: Medium (will initially surface more "failures")
+**Effort**: Low
+
+| Step | Surefire retries | Failsafe retries | Go/No-Go Criteria |
+|------|-----------------|-------------------|-------------------|
+| Current | 3 | 2-3 | — |
+| Step 1 | 2 | 2 | Flaky rate <8% for 2 consecutive weeks AND Thread.sleep tier (a) fixes landed |
+| Step 2 | 1 | 1 | Flaky rate <4% for 2 consecutive weeks AND Thread.sleep tier (a)+(b) fixes landed |
+| Target | 0 | **1** | Flaky rate <2% for 4 consecutive weeks (Surefire only) |
+
+> **Note**: Keep `failsafe.rerunFailingTestsCount=1` permanently. Integration tests are inherently
+> more variable due to Docker, networking, and eventual consistency. Zero retries for Failsafe is
+> unrealistic without architectural changes to the test harness.
+
+Each reduction will surface previously-masked flaky tests. These should be triaged using the flaky test budget process.
+
+**Communication**: Before each reduction step, post to the engineering Slack channel explaining what to expect (more red builds initially) and linking to the flaky test response runbook.
+
+---
+
+## 4.5 Audit and Fix `continue-on-error` Usage
+
+**Impact**: Prevents failures from being silently swallowed
+**Risk**: Medium (must ensure flakiness is under control first)
+**Effort**: Medium
+
+> **Correction**: `ci.yml:989` is on the Hadolint SARIF upload step (an observability step), not on
+> a test execution step. The actual test pass/fail is determined by test steps and aggregated in
+> `check-results`. A systematic audit of ALL `continue-on-error` usage is needed.
+
+There are 26 `continue-on-error` instances in `ci.yml` alone and 90+ across all workflows. Classify each:
+
+| Category | Action |
+|----------|--------|
+| `continue-on-error` on **test execution** steps | **Remove** — tests must fail the pipeline |
+| `continue-on-error` on **observability/reporting** steps (SARIF upload, stats, Slack) | **Keep** — these protect against GitHub API transient failures |
+| `continue-on-error` on **artifact upload** steps | **Evaluate** — may be protecting against legitimate transient failures |
+
+**Prerequisite**: Complete steps 4.1-4.4 first. The enforcement point for strict merging should be in the `check-results` job, not in individual step-level flags.
+
+---
+
+## 4.6 Triage the 97 AWS OpenSearch Disabled Tests
+
+**Impact**: Restores test coverage for an entire database backend
+**Risk**: Low
+**Effort**: High
+
+97 test files contain:
+```java
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+```
+
+**Triage approach**:
+1. **Categorize** the disabled tests by failure mode (timeout, assertion, connection, behavior difference)
+2. **Root cause analysis** — is this a test environment issue, a product behavior difference, or a genuine incompatibility?
+3. **Fix or formally document** — either fix the root cause or document why AWS OpenSearch behaves differently and adjust expectations
+4. **Dedicated CI environment** — if AWS OpenSearch requires special configuration, create a dedicated CI job with proper setup
+
+---
+
+## 4.7 Triage the Disabled/Ignored Test Backlog
+
+**Impact**: Restores lost test coverage
+**Risk**: Low
+**Effort**: Medium
+
+139 files have `@Disabled` / `@Ignore`. **Start with automated analysis** — script the "linked to closed issue" and "disabled >6 months" checks to resolve 40-50% of the backlog immediately. Then manually triage the remainder.
+
+Assign explicit team ownership: each product team (Operate, Tasklist, Optimize, Zeebe) triages their own disabled tests.
+
+For each:
+
+| Condition | Action |
+|-----------|--------|
+| Linked to an open issue | Verify issue is prioritized |
+| Linked to a closed issue | Re-enable the test |
+| No issue linked | Create an issue or delete the test |
+| Comment says "flaky" | Apply flaky test budget process |
+| Disabled for >6 months | Delete (dead disabled tests provide zero value) |
+
+---
+
+## 4.8 Create Missing Flaky Test Issue Template
+
+**Impact**: Standardizes flaky test reporting
+**Risk**: None
+**Effort**: Trivial
+
+The documented template at `unstable_test.md` doesn't exist in `.github/ISSUE_TEMPLATE/`. Create it with fields for:
+- Test class and method name
+- Flake frequency (from Grafana)
+- Error message / stack trace
+- Suspected root cause
+- Link to Grafana dashboard
+- Owning team
+
+---
+
+## 4.9 Add Automated Enforcement Rules
+
+**Impact**: Prevents new flaky patterns from entering the codebase
+**Risk**: Low
+**Effort**: Medium
+
+For the full enforcement rule definitions and configuration, see Enforcement Rules.
+
+Summary of proposed rules:
+- **ArchUnit `FreezingArchRule`** to prevent `Thread.sleep()` in test code — uses ArchUnit's baseline mechanism to capture existing violations and only fail on NEW violations, enabling gradual migration
+- **ESLint rule** to prevent `waitForTimeout()` in Playwright tests — add `/* eslint-disable */` comments on the 15 existing files as a temporary baseline, then remove as files are fixed
+- **ArchUnit rule** to prevent new JUnit 4 usage — ban `@RunWith`, `@Rule`, `org.junit.Test` imports in new files
+- **Metric ratchets** — CI should track Thread.sleep count, disabled test count, and `waitForTimeout` count; fail any PR that increases the count beyond the current baseline
+
+---
+
+# Phase 2: Build Artifact Sharing (Week 2-8)
+
+**Goal**: Eliminate redundant compilation across CI jobs.
+
+> **Note**: Phase 2 starts in parallel with Phase 1 (Week 2), not after it. Reducing the ~75
+> redundant builds per PR also reduces runner resource contention, which itself contributes to
+> flakiness. The shared build investigation should begin immediately after Phase 0 quick wins land.
+
+---
+
+## 5.1 Implement a Shared Build Job
+
+**Impact**: Eliminate ~75 redundant Maven builds across 22 workflow files (~200-600 runner-minutes saved per PR)
+**Risk**: Medium-High (introduces single point of failure — see risks below)
+**Effort**: High
+
+This is the **single highest-impact change**. Currently every test job independently runs `./.github/actions/build-zeebe` which does a full `./mvnw -B -T1C -DskipTests -DskipChecks install`.
+
+**Target architecture**:
+```
+build-artifacts (single job, gcp-perf-core-16)
+  |  ./mvnw install -DskipTests -DskipChecks -T1C
+  |  share via cache (primary) or upload-artifact (fallback)
+  |
+  +-- general-unit-tests (restore cache -> run tests only)
+  +-- zeebe-unit-tests[7] (restore cache -> run tests only)
+  +-- integration-tests[12] (restore cache -> run tests only)
+  +-- database-integration-tests[7] (restore cache -> run tests only)
+  +-- operate-ci (restore cache -> run tests only)
+  +-- tasklist-ci (restore cache -> run tests only)
+  +-- optimize-ci (restore cache -> run tests only)
+```
+
+### Approach Comparison
+
+| Approach | Pros | Cons | Recommendation |
+|----------|------|------|----------------|
+| **`actions/cache@v5`** (SHA-keyed) | Handles concurrent access well, no storage limits per run | 10 GB per-repo limit, LRU eviction | **Primary approach** |
+| **Remote Maven Build Cache** (S3/GCS-backed) | Content-addressable, cross-job reuse, incremental | Requires infrastructure (S3 bucket), cache extension already installed | **Evaluate for Phase 2.5** |
+| **`actions/upload-artifact@v4`** | Simple, per-run isolation | 10 GB per-run limit, thundering-herd downloads, single point of failure | **Fallback only** for non-Maven outputs |
+| **Develocity (Gradle Enterprise for Maven)** | Full build cache + build scan analytics | Commercial license, infrastructure | **Future evaluation** |
+
+### Scaling Risks
+
+- **Single point of failure**: The build-artifacts job becomes a critical path bottleneck. If it fails, everything waits. Today's redundant builds are embarrassingly parallel.
+- **Thundering herd**: 40+ downstream jobs simultaneously downloading a multi-GB artifact can cause download failures — a new source of CI flakiness.
+- **Storage limits**: `~/.m2/repository/io/camunda` for 144 modules may be several hundred MB to multiple GB. Measure the actual size before committing.
+
+### Implementation Steps
+
+1. **Measure first**: Run a full build and measure the size of `~/.m2/repository/io/camunda`
+2. **Primary**: Use `actions/cache@v5` keyed by `hashFiles('**/pom.xml')-${{ github.sha }}` — better concurrent access handling than artifacts
+3. **Selective sharing**: Share only `~/.m2/repository/io/camunda`, not the entire workspace
+4. **Graceful fallback**: If cache restore fails, the job should fall back to building locally (like today) rather than failing the entire pipeline
+5. **Cleanup**: Set `retention-days: 1` on any artifacts to prevent storage bloat
+6. Phase in: start with unit test jobs, then integration tests
+7. **Evaluate remote cache**: Investigate S3/GCS-backed Maven Build Cache (the extension is already installed at `.mvn/maven-build-cache-config.xml`) as a more robust long-term solution
+
+---
+
+## 5.2 Share Frontend Build Outputs
+
+**Impact**: Save ~18-48 min in deploy jobs
+**Risk**: Low
+**Effort**: Medium
+
+The `build-platform-frontend` job already builds all 4 frontends. Upload the output:
+
+```yaml
+build-platform-frontend:
+  steps:
+    # ... existing build steps ...
+    - uses: actions/upload-artifact@v4
+      with:
+        name: frontend-builds
+        path: |
+          operate/client/build/
+          tasklist/client/build/
+          identity/client/build/
+
+deploy-snapshots:
+  needs: [check-results, build-platform-frontend]
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: frontend-builds
+    # Skip frontend rebuild, go straight to Maven deploy
+```
+
+---
+
+## 5.3 Add Docker Layer Caching
+
+**Impact**: Faster Docker builds across all workflows
+**Risk**: Low
+**Effort**: Medium
+
+For all `docker/build-push-action` steps, add GHA cache backend:
+```yaml
+- uses: docker/build-push-action@v6
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+Applies to:
+- `ci.yml` -> `docker-checks` job
+- `ci-zeebe.yml` -> `docker-checks` job
+- `deploy-camunda-docker-snapshot` job
+- All integration test jobs that build Docker images
+
+---
+
+## 5.4 Consolidate Maven Cache Modifiers
+
+**Impact**: Better cache reuse across jobs
+**Risk**: Low
+**Effort**: Low
+
+Reduce from ~20+ unique cache key modifiers to 4:
+
+| Modifier | Used By |
+|----------|---------|
+| `build` | Build artifact job |
+| `test-ut` | All unit test jobs |
+| `test-it` | All integration test jobs |
+| `deploy` | Deploy jobs |
+
+---
+
+# Phase 3: Test Strategy Restructuring (Week 8-16)
+
+**Goal**: Shift left in the testing pyramid — faster feedback, more reliable tests. Adopt the Testing Strategy Manifesto as the binding standard for all new work.
+
+> **Prerequisite**: Phase 1 (flaky test remediation) must be substantially complete. The pipeline
+> must be reliable before restructuring what tests run where.
+>
+> **Important**: Activate enforcement rules (ArchUnit, ESLint) *before* socializing the manifesto.
+> Automated enforcement is more effective than cultural change alone.
+
+---
+
+## 6.1 Adopt the Testing Strategy Manifesto
+
+The Testing Strategy Manifesto defines:
+- What tests are required for every change type (feature, bugfix, incident, refactoring)
+- Prohibited patterns (Thread.sleep, waitForTimeout, JUnit 4 in new code, etc.)
+- Required patterns (given/when/then, Awaitility, TestSearchContainers, Page Object Model)
+- Naming conventions, framework choices, and enforcement mechanisms
+- The PR checklist that every code change must satisfy
+
+**Action**: Socialize the manifesto with all teams, integrate it into `CONTRIBUTING.md`, and create a PR template with the testing checklist.
+
+---
+
+## 6.2 Establish the Testing Pyramid
+
+For the full testing pyramid definition and layer details, see the Testing Strategy README.
+
+**Current state** (estimated):
+```
+       /    E2E + ITs    \     ~50%+ of test time — slow, external-service-dependent
+      /    Unit Tests      \   ~50% — includes 804 JUnit 4 files
+```
+
+**Target state**:
+```
+        /  E2E  \          < 5% of test time, nightly only
+       /  Contract \        ~10% — API contract verification
+      / Integration  \      ~20% — focused, TestContainers-based
+     /    Unit Tests    \   ~65% — fast, isolated, no external deps
+```
+
+---
+
+## 6.3 Strengthen API Contract Validation
+
+**Impact**: Catch API breaking changes fast without full E2E
+**Risk**: Low
+**Effort**: Medium (Tier 2) to High (Tier 3)
+
+### Tier 2: Strengthen What Exists (Do Now)
+
+Currently the only contract-like testing is:
+- OpenAPI linting (Spectral) — validates the spec is well-formed
+- Protobuf backward-compat (Buf) — validates gRPC schema compatibility
+- `validateResponse()` in E2E API tests — validates responses match OpenAPI spec (but only runs nightly)
+
+**Immediate improvements** (no new frameworks needed):
+1. **Add OpenAPI backward compatibility checking**: Use `openapi-diff` or `spectral diff` to detect breaking changes between PR and main. This catches field removals, type changes, and endpoint deletions automatically.
+2. **Validate frontend Zod schemas stay in sync with OpenAPI spec**: Add a CI check that compares `@camunda/camunda-api-zod-schemas` against `rest-api.yaml`. This is already partially covered but should be a hard gate.
+3. **Keep Buf for gRPC** (already enforced).
+
+These get ~80% of contract testing value at ~10% of the implementation and maintenance cost.
+
+### Tier 3: Consumer-Driven Contract Testing with Pact (Aspirational)
+
+> **Recommendation**: Defer full Pact adoption until after the team demonstrates it can maintain
+> the basics (zero new `Thread.sleep`, all new tests on JUnit 5, build cache enabled, flaky rate
+> under control). Introducing a new testing framework to a team already struggling with test
+> reliability adds complexity at the wrong time.
+
+If Pact is pursued, start with **PactFlow bidirectional testing** — compare consumer pacts against the existing OpenAPI spec without provider-side test code. This is the lightest-weight approach for a monorepo. See Contract Tests for the full guide.
+
+**Priority contract boundaries** (for when Pact is adopted):
+
+| # | Consumer | Provider | Priority |
+|---|----------|----------|----------|
+| 1 | Java Client (`clients/java/`) | v2 REST API (Zeebe gateway) | **Highest** — public API |
+| 2 | Tasklist Frontend | v2 REST API | High — already typed via `@camunda/camunda-api-zod-schemas` |
+| 3 | Operate Frontend | v2 REST API + legacy `/api/` | High |
+| 4 | Camunda Exporter | ES/OS index schema (Pact message contracts) | Medium |
+| 5 | Optimize Frontend | Optimize Backend REST API | Medium |
+
+---
+
+## 6.4 Classify and Tier Tests for PR vs. Nightly
+
+**Impact**: Faster PR feedback while maintaining comprehensive coverage
+**Risk**: Medium (requires validation that nightly catches regressions)
+**Effort**: Medium
+
+| Tier | When to Run | What | Est. Time |
+|------|-------------|------|-----------|
+| **Tier 1 (PR-blocking)** | Every PR | Unit tests, ArchUnit, linting, contract tests, affected-component ITs | ~15 min |
+| **Tier 2 (PR-non-blocking)** | Every PR | Primary DB ITs (ES8 + H2), component integration tests | ~20 min |
+| **Tier 3 (Nightly)** | Daily schedule | Multi-DB matrix (ES9, OpenSearch, RDBMS variants), full E2E suites, smoke tests on macOS/Windows/ARM | ~60 min |
+| **Tier 4 (Weekly)** | Weekly schedule | Load tests, version compatibility, full cross-browser E2E, AWS OpenSearch | ~120 min |
+
+**Key change**: Move the 7-way database integration test matrix from PR-blocking to nightly. On PRs, run against 2 DB variants (Elasticsearch 8 + one RDBMS) to catch the most common cross-engine compatibility issues while still cutting the matrix by 5x. If nightly tests fail, auto-create issues.
+
+**Nightly failure SLA**: Regressions detected in nightly must have a fix PR opened within 1 business day and merged within 3 business days. This prevents nightly from becoming a dumping ground for ignored failures.
+
+---
+
+## 6.5 Activate `parallel-tests` Profile by Default in CI
+
+**Impact**: Faster test execution across all CI jobs
+**Risk**: Low
+**Effort**: Low
+
+The `parallel-tests` profile (`parent/pom.xml:3114-3165`) enables `forkCount=0.5C` and JUnit 5 parallel execution. It's already used in some CI jobs but not consistently. Add it to all test-running Maven commands.
+
+---
+
+# Phase 4: Developer Experience (Week 8-16)
+
+**Goal**: Enable developers to run relevant tests locally in <5 minutes, reducing CI dependency.
+
+---
+
+## 7.1 Optimize Local Build Time
+
+Summary of all local build improvements (many from Phase 0):
+
+| Change | File | Impact |
+|--------|------|--------|
+| Enable build cache | `.mvn/maven-build-cache-config.xml:10` | 50-80% faster incremental builds |
+| Add `-T1C` default | `.mvn/maven.config` (new) | 30-50% faster full builds |
+| Re-enable incremental compilation | `parent/pom.xml:2379` | Faster recompilation |
+| Add JVM heap config | `.mvn/jvm.config` | Prevents OOM during parallel builds |
+
+**Target**: `mvn install -Dquickly` in <2 minutes.
+
+---
+
+## 7.2 Create a "PR-Ready" Local Test Profile
+
+**Impact**: Gives developers a fast local check before pushing
+**Risk**: Low
+**Effort**: Medium
+
+Add a new Maven profile that runs exactly what CI Tier 1 would run:
+
+```xml
+<profile>
+  <id>pr-ready</id>
+  <properties>
+    <skipITs>true</skipITs>
+    <skipChecks>false</skipChecks>
+  </properties>
+  <!-- Runs: unit tests + archunit checks -->
+  <!-- Skips: integration tests, E2E, Docker -->
+</profile>
+```
+
+Usage: `mvn verify -Ppr-ready -pl <changed-module>` — should complete in <5 minutes for a single module.
+
+---
+
+## 7.3 Add Pre-Push Git Hook (Optional, Opt-in)
+
+**Impact**: Catches basic failures before pushing to CI
+**Risk**: Low (opt-in)
+**Effort**: Low
+
+Offer an opt-in pre-push hook that runs affected-module unit tests:
+```bash
+#!/bin/bash
+# .githooks/pre-push (opt-in via: git config core.hooksPath .githooks)
+CHANGED_MODULES=$(git diff --name-only origin/main | scripts/affected-modules.sh)
+if [ -n "$CHANGED_MODULES" ]; then
+  ./mvnw test -pl "$CHANGED_MODULES" -am -Dquickly=false -DskipITs
+fi
+```
+
+---
+
+## 7.4 Complete JUnit 4 to JUnit Jupiter Migration
+
+**Impact**: Unlocks parallel execution for all tests
+**Risk**: **Medium-High** (automated migration handles syntax but not custom rule semantics)
+**Effort**: High (804 files, expect 8-12 weeks)
+
+> **Note**: The project already uses JUnit 6.0.3 (`parent/pom.xml` `<version.junit>6.0.3</version.junit>`),
+> which is backward-compatible with JUnit 5 Jupiter APIs. The migration target is the Jupiter API,
+> not a specific JUnit version.
+
+Jupiter's `junit.jupiter.execution.parallel.enabled=true` only works with Jupiter tests. The 804 remaining JUnit 4 files run serially even when the `parallel-tests` profile is active.
+
+> **Note**: For the prohibition of JUnit 4 in new code, see Prohibited Patterns.
+
+### Prerequisites (Before Running OpenRewrite)
+
+1. **Audit all custom JUnit 4 rules** — grep for classes extending `ExternalResource`, `TestRule`, `MethodRule`, and `@RunWith`. Create a mapping table to their JUnit 5 equivalents. Estimate: 2-3 days.
+2. **Write custom OpenRewrite recipes** for the most common custom rules (e.g., `EngineRule` -> `EngineExtension`). OpenRewrite does NOT know about these custom mappings.
+3. **Run in dry-run mode first** and categorize the 804 files by migration complexity.
+
+### Known Gotchas
+
+- **Custom `@Rule` lifecycle semantics**: `EngineRule` has specific `before()/after()` ordering that may differ from the `@RegisterExtension` lifecycle.
+- **`@RuleChain`**: Tests using `RuleChain` for deterministic ordering require manual conversion to extension ordering.
+- **`@ClassRule` / `@Rule` interaction**: Static vs. instance `@RegisterExtension` fields have subtle lifecycle differences.
+- **`@RunWith(Parameterized.class)`**: Migrates to `@ParameterizedTest` but the data provider mechanism changes completely.
+- **Expect 30-40% manual intervention**: OpenRewrite handles annotation/import changes but produces semantically incorrect tests for complex lifecycle cases.
+
+### Approach
+
+Use OpenRewrite recipe for the mechanical parts:
+```bash
+./mvnw rewrite:run -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit4to5Migration
+```
+
+### Phased Rollout (with validation gaps)
+
+| Phase | Scope | Files | Validation |
+|-------|-------|-------|------------|
+| 1 | Protocol, protocol-impl, msgpack | ~30 | Run full suite 20x, compare flake rates |
+| 2 | Gateway-grpc, exporters, clients | ~50 | Wait 2+ weeks before proceeding |
+| 3 | Zeebe engine | ~200 | Largest batch — review by owning team |
+| 4 | Operate/Tasklist/Optimize | ~300 | Each team reviews their own modules |
+| 5 | Remaining modules | ~200 | Cleanup |
+
+**Migration canary**: For each phase, migrate 5% of the module first, run the full test suite 20 times, and compare flake rates before and after. Only proceed if flake rate is stable.
+
+---
+
+## 7.5 Fix Dead Compiler Configuration in Optimize
+
+**Impact**: Removes confusion in build configuration
+**Risk**: None
+**Effort**: Trivial
+
+In `optimize/backend/pom.xml:760-768`:
+```xml
+<!-- Current — contradictory: fork=false but meminitial/maxmem only apply when fork=true -->
+<configuration>
+  <fork>false</fork>
+  <meminitial>128m</meminitial>
+  <maxmem>256m</maxmem>
+</configuration>
+
+<!-- Fix — remove dead configuration -->
+<configuration>
+  <fork>false</fork>
+</configuration>
+```
+
+---
+
+# Phase 5: Pipeline Architecture for CD (Week 12-20)
+
+**Goal**: Achieve a CI pipeline that supports continuous delivery — fast, reliable, and trustworthy.
+
+---
+
+## 8.1 Target Pipeline Architecture
+
+```
+PR Push
+  |
+  +- [Tier 0: ~1 min] Lint + Format
+  |   actionlint, spotless, eslint, commitlint, openapi, protobuf
+  |
+  +- [Tier 1: ~5 min] Build Artifacts (single job, shared via artifacts)
+  |    |
+  |    +- [Tier 2: ~8 min] Unit Tests (parallel, affected modules only)
+  |    +- [Tier 2: ~8 min] Contract Tests (API compatibility)
+  |    +- [Tier 2: ~3 min] ArchUnit + Static Analysis
+  |    |
+  |    +- [Tier 3: ~15 min] Integration Tests (primary DB only, affected components)
+  |    |
+  |    +- [Gate] check-results <- All green = mergeable
+  |
+  Merge to main (via merge queue)
+  |
+  +- [Deploy: ~10 min] Snapshot deploy + Docker image push
+  |
+  Nightly
+  |
+  +- Full DB matrix (ES8, ES9, OpenSearch, H2, PostgreSQL, AWS OS)
+  +- Cross-browser E2E (Chromium, Firefox, Edge)
+  +- Smoke tests (Linux, macOS, Windows, ARM)
+  +- Load tests
+  +- Version compatibility tests
+```
+
+**Target PR wall-clock time: ~20 minutes** (down from ~55 minutes)
+
+---
+
+## 8.2 Leverage Statsig Feature Flags for Safe Deployment
+
+**Impact**: Enables true continuous delivery — deploy != release
+**Risk**: None (infrastructure already exists)
+**Effort**: Low (process adoption)
+
+Statsig is already in place as the feature flag platform. This is a critical CD enabler:
+
+- **Incomplete features merge to `main` safely** — wrap in-progress work behind Statsig gates so it can be deployed without being released to users
+- **Progressive rollouts** — new features roll out to 1% -> 10% -> 50% -> 100% with automatic rollback if error rates spike
+- **Testing in production** — enable features for internal users or specific tenants before general availability
+- **Decoupled deploy/release** — deployments happen continuously; feature releases are a business decision, not an engineering event
+
+**Policy for CD readiness**: Any feature that takes more than one PR to complete must be gated behind a Statsig feature flag. This eliminates the need for long-lived feature branches and allows `main` to always be deployable.
+
+---
+
+## 8.3 Right-Size Runner Specifications
+
+| Current | Proposed | Jobs Affected |
+|---------|----------|---------------|
+| `gcp-core-32-default` | `gcp-perf-core-16-default` | Legacy Operate/Optimize ITs |
+| `gcp-perf-core-16-default` for small UT modules | `gcp-perf-core-8-default` | Protocol, Gateway, Client unit tests |
+| 120-min timeouts | 30-min max | All jobs |
+
+---
+
+## 8.4 Implement Strict Merge Queue
+
+**Impact**: Ensures only green code merges to `main`
+**Risk**: Medium (requires flakiness to be under control)
+**Effort**: Medium
+
+Replace current `continue-on-error` merge queue with strict enforcement:
+- All Tier 1-3 tests must pass (no `continue-on-error`)
+- Merge queue batches up to 5 PRs for combined testing
+- Failed batches bisect to find the offending PR
+- Flaky test budget enforced at merge time
+
+---
+
+## 8.5 Reduce Total Workflow Count
+
+**Impact**: Simpler maintenance, fewer duplicate jobs
+**Risk**: Medium
+**Effort**: High
+
+Target: reduce from 121 workflows to ~60-70 by:
+1. Removing all legacy duplicate workflows (Phase 0)
+2. Consolidating scheduled workflows (combine `zeebe-daily-qa`, `zeebe-search-integration-tests`, `zeebe-rdbms-integration-tests` into a single nightly matrix)
+3. Unifying release workflows into a single parameterized workflow
+
+---
+
+## 8.6 Future: Deployment Safety (Monitoring, Canary, Rollback)
+
+> **Status**: Future improvement — out of scope for the initial CD pipeline work, but essential for
+> full continuous deployment maturity.
+
+Camunda has two distinct distribution models, each with different deployment safety requirements:
+
+| Concern | SaaS | Self-Hosted / Self-Managed |
+|---------|------|---------------------------|
+| **Canary deployments** | Roll out to a subset of SaaS clusters before full fleet | N/A — customers control their own upgrade schedule |
+| **Automated rollback** | Auto-revert if error rates or latency SLOs breach thresholds post-deploy | Provide rollback documentation and tested downgrade paths |
+| **Health monitoring gates** | Post-deploy health checks (error rate, p99 latency, Zeebe throughput) must pass before promoting to next cluster ring | Ship health check endpoints and upgrade verification scripts customers can run |
+| **Deploy/release separation** | Statsig gates control feature visibility independently of deployment | Statsig gates + version-gated feature enablement |
+| **Upgrade compatibility testing** | Tested in CI (rolling update, version compatibility) | Must also test customer-facing upgrade paths (Helm chart, Docker Compose, manual) |
+| **Rollback scope** | Platform team controls full rollback | Customers need clear rollback procedures per distribution (Helm rollback, Docker tag pinning, etc.) |
+
+**Key principle**: CD for Camunda means `main` is always deployable to SaaS *and* releasable as a Self-Managed artifact. The CI pipeline (Phases 0-5) ensures code quality; deployment safety mechanisms ensure the *release process* is safe for both distribution models.
+
+These topics should be scoped as a follow-up initiative once the pipeline achieves the Phase 5 targets (~20 min PR, <2% flaky rate, strict merge queue).
+
+---
+
+# Success Metrics
+
+| Metric | Current | Phase 0+1 (Wk 1-6) | Phase 2+3 (Wk 8-16) | Phase 4+5 (CD) |
+|--------|---------|---------------------|----------------------|----------------|
+| **PR wall-clock time** | ~55 min | ~45 min | ~25 min | ~20 min |
+| **Compute cost per PR** | Baseline | -30% | -55% | -65% |
+| **Flaky test rate** | Unknown (masked by 3x retries) | <10% (measured) | <5% | <2% |
+| **CI retriggers per PR** | Multiple (daily pain) | <1 per PR | ~0 | 0 |
+| **`rerunFailingTestsCount`** | 3 | 2 | 1 | 0-1 |
+| **Local `mvn install -Dquickly`** | ~5-10 min | ~3-5 min | ~2-3 min | <2 min |
+| **Tests disabled for flakiness** | 139+ files | <80 (triaged) | <30 | <10 |
+| **Devs running tests locally** | Rarely | Some | Most | Standard |
+| **Time to deploy after merge** | ~20 min | ~15 min | ~10 min | <10 min |
+| **Main branch red rate** | Unknown | Measured | <5% | <1% |
+
+---
+
+# Priority Summary
+
+| # | Action | Phase | Effort | Impact | Risk |
+|---|--------|-------|--------|--------|------|
+| | **Phase 0 — Quick Wins (Week 1-2)** | | | | |
+| 1 | Disable legacy duplicate workflows | 0 | Low | High | Low |
+| 2 | Create `.mvn/maven.config` with `-T1C` | 0 | Trivial | Medium | Low |
+| 3 | Enable Maven build cache | 0 | Low | High | Medium |
+| 4 | Fix `${env.LIMITS_CPU}` forkCount | 0 | Low | High | Low |
+| 5 | Fix Playwright `actionTimeout: 0` | 0 | Trivial | Medium | Low |
+| 6 | Fix `skip.docker` double definition | 0 | Trivial | Low | Low |
+| 7 | Add JVM heap to `.mvn/jvm.config` | 0 | Trivial | Low | Low |
+| 8 | Re-enable incremental compilation | 0 | Trivial | Low | Low |
+| | **Phase 1 — Flaky Test Remediation (Week 2-6)** | | | | |
+| 9 | Establish flaky test budget + quarantine policy | 1 | Low | **Highest** | Medium |
+| 10 | Replace `Thread.sleep` in 52 test files | 1 | Medium | High | Low |
+| 11 | Replace Playwright `waitForTimeout` (15 occurrences) | 1 | Low | High | Low |
+| 12 | Reduce `rerunFailingTestsCount` progressively (3 -> 2 -> 1) | 1 | Low | High | Medium |
+| 13 | Create flaky test issue template | 1 | Trivial | Medium | None |
+| 14 | Triage disabled tests backlog (139 files) | 1 | High | Medium | Low |
+| 15 | Triage 97 AWS OpenSearch disabled tests | 1 | High | Medium | Low |
+| 16 | Add ArchUnit rule to ban `Thread.sleep` in tests | 1 | Medium | Medium | Low |
+| 17 | Add ESLint rule to ban `waitForTimeout` | 1 | Low | Medium | Low |
+| 18 | Fix merge queue `continue-on-error` | 1 | Trivial | High | Medium |
+| | **Phase 2 — Build Artifact Sharing (Week 2-8)** | | | | |
+| 19 | **Shared build artifact job** | 2 | **High** | **Highest** | Medium |
+| 20 | Share frontend build outputs | 2 | Medium | Medium | Low |
+| 21 | Docker layer caching | 2 | Medium | Medium | Low |
+| 22 | Consolidate Maven cache modifiers | 2 | Low | Low | Low |
+| | **Phase 3 — Test Strategy Restructuring (Week 8-16)** | | | | |
+| 23 | Adopt Testing Strategy Manifesto | 3 | Medium | High | Low |
+| 24 | Strengthen API contract validation (OpenAPI diff, Zod sync) | 3 | Medium | High | Low |
+| 25 | Move DB matrix to nightly (PR runs 2 DB variants) | 3 | Medium | High | Medium |
+| 26 | Activate `parallel-tests` profile by default in CI | 3 | Low | Medium | Low |
+| | **Phase 4 — Developer Experience (Week 12-20)** | | | | |
+| 27 | JUnit 4 to Jupiter migration (804 files) | 4 | High | Medium | **Medium-High** |
+| 28 | Create PR-ready local test profile | 4 | Medium | High | Low |
+| | **Phase 5 — Pipeline Architecture for CD (Week 16-24)** | | | | |
+| 29 | Leverage Statsig feature flags for safe deployment | 5 | Low | High | None |
+| 30 | Strict merge queue (remove `continue-on-error`) | 5 | Medium | High | Medium |
+| 31 | Right-size runners | 5 | Low | Medium | Low |
+| 32 | Consolidate workflow count (121 -> ~60-70) | 5 | High | Medium | Medium |
+
+---
+
+# GitHub Actions Workflow Inventory
+
+## Primary CI Workflows
+
+| # | File | Name | Trigger |
+|---|------|------|---------|
+| 1 | `ci.yml` | Camunda CI | push (main/stable), PR, merge_group, schedule (daily 06:00 UTC) |
+| 2 | `ci-zeebe.yml` | Zeebe CI | workflow_call from ci.yml |
+| 3 | `ci-operate.yml` | Operate CI | workflow_call from ci.yml |
+| 4 | `ci-tasklist.yml` | Tasklist CI | workflow_call from ci.yml |
+| 5 | `ci-optimize.yml` | Optimize CI | workflow_call from ci.yml |
+| 6 | `ci-client-components.yml` | Client Components CI | workflow_call from ci.yml |
+
+## Reusable Workflows
+
+| # | File | Called By | Times Called |
+|---|------|----------|-------------|
+| 7 | `ci-database-integration-tests-reusable.yml` | ci.yml, scheduled workflows | 7+ |
+| 8 | `ci-webapp-run-ut-reuseable.yml` | Operate/Tasklist/Optimize CI | 6 |
+| 9 | `operate-ci-build-reusable.yml` | Legacy Operate CI | 1 |
+| 10 | `operate-ci-test-reusable.yml` | Legacy Operate CI | 1 |
+| 11 | `tasklist-ci-build-reusable.yml` | Tasklist workflows | 1 |
+| 12 | `tasklist-ci-test-reusable.yml` | Tasklist workflows | 1 |
+| 13 | `optimize-ci-build-reusable.yml` | Legacy Optimize workflows | 1 |
+| 14 | `generate-snapshot-docker-tag-and-concurrency-group.yml` | ci.yml, deploy workflows | Multiple |
+
+## Legacy/Duplicate Workflows (Candidates for Removal)
+
+| # | File | Name | Overlap |
+|---|------|------|---------|
+| 15 | `operate-ci.yml` | [Legacy] Operate | ci.yml -> ci-operate.yml |
+| 16 | `operate-docker-tests.yml` | [Legacy] Operate / Docker | ci.yml -> docker-checks |
+| 17 | `optimize-ci-core-features.yml` | [Legacy] Optimize Core Features | ci.yml -> ci-optimize.yml |
+| 18 | `optimize-ci-data-layer.yml` | [Legacy] Optimize Data Layer | ci.yml -> database ITs |
+| 19 | `optimize-e2e-tests-sm.yml` | [Legacy] Optimize E2E SM | Nightly E2E |
+
+## Scheduled/Nightly Workflows
+
+| # | File | Schedule | Purpose |
+|---|------|----------|---------|
+| 20 | `zeebe-daily-qa.yml` | Weekdays 01:00 UTC | QA testbench across stable branches |
+| 21 | `camunda-daily-load-tests.yml` | Daily 04:00 UTC | Max load test |
+| 22 | `camunda-weekly-load-tests.yml` | Weekly | Extended load tests |
+| 23 | `zeebe-weekly-e2e.yml` | Weekly | E2E tests |
+| 24 | `zeebe-search-integration-tests.yml` | Weekdays 05:00 UTC | Multi-version ES/OS tests (6 matrix) |
+| 25 | `zeebe-rdbms-integration-tests.yml` | Weekdays 05:00 UTC | Multi-vendor RDBMS tests (13 matrix) |
+| 26 | `zeebe-version-compatibility.yml` | Daily 06:00 UTC | Rolling update compatibility |
+| 27 | `statistics-daily.yml` | Daily | Flaky test stats + Slack |
+| 28 | `statistics-weekly.yml` | Weekly | Weekly stats + Slack |
+
+---
+
+# Detailed Findings by Area
+
+## B.1 Maven Build Configuration
+
+| Finding | Severity | File:Line | Description |
+|---------|----------|-----------|-------------|
+| Build cache disabled | CRITICAL | `.mvn/maven-build-cache-config.xml:10` | Extension installed but `<enabled>false</enabled>` |
+| `${env.LIMITS_CPU}` forkCount | CRITICAL | `operate/pom.xml:66`, `tasklist/pom.xml:61,74` | Resolves to null when env var unset -> no test isolation |
+| No `.mvn/maven.config` | WARNING | (missing file) | No default parallel builds |
+| No JVM heap in jvm.config | WARNING | `.mvn/jvm.config` | Risk of OOM during parallel builds |
+| `useIncrementalCompilation=false` | WARNING | `parent/pom.xml:2379` | Stale workaround for bug fixed in 3.13+ |
+| `skip.docker` double definition | WARNING | `optimize/pom.xml:86,88` | Docker always starts regardless of skipTests |
+| `parallel-tests` profile not default | IMPROVEMENT | `parent/pom.xml:3114` | Tests run serially unless explicitly opted in |
+| Dead compiler config in optimize | IMPROVEMENT | `optimize/backend/pom.xml:760-768` | `fork=false` with meminitial/maxmem (only apply when fork=true) |
+| Node.js downloaded 4 times | IMPROVEMENT | Frontend pom.xml files | Each frontend module installs Node independently |
+
+## B.2 Flaky Test Indicators
+
+| Pattern | Count | Key Examples |
+|---------|-------|-------------|
+| `@Disabled` annotations | 136 files | `GlobalJobStatisticsIT` (flaky), `HistoryCleanupIT` (flaky #35023) |
+| `@Ignore` annotations | 9 files | `ModifyProcessInstanceOperationZeebeIT` ("Due to flaky CI tests") |
+| Disabled on AWS OpenSearch | 97 files | `@DisabledIfSystemProperty(matches = "AWS_OS")` |
+| `Thread.sleep()` in tests | 52 files | `GlobalJobStatisticsIT`, `RaftTest`, `SwimProtocolTest` |
+| "flaky" in code comments | 19 locations | `RdbmsTableNames`, `MessageCorrelationTest`, `EmbeddedSubProcessConcurrencyTest` |
+| `page.waitForTimeout()` | 15 occurrences | All in Operate Playwright tests |
+| `continue-on-error` in workflows | 90+ instances | Some mask real failures in merge queue context |
+| `rerunFailingTestsCount` | Every test job | 2-3 retries, masking real failure rates |
+
+## B.3 Test Infrastructure Summary
+
+| Category | Count | Frameworks |
+|----------|-------|------------|
+| Java test files with `@Test` | ~3,000+ | JUnit 5, JUnit 4, Mockito, AssertJ |
+| Integration test files (`*IT.java`) | ~300+ | TestContainers, SpringBootTest, Failsafe |
+| TestContainers usage | 89 files | Docker containers for ES/OS/S3/GCS/Azure/PG |
+| WireMock usage | 100+ files | HTTP mocking |
+| Playwright spec files | ~160+ | Chromium, Firefox, Edge |
+| ArchUnit test files | 19 | Architecture validation |
+| Awaitility usage | 200+ files | Async test patterns (should be higher) |
+| JUnit 4 files remaining | ~804 | Migration to JUnit 5 needed |
+
+## B.4 Runner Usage per PR
+
+| Runner | Cores | Approx. Jobs Per PR |
+|--------|-------|-------------------|
+| `ubuntu-latest` | 2-4 | ~15 |
+| `gcp-perf-core-8-default` | 8 | ~10 |
+| `gcp-perf-core-16-default` | 16 | ~15 |
+| `gcp-perf-core-16-longrunning` | 16 | ~4 |
+| `gcp-core-4-default` | 4 | ~1 |
+| `gcp-core-8-default` | 8 | ~2 |
+| `gcp-core-32-default` | 32 | ~3 (legacy only) |
+| `macos-latest` | - | ~1 |
+| `windows-latest` | - | ~1 |
+| `aws-arm-core-4-longrunning` | 4 | ~1 |
+
+## B.5 CI Critical Path Analysis
+
+```
+detect-changes (~2 min)
+  |
+  +-- [Parallel Tier 2]
+  |   +-- integration-tests matrix (30 min timeout, longest chain)
+  |   +-- database-integration-tests x7 (20 min each)
+  |   +-- zeebe-unit-tests x7 (10 min each)
+  |   +-- general-unit-tests (10 min)
+  |   +-- sub-workflows (operate/tasklist/optimize/zeebe CI)
+  |
+  check-results (~1 min)
+  |
+  +-- deploy-snapshots (~20 min)
+  +-- deploy-camunda-docker-snapshot (~15 min, parallel)
+```
+
+**Current critical path: ~55 min (PR), ~75 min (main with deploys)**
+**Target critical path: ~20 min (PR), ~30 min (main with deploys)**

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -1,0 +1,79 @@
+# CI/CD Improvement Plan: Path to Continuous Delivery
+
+**Repository**: `camunda/camunda` (monorepo)
+**Scope**: GitHub Actions pipelines, Maven build configuration, testing strategy, flaky test remediation, developer experience
+
+> **Phase Ordering Rationale**: Flaky test remediation (Phase 1) runs concurrently with build
+> optimization (Phase 2) — not sequentially. Quick wins (Phase 0) and the shared build artifact
+> investigation start immediately, because reducing 75 redundant builds per PR also reduces resource
+> contention that itself causes flakiness. However, reliability work (flaky test fixes, retry
+> reduction) must reach measurable milestones before enforcing strict merge queue rules or
+> restructuring the test strategy.
+
+> **Implementation Tiers**: This plan is structured as three explicit tiers with off-ramps:
+> - **Tier 1 (Must-Do, Weeks 1-8)**: Phase 0 + shared build artifacts + top flaky test fixes. Expected: ~25 min PR, -55% compute.
+> - **Tier 2 (Should-Do, Weeks 8-16)**: Flaky budget enforcement, testing manifesto adoption, parallel-tests, runner right-sizing.
+> - **Tier 3 (Aspirational, Weeks 16+)**: Contract testing, JUnit 4 migration, full CD pipeline, workflow consolidation. Only pursue with continued organizational commitment.
+
+---
+
+## Current vs. Target Metrics
+
+| Metric | Current | Phase 0+1 | Phase 2+3 | CD Target |
+|--------|---------|-----------|-----------|-----------|
+| PR wall-clock time | ~55 min | ~45 min | ~25 min | **~20 min** |
+| Compute cost per PR | Baseline | -30% | -55% | **-65%** |
+| Flaky test rate | Unknown | <10% | <5% | **<2%** |
+| CI retriggers per PR | Multiple | <1 | ~0 | **0** |
+| Local `mvn -Dquickly` | ~5-10 min | ~3-5 min | ~2-3 min | **<2 min** |
+
+## Phase Overview
+
+| Phase | Timeline | Focus | Key Impact |
+|-------|----------|-------|------------|
+| [Phase 0: Quick Wins](./phase-0-quick-wins.md) | Week 1-2 | Build config, low-hanging fruit | -30% compute |
+| [Phase 1: Flaky Test Remediation](./phase-1-flaky-test-remediation.md) | Week 2-6 | Pipeline trustworthiness | Reliable CI |
+| [Phase 2: Build Artifact Sharing](./phase-2-build-artifact-sharing.md) | Week 2-8 | Eliminate redundant builds | -55% compute |
+| [Phase 3: Test Strategy](./phase-3-test-strategy.md) | Week 8-16 | Testing pyramid, OpenAPI contract validation | Faster feedback |
+| [Phase 4: Developer Experience](./phase-4-developer-experience.md) | Week 12-20 | Local dev, JUnit migration | <5 min local tests |
+| [Phase 5: Pipeline Architecture](./phase-5-pipeline-architecture.md) | Week 16-24 | CD-ready pipeline | ~20 min PR time |
+
+## Target Pipeline Architecture
+
+```
+PR Push
+  |
+  +- [Tier 0: ~1 min] Lint + Format
+  |
+  +- [Tier 1: ~5 min] Build Artifacts (single job, shared via artifacts)
+  |    |
+  |    +- [Tier 2: ~8 min] Unit Tests (parallel, affected modules only)
+  |    +- [Tier 2: ~8 min] Contract Tests (API compatibility)
+  |    +- [Tier 2: ~3 min] ArchUnit + Static Analysis
+  |    |
+  |    +- [Tier 3: ~15 min] Integration Tests (primary DB only)
+  |    |
+  |    +- [Gate] check-results <- All green = mergeable
+  |
+  Merge to main -> Deploy snapshots + Docker (~10 min)
+  |
+  Nightly -> Full DB matrix, cross-browser E2E, load tests
+```
+
+## Detailed Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Current State Assessment](./current-state.md) | Key numbers, architecture, what's done well |
+| [Root Cause Analysis](./root-cause-analysis.md) | Slowness, flakiness, developer CI dependency |
+| [Success Metrics](./success-metrics.md) | Full metrics table across all phases |
+| [Priority Summary](./priority-summary.md) | All 32 action items ranked |
+| [Workflow Inventory](./reference/workflow-inventory.md) | All GitHub Actions workflow tables |
+| [Detailed Findings](./reference/detailed-findings.md) | Findings tables by area |
+
+## Related Documentation
+
+- [Testing Strategy Manifesto](../testing-strategy/README.md) — Testing practices, patterns, and policies
+- [Flaky Test Policy](../testing-strategy/flaky-test-policy.md) — Budget, quarantine, runbook
+- [Contract Tests](../testing-strategy/contract-tests.md) — Pact consumer-driven contract testing
+- [Enforcement Rules](../testing-strategy/setup/enforcement-rules.md) — ArchUnit, ESLint, Checkstyle

--- a/docs/ci-cd/current-state.md
+++ b/docs/ci-cd/current-state.md
@@ -1,0 +1,57 @@
+# Current State Assessment
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+## Key Numbers
+
+| Metric | Value |
+|--------|-------|
+| GitHub Actions workflow files | 121 |
+| Maven modules (total pom.xml) | 144 (22 aggregators + 122 buildable) |
+| Top-level modules in root POM | 36 |
+| PR wall-clock CI time | ~50-55 min |
+| Main branch CI time (with deploys) | ~70-75 min |
+| Redundant full Maven builds per PR | ~75 (across 22 workflow files) |
+| Legacy duplicate workflows | 5+ (running in parallel with unified CI) |
+| Test files with `@Disabled` / `@Ignore` | 139 |
+| Tests blanket-disabled on AWS OpenSearch | 97 files |
+| `Thread.sleep()` in test code | 52 files |
+| Hardcoded Playwright `waitForTimeout` | 15 occurrences |
+| `rerunFailingTestsCount` | 2-3 retries on every test job |
+| JUnit 4 test files remaining | ~804 |
+| Maven build cache | Installed but **disabled** |
+| `.mvn/maven.config` | Does not exist |
+
+## Pipeline Architecture Overview
+
+The repository has a unified CI entry point (`ci.yml`) that fans out into component sub-workflows:
+
+```
+ci.yml (main entry point)
+  +-- detect-changes (path-based filtering)
+  +-- [Tier 0] Linting: actionlint, commitlint, spotless, openapi, renovate, protobuf
+  +-- [Tier 1] Build: build-platform-frontend
+  +-- [Tier 2] Unit Tests: general-unit-tests, zeebe-unit-tests (7x matrix)
+  +-- [Tier 2] Integration Tests: integration-tests (12x matrix), database ITs (7 variants)
+  +-- [Tier 2] Sub-workflows:
+  |   +-- ci-operate.yml (10+ jobs)
+  |   +-- ci-tasklist.yml (10+ jobs)
+  |   +-- ci-optimize.yml (4+ jobs)
+  |   +-- ci-zeebe.yml (8+ jobs)
+  |   +-- ci-client-components.yml (1 job)
+  +-- [Gate] check-results (requires ALL jobs)
+  +-- [Deploy] deploy-snapshots, deploy-docker (main/stable only)
+```
+
+**Total effective job count per full PR build: 60+ parallel/sequential jobs.**
+
+## What's Already Done Well
+
+- **Smart path-based change detection** — only affected component tests run on PRs
+- **Concurrency control** — cancels superseded PR builds, preserves main builds
+- **Flaky test observability pipeline** — BigQuery + Grafana + daily/weekly Slack + PR comments + team medic escalation (industry-leading)
+- **Maven cache** design is solid — split local repo, modifier-based keys, restore-only on PRs
+- **Playwright container images** — no browser installation overhead
+- **`-Dquickly` cascading skip system** — well-designed for local dev inner loop
+- **ChatOps `/ci-problems`** command for self-service CI failure analysis
+- **Maven Wrapper** (`mvnw`) ensures reproducible Maven versions

--- a/docs/ci-cd/phase-0-quick-wins.md
+++ b/docs/ci-cd/phase-0-quick-wins.md
@@ -1,0 +1,150 @@
+# Phase 0: Quick Wins (Week 1-2)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Immediate cost and time reduction with minimal risk.
+
+> **Rollback protocol**: Every Phase 0 change must have a revert trigger. If any change increases the
+> CI flaky rate by >5% within 1 week of deployment, revert immediately and investigate before re-applying.
+
+---
+
+## 3.1 Disable Legacy Duplicate Workflows
+
+**Impact**: ~30-40% compute reduction for Operate/Optimize PRs
+**Risk**: Low
+**Effort**: Low
+
+These workflows duplicate work already covered by the unified CI:
+
+| File | Name | Overlap |
+|------|------|---------|
+| `.github/workflows/operate-ci.yml` | [Legacy] Operate | `ci.yml -> ci-operate.yml` |
+| `.github/workflows/operate-docker-tests.yml` | [Legacy] Operate / Docker | `ci.yml -> docker-checks` |
+| `.github/workflows/optimize-ci-core-features.yml` | [Legacy] Optimize Core Features | `ci.yml -> ci-optimize.yml` (uses 120min timeout on 32-core runners) |
+| `.github/workflows/optimize-ci-data-layer.yml` | [Legacy] Optimize Data Layer | `ci.yml -> database-integration-tests` |
+| `.github/workflows/optimize-e2e-tests-sm.yml` | [Legacy] Optimize E2E SM | 120min timeout on ubuntu-latest |
+
+**Action**: Validate unified CI covers all scenarios, then rename to `.yml.disabled` or delete. Start by adding a condition that skips them (e.g., `if: false`) so they can be quickly re-enabled if needed.
+
+---
+
+## 3.2 Create `.mvn/maven.config`
+
+**Impact**: ~30-50% faster full builds (local and CI)
+**Risk**: Low
+**Effort**: Trivial
+
+Create `.mvn/maven.config` with:
+```
+-T1C
+--fail-at-end
+```
+
+This enables parallel module builds by default. Currently only the Tasklist Makefile uses `-T1C`.
+
+---
+
+## 3.3 Enable Maven Build Cache
+
+**Impact**: 50-80% faster incremental local builds
+**Risk**: Medium (test with a small module set first)
+**Effort**: Low
+
+At `.mvn/maven-build-cache-config.xml:10`, change:
+```xml
+<!-- Before -->
+<enabled>false</enabled>
+
+<!-- After -->
+<enabled>true</enabled>
+```
+
+The configuration (xxHash, glob patterns, `maxBuildsCached=5`) is already well-designed. Start with local development only, expand to CI incrementally.
+
+---
+
+## 3.4 Fix `${env.LIMITS_CPU}` forkCount
+
+**Impact**: Eliminates a class of flaky tests caused by missing test isolation
+**Risk**: Low
+**Effort**: Low
+
+**Note**: `operate/pom.xml` already uses the `testForkCount` property indirection, but the default value still resolves to `${env.LIMITS_CPU}`. In `tasklist/pom.xml:61,74`, the forkCount is set directly in the plugin config.
+
+**Fix for both modules**: Ensure the `testForkCount` property defaults to `1` (not `${env.LIMITS_CPU}`):
+```xml
+<!-- In <properties> -->
+<testForkCount>1</testForkCount>
+
+<!-- In surefire/failsafe config -->
+<forkCount>${testForkCount}</forkCount>
+```
+
+CI overrides via `-DtestForkCount=${LIMITS_CPU}`.
+
+**Rollback**: Revert the property default if test isolation causes unexpected failures.
+
+---
+
+## 3.5 Fix Playwright `actionTimeout: 0`
+
+**Impact**: Prevents indefinite hangs in E2E tests
+**Risk**: Low
+**Effort**: Trivial
+
+In `operate/client/playwright.config.ts` and `tasklist/client/playwright.config.ts`, change:
+```typescript
+// Before — unlimited, hangs forever on stuck selectors
+actionTimeout: 0,
+
+// After — 10 seconds, matching the C8 orchestration suite
+actionTimeout: 10_000,
+```
+
+---
+
+## 3.6 Fix `skip.docker` Double Definition
+
+**Impact**: Prevents unnecessary Docker operations when tests are skipped
+**Risk**: Low
+**Effort**: Trivial
+
+In `optimize/pom.xml`, remove the duplicate at line 88:
+```xml
+<!-- Remove line 88, keep line 86 -->
+<skip.docker>${skipTests}</skip.docker>    <!-- line 86: correct -->
+<!-- <skip.docker>false</skip.docker> -->  <!-- line 88: overwrites, always false — REMOVE -->
+```
+
+---
+
+## 3.7 Add JVM Heap Configuration
+
+**Impact**: Prevents OOM during parallel builds
+**Risk**: Low
+**Effort**: Trivial
+
+The file `.mvn/jvm.config` already exists with `--add-exports`/`--add-opens` flags for Java module access, but has no heap settings. Append:
+```
+-Xmx4g -Xms1g
+```
+
+**Rollback**: Remove the heap flags if they cause issues on machines with <8 GB RAM.
+
+---
+
+## 3.8 Re-enable Incremental Compilation
+
+**Impact**: Faster recompilation during local development
+**Risk**: Low (bug was fixed in maven-compiler-plugin 3.13+, project uses 3.15.0)
+**Effort**: Trivial
+
+In `parent/pom.xml:2379`, change:
+```xml
+<!-- Before -->
+<useIncrementalCompilation>false</useIncrementalCompilation>
+
+<!-- After: remove the line entirely, or set to true -->
+<useIncrementalCompilation>true</useIncrementalCompilation>
+```

--- a/docs/ci-cd/phase-1-flaky-test-remediation.md
+++ b/docs/ci-cd/phase-1-flaky-test-remediation.md
@@ -1,0 +1,192 @@
+# Phase 1: Flaky Test Remediation (Week 2-6)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Make the pipeline trustworthy. Stop masking flakiness, start fixing it. Engineers should never need to retrigger a passing build.
+
+> **Why this is Phase 1**: The pipeline currently fails due to flaky tests and engineers retrigger
+> until it passes. This is the #1 source of developer frustration and wasted compute. No amount of
+> build optimization matters if developers don't trust the results. A reliable pipeline is the
+> prerequisite for everything that follows.
+
+---
+
+## 4.1 Establish a Flaky Test Budget
+
+**Impact**: Cultural shift from "tolerate" to "fix"
+**Risk**: Medium (requires team buy-in)
+**Effort**: Low (policy change)
+
+For the full flaky test policy including budget, quarantine process, runbook, and root cause table, see [Flaky Test Policy](../testing-strategy/flaky-test-policy.md).
+
+Summary:
+- **Tiered targets**: <10% by end of Phase 1, <5% by end of Phase 3, <2% as CD stretch goal
+- **Metric definition**: Flaky rate = (test methods that flaked at least once in a week) / (total distinct test methods executed that week). Secondary metric: CI pipeline flake rate = (pipeline runs failed due to flakes) / (total pipeline runs)
+- **Quarantine threshold**: Flake rate >5% for tests run 10+ times/week, OR 3+ flakes for tests run <10 times/week
+- **Quarantine mechanism**: Use JUnit 5 `@Tag("quarantine")` with Surefire `<excludedGroups>quarantine</excludedGroups>` to exclude from PR runs; create GitHub issue with `kind/flake` label; escalate to team medic
+- **Fix SLA**: Quarantined tests must be fixed or deleted within 2 sprints
+- **Enforcement**: Block PR merge if flaky test count exceeds budget
+
+---
+
+## 4.2 Replace `Thread.sleep()` with Awaitility
+
+**Impact**: Eliminates timing-dependent flakiness in 52 files
+**Risk**: Low
+**Effort**: Medium
+
+Awaitility is already a dependency (200+ files use it). Expand adoption to the remaining 52 files. For the rule and examples, see [Prohibited Patterns](../testing-strategy/prohibited-patterns.md).
+
+**Tier the 52 files before starting:**
+
+| Tier | Count | Description | Timeline |
+|------|-------|-------------|----------|
+| **(a) Trivial** | ~30 | Sleep precedes a simple assertion — direct 1:1 replacement | Week 3-4 |
+| **(b) Moderate** | ~15 | Requires custom polling logic or condition identification | Week 5-6 |
+| **(c) Hard** | ~7 | Test architecture needs restructuring (e.g., Raft, SWIM protocol) | Defer to Phase 4 |
+
+Priority files (highest flakiness risk):
+- `qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java` (3 occurrences)
+- `qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java` (2 occurrences)
+- `dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java` (explicit "can be flaky" comment)
+- `zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java`
+- `zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java`
+
+---
+
+## 4.3 Replace Playwright `waitForTimeout` with Proper Assertions
+
+**Impact**: Eliminates 15 timing-dependent E2E flakiness sources
+**Risk**: Low
+**Effort**: Low
+
+For the rule, see [Prohibited Patterns](../testing-strategy/prohibited-patterns.md).
+
+All 15 occurrences in the Operate client E2E tests:
+
+| File | Occurrences | Current Wait |
+|------|------------|-------------|
+| `operate/client/e2e-playwright/visual/processInstance.spec.ts` | 6 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/visual/decisionInstance.spec.ts` | 1 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts` | 3 | `waitForTimeout(500)` |
+| `operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts` | 1 | `waitForTimeout(1000)` |
+| `operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts` | 1 | `waitForTimeout(2000)` |
+| `operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts` | 3 | `waitForTimeout(1000)` |
+
+---
+
+## 4.4 Reduce `rerunFailingTestsCount` Progressively
+
+**Impact**: Surfaces real flakiness instead of masking it
+**Risk**: Medium (will initially surface more "failures")
+**Effort**: Low
+
+| Step | Surefire retries | Failsafe retries | Go/No-Go Criteria |
+|------|-----------------|-------------------|-------------------|
+| Current | 3 | 2-3 | — |
+| Step 1 | 2 | 2 | Flaky rate <8% for 2 consecutive weeks AND Thread.sleep tier (a) fixes landed |
+| Step 2 | 1 | 1 | Flaky rate <4% for 2 consecutive weeks AND Thread.sleep tier (a)+(b) fixes landed |
+| Target | 0 | **1** | Flaky rate <2% for 4 consecutive weeks (Surefire only) |
+
+> **Note**: Keep `failsafe.rerunFailingTestsCount=1` permanently. Integration tests are inherently
+> more variable due to Docker, networking, and eventual consistency. Zero retries for Failsafe is
+> unrealistic without architectural changes to the test harness.
+
+Each reduction will surface previously-masked flaky tests. These should be triaged using the flaky test budget process.
+
+**Communication**: Before each reduction step, post to the engineering Slack channel explaining what to expect (more red builds initially) and linking to the flaky test response runbook.
+
+---
+
+## 4.5 Audit and Fix `continue-on-error` Usage
+
+**Impact**: Prevents failures from being silently swallowed
+**Risk**: Medium (must ensure flakiness is under control first)
+**Effort**: Medium
+
+> **Correction**: `ci.yml:989` is on the Hadolint SARIF upload step (an observability step), not on
+> a test execution step. The actual test pass/fail is determined by test steps and aggregated in
+> `check-results`. A systematic audit of ALL `continue-on-error` usage is needed.
+
+There are 26 `continue-on-error` instances in `ci.yml` alone and 90+ across all workflows. Classify each:
+
+| Category | Action |
+|----------|--------|
+| `continue-on-error` on **test execution** steps | **Remove** — tests must fail the pipeline |
+| `continue-on-error` on **observability/reporting** steps (SARIF upload, stats, Slack) | **Keep** — these protect against GitHub API transient failures |
+| `continue-on-error` on **artifact upload** steps | **Evaluate** — may be protecting against legitimate transient failures |
+
+**Prerequisite**: Complete steps 4.1-4.4 first. The enforcement point for strict merging should be in the `check-results` job, not in individual step-level flags.
+
+---
+
+## 4.6 Triage the 97 AWS OpenSearch Disabled Tests
+
+**Impact**: Restores test coverage for an entire database backend
+**Risk**: Low
+**Effort**: High
+
+97 test files contain:
+```java
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+```
+
+**Triage approach**:
+1. **Categorize** the disabled tests by failure mode (timeout, assertion, connection, behavior difference)
+2. **Root cause analysis** — is this a test environment issue, a product behavior difference, or a genuine incompatibility?
+3. **Fix or formally document** — either fix the root cause or document why AWS OpenSearch behaves differently and adjust expectations
+4. **Dedicated CI environment** — if AWS OpenSearch requires special configuration, create a dedicated CI job with proper setup
+
+---
+
+## 4.7 Triage the Disabled/Ignored Test Backlog
+
+**Impact**: Restores lost test coverage
+**Risk**: Low
+**Effort**: Medium
+
+139 files have `@Disabled` / `@Ignore`. **Start with automated analysis** — script the "linked to closed issue" and "disabled >6 months" checks to resolve 40-50% of the backlog immediately. Then manually triage the remainder.
+
+Assign explicit team ownership: each product team (Operate, Tasklist, Optimize, Zeebe) triages their own disabled tests.
+
+For each:
+
+| Condition | Action |
+|-----------|--------|
+| Linked to an open issue | Verify issue is prioritized |
+| Linked to a closed issue | Re-enable the test |
+| No issue linked | Create an issue or delete the test |
+| Comment says "flaky" | Apply flaky test budget process |
+| Disabled for >6 months | Delete (dead disabled tests provide zero value) |
+
+---
+
+## 4.8 Create Missing Flaky Test Issue Template
+
+**Impact**: Standardizes flaky test reporting
+**Risk**: None
+**Effort**: Trivial
+
+The documented template at `unstable_test.md` doesn't exist in `.github/ISSUE_TEMPLATE/`. Create it with fields for:
+- Test class and method name
+- Flake frequency (from Grafana)
+- Error message / stack trace
+- Suspected root cause
+- Link to Grafana dashboard
+- Owning team
+
+---
+
+## 4.9 Add Automated Enforcement Rules
+
+**Impact**: Prevents new flaky patterns from entering the codebase
+**Risk**: Low
+**Effort**: Medium
+
+For the full enforcement rule definitions and configuration, see [Enforcement Rules](../testing-strategy/setup/enforcement-rules.md).
+
+Summary of proposed rules:
+- **ArchUnit `FreezingArchRule`** to prevent `Thread.sleep()` in test code — uses ArchUnit's baseline mechanism to capture existing violations and only fail on NEW violations, enabling gradual migration
+- **ESLint rule** to prevent `waitForTimeout()` in Playwright tests — add `/* eslint-disable */` comments on the 15 existing files as a temporary baseline, then remove as files are fixed
+- **ArchUnit rule** to prevent new JUnit 4 usage — ban `@RunWith`, `@Rule`, `org.junit.Test` imports in new files
+- **Metric ratchets** — CI should track Thread.sleep count, disabled test count, and `waitForTimeout` count; fail any PR that increases the count beyond the current baseline

--- a/docs/ci-cd/phase-2-build-artifact-sharing.md
+++ b/docs/ci-cd/phase-2-build-artifact-sharing.md
@@ -1,0 +1,129 @@
+# Phase 2: Build Artifact Sharing (Week 2-8)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Eliminate redundant compilation across CI jobs.
+
+> **Note**: Phase 2 starts in parallel with Phase 1 (Week 2), not after it. Reducing the ~75
+> redundant builds per PR also reduces runner resource contention, which itself contributes to
+> flakiness. The shared build investigation should begin immediately after Phase 0 quick wins land.
+
+---
+
+## 5.1 Implement a Shared Build Job
+
+**Impact**: Eliminate ~75 redundant Maven builds across 22 workflow files (~200-600 runner-minutes saved per PR)
+**Risk**: Medium-High (introduces single point of failure — see risks below)
+**Effort**: High
+
+This is the **single highest-impact change**. Currently every test job independently runs `./.github/actions/build-zeebe` which does a full `./mvnw -B -T1C -DskipTests -DskipChecks install`.
+
+**Target architecture**:
+```
+build-artifacts (single job, gcp-perf-core-16)
+  |  ./mvnw install -DskipTests -DskipChecks -T1C
+  |  share via cache (primary) or upload-artifact (fallback)
+  |
+  +-- general-unit-tests (restore cache -> run tests only)
+  +-- zeebe-unit-tests[7] (restore cache -> run tests only)
+  +-- integration-tests[12] (restore cache -> run tests only)
+  +-- database-integration-tests[7] (restore cache -> run tests only)
+  +-- operate-ci (restore cache -> run tests only)
+  +-- tasklist-ci (restore cache -> run tests only)
+  +-- optimize-ci (restore cache -> run tests only)
+```
+
+### Approach Comparison
+
+| Approach | Pros | Cons | Recommendation |
+|----------|------|------|----------------|
+| **`actions/cache@v5`** (SHA-keyed) | Handles concurrent access well, no storage limits per run | 10 GB per-repo limit, LRU eviction | **Primary approach** |
+| **Remote Maven Build Cache** (S3/GCS-backed) | Content-addressable, cross-job reuse, incremental | Requires infrastructure (S3 bucket), cache extension already installed | **Evaluate for Phase 2.5** |
+| **`actions/upload-artifact@v4`** | Simple, per-run isolation | 10 GB per-run limit, thundering-herd downloads, single point of failure | **Fallback only** for non-Maven outputs |
+| **Develocity (Gradle Enterprise for Maven)** | Full build cache + build scan analytics | Commercial license, infrastructure | **Future evaluation** |
+
+### Scaling Risks
+
+- **Single point of failure**: The build-artifacts job becomes a critical path bottleneck. If it fails, everything waits. Today's redundant builds are embarrassingly parallel.
+- **Thundering herd**: 40+ downstream jobs simultaneously downloading a multi-GB artifact can cause download failures — a new source of CI flakiness.
+- **Storage limits**: `~/.m2/repository/io/camunda` for 144 modules may be several hundred MB to multiple GB. Measure the actual size before committing.
+
+### Implementation Steps
+
+1. **Measure first**: Run a full build and measure the size of `~/.m2/repository/io/camunda`
+2. **Primary**: Use `actions/cache@v5` keyed by `hashFiles('**/pom.xml')-${{ github.sha }}` — better concurrent access handling than artifacts
+3. **Selective sharing**: Share only `~/.m2/repository/io/camunda`, not the entire workspace
+4. **Graceful fallback**: If cache restore fails, the job should fall back to building locally (like today) rather than failing the entire pipeline
+5. **Cleanup**: Set `retention-days: 1` on any artifacts to prevent storage bloat
+6. Phase in: start with unit test jobs, then integration tests
+7. **Evaluate remote cache**: Investigate S3/GCS-backed Maven Build Cache (the extension is already installed at `.mvn/maven-build-cache-config.xml`) as a more robust long-term solution
+
+---
+
+## 5.2 Share Frontend Build Outputs
+
+**Impact**: Save ~18-48 min in deploy jobs
+**Risk**: Low
+**Effort**: Medium
+
+The `build-platform-frontend` job already builds all 4 frontends. Upload the output:
+
+```yaml
+build-platform-frontend:
+  steps:
+    # ... existing build steps ...
+    - uses: actions/upload-artifact@v4
+      with:
+        name: frontend-builds
+        path: |
+          operate/client/build/
+          tasklist/client/build/
+          identity/client/build/
+
+deploy-snapshots:
+  needs: [check-results, build-platform-frontend]
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: frontend-builds
+    # Skip frontend rebuild, go straight to Maven deploy
+```
+
+---
+
+## 5.3 Add Docker Layer Caching
+
+**Impact**: Faster Docker builds across all workflows
+**Risk**: Low
+**Effort**: Medium
+
+For all `docker/build-push-action` steps, add GHA cache backend:
+```yaml
+- uses: docker/build-push-action@v6
+  with:
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+Applies to:
+- `ci.yml` -> `docker-checks` job
+- `ci-zeebe.yml` -> `docker-checks` job
+- `deploy-camunda-docker-snapshot` job
+- All integration test jobs that build Docker images
+
+---
+
+## 5.4 Consolidate Maven Cache Modifiers
+
+**Impact**: Better cache reuse across jobs
+**Risk**: Low
+**Effort**: Low
+
+Reduce from ~20+ unique cache key modifiers to 4:
+
+| Modifier | Used By |
+|----------|---------|
+| `build` | Build artifact job |
+| `test-ut` | All unit test jobs |
+| `test-it` | All integration test jobs |
+| `deploy` | Deploy jobs |

--- a/docs/ci-cd/phase-3-test-strategy.md
+++ b/docs/ci-cd/phase-3-test-strategy.md
@@ -1,0 +1,114 @@
+# Phase 3: Test Strategy Restructuring (Week 8-16)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Shift left in the testing pyramid — faster feedback, more reliable tests. Adopt the [Testing Strategy Manifesto](../testing-strategy/README.md) as the binding standard for all new work.
+
+> **Prerequisite**: Phase 1 (flaky test remediation) must be substantially complete. The pipeline
+> must be reliable before restructuring what tests run where.
+>
+> **Important**: Activate enforcement rules (ArchUnit, ESLint) *before* socializing the manifesto.
+> Automated enforcement is more effective than cultural change alone.
+
+---
+
+## 6.1 Adopt the Testing Strategy Manifesto
+
+The [Testing Strategy Manifesto](../testing-strategy/README.md) defines:
+- What tests are required for every change type (feature, bugfix, incident, refactoring)
+- [Prohibited patterns](../testing-strategy/prohibited-patterns.md) (Thread.sleep, waitForTimeout, JUnit 4 in new code, etc.)
+- [Required patterns](../testing-strategy/required-patterns.md) (given/when/then, Awaitility, TestSearchContainers, Page Object Model)
+- [Naming conventions](../testing-strategy/naming-conventions.md), [framework choices](../testing-strategy/setup/frameworks-and-tools.md), and [enforcement mechanisms](../testing-strategy/setup/enforcement-rules.md)
+- The PR checklist that every code change must satisfy
+
+**Action**: Socialize the manifesto with all teams, integrate it into `CONTRIBUTING.md`, and create a PR template with the testing checklist.
+
+---
+
+## 6.2 Establish the Testing Pyramid
+
+For the full testing pyramid definition and layer details, see the [Testing Strategy README](../testing-strategy/README.md).
+
+**Current state** (estimated):
+```
+       /    E2E + ITs    \     ~50%+ of test time — slow, external-service-dependent
+      /    Unit Tests      \   ~50% — includes 804 JUnit 4 files
+```
+
+**Target state**:
+```
+        /  E2E  \          < 5% of test time, nightly only
+       /  Contract \        ~10% — API contract verification
+      / Integration  \      ~20% — focused, TestContainers-based
+     /    Unit Tests    \   ~65% — fast, isolated, no external deps
+```
+
+---
+
+## 6.3 Strengthen API Contract Validation
+
+**Impact**: Catch API breaking changes fast without full E2E
+**Risk**: Low
+**Effort**: Medium (Tier 2) to High (Tier 3)
+
+### Tier 2: Strengthen What Exists (Do Now)
+
+Currently the only contract-like testing is:
+- OpenAPI linting (Spectral) — validates the spec is well-formed
+- Protobuf backward-compat (Buf) — validates gRPC schema compatibility
+- `validateResponse()` in E2E API tests — validates responses match OpenAPI spec (but only runs nightly)
+
+**Immediate improvements** (no new frameworks needed):
+1. **Add OpenAPI backward compatibility checking**: Use `openapi-diff` or `spectral diff` to detect breaking changes between PR and main. This catches field removals, type changes, and endpoint deletions automatically.
+2. **Validate frontend Zod schemas stay in sync with OpenAPI spec**: Add a CI check that compares `@camunda/camunda-api-zod-schemas` against `rest-api.yaml`. This is already partially covered but should be a hard gate.
+3. **Keep Buf for gRPC** (already enforced).
+
+These get ~80% of contract testing value at ~10% of the implementation and maintenance cost.
+
+### Tier 3: Consumer-Driven Contract Testing with Pact (Aspirational)
+
+> **Recommendation**: Defer full Pact adoption until after the team demonstrates it can maintain
+> the basics (zero new `Thread.sleep`, all new tests on JUnit 5, build cache enabled, flaky rate
+> under control). Introducing a new testing framework to a team already struggling with test
+> reliability adds complexity at the wrong time.
+
+If Pact is pursued, start with **PactFlow bidirectional testing** — compare consumer pacts against the existing OpenAPI spec without provider-side test code. This is the lightest-weight approach for a monorepo. See [Contract Tests](../testing-strategy/contract-tests.md) for the full guide.
+
+**Priority contract boundaries** (for when Pact is adopted):
+
+| # | Consumer | Provider | Priority |
+|---|----------|----------|----------|
+| 1 | Java Client (`clients/java/`) | v2 REST API (Zeebe gateway) | **Highest** — public API |
+| 2 | Tasklist Frontend | v2 REST API | High — already typed via `@camunda/camunda-api-zod-schemas` |
+| 3 | Operate Frontend | v2 REST API + legacy `/api/` | High |
+| 4 | Camunda Exporter | ES/OS index schema (Pact message contracts) | Medium |
+| 5 | Optimize Frontend | Optimize Backend REST API | Medium |
+
+---
+
+## 6.4 Classify and Tier Tests for PR vs. Nightly
+
+**Impact**: Faster PR feedback while maintaining comprehensive coverage
+**Risk**: Medium (requires validation that nightly catches regressions)
+**Effort**: Medium
+
+| Tier | When to Run | What | Est. Time |
+|------|-------------|------|-----------|
+| **Tier 1 (PR-blocking)** | Every PR | Unit tests, ArchUnit, linting, contract tests, affected-component ITs | ~15 min |
+| **Tier 2 (PR-non-blocking)** | Every PR | Primary DB ITs (ES8 + H2), component integration tests | ~20 min |
+| **Tier 3 (Nightly)** | Daily schedule | Multi-DB matrix (ES9, OpenSearch, RDBMS variants), full E2E suites, smoke tests on macOS/Windows/ARM | ~60 min |
+| **Tier 4 (Weekly)** | Weekly schedule | Load tests, version compatibility, full cross-browser E2E, AWS OpenSearch | ~120 min |
+
+**Key change**: Move the 7-way database integration test matrix from PR-blocking to nightly. On PRs, run against 2 DB variants (Elasticsearch 8 + one RDBMS) to catch the most common cross-engine compatibility issues while still cutting the matrix by 5x. If nightly tests fail, auto-create issues.
+
+**Nightly failure SLA**: Regressions detected in nightly must have a fix PR opened within 1 business day and merged within 3 business days. This prevents nightly from becoming a dumping ground for ignored failures.
+
+---
+
+## 6.5 Activate `parallel-tests` Profile by Default in CI
+
+**Impact**: Faster test execution across all CI jobs
+**Risk**: Low
+**Effort**: Low
+
+The `parallel-tests` profile (`parent/pom.xml:3114-3165`) enables `forkCount=0.5C` and JUnit 5 parallel execution. It's already used in some CI jobs but not consistently. Add it to all test-running Maven commands.

--- a/docs/ci-cd/phase-4-developer-experience.md
+++ b/docs/ci-cd/phase-4-developer-experience.md
@@ -1,0 +1,134 @@
+# Phase 4: Developer Experience (Week 8-16)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Enable developers to run relevant tests locally in <5 minutes, reducing CI dependency.
+
+---
+
+## 7.1 Optimize Local Build Time
+
+Summary of all local build improvements (many from [Phase 0](./phase-0-quick-wins.md)):
+
+| Change | File | Impact |
+|--------|------|--------|
+| Enable build cache | `.mvn/maven-build-cache-config.xml:10` | 50-80% faster incremental builds |
+| Add `-T1C` default | `.mvn/maven.config` (new) | 30-50% faster full builds |
+| Re-enable incremental compilation | `parent/pom.xml:2379` | Faster recompilation |
+| Add JVM heap config | `.mvn/jvm.config` | Prevents OOM during parallel builds |
+
+**Target**: `mvn install -Dquickly` in <2 minutes.
+
+---
+
+## 7.2 Create a "PR-Ready" Local Test Profile
+
+**Impact**: Gives developers a fast local check before pushing
+**Risk**: Low
+**Effort**: Medium
+
+Add a new Maven profile that runs exactly what CI Tier 1 would run:
+
+```xml
+<profile>
+  <id>pr-ready</id>
+  <properties>
+    <skipITs>true</skipITs>
+    <skipChecks>false</skipChecks>
+  </properties>
+  <!-- Runs: unit tests + archunit checks -->
+  <!-- Skips: integration tests, E2E, Docker -->
+</profile>
+```
+
+Usage: `mvn verify -Ppr-ready -pl <changed-module>` — should complete in <5 minutes for a single module.
+
+---
+
+## 7.3 Add Pre-Push Git Hook (Optional, Opt-in)
+
+**Impact**: Catches basic failures before pushing to CI
+**Risk**: Low (opt-in)
+**Effort**: Low
+
+Offer an opt-in pre-push hook that runs affected-module unit tests:
+```bash
+#!/bin/bash
+# .githooks/pre-push (opt-in via: git config core.hooksPath .githooks)
+CHANGED_MODULES=$(git diff --name-only origin/main | scripts/affected-modules.sh)
+if [ -n "$CHANGED_MODULES" ]; then
+  ./mvnw test -pl "$CHANGED_MODULES" -am -Dquickly=false -DskipITs
+fi
+```
+
+---
+
+## 7.4 Complete JUnit 4 to JUnit Jupiter Migration
+
+**Impact**: Unlocks parallel execution for all tests
+**Risk**: **Medium-High** (automated migration handles syntax but not custom rule semantics)
+**Effort**: High (804 files, expect 8-12 weeks)
+
+> **Note**: The project already uses JUnit 6.0.3 (`parent/pom.xml` `<version.junit>6.0.3</version.junit>`),
+> which is backward-compatible with JUnit 5 Jupiter APIs. The migration target is the Jupiter API,
+> not a specific JUnit version.
+
+Jupiter's `junit.jupiter.execution.parallel.enabled=true` only works with Jupiter tests. The 804 remaining JUnit 4 files run serially even when the `parallel-tests` profile is active.
+
+> **Note**: For the prohibition of JUnit 4 in new code, see [Prohibited Patterns](../testing-strategy/prohibited-patterns.md).
+
+### Prerequisites (Before Running OpenRewrite)
+
+1. **Audit all custom JUnit 4 rules** — grep for classes extending `ExternalResource`, `TestRule`, `MethodRule`, and `@RunWith`. Create a mapping table to their JUnit 5 equivalents. Estimate: 2-3 days.
+2. **Write custom OpenRewrite recipes** for the most common custom rules (e.g., `EngineRule` -> `EngineExtension`). OpenRewrite does NOT know about these custom mappings.
+3. **Run in dry-run mode first** and categorize the 804 files by migration complexity.
+
+### Known Gotchas
+
+- **Custom `@Rule` lifecycle semantics**: `EngineRule` has specific `before()/after()` ordering that may differ from the `@RegisterExtension` lifecycle.
+- **`@RuleChain`**: Tests using `RuleChain` for deterministic ordering require manual conversion to extension ordering.
+- **`@ClassRule` / `@Rule` interaction**: Static vs. instance `@RegisterExtension` fields have subtle lifecycle differences.
+- **`@RunWith(Parameterized.class)`**: Migrates to `@ParameterizedTest` but the data provider mechanism changes completely.
+- **Expect 30-40% manual intervention**: OpenRewrite handles annotation/import changes but produces semantically incorrect tests for complex lifecycle cases.
+
+### Approach
+
+Use OpenRewrite recipe for the mechanical parts:
+```bash
+./mvnw rewrite:run -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit4to5Migration
+```
+
+### Phased Rollout (with validation gaps)
+
+| Phase | Scope | Files | Validation |
+|-------|-------|-------|------------|
+| 1 | Protocol, protocol-impl, msgpack | ~30 | Run full suite 20x, compare flake rates |
+| 2 | Gateway-grpc, exporters, clients | ~50 | Wait 2+ weeks before proceeding |
+| 3 | Zeebe engine | ~200 | Largest batch — review by owning team |
+| 4 | Operate/Tasklist/Optimize | ~300 | Each team reviews their own modules |
+| 5 | Remaining modules | ~200 | Cleanup |
+
+**Migration canary**: For each phase, migrate 5% of the module first, run the full test suite 20 times, and compare flake rates before and after. Only proceed if flake rate is stable.
+
+---
+
+## 7.5 Fix Dead Compiler Configuration in Optimize
+
+**Impact**: Removes confusion in build configuration
+**Risk**: None
+**Effort**: Trivial
+
+In `optimize/backend/pom.xml:760-768`:
+```xml
+<!-- Current — contradictory: fork=false but meminitial/maxmem only apply when fork=true -->
+<configuration>
+  <fork>false</fork>
+  <meminitial>128m</meminitial>
+  <maxmem>256m</maxmem>
+</configuration>
+
+<!-- Fix — remove dead configuration -->
+<configuration>
+  <fork>false</fork>
+</configuration>
+```

--- a/docs/ci-cd/phase-5-pipeline-architecture.md
+++ b/docs/ci-cd/phase-5-pipeline-architecture.md
@@ -1,0 +1,116 @@
+# Phase 5: Pipeline Architecture for CD (Week 12-20)
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+**Goal**: Achieve a CI pipeline that supports continuous delivery — fast, reliable, and trustworthy.
+
+---
+
+## 8.1 Target Pipeline Architecture
+
+```
+PR Push
+  |
+  +- [Tier 0: ~1 min] Lint + Format
+  |   actionlint, spotless, eslint, commitlint, openapi, protobuf
+  |
+  +- [Tier 1: ~5 min] Build Artifacts (single job, shared via artifacts)
+  |    |
+  |    +- [Tier 2: ~8 min] Unit Tests (parallel, affected modules only)
+  |    +- [Tier 2: ~8 min] Contract Tests (API compatibility)
+  |    +- [Tier 2: ~3 min] ArchUnit + Static Analysis
+  |    |
+  |    +- [Tier 3: ~15 min] Integration Tests (primary DB only, affected components)
+  |    |
+  |    +- [Gate] check-results <- All green = mergeable
+  |
+  Merge to main (via merge queue)
+  |
+  +- [Deploy: ~10 min] Snapshot deploy + Docker image push
+  |
+  Nightly
+  |
+  +- Full DB matrix (ES8, ES9, OpenSearch, H2, PostgreSQL, AWS OS)
+  +- Cross-browser E2E (Chromium, Firefox, Edge)
+  +- Smoke tests (Linux, macOS, Windows, ARM)
+  +- Load tests
+  +- Version compatibility tests
+```
+
+**Target PR wall-clock time: ~20 minutes** (down from ~55 minutes)
+
+---
+
+## 8.2 Leverage Statsig Feature Flags for Safe Deployment
+
+**Impact**: Enables true continuous delivery — deploy != release
+**Risk**: None (infrastructure already exists)
+**Effort**: Low (process adoption)
+
+Statsig is already in place as the feature flag platform. This is a critical CD enabler:
+
+- **Incomplete features merge to `main` safely** — wrap in-progress work behind Statsig gates so it can be deployed without being released to users
+- **Progressive rollouts** — new features roll out to 1% -> 10% -> 50% -> 100% with automatic rollback if error rates spike
+- **Testing in production** — enable features for internal users or specific tenants before general availability
+- **Decoupled deploy/release** — deployments happen continuously; feature releases are a business decision, not an engineering event
+
+**Policy for CD readiness**: Any feature that takes more than one PR to complete must be gated behind a Statsig feature flag. This eliminates the need for long-lived feature branches and allows `main` to always be deployable.
+
+---
+
+## 8.3 Right-Size Runner Specifications
+
+| Current | Proposed | Jobs Affected |
+|---------|----------|---------------|
+| `gcp-core-32-default` | `gcp-perf-core-16-default` | Legacy Operate/Optimize ITs |
+| `gcp-perf-core-16-default` for small UT modules | `gcp-perf-core-8-default` | Protocol, Gateway, Client unit tests |
+| 120-min timeouts | 30-min max | All jobs |
+
+---
+
+## 8.4 Implement Strict Merge Queue
+
+**Impact**: Ensures only green code merges to `main`
+**Risk**: Medium (requires flakiness to be under control)
+**Effort**: Medium
+
+Replace current `continue-on-error` merge queue with strict enforcement:
+- All Tier 1-3 tests must pass (no `continue-on-error`)
+- Merge queue batches up to 5 PRs for combined testing
+- Failed batches bisect to find the offending PR
+- Flaky test budget enforced at merge time
+
+---
+
+## 8.5 Reduce Total Workflow Count
+
+**Impact**: Simpler maintenance, fewer duplicate jobs
+**Risk**: Medium
+**Effort**: High
+
+Target: reduce from 121 workflows to ~60-70 by:
+1. Removing all legacy duplicate workflows (Phase 0)
+2. Consolidating scheduled workflows (combine `zeebe-daily-qa`, `zeebe-search-integration-tests`, `zeebe-rdbms-integration-tests` into a single nightly matrix)
+3. Unifying release workflows into a single parameterized workflow
+
+---
+
+## 8.6 Future: Deployment Safety (Monitoring, Canary, Rollback)
+
+> **Status**: Future improvement — out of scope for the initial CD pipeline work, but essential for
+> full continuous deployment maturity.
+
+Camunda has two distinct distribution models, each with different deployment safety requirements:
+
+| Concern | SaaS | Self-Hosted / Self-Managed |
+|---------|------|---------------------------|
+| **Canary deployments** | Roll out to a subset of SaaS clusters before full fleet | N/A — customers control their own upgrade schedule |
+| **Automated rollback** | Auto-revert if error rates or latency SLOs breach thresholds post-deploy | Provide rollback documentation and tested downgrade paths |
+| **Health monitoring gates** | Post-deploy health checks (error rate, p99 latency, Zeebe throughput) must pass before promoting to next cluster ring | Ship health check endpoints and upgrade verification scripts customers can run |
+| **Deploy/release separation** | Statsig gates control feature visibility independently of deployment | Statsig gates + version-gated feature enablement |
+| **Upgrade compatibility testing** | Tested in CI (rolling update, version compatibility) | Must also test customer-facing upgrade paths (Helm chart, Docker Compose, manual) |
+| **Rollback scope** | Platform team controls full rollback | Customers need clear rollback procedures per distribution (Helm rollback, Docker tag pinning, etc.) |
+
+**Key principle**: CD for Camunda means `main` is always deployable to SaaS *and* releasable as a Self-Managed artifact. The CI pipeline (Phases 0-5) ensures code quality; deployment safety mechanisms ensure the *release process* is safe for both distribution models.
+
+These topics should be scoped as a follow-up initiative once the pipeline achieves the Phase 5 targets (~20 min PR, <2% flaky rate, strict merge queue).

--- a/docs/ci-cd/priority-summary.md
+++ b/docs/ci-cd/priority-summary.md
@@ -1,0 +1,44 @@
+# Priority Summary
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+| # | Action | Phase | Effort | Impact | Risk |
+|---|--------|-------|--------|--------|------|
+| | **[Phase 0 — Quick Wins (Week 1-2)](./phase-0-quick-wins.md)** | | | | |
+| 1 | Disable legacy duplicate workflows | 0 | Low | High | Low |
+| 2 | Create `.mvn/maven.config` with `-T1C` | 0 | Trivial | Medium | Low |
+| 3 | Enable Maven build cache | 0 | Low | High | Medium |
+| 4 | Fix `${env.LIMITS_CPU}` forkCount | 0 | Low | High | Low |
+| 5 | Fix Playwright `actionTimeout: 0` | 0 | Trivial | Medium | Low |
+| 6 | Fix `skip.docker` double definition | 0 | Trivial | Low | Low |
+| 7 | Add JVM heap to `.mvn/jvm.config` | 0 | Trivial | Low | Low |
+| 8 | Re-enable incremental compilation | 0 | Trivial | Low | Low |
+| | **[Phase 1 — Flaky Test Remediation (Week 2-6)](./phase-1-flaky-test-remediation.md)** | | | | |
+| 9 | Establish flaky test budget + quarantine policy | 1 | Low | **Highest** | Medium |
+| 10 | Replace `Thread.sleep` in 52 test files | 1 | Medium | High | Low |
+| 11 | Replace Playwright `waitForTimeout` (15 occurrences) | 1 | Low | High | Low |
+| 12 | Reduce `rerunFailingTestsCount` progressively (3 -> 2 -> 1) | 1 | Low | High | Medium |
+| 13 | Create flaky test issue template | 1 | Trivial | Medium | None |
+| 14 | Triage disabled tests backlog (139 files) | 1 | High | Medium | Low |
+| 15 | Triage 97 AWS OpenSearch disabled tests | 1 | High | Medium | Low |
+| 16 | Add ArchUnit rule to ban `Thread.sleep` in tests | 1 | Medium | Medium | Low |
+| 17 | Add ESLint rule to ban `waitForTimeout` | 1 | Low | Medium | Low |
+| 18 | Fix merge queue `continue-on-error` | 1 | Trivial | High | Medium |
+| | **[Phase 2 — Build Artifact Sharing (Week 2-8)](./phase-2-build-artifact-sharing.md)** | | | | |
+| 19 | **Shared build artifact job** | 2 | **High** | **Highest** | Medium |
+| 20 | Share frontend build outputs | 2 | Medium | Medium | Low |
+| 21 | Docker layer caching | 2 | Medium | Medium | Low |
+| 22 | Consolidate Maven cache modifiers | 2 | Low | Low | Low |
+| | **[Phase 3 — Test Strategy Restructuring (Week 8-16)](./phase-3-test-strategy.md)** | | | | |
+| 23 | Adopt Testing Strategy Manifesto | 3 | Medium | High | Low |
+| 24 | Strengthen API contract validation (OpenAPI diff, Zod sync) | 3 | Medium | High | Low |
+| 25 | Move DB matrix to nightly (PR runs 2 DB variants) | 3 | Medium | High | Medium |
+| 26 | Activate `parallel-tests` profile by default in CI | 3 | Low | Medium | Low |
+| | **[Phase 4 — Developer Experience (Week 12-20)](./phase-4-developer-experience.md)** | | | | |
+| 27 | JUnit 4 to Jupiter migration (804 files) | 4 | High | Medium | **Medium-High** |
+| 28 | Create PR-ready local test profile | 4 | Medium | High | Low |
+| | **[Phase 5 — Pipeline Architecture for CD (Week 16-24)](./phase-5-pipeline-architecture.md)** | | | | |
+| 29 | Leverage Statsig feature flags for safe deployment | 5 | Low | High | None |
+| 30 | Strict merge queue (remove `continue-on-error`) | 5 | Medium | High | Medium |
+| 31 | Right-size runners | 5 | Low | Medium | Low |
+| 32 | Consolidate workflow count (121 -> ~60-70) | 5 | High | Medium | Medium |

--- a/docs/ci-cd/reference/detailed-findings.md
+++ b/docs/ci-cd/reference/detailed-findings.md
@@ -1,0 +1,79 @@
+# Detailed Findings by Area
+
+> Back to [CI/CD Improvement Plan](../README.md)
+
+## B.1 Maven Build Configuration
+
+| Finding | Severity | File:Line | Description |
+|---------|----------|-----------|-------------|
+| Build cache disabled | CRITICAL | `.mvn/maven-build-cache-config.xml:10` | Extension installed but `<enabled>false</enabled>` |
+| `${env.LIMITS_CPU}` forkCount | CRITICAL | `operate/pom.xml:66`, `tasklist/pom.xml:61,74` | Resolves to null when env var unset -> no test isolation |
+| No `.mvn/maven.config` | WARNING | (missing file) | No default parallel builds |
+| No JVM heap in jvm.config | WARNING | `.mvn/jvm.config` | Risk of OOM during parallel builds |
+| `useIncrementalCompilation=false` | WARNING | `parent/pom.xml:2379` | Stale workaround for bug fixed in 3.13+ |
+| `skip.docker` double definition | WARNING | `optimize/pom.xml:86,88` | Docker always starts regardless of skipTests |
+| `parallel-tests` profile not default | IMPROVEMENT | `parent/pom.xml:3114` | Tests run serially unless explicitly opted in |
+| Dead compiler config in optimize | IMPROVEMENT | `optimize/backend/pom.xml:760-768` | `fork=false` with meminitial/maxmem (only apply when fork=true) |
+| Node.js downloaded 4 times | IMPROVEMENT | Frontend pom.xml files | Each frontend module installs Node independently |
+
+## B.2 Flaky Test Indicators
+
+| Pattern | Count | Key Examples |
+|---------|-------|-------------|
+| `@Disabled` annotations | 136 files | `GlobalJobStatisticsIT` (flaky), `HistoryCleanupIT` (flaky #35023) |
+| `@Ignore` annotations | 9 files | `ModifyProcessInstanceOperationZeebeIT` ("Due to flaky CI tests") |
+| Disabled on AWS OpenSearch | 97 files | `@DisabledIfSystemProperty(matches = "AWS_OS")` |
+| `Thread.sleep()` in tests | 52 files | `GlobalJobStatisticsIT`, `RaftTest`, `SwimProtocolTest` |
+| "flaky" in code comments | 19 locations | `RdbmsTableNames`, `MessageCorrelationTest`, `EmbeddedSubProcessConcurrencyTest` |
+| `page.waitForTimeout()` | 15 occurrences | All in Operate Playwright tests |
+| `continue-on-error` in workflows | 90+ instances | Some mask real failures in merge queue context |
+| `rerunFailingTestsCount` | Every test job | 2-3 retries, masking real failure rates |
+
+## B.3 Test Infrastructure Summary
+
+| Category | Count | Frameworks |
+|----------|-------|------------|
+| Java test files with `@Test` | ~3,000+ | JUnit 5, JUnit 4, Mockito, AssertJ |
+| Integration test files (`*IT.java`) | ~300+ | TestContainers, SpringBootTest, Failsafe |
+| TestContainers usage | 89 files | Docker containers for ES/OS/S3/GCS/Azure/PG |
+| WireMock usage | 100+ files | HTTP mocking |
+| Playwright spec files | ~160+ | Chromium, Firefox, Edge |
+| ArchUnit test files | 19 | Architecture validation |
+| Awaitility usage | 200+ files | Async test patterns (should be higher) |
+| JUnit 4 files remaining | ~804 | Migration to JUnit 5 needed |
+
+## B.4 Runner Usage per PR
+
+| Runner | Cores | Approx. Jobs Per PR |
+|--------|-------|-------------------|
+| `ubuntu-latest` | 2-4 | ~15 |
+| `gcp-perf-core-8-default` | 8 | ~10 |
+| `gcp-perf-core-16-default` | 16 | ~15 |
+| `gcp-perf-core-16-longrunning` | 16 | ~4 |
+| `gcp-core-4-default` | 4 | ~1 |
+| `gcp-core-8-default` | 8 | ~2 |
+| `gcp-core-32-default` | 32 | ~3 (legacy only) |
+| `macos-latest` | - | ~1 |
+| `windows-latest` | - | ~1 |
+| `aws-arm-core-4-longrunning` | 4 | ~1 |
+
+## B.5 CI Critical Path Analysis
+
+```
+detect-changes (~2 min)
+  |
+  +-- [Parallel Tier 2]
+  |   +-- integration-tests matrix (30 min timeout, longest chain)
+  |   +-- database-integration-tests x7 (20 min each)
+  |   +-- zeebe-unit-tests x7 (10 min each)
+  |   +-- general-unit-tests (10 min)
+  |   +-- sub-workflows (operate/tasklist/optimize/zeebe CI)
+  |
+  check-results (~1 min)
+  |
+  +-- deploy-snapshots (~20 min)
+  +-- deploy-camunda-docker-snapshot (~15 min, parallel)
+```
+
+**Current critical path: ~55 min (PR), ~75 min (main with deploys)**
+**Target critical path: ~20 min (PR), ~30 min (main with deploys)**

--- a/docs/ci-cd/reference/workflow-inventory.md
+++ b/docs/ci-cd/reference/workflow-inventory.md
@@ -1,0 +1,51 @@
+# GitHub Actions Workflow Inventory
+
+> Back to [CI/CD Improvement Plan](../README.md)
+
+## Primary CI Workflows
+
+| # | File | Name | Trigger |
+|---|------|------|---------|
+| 1 | `ci.yml` | Camunda CI | push (main/stable), PR, merge_group, schedule (daily 06:00 UTC) |
+| 2 | `ci-zeebe.yml` | Zeebe CI | workflow_call from ci.yml |
+| 3 | `ci-operate.yml` | Operate CI | workflow_call from ci.yml |
+| 4 | `ci-tasklist.yml` | Tasklist CI | workflow_call from ci.yml |
+| 5 | `ci-optimize.yml` | Optimize CI | workflow_call from ci.yml |
+| 6 | `ci-client-components.yml` | Client Components CI | workflow_call from ci.yml |
+
+## Reusable Workflows
+
+| # | File | Called By | Times Called |
+|---|------|----------|-------------|
+| 7 | `ci-database-integration-tests-reusable.yml` | ci.yml, scheduled workflows | 7+ |
+| 8 | `ci-webapp-run-ut-reuseable.yml` | Operate/Tasklist/Optimize CI | 6 |
+| 9 | `operate-ci-build-reusable.yml` | Legacy Operate CI | 1 |
+| 10 | `operate-ci-test-reusable.yml` | Legacy Operate CI | 1 |
+| 11 | `tasklist-ci-build-reusable.yml` | Tasklist workflows | 1 |
+| 12 | `tasklist-ci-test-reusable.yml` | Tasklist workflows | 1 |
+| 13 | `optimize-ci-build-reusable.yml` | Legacy Optimize workflows | 1 |
+| 14 | `generate-snapshot-docker-tag-and-concurrency-group.yml` | ci.yml, deploy workflows | Multiple |
+
+## Legacy/Duplicate Workflows (Candidates for Removal)
+
+| # | File | Name | Overlap |
+|---|------|------|---------|
+| 15 | `operate-ci.yml` | [Legacy] Operate | ci.yml -> ci-operate.yml |
+| 16 | `operate-docker-tests.yml` | [Legacy] Operate / Docker | ci.yml -> docker-checks |
+| 17 | `optimize-ci-core-features.yml` | [Legacy] Optimize Core Features | ci.yml -> ci-optimize.yml |
+| 18 | `optimize-ci-data-layer.yml` | [Legacy] Optimize Data Layer | ci.yml -> database ITs |
+| 19 | `optimize-e2e-tests-sm.yml` | [Legacy] Optimize E2E SM | Nightly E2E |
+
+## Scheduled/Nightly Workflows
+
+| # | File | Schedule | Purpose |
+|---|------|----------|---------|
+| 20 | `zeebe-daily-qa.yml` | Weekdays 01:00 UTC | QA testbench across stable branches |
+| 21 | `camunda-daily-load-tests.yml` | Daily 04:00 UTC | Max load test |
+| 22 | `camunda-weekly-load-tests.yml` | Weekly | Extended load tests |
+| 23 | `zeebe-weekly-e2e.yml` | Weekly | E2E tests |
+| 24 | `zeebe-search-integration-tests.yml` | Weekdays 05:00 UTC | Multi-version ES/OS tests (6 matrix) |
+| 25 | `zeebe-rdbms-integration-tests.yml` | Weekdays 05:00 UTC | Multi-vendor RDBMS tests (13 matrix) |
+| 26 | `zeebe-version-compatibility.yml` | Daily 06:00 UTC | Rolling update compatibility |
+| 27 | `statistics-daily.yml` | Daily | Flaky test stats + Slack |
+| 28 | `statistics-weekly.yml` | Weekly | Weekly stats + Slack |

--- a/docs/ci-cd/root-cause-analysis.md
+++ b/docs/ci-cd/root-cause-analysis.md
@@ -1,0 +1,43 @@
+# Root Cause Analysis
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+## Root Causes of Slowness
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| S1 | No shared build artifacts — every test job independently runs full `mvn install -DskipTests` | `.github/actions/build-zeebe` called ~75 times across 22 workflow files | ~200-600 runner-minutes wasted per PR |
+| S2 | Legacy workflows run in parallel with unified CI | `operate-ci.yml`, `optimize-ci-core-features.yml`, etc. | Doubles compute for Operate/Optimize PRs |
+| S3 | Frontend builds repeated — `build-platform-frontend` output never shared | `deploy-snapshots` and `deploy-docker` rebuild all 3 frontends | 18-48 min wasted in deploy jobs |
+| S4 | No Docker layer caching | `docker/build-push-action` without `cache-from`/`cache-to` | Slow Docker builds across all workflows |
+| S5 | Maven build cache disabled | `.mvn/maven-build-cache-config.xml:10` — `<enabled>false</enabled>` | No incremental build benefit |
+| S6 | No default parallel module builds | No `.mvn/maven.config` with `-T1C` | Modules build serially by default |
+| S7 | `parallel-tests` profile not activated by default | `parent/pom.xml:3114` requires explicit `-Pparallel-tests` | Tests run serially by default |
+| S8 | `useIncrementalCompilation=false` | `parent/pom.xml:2379` — stale workaround for bug fixed in compiler plugin 3.13+ | Slower recompilation |
+| S9 | Database integration tests run full matrix on every PR | 7 DB variants on every PR | Each variant takes ~20 min on gcp-perf-core-16 |
+| S10 | Node.js downloaded 4 times per build | Each frontend module independently installs Node via `frontend-maven-plugin` | ~2-4 min wasted |
+
+## Root Causes of Flakiness
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| F1 | `${env.LIMITS_CPU}` forkCount resolves to null when unset | `tasklist/pom.xml:61,74` (operate already uses `testForkCount` property but defaults to `${env.LIMITS_CPU}`) | forkCount=0 -> no test isolation -> shared JVM state pollution |
+| F2 | Retry-as-a-strategy masks flakiness | `rerunFailingTestsCount=3` on every job | Tests failing 66% of the time appear "green" |
+| F3 | `Thread.sleep()` in 52 test files | Hardcoded timing waits instead of polling | Timing-dependent failures on varying CI load |
+| F4 | Playwright `actionTimeout: 0` | `operate/client/playwright.config.ts`, `tasklist/client/playwright.config.ts` | Stuck selectors hang indefinitely |
+| F5 | 15 hardcoded `waitForTimeout()` in Playwright | All in Operate client E2E tests | Fragile timing on varying CI load |
+| F6 | `continue-on-error` in CI workflows | `ci.yml:989` is on the Hadolint SARIF upload step (not a test step); however, 26 `continue-on-error` instances in `ci.yml` and 90+ across all workflows need systematic audit | Some may mask real failures in observability/reporting steps |
+| F7 | 97 tests blanket-disabled on AWS OpenSearch | `@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")` | Entire DB backend has degraded test coverage |
+| F8 | Database cleanup ordering sensitivity | `RdbmsTableNames.java:20-23` — FK ordering is a known flakiness source | Adding a table in wrong order breaks `RdbmsPurgerIT` |
+| F9 | Race conditions in test helpers | `ElasticsearchSetupHelperTest.java:169` — explicit "race condition" comment | Non-deterministic test behavior |
+| F10 | `skip.docker` double definition | `optimize/pom.xml:86,88` — second definition always wins | Docker containers start even when `skipTests=true` |
+
+## Root Causes of Developer CI Dependency
+
+| # | Root Cause | Evidence | Impact |
+|---|-----------|----------|--------|
+| D1 | Build cache disabled | `.mvn/maven-build-cache-config.xml:10` | Full rebuild every time locally |
+| D2 | No default `-T1C` parallel builds | No `.mvn/maven.config` | Serial module builds by default |
+| D3 | No JVM heap configuration | `.mvn/jvm.config` exists but only has `--add-exports`/`--add-opens` flags, no `-Xmx` | OOM during parallel builds |
+| D4 | No "PR-ready" local test profile | Only `quickly` (skips ALL tests) exists | No middle ground between "skip all" and "run all" |
+| D5 | 804 JUnit 4 test files | Can't use JUnit 5 parallel execution | Slower test execution locally |

--- a/docs/ci-cd/success-metrics.md
+++ b/docs/ci-cd/success-metrics.md
@@ -1,0 +1,16 @@
+# Success Metrics
+
+> Back to [CI/CD Improvement Plan](./README.md)
+
+| Metric | Current | Phase 0+1 (Wk 1-6) | Phase 2+3 (Wk 8-16) | Phase 4+5 (CD) |
+|--------|---------|---------------------|----------------------|----------------|
+| **PR wall-clock time** | ~55 min | ~45 min | ~25 min | ~20 min |
+| **Compute cost per PR** | Baseline | -30% | -55% | -65% |
+| **Flaky test rate** | Unknown (masked by 3x retries) | <10% (measured) | <5% | <2% |
+| **CI retriggers per PR** | Multiple (daily pain) | <1 per PR | ~0 | 0 |
+| **`rerunFailingTestsCount`** | 3 | 2 | 1 | 0-1 |
+| **Local `mvn install -Dquickly`** | ~5-10 min | ~3-5 min | ~2-3 min | <2 min |
+| **Tests disabled for flakiness** | 139+ files | <80 (triaged) | <30 | <10 |
+| **Devs running tests locally** | Rarely | Some | Most | Standard |
+| **Time to deploy after merge** | ~20 min | ~15 min | ~10 min | <10 min |
+| **Main branch red rate** | Unknown | Measured | <5% | <1% |

--- a/docs/monorepo-docs/index.md
+++ b/docs/monorepo-docs/index.md
@@ -21,6 +21,10 @@ There you'll find anything to get started using Camunda 8, best practices, and r
 - Code review and integration expectations
 - How all teams can independently own and maintain their workflows
 
+### CI/CD Improvement Plan
+
+**[CI/CD Improvement Plan](../ci-cd/README.md)** - Comprehensive plan for achieving continuous delivery in the Camunda monorepo, including phase-by-phase improvements from quick wins to full pipeline architecture, success metrics, and priority-ranked action items.
+
 ### CI & Automation
 
 **[CI & Automation](./ci)** - Complete guide to continuous integration and automation processes including:

--- a/docs/testing-strategy-consolidated.md
+++ b/docs/testing-strategy-consolidated.md
@@ -1,0 +1,1548 @@
+# Testing Strategy Manifesto — Consolidated Document
+
+> This is a consolidated version of the Testing Strategy Manifesto for easier reading and import. For the structured version, see the [`docs/testing-strategy/`](./testing-strategy/) folder.
+
+**Camunda 8 Monorepo** | **Status**: DRAFT — Pending team review and adoption
+
+> Every line of production code that reaches `main` must be backed by automated tests
+> that are fast, deterministic, and maintainable. If you can't run it locally in minutes,
+> it belongs in nightly — not in your PR.
+
+---
+
+## Guiding Principles
+
+1. **Tests are a first-class deliverable** — A feature without tests is not done. A bugfix without a regression test is incomplete.
+2. **Optimize for developer feedback speed** — A test that takes 20 minutes and fails intermittently is worse than no test.
+3. **Determinism over coverage** — A deterministic suite with 70% coverage beats a flaky suite with 90%.
+4. **Test at the lowest possible level** — Unit > Integration > E2E. Higher-level tests are slower, flakier, and harder to debug.
+5. **Tests must be runnable locally** — If it requires infrastructure that can't be replicated locally, it belongs in nightly.
+
+---
+
+## The Testing Pyramid
+
+```
+                    /    E2E    \                 Nightly only. < 5% of test time.
+                   /  Contract   \              PR-blocking. Fast. ~10% of test time.
+                  /  Integration  \            PR-blocking (primary DB). ~20% of test time.
+                 /    Unit Tests   \         PR-blocking. Fast. ~65% of test time.
+                /___________________\
+```
+
+| Layer | Scope | External Deps | Target Time | When |
+|-------|-------|---------------|-------------|------|
+| **Unit** | Single class/function | None (mocked) | < 100ms/test | Every PR, locally |
+| **Integration** | Multiple components | TestContainers | < 30s/test | PR (primary DB), nightly (matrix) |
+| **Contract** | API boundary | None (mock consumer/provider) | < 1s/test | Every PR |
+| **E2E** | Full system | Full running system | < 2 min/test | Nightly, release |
+| **Architecture** | Code structure | None | < 10s total | Every PR |
+| **Performance** | Throughput/latency | Full running system | Minutes-hours | Weekly, release |
+
+---
+
+## Test Requirements by Change Type
+
+| Change Type | Required Tests |
+|-------------|---------------|
+| **New feature** | Unit tests for all public classes/methods; integration test if DB/search/external; contract test if REST/gRPC endpoint; update affected tests |
+| **Bug fix** | Regression test (`@RegressionTest`) at lowest possible level |
+| **Incident** | Regression test; integration test if data corruption; contract test if cross-service; post-mortem identifies correct layer |
+| **Refactoring** | All existing tests pass without modification (or PR explains why) |
+| **Dependency update** | All existing tests pass; contract tests if public API affected |
+
+---
+
+## PR Checklist
+
+Every PR that modifies production code must satisfy:
+
+- [ ] **Tests added or updated** — Every public change is verified by an automated test
+- [ ] **Bug fixes include regression test** — annotated with `@RegressionTest`
+- [ ] **No `Thread.sleep()` in test code** — use Awaitility or `expect.poll()`
+- [ ] **No `waitForTimeout()` in Playwright tests** — use assertion-based waiting
+- [ ] **Test naming follows conventions** — `should<Verb><Object>` for Java, descriptive text for Playwright
+- [ ] **Given/When/Then structure** — all test methods use the structured comment pattern
+- [ ] **Integration tests use `*IT.java` suffix** — executed by Failsafe
+- [ ] **TestContainers use `TestSearchContainers` factory** — not hardcoded image tags
+- [ ] **No `@Disabled` without issue link** — every disabled test tracks a resolution
+- [ ] **New/modified REST/gRPC endpoints have contract tests** — Pact consumer test per consumer, Buf for gRPC
+
+---
+
+## Detailed Guides
+
+| Guide | Description |
+|-------|-------------|
+| Unit Tests | Rules, gold standard examples |
+| Integration Tests | TestContainers, Spring slicing, patterns |
+| Contract Tests | Consumer-driven contract testing with Pact |
+| E2E Tests | Playwright rules, Page Object Model |
+| Architecture Tests | ArchUnit rules and coverage |
+| Performance & Reliability Tests | JMH, chaos engineering |
+| Prohibited Patterns | 8 anti-patterns with examples |
+| Required Patterns | 6 required patterns with examples |
+| Naming Conventions | File suffixes, method naming, locations |
+| Flaky Test Policy | Budget, quarantine, runbook, root causes |
+| Test Data Management | Isolation, builders, Instancio |
+
+## Setup & Configuration
+
+| Guide | Description |
+|-------|-------------|
+| Frameworks and Tools | Mandatory/prohibited frameworks, versions |
+| Enforcement Rules | ArchUnit, ESLint, Checkstyle config |
+| Pact Setup | Dependencies, broker, CI YAML |
+
+## Reference
+
+| Guide | Description |
+|-------|-------------|
+| Examples | Gold standard file paths, utilities |
+
+---
+
+# Unit Tests
+
+## Definition
+
+A unit test verifies a single class or function in complete isolation. All collaborators are mocked or stubbed. No I/O, no network, no database, no file system, no Docker containers.
+
+## Rules
+
+1. **One assertion focus per test** — test a single behavior, not multiple scenarios
+2. **Given/When/Then structure** — every test must use `// given`, `// when`, `// then` comments
+3. **No shared mutable state** — use `@BeforeEach` for per-test setup, never static mutable fields
+4. **Mock external dependencies** — use `@ExtendWith(MockitoExtension.class)` and `@Mock` / `@InjectMocks`
+5. **Fast** — individual unit tests should execute in < 100ms. If a "unit test" needs > 1 second, it's an integration test
+6. **No Spring context** — unit tests must never use `@SpringBootTest`, `@WebMvcTest`, or any Spring test annotation that loads an application context
+
+## Gold Standard Example
+
+From `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java`:
+
+```java
+class BatchOperationPageProcessorTest {
+
+  private static final long BATCH_OPERATION_KEY = 123L;
+  private static final int CHUNK_SIZE = 2;
+
+  private BatchOperationPageProcessor processor;
+  private TaskResultBuilder mockTaskResultBuilder;
+
+  @BeforeEach
+  void setUp() {
+    processor = new BatchOperationPageProcessor(CHUNK_SIZE);
+    mockTaskResultBuilder = mock(TaskResultBuilder.class);
+  }
+
+  @Test
+  void shouldProcessPageWithSingleChunk() {
+    // given
+    final var item1 = new Item(100L, 200L, null);
+    final var item2 = new Item(101L, 201L, null);
+    final var page = new ItemPage(List.of(item1, item2), "cursor123", 2L, false);
+    when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
+
+    // when
+    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+
+    // then
+    assertThat(result.chunksAppended()).isTrue();
+    assertThat(result.endCursor()).isEqualTo("cursor123");
+    assertThat(result.itemsProcessed()).isEqualTo(2);
+    assertThat(result.isLastPage()).isFalse();
+  }
+}
+```
+
+**Why this is the standard:**
+- Clear naming: `shouldProcessPageWithSingleChunk`
+- Constants are named: `BATCH_OPERATION_KEY`, `CHUNK_SIZE`
+- `@BeforeEach` creates fresh instances — no shared state
+- Single behavior per test
+- Given/when/then structure
+- AssertJ assertions
+- No Spring context, no I/O
+
+---
+
+# Integration Tests
+
+## Definition
+
+An integration test verifies the interaction between two or more real components — typically your code with a real database, search engine, or message broker. External dependencies run in Docker via TestContainers.
+
+## Rules
+
+1. **Use TestContainers** — never depend on pre-installed infrastructure. Tests must be self-contained
+2. **Use the `TestSearchContainers` factory** (`zeebe/test-util`) for all Elasticsearch/OpenSearch containers — this is the single source of truth for container image versions
+3. **Prefer singleton containers** — use `static @Container` with `@Testcontainers` to share a container across all tests in a class. Starting a new container per test is wasteful (~5-10 seconds per start)
+4. **Clean up between tests** — truncate data, reset indexes, or use unique prefixes. Never rely on test execution order
+5. **File naming** — integration tests MUST end with `IT.java` (e.g., `UserServiceIT.java`). This ensures Failsafe (not Surefire) executes them
+6. **Timeout** — individual integration tests should complete in < 30 seconds. If a test needs more, it likely tests too much
+7. **Use `Awaitility`** for eventual consistency — never `Thread.sleep()`
+
+## Gold Standard Example
+
+From `zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java`:
+
+```java
+@Testcontainers
+final class ElasticsearchExporterIT {
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer()
+          .withEnv("action.destructive_requires_name", "false");
+
+  @BeforeEach
+  public void beforeEach(final TestInfo testInfo) {
+    // Only recreate indexes when the test method changes (performance optimization)
+    final String currentTestMethod = getTestMethod(testInfo);
+    if (!currentTestMethod.equals(previousTestMethod)) {
+      if (previousTestMethod != null) {
+        deletedIndices();
+      }
+      setup();
+      previousTestMethod = currentTestMethod;
+    }
+  }
+}
+```
+
+**Why this is the standard:**
+- Singleton container (`static @Container`) — started once for the class
+- `TestSearchContainers` factory for consistent versioning
+- Smart cleanup: only resets state when the test method changes
+- Self-contained: no dependency on external infrastructure
+
+## TestContainers Patterns
+
+**Singleton container (preferred for most cases):**
+```java
+@Testcontainers
+class MyServiceIT {
+  @Container
+  private static final ElasticsearchContainer ES =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+}
+```
+
+**Network-aware multi-container (for cross-service tests):**
+```java
+class CrossServiceIT {
+  private Network network;
+  private final List<GenericContainer<?>> containers = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    network = Network.newNetwork();
+  }
+
+  @AfterEach
+  void tearDown() {
+    containers.forEach(GenericContainer::stop);
+    network.close();
+  }
+}
+```
+
+Reference: `dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java`
+
+## Spring Integration Tests
+
+When Spring context is required, use the narrowest possible slice:
+
+| Annotation | Use When | Context Size |
+|-----------|----------|-------------|
+| `@WebMvcTest(Controller.class)` | Testing a single REST controller | Minimal (web layer only) |
+| `@DataJpaTest` | Testing repository/DAO layer | JPA layer only |
+| `@SpringBootTest(classes = {SpecificConfig.class})` | Testing with specific beans only | Specified classes only |
+| `@SpringBootTest` (full) | **Last resort** — only for acceptance tests | Full application context |
+
+---
+
+# Contract Tests
+
+## Definition
+
+A contract test verifies the **agreement between a consumer and a provider** at their API boundary, without starting the full system. Unlike integration tests that verify internal wiring, contract tests verify that:
+
+- **Consumers** can rely on the API behaving as they expect (consumer-driven)
+- **Providers** don't accidentally break consumers when they change the API
+- **Services can be deployed independently** with confidence that they remain compatible
+
+Contract tests are **not** controller slice tests (`@WebMvcTest`). Controller slice tests verify internal wiring between a controller and its service layer — that is an integration test concern. Contract tests verify the **external API contract** between independently deployable components.
+
+## Camunda Service Communication Architecture
+
+Understanding the architecture is essential for defining contract boundaries:
+
+```
+                    +----------------------------------+
+                    |         v2 REST API              |
+                    |   (Orchestration Cluster API)    |
+                    |   rest-api.yaml (OpenAPI 3.0.3)  |
+                    +---------------+------------------+
+                                    |
+               +--------------------+--------------------+
+               |                    |                    |
+      Operate Frontend      Tasklist Frontend      Java Client
+      (fetch + Zod)         (fetch + Zod)          (HTTP + gRPC)
+               |                    |                    |
+               |   +----------------+                    |
+               |   |                                     |
+      Operate Backend     Tasklist Backend               |
+      (gRPC writes)       (gRPC writes)                  |
+               |                    |                    |
+               +--------+---------+                     |
+                        |                                |
+               Zeebe Gateway / Broker <-----------------+
+                        |
+                        | [Record Stream]
+                        v
+                 Camunda Exporter
+                        |
+                        | [Bulk Write]
+                        v
+                Elasticsearch / OpenSearch
+                        |
+            +-----------+-----------+
+            |           |           |
+         Operate    Tasklist    Optimize
+         (reads)    (reads)     (reads)
+```
+
+**Key insight**: Operate, Tasklist, and Optimize do **not** call each other. They share data only through Elasticsearch/OpenSearch indices written by the Camunda Exporter. The v2 REST API is the single unified provider for all consumers.
+
+## Contract Boundary Definitions
+
+| Consumer | Provider | Protocol | Contract Type | Tool |
+|----------|----------|----------|--------------|------|
+| **Java Client** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate Frontend** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Tasklist Frontend** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate Frontend** | Operate Internal API (`/api/`) | HTTP/JSON | REST consumer contract (legacy) | **Pact** |
+| **Optimize Frontend** | Optimize Backend REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate/Tasklist Backend** | Zeebe gRPC | gRPC/Protobuf | Schema compatibility | **Buf** (already in CI) |
+| **Camunda Exporter** | ES/OS index schema | Data/Message | Message contract | **Pact message** or schema assertions |
+| **Any consumer** | v2 REST API spec | OpenAPI 3.0.3 | Spec validity | **Spectral** (already in CI) |
+
+## Java Client Consumer Tests (Priority 1)
+
+The Java client (`clients/java/`) is the highest-priority Pact consumer because it is the **public API contract** used by all external integrators.
+
+```java
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "camunda-orchestration-api", port = "8080")
+class JobApiContractTest {
+
+  @Pact(consumer = "camunda-java-client")
+  V4Pact failJobContract(PactDslWithProvider builder) {
+    return builder
+        .given("a job with key 123 exists")
+        .uponReceiving("a request to fail job 123")
+          .path("/v2/jobs/123/failure")
+          .method("POST")
+          .headers("Content-Type", "application/json")
+          .body(new PactDslJsonBody()
+              .integerType("retries", 1)
+              .stringType("errorMessage", "task failed")
+              .integerType("retryBackOff", 1000))
+        .willRespondWith()
+          .status(204)
+        .toPact(V4Pact.class);
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "failJobContract")
+  void shouldFailJob(MockServer mockServer) {
+    // given
+    var client = CamundaClient.newClientBuilder()
+        .restAddress(URI.create(mockServer.getUrl()))
+        .preferRestOverGrpc(true)
+        .build();
+
+    // when + then — no exception means contract is satisfied
+    client.newFailCommand(123L)
+        .retries(1)
+        .errorMessage("task failed")
+        .retryBackoff(Duration.ofSeconds(1))
+        .send()
+        .join();
+  }
+}
+```
+
+**What this catches that `@WebMvcTest` doesn't:**
+- If the Java client sends a field the provider doesn't expect -> contract fails
+- If the provider removes a field the client depends on -> contract fails
+- If the client assumes a 200 but the provider returns 204 -> contract fails
+- These failures are detected **without running the provider at all**
+
+## Frontend Consumer Tests (Priority 2)
+
+The Operate and Tasklist frontends already use `@camunda/camunda-api-zod-schemas` for typed API calls. Pact JS can generate contracts from these.
+
+```typescript
+import {PactV4} from '@pact-foundation/pact';
+
+const provider = new PactV4({
+  consumer: 'tasklist-frontend',
+  provider: 'camunda-orchestration-api',
+});
+
+describe('User Tasks API Contract', () => {
+  it('should search user tasks', async () => {
+    await provider
+      .addInteraction()
+      .given('user tasks exist')
+      .uponReceiving('a search request for user tasks')
+      .withRequest('POST', '/v2/user-tasks/search', (builder) => {
+        builder.headers({'Content-Type': 'application/json'});
+        builder.jsonBody({
+          filter: {state: 'CREATED', assigned: true},
+          page: {limit: 50},
+        });
+      })
+      .willRespondWith(200, (builder) => {
+        builder.headers({'Content-Type': 'application/json'});
+        builder.jsonBody({
+          items: eachLike({
+            userTaskKey: string('12345'),
+            name: string('Review document'),
+            taskState: string('CREATED'),
+            assignee: string('demo'),
+          }),
+          page: {totalItems: integer(1)},
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const response = await fetch(`${mockServer.url}/v2/user-tasks/search`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            filter: {state: 'CREATED', assigned: true},
+            page: {limit: 50},
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.items).toBeDefined();
+        expect(body.items[0].userTaskKey).toBeDefined();
+      });
+  });
+});
+```
+
+## Provider Verification (Zeebe Gateway)
+
+The Zeebe gateway (the v2 REST API provider) verifies all consumer contracts:
+
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "${PACT_BROKER_URL}")  // or @PactFolder("pacts") for local dev
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrchestrationApiProviderVerificationIT {
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void verifyPact(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  @State("a job with key 123 exists")
+  void setupJobExists() {
+    // Create test data in the provider's state
+  }
+
+  @State("user tasks exist")
+  void setupUserTasksExist() {
+    // Create test data for user task search
+  }
+}
+```
+
+This runs on every PR that changes the gateway, catching any provider-side breaks before merge.
+
+## Exporter Data Contract (Priority 3)
+
+The Elasticsearch index schema is an implicit data contract between the Camunda Exporter (producer) and Operate/Tasklist/Optimize (consumers). Use **Pact message contracts** for this:
+
+```java
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "camunda-exporter", providerType = ProviderType.ASYNCH)
+class OperateExporterContractTest {
+
+  @Pact(consumer = "operate")
+  MessagePact processInstanceRecord(MessagePactBuilder builder) {
+    return builder
+        .expectsToReceive("a process instance CREATED record")
+        .withContent(new PactDslJsonBody()
+            .integerType("key")
+            .stringType("intent", "CREATED")
+            .object("value")
+              .stringType("bpmnProcessId")
+              .integerType("processDefinitionKey")
+              .integerType("version")
+            .closeObject())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "processInstanceRecord")
+  void shouldConsumeProcessInstanceRecord(List<Message> messages) {
+    // Verify Operate can deserialize the exporter record
+    var record = objectMapper.readValue(
+        messages.get(0).contentsAsString(), ProcessInstanceRecord.class);
+    assertThat(record.getKey()).isNotNull();
+    assertThat(record.getValue().getBpmnProcessId()).isNotNull();
+  }
+}
+```
+
+## What Existing Tests Become
+
+| Current Test | Current Classification | Correct Classification |
+|-------------|----------------------|----------------------|
+| `JobControllerTest` (`@WebMvcTest`) | Was labeled "contract test" | **API slice test** (integration test layer) — verifies controller wiring |
+| Spectral OpenAPI linting | Spec validation | **Spec validation** (keep as-is, complementary to Pact) |
+| Buf protobuf check | gRPC schema compat | **Schema contract test** (keep as-is) |
+| `validateResponse()` in E2E API tests | API response validation | **E2E validation** (keep, but too slow for PR feedback) |
+| Zod schema validation (frontend) | Runtime type checking | **Client-side validation** (complementary to Pact) |
+
+The existing `@WebMvcTest` tests (like `JobControllerTest`) are still valuable — they verify that the controller correctly parses requests and delegates to services. They just aren't contract tests. They should be classified as **API slice tests** within the integration test layer.
+
+## When to Write Contract Tests
+
+**Rule: Every new or modified REST/gRPC endpoint must have a Pact consumer contract test.** This applies to all API surfaces — v2, legacy internal, Optimize backend, or any other endpoint consumed by another application or frontend.
+
+| Change | Contract Test Required? |
+|--------|----------------------|
+| **New REST endpoint** (any API surface) | **Yes** — Pact consumer test for each consuming application |
+| **Modified REST endpoint** (request/response change) | **Yes** — update existing Pact consumer tests |
+| **Removed or renamed API field** | **Yes** — Pact will catch if any consumer depends on it |
+| **New field in exporter record** | **Yes** — Pact message contract for consuming applications |
+| **New or modified gRPC service method** | **Yes** — Buf backward compat (already enforced) + Pact consumer test if consumed by Java client |
+| **New query parameter, header, or status code** | **Yes** — if any consumer relies on it |
+| Internal refactoring (no API change) | No |
+
+**No endpoint ships without a contract.** If the endpoint has no consumer test, either:
+1. There is no consumer yet (add the contract when the first consumer is built), or
+2. The consumers are untested — fix that first
+
+## Rollout Strategy
+
+| Phase | Scope | Timeline |
+|-------|-------|----------|
+| **Phase A** | Java Client -> v2 REST API (file-based pacts in repo) | Week 1-3 |
+| **Phase B** | Tasklist Frontend -> v2 REST API (leveraging Zod schemas) | Week 2-4 |
+| **Phase C** | Operate Frontend -> v2 REST API + legacy `/api/` | Week 3-5 |
+| **Phase D** | Exporter -> ES/OS index schema (Pact message contracts) | Week 4-6 |
+| **Phase E** | Optimize Frontend -> Optimize Backend REST API | Week 5-7 |
+| **Phase F** | Set up Pact Broker + `can-i-deploy` in CI | Week 6-8 |
+
+---
+
+# End-to-End Tests
+
+## Definition
+
+An E2E test exercises the full system through its external interfaces (UI or API) with all real dependencies running. These are the most expensive tests and should be used sparingly.
+
+## Rules
+
+1. **E2E tests do NOT block PRs** — they run nightly and on release branches only
+2. **Use Playwright** for all browser-based E2E tests
+3. **Use the Page Object Model** — all page interactions go through page objects, never raw selectors in test files
+4. **Never use `waitForTimeout()`** — use assertion-based waiting (`expect(locator).toBeVisible()`, `expect.poll()`)
+5. **Never use `actionTimeout: 0`** — always set a bounded action timeout (10 seconds)
+6. **Use accessible selectors** — `getByRole()`, `getByLabel()`, `getByText()` over `getByTestId()` over CSS selectors
+7. **Retries are not a substitute for reliability** — `retries: 2` in Playwright config is acceptable for CI resilience, but a test that needs retries to pass should be investigated
+8. **Use `test.step()`** for multi-step tests — provides clear failure attribution
+
+## Gold Standard Example
+
+From `operate/client/e2e-playwright/tests/login.spec.ts`:
+
+```typescript
+test.describe('login page', () => {
+  test('Log in with invalid user account', async ({loginPage, page}) => {
+    await loginPage.login({username: 'demo', password: 'wrong-password'});
+    await expect(
+      page.getByRole('alert').getByText('Username and password do not match'),
+    ).toBeVisible();
+    await expect(page).toHaveURL('/operate/login');
+  });
+
+  test('Log in with valid user account', async ({loginPage, page}) => {
+    await loginPage.login({username: 'demo', password: 'demo'});
+    await expect(page).toHaveURL('../operate');
+  });
+});
+```
+
+**Why this is the standard:**
+- No `waitForTimeout` — all waits are assertion-based
+- Page Object Model via fixtures (`loginPage`)
+- Accessible selectors (`getByRole('alert')`)
+- Short, focused — one scenario per test
+- No hardcoded URLs or magic strings
+
+## Page Object Model
+
+Every page or component that tests interact with must have a corresponding page object class:
+
+```typescript
+// pages/Login.ts
+export class Login {
+  private page: Page;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.getByLabel(/^username$/i);
+    this.passwordInput = page.getByLabel(/^password$/i);
+    this.loginButton = page.getByRole('button', {name: 'Login'});
+  }
+
+  async login(credentials: {username: string; password: string}) {
+    await this.fillUsername(credentials.username);
+    await this.fillPassword(credentials.password);
+    await this.clickLoginButton();
+  }
+}
+```
+
+Reference: `operate/client/e2e-playwright/pages/Login.ts`
+
+## Eventual Consistency in E2E Tests
+
+Use `expect.poll()` or `expect().toPass()` for assertions that depend on asynchronous data:
+
+```typescript
+// CORRECT: polling with timeout
+await expect.poll(async () => {
+  const response = await request.get(`${baseUrl}/v1/process-instances/${key}`);
+  return response.status();
+}, {timeout: 30_000}).toBe(200);
+
+// CORRECT: retry assertion block
+await expect(async () => {
+  const res = await request.get(buildUrl(`/process-instances/${key}`));
+  await assertStatusCode(res, 200);
+  await validateResponse({path: '/process-instances/{key}', method: 'GET', status: '200'}, res);
+}).toPass(defaultAssertionOptions);
+
+// WRONG: hardcoded wait
+await page.waitForTimeout(5000);  // NEVER DO THIS
+```
+
+Reference: `operate/client/e2e-playwright/tests/processInstance.spec.ts`
+
+---
+
+# Architecture Tests
+
+## Definition
+
+Architecture tests (ArchUnit) verify structural properties of the codebase: dependency directions, naming conventions, annotation usage, and module boundaries.
+
+## Rules
+
+1. All ArchUnit tests live in `qa/archunit-tests/` — not scattered across modules
+2. All ArchUnit test classes must be named `*ArchTest.java`
+3. ArchUnit tests run on every PR as part of the `archunit-tests` CI job
+4. New architectural constraints should be proposed via PR and reviewed by the team
+
+## Current Coverage
+
+The following architectural properties are enforced (see `qa/archunit-tests/`):
+
+- Processor naming conventions
+- `@VisibleForTesting` usage (only accessed from test code)
+- Client dependency isolation (no protocol dependency)
+- Controller authorization patterns
+- Engine class dependency rules
+- Protocol immutability
+- REST controller annotations
+- State modification rules
+- Migration task registration
+
+---
+
+# Performance and Reliability Tests
+
+## Performance Tests
+
+- Run **weekly** and before releases — never on PRs
+- Use JMH for microbenchmarks (`microbenchmarks/` module)
+- Use the load tester (`load-tests/load-tester/`) for system-level throughput tests
+- Throughput SLOs: 50 PI/s (typical), 300 PI/s (stress) — see `docs/testing/reliability-testing.md`
+
+## Reliability Tests
+
+- Chaos engineering via `zbchaos` CLI
+- Automated chaos experiments via Camunda BPMN processes
+- Run weekly on dedicated GKE infrastructure
+
+---
+
+# Prohibited Patterns
+
+These patterns are **banned** from all new code and must be removed from existing code during maintenance.
+
+---
+
+## 1. `Thread.sleep()` in test code
+
+```java
+// PROHIBITED
+Thread.sleep(5000);
+assertThat(service.getStatus()).isEqualTo("READY");
+
+// REQUIRED: use Awaitility
+Awaitility.await()
+    .atMost(Duration.ofSeconds(10))
+    .pollInterval(Duration.ofMillis(100))
+    .untilAsserted(() ->
+        assertThat(service.getStatus()).isEqualTo("READY"));
+```
+
+**Exception**: `Thread.sleep()` is acceptable only in production code for deliberate backoff/throttling, never in tests.
+
+---
+
+## 2. `page.waitForTimeout()` in Playwright tests
+
+```typescript
+// PROHIBITED
+await page.waitForTimeout(500);
+
+// REQUIRED: use assertion-based waiting
+await expect(page.locator('.modal')).toBeVisible();
+```
+
+**No exceptions.**
+
+---
+
+## 3. `actionTimeout: 0` in Playwright configuration
+
+```typescript
+// PROHIBITED
+actionTimeout: 0,  // unlimited — will hang forever
+
+// REQUIRED
+actionTimeout: 10_000,  // bounded timeout
+```
+
+---
+
+## 4. JUnit / Hamcrest assertions
+
+```java
+// PROHIBITED (enforced by Checkstyle)
+assertEquals(expected, actual);        // JUnit
+assertThat(actual, is(expected));      // Hamcrest
+
+// REQUIRED
+assertThat(actual).isEqualTo(expected);  // AssertJ
+```
+
+This is already enforced by Checkstyle (`IllegalImport` rule in `build-tools/src/main/resources/check/.checkstyle.xml`).
+
+---
+
+## 5. JUnit 4 in new code
+
+```java
+// PROHIBITED in new code
+@RunWith(SpringRunner.class)
+@Rule public final EngineRule engine = EngineRule.singlePartition();
+
+// REQUIRED
+@ExtendWith(SpringExtension.class)
+@RegisterExtension final EngineExtension engine = EngineExtension.create();
+```
+
+> **Note**: For the JUnit 4 -> 5 migration plan for existing code, see CI/CD Phase 4: Developer Experience.
+
+---
+
+## 6. Raw `Thread` management in concurrency tests
+
+```java
+// PROHIBITED
+Thread[] threads = new Thread[5];
+for (int i = 0; i < threads.length; i++) {
+  threads[i] = new Thread(task);
+  threads[i].start();
+  Thread.sleep(10);
+}
+
+// REQUIRED
+ExecutorService executor = Executors.newFixedThreadPool(5);
+CountDownLatch startLatch = new CountDownLatch(1);
+for (int i = 0; i < 5; i++) {
+  executor.submit(() -> {
+    startLatch.await();  // all threads start simultaneously
+    task.run();
+  });
+}
+startLatch.countDown();
+executor.shutdown();
+executor.awaitTermination(10, TimeUnit.SECONDS);
+```
+
+---
+
+## 7. Non-deterministic test data without seed
+
+```java
+// PROHIBITED — different data each run, unreproducible failures
+var randomName = UUID.randomUUID().toString();
+
+// REQUIRED — seeded random or deterministic
+var testName = "test-process-" + testInfo.getDisplayName().hashCode();
+
+// OR use Instancio with seed
+var data = Instancio.of(MyModel.class)
+    .withSeed(12345L)
+    .create();
+```
+
+**Exception**: UUIDs are acceptable when used for isolation (unique index names, unique process IDs) and the specific value doesn't matter for the assertion.
+
+---
+
+## 8. `@Disabled` without an issue link
+
+```java
+// PROHIBITED
+@Disabled("it's broken")
+
+// REQUIRED
+@Disabled("Flaky, tracked in https://github.com/camunda/camunda/issues/42928")
+```
+
+---
+
+# Required Patterns
+
+---
+
+## 1. Given/When/Then structure
+
+Every test method must contain `// given`, `// when`, `// then` comments:
+
+```java
+@Test
+void shouldRejectInvalidInput() {
+    // given
+    final var request = new CreateRequest(null, -1);
+
+    // when
+    final var result = assertThrows(ValidationException.class,
+        () -> service.create(request));
+
+    // then
+    assertThat(result.getMessage()).contains("name must not be null");
+}
+```
+
+---
+
+## 2. Regression test annotation for bug fixes
+
+```java
+@Test
+@RegressionTest("https://github.com/camunda/camunda/issues/12345")
+void shouldNotCrashWhenInputIsEmpty() {
+    // given — the exact scenario that caused the bug
+    // when — the action that triggered the bug
+    // then — the correct behavior
+}
+```
+
+---
+
+## 3. Awaitility for all asynchronous assertions
+
+```java
+Awaitility.await("process instance should be active")
+    .atMost(Duration.ofSeconds(10))
+    .pollInterval(Duration.ofMillis(200))
+    .untilAsserted(() ->
+        assertThat(getProcessInstance(key).getState()).isEqualTo(ACTIVE));
+```
+
+---
+
+## 4. `expect.poll()` or `expect().toPass()` in Playwright
+
+```typescript
+await expect.poll(async () => {
+  const response = await request.get(url);
+  return response.status();
+}, {timeout: 30_000, intervals: [500, 1000, 2000]}).toBe(200);
+```
+
+---
+
+## 5. TestContainers via `TestSearchContainers` factory
+
+```java
+// REQUIRED: use the central factory
+@Container
+private static final ElasticsearchContainer CONTAINER =
+    TestSearchContainers.createDefeaultElasticsearchContainer();
+
+// PROHIBITED: hardcoded image tags
+@Container
+private static final ElasticsearchContainer CONTAINER =
+    new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.18.4");
+```
+
+---
+
+## 6. Page Object Model in Playwright
+
+```typescript
+// REQUIRED: interact through page objects
+await loginPage.login({username: 'demo', password: 'demo'});
+
+// PROHIBITED: raw selectors in test files
+await page.locator('#username-input').fill('demo');
+await page.locator('#password-input').fill('demo');
+await page.locator('button[type="submit"]').click();
+```
+
+---
+
+# Naming Conventions
+
+## File Naming
+
+| Test Type | Suffix | Example | Executed By |
+|-----------|--------|---------|------------|
+| Unit test | `*Test.java` | `BatchOperationPageProcessorTest.java` | Surefire |
+| Integration test | `*IT.java` | `ElasticsearchExporterIT.java` | Failsafe |
+| Architecture test | `*ArchTest.java` | `VisibleForTestingArchTest.java` | Surefire (in `qa/archunit-tests`) |
+| Property-based test | `*PropertyTest.java` | `RandomizedPropertyTest.java` | Surefire (dedicated profile) |
+| Playwright spec | `*.spec.ts` | `login.spec.ts` | Playwright Test |
+
+**Critical**: Using the wrong suffix means the test runs with the wrong plugin (or not at all).
+- `*Test.java` -> Surefire (unit tests, no Docker, fast)
+- `*IT.java` -> Failsafe (integration tests, Docker allowed, lifecycle hooks)
+
+## Method Naming
+
+**Java test methods** must use the `should<Verb><Object>` pattern:
+
+```java
+// CORRECT
+void shouldRejectInvalidCredentials()
+void shouldReturnEmptyListWhenNoProcessesExist()
+void shouldCreateProcessInstanceWithVariables()
+void shouldFailWhenDatabaseIsUnavailable()
+
+// INCORRECT
+void test1()
+void testCreateProcess()
+void createProcessWorks()
+void invalidCredentials()
+```
+
+**Playwright test descriptions** should describe the user action or scenario:
+
+```typescript
+// CORRECT
+test('Log in with valid user account', ...)
+test('Resolve an incident @roundtrip', ...)
+test('should display error when process not found', ...)
+
+// INCORRECT
+test('test login', ...)
+test('TC-001', ...)
+```
+
+## Test Class Location
+
+| Test Type | Location | Example |
+|-----------|----------|---------|
+| Unit tests | Same module: `src/test/java/` | `zeebe/engine/src/test/java/.../MyTest.java` |
+| Integration tests for a module | Same module or module's `qa/` | `operate/qa/integration-tests/` |
+| Cross-module acceptance tests | `qa/acceptance-tests/` | `qa/acceptance-tests/src/test/java/` |
+| Architecture tests | `qa/archunit-tests/` | `qa/archunit-tests/src/test/java/` |
+| Playwright E2E | Module's `e2e-playwright/` or `qa/c8-orchestration-cluster-e2e-test-suite/` | `operate/client/e2e-playwright/` |
+
+---
+
+# Flaky Test Policy
+
+## Definition
+
+A flaky test is a test that produces different results (pass/fail) on the same code without any code change. A test that passes only on retry is flaky.
+
+## Metric Definitions
+
+Precise definitions are critical for enforceability:
+
+- **Test-level flaky rate** = (number of test methods that flaked at least once in a week) / (total distinct test methods executed that week). This is the primary metric. Benchmark: Google targets 1.5%, Netflix <2%, Uber <3%.
+- **Pipeline flake rate** = (pipeline runs that failed due to flakes) / (total pipeline runs). This is the developer-facing metric that drives trust.
+
+## Tiered Targets
+
+| Phase | Test-Level Target | Pipeline Target | Timeline |
+|-------|-------------------|-----------------|----------|
+| End of Phase 1 | <10% | Measured | Week 6 |
+| End of Phase 3 | <5% | <10% | Week 16 |
+| CD Readiness | **<2%** | **<2%** | Stretch goal |
+
+## Policy
+
+1. **Detection**: The existing `flaky-test-extractor-maven-plugin` and BigQuery/Grafana pipeline will track flaky tests
+2. **Quarantine threshold**: Flake rate >5% for tests run 10+ times/week, OR 3+ flakes for tests run <10 times/week. The threshold is rate-based (not count-based) to account for execution frequency
+3. **Quarantine mechanism**: Apply JUnit 5 `@Tag("quarantine")` to the test class/method. Configure Surefire with `<excludedGroups>quarantine</excludedGroups>` for PR runs. Quarantined tests still run nightly
+4. **Fix SLA**: Quarantined tests must be fixed or deleted within 2 sprints
+5. **No `@Disabled` without an issue**: Every disabled test must link to a tracking issue
+6. **Progressive retry reduction**: `rerunFailingTestsCount` will be reduced from 3 -> 2 -> 1 -> 0 (Surefire) with explicit go/no-go gates. Keep Failsafe at 1 permanently — see Phase 1
+
+## Flakiness Classification
+
+Not all flakiness is the same. Classify by root cause before setting fix expectations:
+
+| Category | Examples | Fixable? | Approach |
+|----------|----------|----------|----------|
+| **Timing-dependent** | `Thread.sleep()`, hardcoded timeouts | Yes | Awaitility / `expect.poll()` |
+| **Resource contention** | Tests fail under CI load but pass locally | Partially | Reduce CI waste (Phase 2), singleton containers |
+| **Architecturally eventual-consistent** | Raft consensus, ES write-to-read delay | Harder | May legitimately need 1 Failsafe retry |
+| **Shared mutable state** | Static fields, containers without cleanup | Yes | Per-test isolation |
+| **Environment-specific** | Docker pull failures, port conflicts | Partially | Registry mirrors, OS-assigned ports |
+
+## Flaky Test Response Runbook
+
+When a test flakes:
+
+1. Check the Grafana dashboard: `https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo`
+2. Search for an existing issue: `gh issue list --label kind/flake --search "<test class name>"`
+3. If no issue exists, create one using the flaky test issue template
+4. Reproduce locally using IntelliJ "Repeat Until Failure" (see `docs/zeebe/failing-tests.md`)
+5. Fix the root cause, don't add retry logic
+
+## Common Root Causes and Fixes
+
+| Root Cause | Pattern | Fix |
+|-----------|---------|-----|
+| Timing dependency | `Thread.sleep()`, hardcoded timeouts | Awaitility / `expect.poll()` |
+| Shared mutable state | Static fields, shared containers without cleanup | Per-test isolation, `@BeforeEach` cleanup |
+| Port conflicts | Random ports without checking availability | Let the OS assign ports (`0`), TestContainers handles this |
+| Test order dependency | Test B depends on data created by Test A | Each test creates its own data |
+| Resource exhaustion | Too many concurrent containers, file handle leaks | Singleton containers, proper `@AfterEach` cleanup |
+| Eventual consistency | Assert immediately after write to async system | Awaitility polling |
+
+---
+
+# Test Data Management
+
+## Principles
+
+1. **Each test creates its own data** — never depend on data from another test
+2. **Use unique identifiers** — prefix test data with test method name or unique key to prevent collisions in parallel execution
+3. **Clean up after yourself** — integration tests must clean up created data in `@AfterEach` or use unique prefixes that don't collide
+
+## Patterns
+
+**Builder/factory pattern for test data:**
+```java
+// CORRECT
+var process = Bpmn.createExecutableProcess("test-" + testInfo.getDisplayName())
+    .startEvent()
+    .userTask("task-1")
+    .endEvent()
+    .done();
+
+// INCORRECT — shared, mutable, reused across tests
+static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess("shared-process")...;
+```
+
+**Instancio for random but reproducible data:**
+```java
+var user = Instancio.of(UserEntity.class)
+    .set(field(UserEntity::getEmail), "test@example.com")
+    .create();
+```
+
+---
+
+# Frameworks and Tools
+
+## Mandatory Frameworks
+
+| Purpose | Framework | Version Source |
+|---------|-----------|----------------|
+| Test runner | JUnit 5 (Jupiter) | `parent/pom.xml` |
+| Assertions | AssertJ | `parent/pom.xml` |
+| Mocking | Mockito | `parent/pom.xml` |
+| Async assertions | Awaitility | `parent/pom.xml` |
+| Containers | TestContainers | `parent/pom.xml` |
+| Contract testing (Java) | Pact JVM (`au.com.dius.pact`) | `parent/pom.xml` (to be added) |
+| Contract testing (JS/TS) | Pact JS (`@pact-foundation/pact`) | `package.json` (to be added) |
+| Browser E2E | Playwright Test | `package.json` |
+| Architecture | ArchUnit | `parent/pom.xml` |
+| Test data generation | Instancio | `parent/pom.xml` |
+
+## Prohibited Frameworks
+
+| Framework | Reason | Alternative |
+|-----------|--------|-------------|
+| JUnit 4 (in new code) | Legacy, no parallel execution support | JUnit 5 |
+| Hamcrest | Inconsistent with AssertJ conventions | AssertJ |
+| PowerMock | Fragile, encourages bad design | Refactor to use interfaces + Mockito |
+| Selenium | Superseded | Playwright |
+
+## Spring Test Slicing (Use the Narrowest Slice)
+
+| Annotation | When to Use | Startup Time |
+|-----------|-------------|-------------|
+| No Spring annotations | Unit tests — preferred | 0ms |
+| `@WebMvcTest(Controller.class)` | REST controller slice tests | ~2-3s |
+| `@DataJpaTest` | Repository/DAO tests | ~2-3s |
+| `@SpringBootTest(classes = {...})` | Targeted integration tests | ~5-10s |
+| `@SpringBootTest` (full) | Acceptance tests only | ~15-30s |
+
+---
+
+# Enforcement Rules
+
+## Automated Enforcement (CI)
+
+| Rule | Enforcement Mechanism | Status |
+|------|----------------------|--------|
+| AssertJ-only assertions | Checkstyle `IllegalImport` rule | Active |
+| ArchUnit structural rules | `archunit-tests` CI job | Active |
+| Code formatting | Spotless CI job | Active |
+| OpenAPI spec validity | Spectral linting CI job | Active |
+| Protobuf backward compat | Buf CI job | Active |
+| No `Thread.sleep()` in tests | **Proposed**: Checkstyle or ArchUnit rule | Not yet active |
+| No `waitForTimeout()` in Playwright | **Proposed**: ESLint rule | Not yet active |
+| Test naming conventions (`should*`) | **Proposed**: ArchUnit rule | Not yet active |
+| Coverage thresholds | **Proposed**: JaCoCo minimum limits | Not yet active |
+
+## Code Review Enforcement (Human)
+
+Reviewers must verify:
+1. Appropriate test level (unit > integration > E2E)
+2. Test quality (single behavior, clear naming, no anti-patterns)
+3. No test-less production code changes (unless pure refactoring with unchanged behavior)
+4. PR checklist is complete
+
+## Proposed New Automated Rules
+
+### Priority 1: Three Hard CI Rules (Enforce Immediately)
+
+These three rules should be the first to go live. Start with exactly these three — more rules can be added later once the team demonstrates it can maintain compliance.
+
+**1. ArchUnit `FreezingArchRule` — No NEW `Thread.sleep()` in test code:**
+
+> Use `FreezingArchRule` to capture existing violations as a baseline. Only new violations fail the build. This enables gradual migration without breaking existing code.
+
+```java
+@ArchTest
+static final ArchRule noThreadSleepInTests = FreezingArchRule.freeze(
+    noClasses()
+        .that().resideInAPackage("..test..")
+        .should().callMethod(Thread.class, "sleep", long.class)
+        .because("Use Awaitility instead of Thread.sleep() in tests"));
+```
+
+**2. ESLint rule — No `waitForTimeout()` in Playwright:**
+
+Add `/* eslint-disable */` comments on the 15 existing files as a temporary baseline, then remove as files are fixed.
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", {
+      "selector": "CallExpression[callee.property.name='waitForTimeout']",
+      "message": "Use assertion-based waiting instead of waitForTimeout()"
+    }]
+  }
+}
+```
+
+**3. ArchUnit rule — No new JUnit 4 usage:**
+
+```java
+@ArchTest
+static final ArchRule noNewJUnit4 = noClasses()
+    .should().dependOnClassesThat().resideInAPackage("org.junit")
+    .andShould().not().dependOnClassesThat().resideInAPackage("org.junit.jupiter..")
+    .because("New tests must use JUnit Jupiter, not JUnit 4");
+```
+
+### Priority 2: Additional Rules (After Priority 1 is Stable)
+
+**ArchUnit rule — Test naming conventions (`should*`):**
+```java
+@ArchTest
+static final ArchRule testMethodNaming = methods()
+    .that().areAnnotatedWith(Test.class)
+    .should().haveNameStartingWith("should")
+    .because("Test methods must follow the should<Verb><Object> pattern");
+```
+
+**ArchUnit rule — No `@Disabled` without issue link:**
+```java
+// Custom rule that checks @Disabled annotation value contains "github.com/camunda/camunda/issues/"
+```
+
+**ArchUnit rule — TestContainers use `TestSearchContainers` factory:**
+```java
+// Custom rule banning direct ElasticsearchContainer/OpensearchContainer instantiation
+```
+
+### Metric Ratchets
+
+CI should track these counts and fail any PR that increases them beyond the current baseline:
+
+| Metric | Current Baseline | Tracked By |
+|--------|-----------------|------------|
+| `Thread.sleep()` in test files | 52 | FreezingArchRule violation store |
+| `waitForTimeout()` in Playwright | 15 | ESLint baseline comments |
+| `@Disabled` without issue link | TBD (measure) | Custom ArchUnit rule |
+| JUnit 4 test files | 804 | ArchUnit / grep |
+
+---
+
+# Pact Setup
+
+This document covers the installation, configuration, and CI integration for Pact contract testing. For when and how to write contract tests, see the Contract Tests section above.
+
+## Dependencies
+
+**Java consumer (add to `clients/java/pom.xml` or relevant consumer module):**
+```xml
+<dependency>
+  <groupId>au.com.dius.pact.consumer</groupId>
+  <artifactId>junit5</artifactId>
+  <version>4.6.x</version>
+  <scope>test</scope>
+</dependency>
+```
+
+**JavaScript/TypeScript consumer (add to `operate/client/package.json` or relevant frontend):**
+```json
+{
+  "devDependencies": {
+    "@pact-foundation/pact": "^13.x"
+  }
+}
+```
+
+## How Pact Works: The Full Lifecycle
+
+> **References**:
+> - Pact documentation: <https://docs.pact.io>
+> - Pact JVM (Java): <https://docs.pact.io/implementation_guides/jvm>
+> - Pact JS (TypeScript/JavaScript): <https://docs.pact.io/implementation_guides/javascript>
+> - Consumer-Driven Contract Testing concepts: <https://docs.pact.io/getting_started/how_pact_works>
+> - Pact Broker (self-hosted): <https://github.com/pact-foundation/pact_broker>
+> - PactFlow (managed SaaS): <https://pactflow.io>
+> - Pact + OpenAPI (bidirectional contract testing): <https://docs.pactflow.io/docs/bi-directional-contract-testing>
+
+### Step 1: Consumer writes tests (generates contracts)
+
+The consumer team writes Pact tests as part of their regular unit/integration test suite. When tests run, Pact generates a **contract file** (JSON) in the `target/pacts/` (Java) or `pacts/` (JS) directory.
+
+```
+# Java consumer test execution
+./mvnw test -pl clients/java -Dtest=JobApiContractTest
+
+# Output:
+# target/pacts/camunda-java-client-camunda-orchestration-api.json
+```
+
+```
+# JS/TS consumer test execution
+cd tasklist/client && npm test -- --grep "contract"
+
+# Output:
+# pacts/tasklist-frontend-camunda-orchestration-api.json
+```
+
+The generated pact file contains every interaction the consumer expects:
+
+```json
+{
+  "consumer": { "name": "camunda-java-client" },
+  "provider": { "name": "camunda-orchestration-api" },
+  "interactions": [
+    {
+      "description": "a request to fail job 123",
+      "providerState": "a job with key 123 exists",
+      "request": {
+        "method": "POST",
+        "path": "/v2/jobs/123/failure",
+        "headers": { "Content-Type": "application/json" },
+        "body": { "retries": 1, "errorMessage": "task failed" }
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ]
+}
+```
+
+### Step 2: Contracts are stored and shared
+
+Contracts must be accessible to both consumers and providers. Three options, from simplest to most mature:
+
+**Option A: File-based (start here)**
+
+Store pact files in the repository under a shared directory:
+
+```
+contracts/
+  pacts/
+    camunda-java-client-camunda-orchestration-api.json
+    tasklist-frontend-camunda-orchestration-api.json
+    operate-frontend-camunda-orchestration-api.json
+```
+
+Consumer CI publishes pacts by committing to this directory. Provider CI reads from it. This works well for a monorepo where consumers and providers are in the same repository.
+
+**Pros**: Zero infrastructure, works immediately
+**Cons**: No versioning, no `can-i-deploy`, no branch-aware verification
+
+**Option B: Self-hosted Pact Broker**
+
+Deploy the open-source Pact Broker (<https://github.com/pact-foundation/pact_broker>):
+
+```yaml
+# docker-compose.pact-broker.yml
+services:
+  pact-broker:
+    image: pactfoundation/pact-broker:latest
+    ports:
+      - "9292:9292"
+    environment:
+      PACT_BROKER_DATABASE_URL: "sqlite:///pact_broker.sqlite3"
+```
+
+Consumers publish pacts after tests pass:
+```bash
+# Java (via pact-jvm plugin)
+./mvnw pact:publish -Dpact.broker.url=https://pact-broker.internal.camunda.com
+
+# JS (via @pact-foundation/pact-cli)
+npx pact-broker publish ./pacts \
+  --broker-base-url=https://pact-broker.internal.camunda.com \
+  --consumer-app-version=$(git rev-parse HEAD) \
+  --tag=$(git branch --show-current)
+```
+
+Providers fetch and verify:
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "https://pact-broker.internal.camunda.com")
+class OrchestrationApiProviderVerificationIT { ... }
+```
+
+The broker provides:
+- **Contract versioning**: each consumer version has its own pact
+- **`can-i-deploy`**: query whether a version is safe to deploy
+- **Webhooks**: trigger provider verification when a new pact is published
+- **Network diagram**: visual map of all consumer-provider relationships
+- **Tags/branches**: branch-aware verification (verify `main` pacts vs. feature branch pacts)
+
+```bash
+# Before deploying: check if this version is compatible with all consumers/providers
+pact-broker can-i-deploy \
+  --pacticipant camunda-orchestration-api \
+  --version $(git rev-parse HEAD) \
+  --to-environment production
+```
+
+**Pros**: Full Pact workflow, free, self-hosted
+**Cons**: Requires infrastructure to host and maintain
+
+**Option C: PactFlow (managed SaaS)**
+
+PactFlow (<https://pactflow.io>) is the managed Pact Broker with additional features:
+
+- **Bidirectional contract testing**: verify consumer pacts against the OpenAPI spec (`rest-api.yaml`) without running the provider
+- **Teams and permissions**: control who can publish/verify
+- **CI integration**: native GitHub Actions support
+- **Support and SLAs**
+
+**Bidirectional contract testing** is especially powerful here because:
+1. Consumer pacts are generated from consumer tests (as normal)
+2. Instead of running provider verification tests, PactFlow compares the consumer pact against the published OpenAPI spec
+3. If the consumer's expectations are a subset of what the OpenAPI spec promises -> compatible
+4. This means **no provider-side test code is needed** for the initial rollout
+
+```
+Consumer Pact ---+
+                 +--- PactFlow comparison ---> Compatible? Y/N
+OpenAPI Spec ----+
+```
+
+Reference: <https://docs.pactflow.io/docs/bi-directional-contract-testing>
+
+**Pros**: Zero infrastructure, bidirectional testing with OpenAPI, managed
+**Cons**: Paid service (free tier available for small teams)
+
+### Step 3: Provider verifies contracts
+
+When the provider (Zeebe gateway) changes, it verifies all consumer contracts:
+
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "${PACT_BROKER_URL}")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrchestrationApiProviderVerificationIT {
+
+  @BeforeEach
+  void setupTarget(PactVerificationContext context) {
+    context.setTarget(new HttpTestTarget("localhost", port));
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void verifyPact(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  // Provider state handlers — set up test data for each consumer scenario
+  @State("a job with key 123 exists")
+  void setupJobExists() {
+    testHelper.createJob(123L);
+  }
+
+  @State("user tasks exist")
+  void setupUserTasksExist() {
+    testHelper.createUserTask("Review document", "demo");
+  }
+}
+```
+
+### Step 4: CI Integration
+
+```yaml
+# .github/workflows/ci.yml (additions)
+
+# Consumer side — runs as part of unit tests
+consumer-contract-tests:
+  name: "Contract / Consumer Tests"
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Run Java client consumer tests
+      run: ./mvnw test -pl clients/java -Dgroups=contract
+    - name: Run Tasklist frontend consumer tests
+      run: cd tasklist/client && npm test -- --grep "contract"
+    - name: Publish pacts to broker
+      run: |
+        ./mvnw pact:publish \
+          -Dpact.broker.url=${{ secrets.PACT_BROKER_URL }} \
+          -Dpact.consumer.version=${{ github.sha }} \
+          -Dpact.consumer.tags=${{ github.ref_name }}
+
+# Provider side — runs when gateway code changes
+provider-contract-verification:
+  name: "Contract / Provider Verification"
+  needs: [consumer-contract-tests]
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Verify provider against all consumer pacts
+      run: |
+        ./mvnw verify -pl zeebe/gateway-rest \
+          -Dpact.broker.url=${{ secrets.PACT_BROKER_URL }} \
+          -Dpact.provider.version=${{ github.sha }} \
+          -Dpact.provider.tags=${{ github.ref_name }} \
+          -Dgroups=contract
+
+# Deployment gate
+can-i-deploy:
+  name: "Contract / Can I Deploy?"
+  needs: [provider-contract-verification]
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check deployment compatibility
+      run: |
+        pact-broker can-i-deploy \
+          --pacticipant camunda-orchestration-api \
+          --version ${{ github.sha }} \
+          --to-environment production \
+          --broker-base-url ${{ secrets.PACT_BROKER_URL }}
+```
+
+## Recommended Progression
+
+| Stage | Approach | When |
+|-------|----------|------|
+| **Start** | **File-based** (`contracts/pacts/` in repo) | Immediately — zero setup |
+| **Scale** | **Self-hosted Pact Broker** or **PactFlow free tier** | When contract count exceeds ~10 or need `can-i-deploy` |
+| **Mature** | **PactFlow** with bidirectional testing against OpenAPI spec | When ready for independent deployability |
+
+The monorepo actually simplifies the initial rollout because consumer and provider code live in the same repo — pact files can be generated and verified in the same CI run without a broker.
+
+---
+
+# Reference Examples
+
+## Unit Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `zeebe/engine/.../BatchOperationPageProcessorTest.java` | Given/when/then, single behavior, clean mocking |
+| Gold | `operate/webapp/.../ResolveIncidentHandlerTest.java` | `@ExtendWith(MockitoExtension.class)`, `InOrder` verification |
+| Gold | `tasklist/webapp/.../TaskServiceTest.java` | `@ParameterizedTest`, error path testing |
+
+## Integration Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `zeebe/exporters/.../ElasticsearchExporterIT.java` | Singleton container, `TestSearchContainers`, smart cleanup |
+| Gold | `dist/.../AbstractCamundaDockerIT.java` | Network-aware multi-container, deterministic cleanup |
+| Gold | `operate/qa/.../OperateSearchAbstractIT.java` | Lifecycle hooks, cache clearing, mock auth |
+
+## Contract Test References
+
+| Quality | File / Concept | Why |
+|---------|---------------|-----|
+| Target | Java Client Pact consumer tests (to be created) | Consumer-driven, verifies client assumptions against v2 REST API |
+| Target | Tasklist Frontend Pact consumer tests (to be created) | Leverages existing Zod schemas, verifies FE expectations |
+| Target | Exporter message Pact (to be created) | Verifies ES/OS index schema contract between exporter and consumers |
+| Keep | Spectral OpenAPI linting (existing) | Spec validity — complementary to Pact |
+| Keep | Buf protobuf backward compat (existing) | gRPC schema contract — already enforced |
+| Reclassify | `zeebe/gateway-rest/.../JobControllerTest.java` | **API slice test** (integration), not a contract test |
+| Reclassify | `qa/c8-orchestration-cluster-e2e-test-suite/.../process-instance-get-api.spec.ts` | **E2E API validation** — too slow for PR feedback, keep as nightly |
+
+## E2E Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `operate/client/e2e-playwright/tests/login.spec.ts` | No `waitForTimeout`, Page Object Model, accessible selectors |
+| Gold | `operate/client/e2e-playwright/tests/processInstance.spec.ts` | `expect.poll()`, `test.slow()`, fixture architecture |
+| Avoid | `operate/client/e2e-playwright/visual/processInstance.spec.ts` | 6x `waitForTimeout(500)` — anti-pattern |
+
+## Test Utility References
+
+| Utility | File | Purpose |
+|---------|------|---------|
+| Container factory | `zeebe/test-util/.../TestSearchContainers.java` | Single source of truth for container images |
+| Engine test rule | `zeebe/engine/.../EngineRule.java` | Full engine bootstrap for engine tests |
+| State extension | `zeebe/engine/.../ProcessingStateExtension.java` | Inject ZeebeDb state per test |
+| Recording exporter | `zeebe/test-util/.../RecordingExporterTestWatcher.java` | Record/replay events, dump on failure |
+| REST test base | `zeebe/gateway-rest/.../RestControllerTest.java` | `WebTestClient` + auth stubs |
+| Operate IT base | `operate/qa/.../OperateSearchAbstractIT.java` | Container lifecycle + auth mocking |
+| Playwright fixtures | `operate/client/e2e-playwright/e2e-fixtures.ts` | Page objects + auth session reuse |

--- a/docs/testing-strategy/README.md
+++ b/docs/testing-strategy/README.md
@@ -1,0 +1,99 @@
+# Testing Strategy Manifesto
+
+**Camunda 8 Monorepo** | **Status**: DRAFT — Pending team review and adoption
+
+> Every line of production code that reaches `main` must be backed by automated tests
+> that are fast, deterministic, and maintainable. If you can't run it locally in minutes,
+> it belongs in nightly — not in your PR.
+
+---
+
+## Guiding Principles
+
+1. **Tests are a first-class deliverable** — A feature without tests is not done. A bugfix without a regression test is incomplete.
+2. **Optimize for developer feedback speed** — A test that takes 20 minutes and fails intermittently is worse than no test.
+3. **Determinism over coverage** — A deterministic suite with 70% coverage beats a flaky suite with 90%.
+4. **Test at the lowest possible level** — Unit > Integration > E2E. Higher-level tests are slower, flakier, and harder to debug.
+5. **Tests must be runnable locally** — If it requires infrastructure that can't be replicated locally, it belongs in nightly.
+
+---
+
+## The Testing Pyramid
+
+```
+                    /    E2E    \                 Nightly only. < 5% of test time.
+                   /  Contract   \              PR-blocking. Fast. ~10% of test time.
+                  /  Integration  \            PR-blocking (primary DB). ~20% of test time.
+                 /    Unit Tests   \         PR-blocking. Fast. ~65% of test time.
+                /___________________\
+```
+
+| Layer | Scope | External Deps | Target Time | When |
+|-------|-------|---------------|-------------|------|
+| **Unit** | Single class/function | None (mocked) | < 100ms/test | Every PR, locally |
+| **Integration** | Multiple components | TestContainers | < 30s/test | PR (primary DB), nightly (matrix) |
+| **Contract** | API boundary | None (mock consumer/provider) | < 1s/test | Every PR |
+| **E2E** | Full system | Full running system | < 2 min/test | Nightly, release |
+| **Architecture** | Code structure | None | < 10s total | Every PR |
+| **Performance** | Throughput/latency | Full running system | Minutes-hours | Weekly, release |
+
+---
+
+## Test Requirements by Change Type
+
+| Change Type | Required Tests |
+|-------------|---------------|
+| **New feature** | Unit tests for all public classes/methods; integration test if DB/search/external; contract test if REST/gRPC endpoint; update affected tests |
+| **Bug fix** | Regression test (`@RegressionTest`) at lowest possible level |
+| **Incident** | Regression test; integration test if data corruption; contract test if cross-service; post-mortem identifies correct layer |
+| **Refactoring** | All existing tests pass without modification (or PR explains why) |
+| **Dependency update** | All existing tests pass; contract tests if public API affected |
+
+---
+
+## PR Checklist
+
+Every PR that modifies production code must satisfy:
+
+- [ ] **Tests added or updated** — Every public change is verified by an automated test
+- [ ] **Bug fixes include regression test** — annotated with `@RegressionTest`
+- [ ] **No `Thread.sleep()` in test code** — use Awaitility or `expect.poll()`
+- [ ] **No `waitForTimeout()` in Playwright tests** — use assertion-based waiting
+- [ ] **Test naming follows conventions** — `should<Verb><Object>` for Java, descriptive text for Playwright
+- [ ] **Given/When/Then structure** — all test methods use the structured comment pattern
+- [ ] **Integration tests use `*IT.java` suffix** — executed by Failsafe
+- [ ] **TestContainers use `TestSearchContainers` factory** — not hardcoded image tags
+- [ ] **No `@Disabled` without issue link** — every disabled test tracks a resolution
+- [ ] **New/modified REST/gRPC endpoints have contract tests** — Pact consumer test per consumer, Buf for gRPC
+
+---
+
+## Detailed Guides
+
+| Guide | Description |
+|-------|-------------|
+| [Unit Tests](./unit-tests.md) | Rules, gold standard examples |
+| [Integration Tests](./integration-tests.md) | TestContainers, Spring slicing, patterns |
+| [Contract Tests](./contract-tests.md) | Consumer-driven contract testing with Pact |
+| [E2E Tests](./e2e-tests.md) | Playwright rules, Page Object Model |
+| [Architecture Tests](./architecture-tests.md) | ArchUnit rules and coverage |
+| [Performance & Reliability Tests](./performance-reliability-tests.md) | JMH, chaos engineering |
+| [Prohibited Patterns](./prohibited-patterns.md) | 8 anti-patterns with examples |
+| [Required Patterns](./required-patterns.md) | 6 required patterns with examples |
+| [Naming Conventions](./naming-conventions.md) | File suffixes, method naming, locations |
+| [Flaky Test Policy](./flaky-test-policy.md) | Budget, quarantine, runbook, root causes |
+| [Test Data Management](./test-data-management.md) | Isolation, builders, Instancio |
+
+## Setup & Configuration
+
+| Guide | Description |
+|-------|-------------|
+| [Frameworks and Tools](./setup/frameworks-and-tools.md) | Mandatory/prohibited frameworks, versions |
+| [Enforcement Rules](./setup/enforcement-rules.md) | ArchUnit, ESLint, Checkstyle config |
+| [Pact Setup](./setup/pact-setup.md) | Dependencies, broker, CI YAML |
+
+## Reference
+
+| Guide | Description |
+|-------|-------------|
+| [Examples](./reference/examples.md) | Gold standard file paths, utilities |

--- a/docs/testing-strategy/architecture-tests.md
+++ b/docs/testing-strategy/architecture-tests.md
@@ -1,0 +1,28 @@
+# Architecture Tests
+
+> Back to [Testing Strategy](./README.md)
+
+## Definition
+
+Architecture tests (ArchUnit) verify structural properties of the codebase: dependency directions, naming conventions, annotation usage, and module boundaries.
+
+## Rules
+
+1. All ArchUnit tests live in `qa/archunit-tests/` — not scattered across modules
+2. All ArchUnit test classes must be named `*ArchTest.java`
+3. ArchUnit tests run on every PR as part of the `archunit-tests` CI job
+4. New architectural constraints should be proposed via PR and reviewed by the team
+
+## Current Coverage
+
+The following architectural properties are enforced (see `qa/archunit-tests/`):
+
+- Processor naming conventions
+- `@VisibleForTesting` usage (only accessed from test code)
+- Client dependency isolation (no protocol dependency)
+- Controller authorization patterns
+- Engine class dependency rules
+- Protocol immutability
+- REST controller annotations
+- State modification rules
+- Migration task registration

--- a/docs/testing-strategy/contract-tests.md
+++ b/docs/testing-strategy/contract-tests.md
@@ -1,0 +1,282 @@
+# Contract Tests
+
+> Back to [Testing Strategy](./README.md) | Setup: [Pact Setup](./setup/pact-setup.md)
+
+## Definition
+
+A contract test verifies the **agreement between a consumer and a provider** at their API boundary, without starting the full system. Unlike integration tests that verify internal wiring, contract tests verify that:
+
+- **Consumers** can rely on the API behaving as they expect (consumer-driven)
+- **Providers** don't accidentally break consumers when they change the API
+- **Services can be deployed independently** with confidence that they remain compatible
+
+Contract tests are **not** controller slice tests (`@WebMvcTest`). Controller slice tests verify internal wiring between a controller and its service layer — that is an integration test concern. Contract tests verify the **external API contract** between independently deployable components.
+
+## Camunda Service Communication Architecture
+
+Understanding the architecture is essential for defining contract boundaries:
+
+```
+                    +----------------------------------+
+                    |         v2 REST API              |
+                    |   (Orchestration Cluster API)    |
+                    |   rest-api.yaml (OpenAPI 3.0.3)  |
+                    +---------------+------------------+
+                                    |
+               +--------------------+--------------------+
+               |                    |                    |
+      Operate Frontend      Tasklist Frontend      Java Client
+      (fetch + Zod)         (fetch + Zod)          (HTTP + gRPC)
+               |                    |                    |
+               |   +----------------+                    |
+               |   |                                     |
+      Operate Backend     Tasklist Backend               |
+      (gRPC writes)       (gRPC writes)                  |
+               |                    |                    |
+               +--------+---------+                     |
+                        |                                |
+               Zeebe Gateway / Broker <-----------------+
+                        |
+                        | [Record Stream]
+                        v
+                 Camunda Exporter
+                        |
+                        | [Bulk Write]
+                        v
+                Elasticsearch / OpenSearch
+                        |
+            +-----------+-----------+
+            |           |           |
+         Operate    Tasklist    Optimize
+         (reads)    (reads)     (reads)
+```
+
+**Key insight**: Operate, Tasklist, and Optimize do **not** call each other. They share data only through Elasticsearch/OpenSearch indices written by the Camunda Exporter. The v2 REST API is the single unified provider for all consumers.
+
+## Contract Boundary Definitions
+
+| Consumer | Provider | Protocol | Contract Type | Tool |
+|----------|----------|----------|--------------|------|
+| **Java Client** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate Frontend** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Tasklist Frontend** | v2 REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate Frontend** | Operate Internal API (`/api/`) | HTTP/JSON | REST consumer contract (legacy) | **Pact** |
+| **Optimize Frontend** | Optimize Backend REST API | HTTP/JSON | REST consumer contract | **Pact** |
+| **Operate/Tasklist Backend** | Zeebe gRPC | gRPC/Protobuf | Schema compatibility | **Buf** (already in CI) |
+| **Camunda Exporter** | ES/OS index schema | Data/Message | Message contract | **Pact message** or schema assertions |
+| **Any consumer** | v2 REST API spec | OpenAPI 3.0.3 | Spec validity | **Spectral** (already in CI) |
+
+## Java Client Consumer Tests (Priority 1)
+
+The Java client (`clients/java/`) is the highest-priority Pact consumer because it is the **public API contract** used by all external integrators.
+
+```java
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "camunda-orchestration-api", port = "8080")
+class JobApiContractTest {
+
+  @Pact(consumer = "camunda-java-client")
+  V4Pact failJobContract(PactDslWithProvider builder) {
+    return builder
+        .given("a job with key 123 exists")
+        .uponReceiving("a request to fail job 123")
+          .path("/v2/jobs/123/failure")
+          .method("POST")
+          .headers("Content-Type", "application/json")
+          .body(new PactDslJsonBody()
+              .integerType("retries", 1)
+              .stringType("errorMessage", "task failed")
+              .integerType("retryBackOff", 1000))
+        .willRespondWith()
+          .status(204)
+        .toPact(V4Pact.class);
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "failJobContract")
+  void shouldFailJob(MockServer mockServer) {
+    // given
+    var client = CamundaClient.newClientBuilder()
+        .restAddress(URI.create(mockServer.getUrl()))
+        .preferRestOverGrpc(true)
+        .build();
+
+    // when + then — no exception means contract is satisfied
+    client.newFailCommand(123L)
+        .retries(1)
+        .errorMessage("task failed")
+        .retryBackoff(Duration.ofSeconds(1))
+        .send()
+        .join();
+  }
+}
+```
+
+**What this catches that `@WebMvcTest` doesn't:**
+- If the Java client sends a field the provider doesn't expect -> contract fails
+- If the provider removes a field the client depends on -> contract fails
+- If the client assumes a 200 but the provider returns 204 -> contract fails
+- These failures are detected **without running the provider at all**
+
+## Frontend Consumer Tests (Priority 2)
+
+The Operate and Tasklist frontends already use `@camunda/camunda-api-zod-schemas` for typed API calls. Pact JS can generate contracts from these.
+
+```typescript
+import {PactV4} from '@pact-foundation/pact';
+
+const provider = new PactV4({
+  consumer: 'tasklist-frontend',
+  provider: 'camunda-orchestration-api',
+});
+
+describe('User Tasks API Contract', () => {
+  it('should search user tasks', async () => {
+    await provider
+      .addInteraction()
+      .given('user tasks exist')
+      .uponReceiving('a search request for user tasks')
+      .withRequest('POST', '/v2/user-tasks/search', (builder) => {
+        builder.headers({'Content-Type': 'application/json'});
+        builder.jsonBody({
+          filter: {state: 'CREATED', assigned: true},
+          page: {limit: 50},
+        });
+      })
+      .willRespondWith(200, (builder) => {
+        builder.headers({'Content-Type': 'application/json'});
+        builder.jsonBody({
+          items: eachLike({
+            userTaskKey: string('12345'),
+            name: string('Review document'),
+            taskState: string('CREATED'),
+            assignee: string('demo'),
+          }),
+          page: {totalItems: integer(1)},
+        });
+      })
+      .executeTest(async (mockServer) => {
+        const response = await fetch(`${mockServer.url}/v2/user-tasks/search`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            filter: {state: 'CREATED', assigned: true},
+            page: {limit: 50},
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.items).toBeDefined();
+        expect(body.items[0].userTaskKey).toBeDefined();
+      });
+  });
+});
+```
+
+## Provider Verification (Zeebe Gateway)
+
+The Zeebe gateway (the v2 REST API provider) verifies all consumer contracts:
+
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "${PACT_BROKER_URL}")  // or @PactFolder("pacts") for local dev
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrchestrationApiProviderVerificationIT {
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void verifyPact(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  @State("a job with key 123 exists")
+  void setupJobExists() {
+    // Create test data in the provider's state
+  }
+
+  @State("user tasks exist")
+  void setupUserTasksExist() {
+    // Create test data for user task search
+  }
+}
+```
+
+This runs on every PR that changes the gateway, catching any provider-side breaks before merge.
+
+## Exporter Data Contract (Priority 3)
+
+The Elasticsearch index schema is an implicit data contract between the Camunda Exporter (producer) and Operate/Tasklist/Optimize (consumers). Use **Pact message contracts** for this:
+
+```java
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "camunda-exporter", providerType = ProviderType.ASYNCH)
+class OperateExporterContractTest {
+
+  @Pact(consumer = "operate")
+  MessagePact processInstanceRecord(MessagePactBuilder builder) {
+    return builder
+        .expectsToReceive("a process instance CREATED record")
+        .withContent(new PactDslJsonBody()
+            .integerType("key")
+            .stringType("intent", "CREATED")
+            .object("value")
+              .stringType("bpmnProcessId")
+              .integerType("processDefinitionKey")
+              .integerType("version")
+            .closeObject())
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "processInstanceRecord")
+  void shouldConsumeProcessInstanceRecord(List<Message> messages) {
+    // Verify Operate can deserialize the exporter record
+    var record = objectMapper.readValue(
+        messages.get(0).contentsAsString(), ProcessInstanceRecord.class);
+    assertThat(record.getKey()).isNotNull();
+    assertThat(record.getValue().getBpmnProcessId()).isNotNull();
+  }
+}
+```
+
+## What Existing Tests Become
+
+| Current Test | Current Classification | Correct Classification |
+|-------------|----------------------|----------------------|
+| `JobControllerTest` (`@WebMvcTest`) | Was labeled "contract test" | **API slice test** (integration test layer) — verifies controller wiring |
+| Spectral OpenAPI linting | Spec validation | **Spec validation** (keep as-is, complementary to Pact) |
+| Buf protobuf check | gRPC schema compat | **Schema contract test** (keep as-is) |
+| `validateResponse()` in E2E API tests | API response validation | **E2E validation** (keep, but too slow for PR feedback) |
+| Zod schema validation (frontend) | Runtime type checking | **Client-side validation** (complementary to Pact) |
+
+The existing `@WebMvcTest` tests (like `JobControllerTest`) are still valuable — they verify that the controller correctly parses requests and delegates to services. They just aren't contract tests. They should be classified as **API slice tests** within the integration test layer.
+
+## When to Write Contract Tests
+
+**Rule: Every new or modified REST/gRPC endpoint must have a Pact consumer contract test.** This applies to all API surfaces — v2, legacy internal, Optimize backend, or any other endpoint consumed by another application or frontend.
+
+| Change | Contract Test Required? |
+|--------|----------------------|
+| **New REST endpoint** (any API surface) | **Yes** — Pact consumer test for each consuming application |
+| **Modified REST endpoint** (request/response change) | **Yes** — update existing Pact consumer tests |
+| **Removed or renamed API field** | **Yes** — Pact will catch if any consumer depends on it |
+| **New field in exporter record** | **Yes** — Pact message contract for consuming applications |
+| **New or modified gRPC service method** | **Yes** — Buf backward compat (already enforced) + Pact consumer test if consumed by Java client |
+| **New query parameter, header, or status code** | **Yes** — if any consumer relies on it |
+| Internal refactoring (no API change) | No |
+
+**No endpoint ships without a contract.** If the endpoint has no consumer test, either:
+1. There is no consumer yet (add the contract when the first consumer is built), or
+2. The consumers are untested — fix that first
+
+## Rollout Strategy
+
+| Phase | Scope | Timeline |
+|-------|-------|----------|
+| **Phase A** | Java Client -> v2 REST API (file-based pacts in repo) | Week 1-3 |
+| **Phase B** | Tasklist Frontend -> v2 REST API (leveraging Zod schemas) | Week 2-4 |
+| **Phase C** | Operate Frontend -> v2 REST API + legacy `/api/` | Week 3-5 |
+| **Phase D** | Exporter -> ES/OS index schema (Pact message contracts) | Week 4-6 |
+| **Phase E** | Optimize Frontend -> Optimize Backend REST API | Week 5-7 |
+| **Phase F** | Set up Pact Broker + `can-i-deploy` in CI | Week 6-8 |

--- a/docs/testing-strategy/e2e-tests.md
+++ b/docs/testing-strategy/e2e-tests.md
@@ -1,0 +1,99 @@
+# End-to-End Tests
+
+> Back to [Testing Strategy](./README.md)
+
+## Definition
+
+An E2E test exercises the full system through its external interfaces (UI or API) with all real dependencies running. These are the most expensive tests and should be used sparingly.
+
+## Rules
+
+1. **E2E tests do NOT block PRs** — they run nightly and on release branches only
+2. **Use Playwright** for all browser-based E2E tests
+3. **Use the Page Object Model** — all page interactions go through page objects, never raw selectors in test files
+4. **Never use `waitForTimeout()`** — use assertion-based waiting (`expect(locator).toBeVisible()`, `expect.poll()`)
+5. **Never use `actionTimeout: 0`** — always set a bounded action timeout (10 seconds)
+6. **Use accessible selectors** — `getByRole()`, `getByLabel()`, `getByText()` over `getByTestId()` over CSS selectors
+7. **Retries are not a substitute for reliability** — `retries: 2` in Playwright config is acceptable for CI resilience, but a test that needs retries to pass should be investigated
+8. **Use `test.step()`** for multi-step tests — provides clear failure attribution
+
+## Gold Standard Example
+
+From `operate/client/e2e-playwright/tests/login.spec.ts`:
+
+```typescript
+test.describe('login page', () => {
+  test('Log in with invalid user account', async ({loginPage, page}) => {
+    await loginPage.login({username: 'demo', password: 'wrong-password'});
+    await expect(
+      page.getByRole('alert').getByText('Username and password do not match'),
+    ).toBeVisible();
+    await expect(page).toHaveURL('/operate/login');
+  });
+
+  test('Log in with valid user account', async ({loginPage, page}) => {
+    await loginPage.login({username: 'demo', password: 'demo'});
+    await expect(page).toHaveURL('../operate');
+  });
+});
+```
+
+**Why this is the standard:**
+- No `waitForTimeout` — all waits are assertion-based
+- Page Object Model via fixtures (`loginPage`)
+- Accessible selectors (`getByRole('alert')`)
+- Short, focused — one scenario per test
+- No hardcoded URLs or magic strings
+
+## Page Object Model
+
+Every page or component that tests interact with must have a corresponding page object class:
+
+```typescript
+// pages/Login.ts
+export class Login {
+  private page: Page;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly loginButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.getByLabel(/^username$/i);
+    this.passwordInput = page.getByLabel(/^password$/i);
+    this.loginButton = page.getByRole('button', {name: 'Login'});
+  }
+
+  async login(credentials: {username: string; password: string}) {
+    await this.fillUsername(credentials.username);
+    await this.fillPassword(credentials.password);
+    await this.clickLoginButton();
+  }
+}
+```
+
+Reference: `operate/client/e2e-playwright/pages/Login.ts`
+
+## Eventual Consistency in E2E Tests
+
+Use `expect.poll()` or `expect().toPass()` for assertions that depend on asynchronous data:
+
+```typescript
+// CORRECT: polling with timeout
+await expect.poll(async () => {
+  const response = await request.get(`${baseUrl}/v1/process-instances/${key}`);
+  return response.status();
+}, {timeout: 30_000}).toBe(200);
+
+// CORRECT: retry assertion block
+await expect(async () => {
+  const res = await request.get(buildUrl(`/process-instances/${key}`));
+  await assertStatusCode(res, 200);
+  await validateResponse({path: '/process-instances/{key}', method: 'GET', status: '200'}, res);
+}).toPass(defaultAssertionOptions);
+
+// WRONG: hardcoded wait
+await page.waitForTimeout(5000);  // NEVER DO THIS
+```
+
+Reference: `operate/client/e2e-playwright/tests/processInstance.spec.ts`

--- a/docs/testing-strategy/flaky-test-policy.md
+++ b/docs/testing-strategy/flaky-test-policy.md
@@ -1,0 +1,64 @@
+# Flaky Test Policy
+
+> Back to [Testing Strategy](./README.md)
+
+## Definition
+
+A flaky test is a test that produces different results (pass/fail) on the same code without any code change. A test that passes only on retry is flaky.
+
+## Metric Definitions
+
+Precise definitions are critical for enforceability:
+
+- **Test-level flaky rate** = (number of test methods that flaked at least once in a week) / (total distinct test methods executed that week). This is the primary metric. Benchmark: Google targets 1.5%, Netflix <2%, Uber <3%.
+- **Pipeline flake rate** = (pipeline runs that failed due to flakes) / (total pipeline runs). This is the developer-facing metric that drives trust.
+
+## Tiered Targets
+
+| Phase | Test-Level Target | Pipeline Target | Timeline |
+|-------|-------------------|-----------------|----------|
+| End of Phase 1 | <10% | Measured | Week 6 |
+| End of Phase 3 | <5% | <10% | Week 16 |
+| CD Readiness | **<2%** | **<2%** | Stretch goal |
+
+## Policy
+
+1. **Detection**: The existing `flaky-test-extractor-maven-plugin` and BigQuery/Grafana pipeline will track flaky tests
+2. **Quarantine threshold**: Flake rate >5% for tests run 10+ times/week, OR 3+ flakes for tests run <10 times/week. The threshold is rate-based (not count-based) to account for execution frequency
+3. **Quarantine mechanism**: Apply JUnit 5 `@Tag("quarantine")` to the test class/method. Configure Surefire with `<excludedGroups>quarantine</excludedGroups>` for PR runs. Quarantined tests still run nightly
+4. **Fix SLA**: Quarantined tests must be fixed or deleted within 2 sprints
+5. **No `@Disabled` without an issue**: Every disabled test must link to a tracking issue
+6. **Progressive retry reduction**: `rerunFailingTestsCount` will be reduced from 3 -> 2 -> 1 -> 0 (Surefire) with explicit go/no-go gates. Keep Failsafe at 1 permanently — see [Phase 1](../ci-cd/phase-1-flaky-test-remediation.md)
+
+## Flakiness Classification
+
+Not all flakiness is the same. Classify by root cause before setting fix expectations:
+
+| Category | Examples | Fixable? | Approach |
+|----------|----------|----------|----------|
+| **Timing-dependent** | `Thread.sleep()`, hardcoded timeouts | Yes | Awaitility / `expect.poll()` |
+| **Resource contention** | Tests fail under CI load but pass locally | Partially | Reduce CI waste (Phase 2), singleton containers |
+| **Architecturally eventual-consistent** | Raft consensus, ES write-to-read delay | Harder | May legitimately need 1 Failsafe retry |
+| **Shared mutable state** | Static fields, containers without cleanup | Yes | Per-test isolation |
+| **Environment-specific** | Docker pull failures, port conflicts | Partially | Registry mirrors, OS-assigned ports |
+
+## Flaky Test Response Runbook
+
+When a test flakes:
+
+1. Check the Grafana dashboard: `https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo`
+2. Search for an existing issue: `gh issue list --label kind/flake --search "<test class name>"`
+3. If no issue exists, create one using the flaky test issue template
+4. Reproduce locally using IntelliJ "Repeat Until Failure" (see `docs/zeebe/failing-tests.md`)
+5. Fix the root cause, don't add retry logic
+
+## Common Root Causes and Fixes
+
+| Root Cause | Pattern | Fix |
+|-----------|---------|-----|
+| Timing dependency | `Thread.sleep()`, hardcoded timeouts | Awaitility / `expect.poll()` |
+| Shared mutable state | Static fields, shared containers without cleanup | Per-test isolation, `@BeforeEach` cleanup |
+| Port conflicts | Random ports without checking availability | Let the OS assign ports (`0`), TestContainers handles this |
+| Test order dependency | Test B depends on data created by Test A | Each test creates its own data |
+| Resource exhaustion | Too many concurrent containers, file handle leaks | Singleton containers, proper `@AfterEach` cleanup |
+| Eventual consistency | Assert immediately after write to async system | Awaitility polling |

--- a/docs/testing-strategy/integration-tests.md
+++ b/docs/testing-strategy/integration-tests.md
@@ -1,0 +1,95 @@
+# Integration Tests
+
+> Back to [Testing Strategy](./README.md)
+
+## Definition
+
+An integration test verifies the interaction between two or more real components — typically your code with a real database, search engine, or message broker. External dependencies run in Docker via TestContainers.
+
+## Rules
+
+1. **Use TestContainers** — never depend on pre-installed infrastructure. Tests must be self-contained
+2. **Use the `TestSearchContainers` factory** (`zeebe/test-util`) for all Elasticsearch/OpenSearch containers — this is the single source of truth for container image versions
+3. **Prefer singleton containers** — use `static @Container` with `@Testcontainers` to share a container across all tests in a class. Starting a new container per test is wasteful (~5-10 seconds per start)
+4. **Clean up between tests** — truncate data, reset indexes, or use unique prefixes. Never rely on test execution order
+5. **File naming** — integration tests MUST end with `IT.java` (e.g., `UserServiceIT.java`). This ensures Failsafe (not Surefire) executes them
+6. **Timeout** — individual integration tests should complete in < 30 seconds. If a test needs more, it likely tests too much
+7. **Use `Awaitility`** for eventual consistency — never `Thread.sleep()`
+
+## Gold Standard Example
+
+From `zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java`:
+
+```java
+@Testcontainers
+final class ElasticsearchExporterIT {
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer()
+          .withEnv("action.destructive_requires_name", "false");
+
+  @BeforeEach
+  public void beforeEach(final TestInfo testInfo) {
+    // Only recreate indexes when the test method changes (performance optimization)
+    final String currentTestMethod = getTestMethod(testInfo);
+    if (!currentTestMethod.equals(previousTestMethod)) {
+      if (previousTestMethod != null) {
+        deletedIndices();
+      }
+      setup();
+      previousTestMethod = currentTestMethod;
+    }
+  }
+}
+```
+
+**Why this is the standard:**
+- Singleton container (`static @Container`) — started once for the class
+- `TestSearchContainers` factory for consistent versioning
+- Smart cleanup: only resets state when the test method changes
+- Self-contained: no dependency on external infrastructure
+
+## TestContainers Patterns
+
+**Singleton container (preferred for most cases):**
+```java
+@Testcontainers
+class MyServiceIT {
+  @Container
+  private static final ElasticsearchContainer ES =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+}
+```
+
+**Network-aware multi-container (for cross-service tests):**
+```java
+class CrossServiceIT {
+  private Network network;
+  private final List<GenericContainer<?>> containers = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    network = Network.newNetwork();
+  }
+
+  @AfterEach
+  void tearDown() {
+    containers.forEach(GenericContainer::stop);
+    network.close();
+  }
+}
+```
+
+Reference: `dist/src/test/java/io/camunda/application/AbstractCamundaDockerIT.java`
+
+## Spring Integration Tests
+
+When Spring context is required, use the narrowest possible slice:
+
+| Annotation | Use When | Context Size |
+|-----------|----------|-------------|
+| `@WebMvcTest(Controller.class)` | Testing a single REST controller | Minimal (web layer only) |
+| `@DataJpaTest` | Testing repository/DAO layer | JPA layer only |
+| `@SpringBootTest(classes = {SpecificConfig.class})` | Testing with specific beans only | Specified classes only |
+| `@SpringBootTest` (full) | **Last resort** — only for acceptance tests | Full application context |

--- a/docs/testing-strategy/naming-conventions.md
+++ b/docs/testing-strategy/naming-conventions.md
@@ -1,0 +1,58 @@
+# Naming Conventions
+
+> Back to [Testing Strategy](./README.md)
+
+## File Naming
+
+| Test Type | Suffix | Example | Executed By |
+|-----------|--------|---------|------------|
+| Unit test | `*Test.java` | `BatchOperationPageProcessorTest.java` | Surefire |
+| Integration test | `*IT.java` | `ElasticsearchExporterIT.java` | Failsafe |
+| Architecture test | `*ArchTest.java` | `VisibleForTestingArchTest.java` | Surefire (in `qa/archunit-tests`) |
+| Property-based test | `*PropertyTest.java` | `RandomizedPropertyTest.java` | Surefire (dedicated profile) |
+| Playwright spec | `*.spec.ts` | `login.spec.ts` | Playwright Test |
+
+**Critical**: Using the wrong suffix means the test runs with the wrong plugin (or not at all).
+- `*Test.java` -> Surefire (unit tests, no Docker, fast)
+- `*IT.java` -> Failsafe (integration tests, Docker allowed, lifecycle hooks)
+
+## Method Naming
+
+**Java test methods** must use the `should<Verb><Object>` pattern:
+
+```java
+// CORRECT
+void shouldRejectInvalidCredentials()
+void shouldReturnEmptyListWhenNoProcessesExist()
+void shouldCreateProcessInstanceWithVariables()
+void shouldFailWhenDatabaseIsUnavailable()
+
+// INCORRECT
+void test1()
+void testCreateProcess()
+void createProcessWorks()
+void invalidCredentials()
+```
+
+**Playwright test descriptions** should describe the user action or scenario:
+
+```typescript
+// CORRECT
+test('Log in with valid user account', ...)
+test('Resolve an incident @roundtrip', ...)
+test('should display error when process not found', ...)
+
+// INCORRECT
+test('test login', ...)
+test('TC-001', ...)
+```
+
+## Test Class Location
+
+| Test Type | Location | Example |
+|-----------|----------|---------|
+| Unit tests | Same module: `src/test/java/` | `zeebe/engine/src/test/java/.../MyTest.java` |
+| Integration tests for a module | Same module or module's `qa/` | `operate/qa/integration-tests/` |
+| Cross-module acceptance tests | `qa/acceptance-tests/` | `qa/acceptance-tests/src/test/java/` |
+| Architecture tests | `qa/archunit-tests/` | `qa/archunit-tests/src/test/java/` |
+| Playwright E2E | Module's `e2e-playwright/` or `qa/c8-orchestration-cluster-e2e-test-suite/` | `operate/client/e2e-playwright/` |

--- a/docs/testing-strategy/performance-reliability-tests.md
+++ b/docs/testing-strategy/performance-reliability-tests.md
@@ -1,0 +1,16 @@
+# Performance and Reliability Tests
+
+> Back to [Testing Strategy](./README.md)
+
+## Performance Tests
+
+- Run **weekly** and before releases — never on PRs
+- Use JMH for microbenchmarks (`microbenchmarks/` module)
+- Use the load tester (`load-tests/load-tester/`) for system-level throughput tests
+- Throughput SLOs: 50 PI/s (typical), 300 PI/s (stress) — see `docs/testing/reliability-testing.md`
+
+## Reliability Tests
+
+- Chaos engineering via `zbchaos` CLI
+- Automated chaos experiments via Camunda BPMN processes
+- Run weekly on dedicated GKE infrastructure

--- a/docs/testing-strategy/prohibited-patterns.md
+++ b/docs/testing-strategy/prohibited-patterns.md
@@ -1,0 +1,139 @@
+# Prohibited Patterns
+
+> Back to [Testing Strategy](./README.md)
+
+These patterns are **banned** from all new code and must be removed from existing code during maintenance.
+
+---
+
+## 1. `Thread.sleep()` in test code
+
+```java
+// PROHIBITED
+Thread.sleep(5000);
+assertThat(service.getStatus()).isEqualTo("READY");
+
+// REQUIRED: use Awaitility
+Awaitility.await()
+    .atMost(Duration.ofSeconds(10))
+    .pollInterval(Duration.ofMillis(100))
+    .untilAsserted(() ->
+        assertThat(service.getStatus()).isEqualTo("READY"));
+```
+
+**Exception**: `Thread.sleep()` is acceptable only in production code for deliberate backoff/throttling, never in tests.
+
+---
+
+## 2. `page.waitForTimeout()` in Playwright tests
+
+```typescript
+// PROHIBITED
+await page.waitForTimeout(500);
+
+// REQUIRED: use assertion-based waiting
+await expect(page.locator('.modal')).toBeVisible();
+```
+
+**No exceptions.**
+
+---
+
+## 3. `actionTimeout: 0` in Playwright configuration
+
+```typescript
+// PROHIBITED
+actionTimeout: 0,  // unlimited — will hang forever
+
+// REQUIRED
+actionTimeout: 10_000,  // bounded timeout
+```
+
+---
+
+## 4. JUnit / Hamcrest assertions
+
+```java
+// PROHIBITED (enforced by Checkstyle)
+assertEquals(expected, actual);        // JUnit
+assertThat(actual, is(expected));      // Hamcrest
+
+// REQUIRED
+assertThat(actual).isEqualTo(expected);  // AssertJ
+```
+
+This is already enforced by Checkstyle (`IllegalImport` rule in `build-tools/src/main/resources/check/.checkstyle.xml`).
+
+---
+
+## 5. JUnit 4 in new code
+
+```java
+// PROHIBITED in new code
+@RunWith(SpringRunner.class)
+@Rule public final EngineRule engine = EngineRule.singlePartition();
+
+// REQUIRED
+@ExtendWith(SpringExtension.class)
+@RegisterExtension final EngineExtension engine = EngineExtension.create();
+```
+
+> **Note**: For the JUnit 4 -> 5 migration plan for existing code, see [CI/CD Phase 4: Developer Experience](../ci-cd/phase-4-developer-experience.md).
+
+---
+
+## 6. Raw `Thread` management in concurrency tests
+
+```java
+// PROHIBITED
+Thread[] threads = new Thread[5];
+for (int i = 0; i < threads.length; i++) {
+  threads[i] = new Thread(task);
+  threads[i].start();
+  Thread.sleep(10);
+}
+
+// REQUIRED
+ExecutorService executor = Executors.newFixedThreadPool(5);
+CountDownLatch startLatch = new CountDownLatch(1);
+for (int i = 0; i < 5; i++) {
+  executor.submit(() -> {
+    startLatch.await();  // all threads start simultaneously
+    task.run();
+  });
+}
+startLatch.countDown();
+executor.shutdown();
+executor.awaitTermination(10, TimeUnit.SECONDS);
+```
+
+---
+
+## 7. Non-deterministic test data without seed
+
+```java
+// PROHIBITED — different data each run, unreproducible failures
+var randomName = UUID.randomUUID().toString();
+
+// REQUIRED — seeded random or deterministic
+var testName = "test-process-" + testInfo.getDisplayName().hashCode();
+
+// OR use Instancio with seed
+var data = Instancio.of(MyModel.class)
+    .withSeed(12345L)
+    .create();
+```
+
+**Exception**: UUIDs are acceptable when used for isolation (unique index names, unique process IDs) and the specific value doesn't matter for the assertion.
+
+---
+
+## 8. `@Disabled` without an issue link
+
+```java
+// PROHIBITED
+@Disabled("it's broken")
+
+// REQUIRED
+@Disabled("Flaky, tracked in https://github.com/camunda/camunda/issues/42928")
+```

--- a/docs/testing-strategy/reference/examples.md
+++ b/docs/testing-strategy/reference/examples.md
@@ -1,0 +1,51 @@
+# Reference Examples
+
+> Back to [Testing Strategy](../README.md)
+
+## Unit Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `zeebe/engine/.../BatchOperationPageProcessorTest.java` | Given/when/then, single behavior, clean mocking |
+| Gold | `operate/webapp/.../ResolveIncidentHandlerTest.java` | `@ExtendWith(MockitoExtension.class)`, `InOrder` verification |
+| Gold | `tasklist/webapp/.../TaskServiceTest.java` | `@ParameterizedTest`, error path testing |
+
+## Integration Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `zeebe/exporters/.../ElasticsearchExporterIT.java` | Singleton container, `TestSearchContainers`, smart cleanup |
+| Gold | `dist/.../AbstractCamundaDockerIT.java` | Network-aware multi-container, deterministic cleanup |
+| Gold | `operate/qa/.../OperateSearchAbstractIT.java` | Lifecycle hooks, cache clearing, mock auth |
+
+## Contract Test References
+
+| Quality | File / Concept | Why |
+|---------|---------------|-----|
+| Target | Java Client Pact consumer tests (to be created) | Consumer-driven, verifies client assumptions against v2 REST API |
+| Target | Tasklist Frontend Pact consumer tests (to be created) | Leverages existing Zod schemas, verifies FE expectations |
+| Target | Exporter message Pact (to be created) | Verifies ES/OS index schema contract between exporter and consumers |
+| Keep | Spectral OpenAPI linting (existing) | Spec validity — complementary to Pact |
+| Keep | Buf protobuf backward compat (existing) | gRPC schema contract — already enforced |
+| Reclassify | `zeebe/gateway-rest/.../JobControllerTest.java` | **API slice test** (integration), not a contract test |
+| Reclassify | `qa/c8-orchestration-cluster-e2e-test-suite/.../process-instance-get-api.spec.ts` | **E2E API validation** — too slow for PR feedback, keep as nightly |
+
+## E2E Test References
+
+| Quality | File | Why |
+|---------|------|-----|
+| Gold | `operate/client/e2e-playwright/tests/login.spec.ts` | No `waitForTimeout`, Page Object Model, accessible selectors |
+| Gold | `operate/client/e2e-playwright/tests/processInstance.spec.ts` | `expect.poll()`, `test.slow()`, fixture architecture |
+| Avoid | `operate/client/e2e-playwright/visual/processInstance.spec.ts` | 6x `waitForTimeout(500)` — anti-pattern |
+
+## Test Utility References
+
+| Utility | File | Purpose |
+|---------|------|---------|
+| Container factory | `zeebe/test-util/.../TestSearchContainers.java` | Single source of truth for container images |
+| Engine test rule | `zeebe/engine/.../EngineRule.java` | Full engine bootstrap for engine tests |
+| State extension | `zeebe/engine/.../ProcessingStateExtension.java` | Inject ZeebeDb state per test |
+| Recording exporter | `zeebe/test-util/.../RecordingExporterTestWatcher.java` | Record/replay events, dump on failure |
+| REST test base | `zeebe/gateway-rest/.../RestControllerTest.java` | `WebTestClient` + auth stubs |
+| Operate IT base | `operate/qa/.../OperateSearchAbstractIT.java` | Container lifecycle + auth mocking |
+| Playwright fixtures | `operate/client/e2e-playwright/e2e-fixtures.ts` | Page objects + auth session reuse |

--- a/docs/testing-strategy/required-patterns.md
+++ b/docs/testing-strategy/required-patterns.md
@@ -1,0 +1,91 @@
+# Required Patterns
+
+> Back to [Testing Strategy](./README.md)
+
+---
+
+## 1. Given/When/Then structure
+
+Every test method must contain `// given`, `// when`, `// then` comments:
+
+```java
+@Test
+void shouldRejectInvalidInput() {
+    // given
+    final var request = new CreateRequest(null, -1);
+
+    // when
+    final var result = assertThrows(ValidationException.class,
+        () -> service.create(request));
+
+    // then
+    assertThat(result.getMessage()).contains("name must not be null");
+}
+```
+
+---
+
+## 2. Regression test annotation for bug fixes
+
+```java
+@Test
+@RegressionTest("https://github.com/camunda/camunda/issues/12345")
+void shouldNotCrashWhenInputIsEmpty() {
+    // given — the exact scenario that caused the bug
+    // when — the action that triggered the bug
+    // then — the correct behavior
+}
+```
+
+---
+
+## 3. Awaitility for all asynchronous assertions
+
+```java
+Awaitility.await("process instance should be active")
+    .atMost(Duration.ofSeconds(10))
+    .pollInterval(Duration.ofMillis(200))
+    .untilAsserted(() ->
+        assertThat(getProcessInstance(key).getState()).isEqualTo(ACTIVE));
+```
+
+---
+
+## 4. `expect.poll()` or `expect().toPass()` in Playwright
+
+```typescript
+await expect.poll(async () => {
+  const response = await request.get(url);
+  return response.status();
+}, {timeout: 30_000, intervals: [500, 1000, 2000]}).toBe(200);
+```
+
+---
+
+## 5. TestContainers via `TestSearchContainers` factory
+
+```java
+// REQUIRED: use the central factory
+@Container
+private static final ElasticsearchContainer CONTAINER =
+    TestSearchContainers.createDefeaultElasticsearchContainer();
+
+// PROHIBITED: hardcoded image tags
+@Container
+private static final ElasticsearchContainer CONTAINER =
+    new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.18.4");
+```
+
+---
+
+## 6. Page Object Model in Playwright
+
+```typescript
+// REQUIRED: interact through page objects
+await loginPage.login({username: 'demo', password: 'demo'});
+
+// PROHIBITED: raw selectors in test files
+await page.locator('#username-input').fill('demo');
+await page.locator('#password-input').fill('demo');
+await page.locator('button[type="submit"]').click();
+```

--- a/docs/testing-strategy/setup/enforcement-rules.md
+++ b/docs/testing-strategy/setup/enforcement-rules.md
@@ -1,0 +1,101 @@
+# Enforcement Rules
+
+> Back to [Testing Strategy](../README.md)
+
+## Automated Enforcement (CI)
+
+| Rule | Enforcement Mechanism | Status |
+|------|----------------------|--------|
+| AssertJ-only assertions | Checkstyle `IllegalImport` rule | Active |
+| ArchUnit structural rules | `archunit-tests` CI job | Active |
+| Code formatting | Spotless CI job | Active |
+| OpenAPI spec validity | Spectral linting CI job | Active |
+| Protobuf backward compat | Buf CI job | Active |
+| No `Thread.sleep()` in tests | **Proposed**: Checkstyle or ArchUnit rule | Not yet active |
+| No `waitForTimeout()` in Playwright | **Proposed**: ESLint rule | Not yet active |
+| Test naming conventions (`should*`) | **Proposed**: ArchUnit rule | Not yet active |
+| Coverage thresholds | **Proposed**: JaCoCo minimum limits | Not yet active |
+
+## Code Review Enforcement (Human)
+
+Reviewers must verify:
+1. Appropriate test level (unit > integration > E2E)
+2. Test quality (single behavior, clear naming, no anti-patterns)
+3. No test-less production code changes (unless pure refactoring with unchanged behavior)
+4. PR checklist is complete
+
+## Proposed New Automated Rules
+
+### Priority 1: Three Hard CI Rules (Enforce Immediately)
+
+These three rules should be the first to go live. Start with exactly these three — more rules can be added later once the team demonstrates it can maintain compliance.
+
+**1. ArchUnit `FreezingArchRule` — No NEW `Thread.sleep()` in test code:**
+
+> Use `FreezingArchRule` to capture existing violations as a baseline. Only new violations fail the build. This enables gradual migration without breaking existing code.
+
+```java
+@ArchTest
+static final ArchRule noThreadSleepInTests = FreezingArchRule.freeze(
+    noClasses()
+        .that().resideInAPackage("..test..")
+        .should().callMethod(Thread.class, "sleep", long.class)
+        .because("Use Awaitility instead of Thread.sleep() in tests"));
+```
+
+**2. ESLint rule — No `waitForTimeout()` in Playwright:**
+
+Add `/* eslint-disable */` comments on the 15 existing files as a temporary baseline, then remove as files are fixed.
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", {
+      "selector": "CallExpression[callee.property.name='waitForTimeout']",
+      "message": "Use assertion-based waiting instead of waitForTimeout()"
+    }]
+  }
+}
+```
+
+**3. ArchUnit rule — No new JUnit 4 usage:**
+
+```java
+@ArchTest
+static final ArchRule noNewJUnit4 = noClasses()
+    .should().dependOnClassesThat().resideInAPackage("org.junit")
+    .andShould().not().dependOnClassesThat().resideInAPackage("org.junit.jupiter..")
+    .because("New tests must use JUnit Jupiter, not JUnit 4");
+```
+
+### Priority 2: Additional Rules (After Priority 1 is Stable)
+
+**ArchUnit rule — Test naming conventions (`should*`):**
+```java
+@ArchTest
+static final ArchRule testMethodNaming = methods()
+    .that().areAnnotatedWith(Test.class)
+    .should().haveNameStartingWith("should")
+    .because("Test methods must follow the should<Verb><Object> pattern");
+```
+
+**ArchUnit rule — No `@Disabled` without issue link:**
+```java
+// Custom rule that checks @Disabled annotation value contains "github.com/camunda/camunda/issues/"
+```
+
+**ArchUnit rule — TestContainers use `TestSearchContainers` factory:**
+```java
+// Custom rule banning direct ElasticsearchContainer/OpensearchContainer instantiation
+```
+
+### Metric Ratchets
+
+CI should track these counts and fail any PR that increases them beyond the current baseline:
+
+| Metric | Current Baseline | Tracked By |
+|--------|-----------------|------------|
+| `Thread.sleep()` in test files | 52 | FreezingArchRule violation store |
+| `waitForTimeout()` in Playwright | 15 | ESLint baseline comments |
+| `@Disabled` without issue link | TBD (measure) | Custom ArchUnit rule |
+| JUnit 4 test files | 804 | ArchUnit / grep |

--- a/docs/testing-strategy/setup/frameworks-and-tools.md
+++ b/docs/testing-strategy/setup/frameworks-and-tools.md
@@ -1,0 +1,37 @@
+# Frameworks and Tools
+
+> Back to [Testing Strategy](../README.md)
+
+## Mandatory Frameworks
+
+| Purpose | Framework | Version Source |
+|---------|-----------|----------------|
+| Test runner | JUnit 5 (Jupiter) | `parent/pom.xml` |
+| Assertions | AssertJ | `parent/pom.xml` |
+| Mocking | Mockito | `parent/pom.xml` |
+| Async assertions | Awaitility | `parent/pom.xml` |
+| Containers | TestContainers | `parent/pom.xml` |
+| Contract testing (Java) | Pact JVM (`au.com.dius.pact`) | `parent/pom.xml` (to be added) |
+| Contract testing (JS/TS) | Pact JS (`@pact-foundation/pact`) | `package.json` (to be added) |
+| Browser E2E | Playwright Test | `package.json` |
+| Architecture | ArchUnit | `parent/pom.xml` |
+| Test data generation | Instancio | `parent/pom.xml` |
+
+## Prohibited Frameworks
+
+| Framework | Reason | Alternative |
+|-----------|--------|-------------|
+| JUnit 4 (in new code) | Legacy, no parallel execution support | JUnit 5 |
+| Hamcrest | Inconsistent with AssertJ conventions | AssertJ |
+| PowerMock | Fragile, encourages bad design | Refactor to use interfaces + Mockito |
+| Selenium | Superseded | Playwright |
+
+## Spring Test Slicing (Use the Narrowest Slice)
+
+| Annotation | When to Use | Startup Time |
+|-----------|-------------|-------------|
+| No Spring annotations | Unit tests — preferred | 0ms |
+| `@WebMvcTest(Controller.class)` | REST controller slice tests | ~2-3s |
+| `@DataJpaTest` | Repository/DAO tests | ~2-3s |
+| `@SpringBootTest(classes = {...})` | Targeted integration tests | ~5-10s |
+| `@SpringBootTest` (full) | Acceptance tests only | ~15-30s |

--- a/docs/testing-strategy/setup/pact-setup.md
+++ b/docs/testing-strategy/setup/pact-setup.md
@@ -1,0 +1,276 @@
+# Pact Setup
+
+> Back to [Testing Strategy](../README.md) | Practices: [Contract Tests](../contract-tests.md)
+
+This document covers the installation, configuration, and CI integration for Pact contract testing. For when and how to write contract tests, see [Contract Tests](../contract-tests.md).
+
+## Dependencies
+
+**Java consumer (add to `clients/java/pom.xml` or relevant consumer module):**
+```xml
+<dependency>
+  <groupId>au.com.dius.pact.consumer</groupId>
+  <artifactId>junit5</artifactId>
+  <version>4.6.x</version>
+  <scope>test</scope>
+</dependency>
+```
+
+**JavaScript/TypeScript consumer (add to `operate/client/package.json` or relevant frontend):**
+```json
+{
+  "devDependencies": {
+    "@pact-foundation/pact": "^13.x"
+  }
+}
+```
+
+## How Pact Works: The Full Lifecycle
+
+> **References**:
+> - Pact documentation: <https://docs.pact.io>
+> - Pact JVM (Java): <https://docs.pact.io/implementation_guides/jvm>
+> - Pact JS (TypeScript/JavaScript): <https://docs.pact.io/implementation_guides/javascript>
+> - Consumer-Driven Contract Testing concepts: <https://docs.pact.io/getting_started/how_pact_works>
+> - Pact Broker (self-hosted): <https://github.com/pact-foundation/pact_broker>
+> - PactFlow (managed SaaS): <https://pactflow.io>
+> - Pact + OpenAPI (bidirectional contract testing): <https://docs.pactflow.io/docs/bi-directional-contract-testing>
+
+### Step 1: Consumer writes tests (generates contracts)
+
+The consumer team writes Pact tests as part of their regular unit/integration test suite. When tests run, Pact generates a **contract file** (JSON) in the `target/pacts/` (Java) or `pacts/` (JS) directory.
+
+```
+# Java consumer test execution
+./mvnw test -pl clients/java -Dtest=JobApiContractTest
+
+# Output:
+# target/pacts/camunda-java-client-camunda-orchestration-api.json
+```
+
+```
+# JS/TS consumer test execution
+cd tasklist/client && npm test -- --grep "contract"
+
+# Output:
+# pacts/tasklist-frontend-camunda-orchestration-api.json
+```
+
+The generated pact file contains every interaction the consumer expects:
+
+```json
+{
+  "consumer": { "name": "camunda-java-client" },
+  "provider": { "name": "camunda-orchestration-api" },
+  "interactions": [
+    {
+      "description": "a request to fail job 123",
+      "providerState": "a job with key 123 exists",
+      "request": {
+        "method": "POST",
+        "path": "/v2/jobs/123/failure",
+        "headers": { "Content-Type": "application/json" },
+        "body": { "retries": 1, "errorMessage": "task failed" }
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ]
+}
+```
+
+### Step 2: Contracts are stored and shared
+
+Contracts must be accessible to both consumers and providers. Three options, from simplest to most mature:
+
+**Option A: File-based (start here)**
+
+Store pact files in the repository under a shared directory:
+
+```
+contracts/
+  pacts/
+    camunda-java-client-camunda-orchestration-api.json
+    tasklist-frontend-camunda-orchestration-api.json
+    operate-frontend-camunda-orchestration-api.json
+```
+
+Consumer CI publishes pacts by committing to this directory. Provider CI reads from it. This works well for a monorepo where consumers and providers are in the same repository.
+
+**Pros**: Zero infrastructure, works immediately
+**Cons**: No versioning, no `can-i-deploy`, no branch-aware verification
+
+**Option B: Self-hosted Pact Broker**
+
+Deploy the open-source Pact Broker (<https://github.com/pact-foundation/pact_broker>):
+
+```yaml
+# docker-compose.pact-broker.yml
+services:
+  pact-broker:
+    image: pactfoundation/pact-broker:latest
+    ports:
+      - "9292:9292"
+    environment:
+      PACT_BROKER_DATABASE_URL: "sqlite:///pact_broker.sqlite3"
+```
+
+Consumers publish pacts after tests pass:
+```bash
+# Java (via pact-jvm plugin)
+./mvnw pact:publish -Dpact.broker.url=https://pact-broker.internal.camunda.com
+
+# JS (via @pact-foundation/pact-cli)
+npx pact-broker publish ./pacts \
+  --broker-base-url=https://pact-broker.internal.camunda.com \
+  --consumer-app-version=$(git rev-parse HEAD) \
+  --tag=$(git branch --show-current)
+```
+
+Providers fetch and verify:
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "https://pact-broker.internal.camunda.com")
+class OrchestrationApiProviderVerificationIT { ... }
+```
+
+The broker provides:
+- **Contract versioning**: each consumer version has its own pact
+- **`can-i-deploy`**: query whether a version is safe to deploy
+- **Webhooks**: trigger provider verification when a new pact is published
+- **Network diagram**: visual map of all consumer-provider relationships
+- **Tags/branches**: branch-aware verification (verify `main` pacts vs. feature branch pacts)
+
+```bash
+# Before deploying: check if this version is compatible with all consumers/providers
+pact-broker can-i-deploy \
+  --pacticipant camunda-orchestration-api \
+  --version $(git rev-parse HEAD) \
+  --to-environment production
+```
+
+**Pros**: Full Pact workflow, free, self-hosted
+**Cons**: Requires infrastructure to host and maintain
+
+**Option C: PactFlow (managed SaaS)**
+
+PactFlow (<https://pactflow.io>) is the managed Pact Broker with additional features:
+
+- **Bidirectional contract testing**: verify consumer pacts against the OpenAPI spec (`rest-api.yaml`) without running the provider
+- **Teams and permissions**: control who can publish/verify
+- **CI integration**: native GitHub Actions support
+- **Support and SLAs**
+
+**Bidirectional contract testing** is especially powerful here because:
+1. Consumer pacts are generated from consumer tests (as normal)
+2. Instead of running provider verification tests, PactFlow compares the consumer pact against the published OpenAPI spec
+3. If the consumer's expectations are a subset of what the OpenAPI spec promises -> compatible
+4. This means **no provider-side test code is needed** for the initial rollout
+
+```
+Consumer Pact ---+
+                 +--- PactFlow comparison ---> Compatible? Y/N
+OpenAPI Spec ----+
+```
+
+Reference: <https://docs.pactflow.io/docs/bi-directional-contract-testing>
+
+**Pros**: Zero infrastructure, bidirectional testing with OpenAPI, managed
+**Cons**: Paid service (free tier available for small teams)
+
+### Step 3: Provider verifies contracts
+
+When the provider (Zeebe gateway) changes, it verifies all consumer contracts:
+
+```java
+@Provider("camunda-orchestration-api")
+@PactBroker(url = "${PACT_BROKER_URL}")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OrchestrationApiProviderVerificationIT {
+
+  @BeforeEach
+  void setupTarget(PactVerificationContext context) {
+    context.setTarget(new HttpTestTarget("localhost", port));
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void verifyPact(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  // Provider state handlers — set up test data for each consumer scenario
+  @State("a job with key 123 exists")
+  void setupJobExists() {
+    testHelper.createJob(123L);
+  }
+
+  @State("user tasks exist")
+  void setupUserTasksExist() {
+    testHelper.createUserTask("Review document", "demo");
+  }
+}
+```
+
+### Step 4: CI Integration
+
+```yaml
+# .github/workflows/ci.yml (additions)
+
+# Consumer side — runs as part of unit tests
+consumer-contract-tests:
+  name: "Contract / Consumer Tests"
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Run Java client consumer tests
+      run: ./mvnw test -pl clients/java -Dgroups=contract
+    - name: Run Tasklist frontend consumer tests
+      run: cd tasklist/client && npm test -- --grep "contract"
+    - name: Publish pacts to broker
+      run: |
+        ./mvnw pact:publish \
+          -Dpact.broker.url=${{ secrets.PACT_BROKER_URL }} \
+          -Dpact.consumer.version=${{ github.sha }} \
+          -Dpact.consumer.tags=${{ github.ref_name }}
+
+# Provider side — runs when gateway code changes
+provider-contract-verification:
+  name: "Contract / Provider Verification"
+  needs: [consumer-contract-tests]
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Verify provider against all consumer pacts
+      run: |
+        ./mvnw verify -pl zeebe/gateway-rest \
+          -Dpact.broker.url=${{ secrets.PACT_BROKER_URL }} \
+          -Dpact.provider.version=${{ github.sha }} \
+          -Dpact.provider.tags=${{ github.ref_name }} \
+          -Dgroups=contract
+
+# Deployment gate
+can-i-deploy:
+  name: "Contract / Can I Deploy?"
+  needs: [provider-contract-verification]
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check deployment compatibility
+      run: |
+        pact-broker can-i-deploy \
+          --pacticipant camunda-orchestration-api \
+          --version ${{ github.sha }} \
+          --to-environment production \
+          --broker-base-url ${{ secrets.PACT_BROKER_URL }}
+```
+
+## Recommended Progression
+
+| Stage | Approach | When |
+|-------|----------|------|
+| **Start** | **File-based** (`contracts/pacts/` in repo) | Immediately — zero setup |
+| **Scale** | **Self-hosted Pact Broker** or **PactFlow free tier** | When contract count exceeds ~10 or need `can-i-deploy` |
+| **Mature** | **PactFlow** with bidirectional testing against OpenAPI spec | When ready for independent deployability |
+
+The monorepo actually simplifies the initial rollout because consumer and provider code live in the same repo — pact files can be generated and verified in the same CI run without a broker.

--- a/docs/testing-strategy/test-data-management.md
+++ b/docs/testing-strategy/test-data-management.md
@@ -1,0 +1,31 @@
+# Test Data Management
+
+> Back to [Testing Strategy](./README.md)
+
+## Principles
+
+1. **Each test creates its own data** — never depend on data from another test
+2. **Use unique identifiers** — prefix test data with test method name or unique key to prevent collisions in parallel execution
+3. **Clean up after yourself** — integration tests must clean up created data in `@AfterEach` or use unique prefixes that don't collide
+
+## Patterns
+
+**Builder/factory pattern for test data:**
+```java
+// CORRECT
+var process = Bpmn.createExecutableProcess("test-" + testInfo.getDisplayName())
+    .startEvent()
+    .userTask("task-1")
+    .endEvent()
+    .done();
+
+// INCORRECT — shared, mutable, reused across tests
+static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess("shared-process")...;
+```
+
+**Instancio for random but reproducible data:**
+```java
+var user = Instancio.of(UserEntity.class)
+    .set(field(UserEntity::getEmail), "test@example.com")
+    .create();
+```

--- a/docs/testing-strategy/unit-tests.md
+++ b/docs/testing-strategy/unit-tests.md
@@ -1,0 +1,64 @@
+# Unit Tests
+
+> Back to [Testing Strategy](./README.md)
+
+## Definition
+
+A unit test verifies a single class or function in complete isolation. All collaborators are mocked or stubbed. No I/O, no network, no database, no file system, no Docker containers.
+
+## Rules
+
+1. **One assertion focus per test** — test a single behavior, not multiple scenarios
+2. **Given/When/Then structure** — every test must use `// given`, `// when`, `// then` comments
+3. **No shared mutable state** — use `@BeforeEach` for per-test setup, never static mutable fields
+4. **Mock external dependencies** — use `@ExtendWith(MockitoExtension.class)` and `@Mock` / `@InjectMocks`
+5. **Fast** — individual unit tests should execute in < 100ms. If a "unit test" needs > 1 second, it's an integration test
+6. **No Spring context** — unit tests must never use `@SpringBootTest`, `@WebMvcTest`, or any Spring test annotation that loads an application context
+
+## Gold Standard Example
+
+From `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationPageProcessorTest.java`:
+
+```java
+class BatchOperationPageProcessorTest {
+
+  private static final long BATCH_OPERATION_KEY = 123L;
+  private static final int CHUNK_SIZE = 2;
+
+  private BatchOperationPageProcessor processor;
+  private TaskResultBuilder mockTaskResultBuilder;
+
+  @BeforeEach
+  void setUp() {
+    processor = new BatchOperationPageProcessor(CHUNK_SIZE);
+    mockTaskResultBuilder = mock(TaskResultBuilder.class);
+  }
+
+  @Test
+  void shouldProcessPageWithSingleChunk() {
+    // given
+    final var item1 = new Item(100L, 200L, null);
+    final var item2 = new Item(101L, 201L, null);
+    final var page = new ItemPage(List.of(item1, item2), "cursor123", 2L, false);
+    when(mockTaskResultBuilder.canAppendRecords(any(), any())).thenReturn(true);
+
+    // when
+    final var result = processor.processPage(BATCH_OPERATION_KEY, page, mockTaskResultBuilder);
+
+    // then
+    assertThat(result.chunksAppended()).isTrue();
+    assertThat(result.endCursor()).isEqualTo("cursor123");
+    assertThat(result.itemsProcessed()).isEqualTo(2);
+    assertThat(result.isLastPage()).isFalse();
+  }
+}
+```
+
+**Why this is the standard:**
+- Clear naming: `shouldProcessPageWithSingleChunk`
+- Constants are named: `BATCH_OPERATION_KEY`, `CHUNK_SIZE`
+- `@BeforeEach` creates fresh instances — no shared state
+- Single behavior per test
+- Given/when/then structure
+- AssertJ assertions
+- No Spring context, no I/O

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,6 +109,17 @@ successfully before running the tests.
 Acceptance tests (ATs) are mostly slow, testing a complete user journey or a feature end-to-end (E2E), covering multiple or even all components at the same time in an integrated manner.
 Details, general recommendations, and how-tos/examples of how to write them, you can find in the [acceptance test guide](./testing/acceptance.md).
 
+## Testing Strategy
+
+For comprehensive testing practices, patterns, and policies for the Camunda monorepo, see the [Testing Strategy Manifesto](./testing-strategy/README.md). It covers:
+
+- Guiding principles and the testing pyramid
+- Detailed guides for each test layer (unit, integration, contract, E2E, architecture, performance)
+- Prohibited and required patterns
+- Naming conventions and framework choices
+- Flaky test policy and enforcement rules
+- PR checklist
+
 ## Reliability testing
 
 We define reliability testing as a type of software testing and practice that validates system performance and reliability. It can thus be done over time and with injection failure scenarios (injecting chaos).


### PR DESCRIPTION
## Summary

- **CI/CD Improvement Plan** (`docs/ci-cd/`, 13 files): Phased plan to reduce PR wall-clock time from ~55 min to ~20 min, cut compute costs by 65%, and bring flaky test rate below 2%. Structured as three implementation tiers with explicit off-ramps (Must-Do / Should-Do / Aspirational).
- **Testing Strategy Manifesto** (`docs/testing-strategy/`, 16 files): Testing practices, prohibited/required patterns, naming conventions, enforcement rules (FreezingArchRule, metric ratchets), flaky test policy with tiered budgets, and contract testing guidance.
- **Consolidated versions** for Google Docs import: `docs/ci-cd-consolidated.md` and `docs/testing-strategy-consolidated.md`.
- Cross-references added to `docs/testing.md` and `docs/monorepo-docs/index.md`.

### Key highlights

- **Tiered flaky targets**: Unknown → <10% → <5% → <2% with go/no-go gates before each retry reduction step
- **Phase 1+2 run concurrently** — flaky test remediation and build artifact sharing start in parallel
- **FreezingArchRule** for gradual Thread.sleep migration — captures baseline violations, only fails on new ones
- **JUnit migration risk upgraded to Medium-High** — expect 30-40% manual intervention due to custom rules (EngineRule, RuleChain)
- **Contract testing tiered**: Tier 2 strengthens existing tools (OpenAPI diff, Zod sync, Buf); Tier 3 introduces Pact as aspirational
- **Reviewed by 3 specialist perspectives**: Solutions Architecture, CI/CD reliability, and devil's advocate

## Test plan

- [ ] Verify all 82 internal cross-reference links resolve correctly
- [ ] Review phase timelines and targets for feasibility
- [ ] Confirm factual corrections (build counts, existing configs, JUnit version)
- [ ] Team review of enforcement rules and flaky test policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)