### PR TITLE
ci: exclude integration tests in surefire plugin of cpt

### DIFF
--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -99,8 +99,10 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>
-            <!-- Run tests with failsafe as integration tests -->
+            <!-- Run all tests as integration tests -->
             <exclude>**/*Test.java</exclude>
+            <!-- Exclude nested classes of test classes (compiled as OuterClass$InnerClass.class) -->
+            <exclude>**/*Test$*.class</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -112,6 +114,7 @@
           <includes>
             <!-- Run all tests as integration tests -->
             <include>**/*Test.java</include>
+            <include>**/*Test$*.class</include>
           </includes>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -203,7 +203,27 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- We run integration tests with failsafe -->
+            <exclude>**/*IT.class</exclude>
+            <!-- Exclude nested classes of IT classes (compiled as OuterIT$NestedClass.class) -->
+            <exclude>**/*IT$*.class</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <includes>
+            <!-- Run all IT classes and their nested classes as integration tests -->
+            <include>**/*IT.class</include>
+            <include>**/*IT$*.class</include>
+          </includes>
+        </configuration>
       </plugin>
 
       <!-- Coverage frontend build with frontend-maven-plugin -->


### PR DESCRIPTION
## Description

Integration tests require a freshly built docker image. This is not available in unit test workflows such as General / Unit - Back End.

Make sure nested integration tests are picked up.

TODO:

- [ ] add linting rule to fail on test classes that contain `Test` and `IT`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

See https://camunda.slack.com/archives/C071KP5BTHB/p1771600115315819

I addressed this on `stable/8.9` already with https://github.com/camunda/camunda/pull/46385/changes/a7e1c3c6357964da99fba2dc45f96ff3ff42bc1a to unblock the merge of another PR https://github.com/camunda/camunda/pull/46385
