### PR TITLE
refactor: emit violating value to assist debugging

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationAdvice.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationAdvice.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.validation;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -85,12 +86,24 @@ public class ResponseValidationAdvice implements ResponseBodyAdvice<Object> {
 
     final Set<ConstraintViolation<Object>> violations = validator.validate(body);
     if (!violations.isEmpty()) {
+      final String details =
+          violations.stream()
+              .map(
+                  v ->
+                      v.getPropertyPath()
+                          + ": "
+                          + v.getMessage()
+                          + " (was: "
+                          + v.getInvalidValue()
+                          + ")")
+              .sorted()
+              .collect(Collectors.joining("; "));
       LOG.error(
-          "Response validation failed for {} {} — {} violation(s) detected: {}",
+          "Response validation failed for {} {} — {} violation(s): {}",
           request.getMethod(),
           request.getURI().getPath(),
           violations.size(),
-          violations);
+          details);
       throw new ResponseValidationException(violations);
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationException.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationException.java
@@ -33,7 +33,14 @@ public class ResponseValidationException extends RuntimeException {
   private static String buildMessage(final Set<? extends ConstraintViolation<?>> violations) {
     final String details =
         violations.stream()
-            .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+            .map(
+                v ->
+                    v.getPropertyPath()
+                        + ": "
+                        + v.getMessage()
+                        + " (was: "
+                        + v.getInvalidValue()
+                        + ")")
             .sorted()
             .collect(Collectors.joining("; "));
     return "Response validation failed: " + details;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationAdviceTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationAdviceTest.java
@@ -184,6 +184,21 @@ class ResponseValidationAdviceTest {
           .hasMessageContaining("licenseType")
           .hasMessageContaining("must not be null");
     }
+
+    @Test
+    void shouldIncludeInvalidValueInViolationMessage() {
+      // given — licenseType is null
+      final LicenseResponse invalidResponse =
+          new LicenseResponse()
+              .validLicense(true)
+              .isCommercial(true)
+              .expiresAt("2025-12-31T23:59:59Z");
+
+      // when / then
+      assertThatThrownBy(() -> callBeforeBodyWrite(invalidResponse))
+          .isInstanceOf(ResponseValidationException.class)
+          .hasMessageContaining("licenseType: must not be null (was: null)");
+    }
   }
 
   @Nested
@@ -205,8 +220,9 @@ class ResponseValidationAdviceTest {
               ex -> {
                 final ResponseValidationException rve = (ResponseValidationException) ex;
                 assertThat(rve.getViolations()).hasSize(1);
-                assertThat(rve.getViolations().iterator().next().getPropertyPath().toString())
-                    .isEqualTo("licenseType");
+                final var violation = rve.getViolations().iterator().next();
+                assertThat(violation.getPropertyPath().toString()).isEqualTo("licenseType");
+                assertThat(violation.getInvalidValue()).isNull();
               });
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationSpringMvcIntegrationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/validation/ResponseValidationSpringMvcIntegrationTest.java
@@ -90,7 +90,8 @@ class ResponseValidationSpringMvcIntegrationTest {
                 final String detailStr = (String) detail;
                 org.assertj.core.api.Assertions.assertThat(detailStr)
                     .contains("licenseType")
-                    .contains("must not be null");
+                    .contains("must not be null")
+                    .contains("(was: null)");
               });
     }
 
@@ -113,7 +114,8 @@ class ResponseValidationSpringMvcIntegrationTest {
                 org.assertj.core.api.Assertions.assertThat(detailStr)
                     .contains("validLicense")
                     .contains("licenseType")
-                    .contains("isCommercial");
+                    .contains("isCommercial")
+                    .contains("(was: null)");
               });
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The gateway response schema violation report now includes the value that violated the schema constraint. 

This is particularly useful when debugging constraint violations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
