### PR TITLE
refactor: Use enhanced switch where possible

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -63,25 +63,17 @@ public class SearchEngineConnectPropertiesOverride {
     final SecondaryStorageDatabase database;
 
     switch (secondaryStorage.getType()) {
-      case elasticsearch:
-        {
-          database = secondaryStorage.getElasticsearch();
-          populateFromDocumentBasedSecondaryStorageDatabase(
-              (DocumentBasedSecondaryStorageDatabase) database, override);
-          break;
-        }
-      case rdbms:
-        {
-          database = secondaryStorage.getRdbms();
-          break;
-        }
-      default:
-        {
-          database = secondaryStorage.getOpensearch();
-          populateFromDocumentBasedSecondaryStorageDatabase(
-              (DocumentBasedSecondaryStorageDatabase) database, override);
-          break;
-        }
+      case elasticsearch -> {
+        database = secondaryStorage.getElasticsearch();
+        populateFromDocumentBasedSecondaryStorageDatabase(
+            (DocumentBasedSecondaryStorageDatabase) database, override);
+      }
+      case rdbms -> database = secondaryStorage.getRdbms();
+      default -> {
+        database = secondaryStorage.getOpensearch();
+        populateFromDocumentBasedSecondaryStorageDatabase(
+            (DocumentBasedSecondaryStorageDatabase) database, override);
+      }
     }
 
     override.setType(secondaryStorage.getType().name());

--- a/debug-cli/src/test/java/io/camunda/debug/cli/TopologyMetaCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/TopologyMetaCommandTest.java
@@ -94,20 +94,11 @@ public class TopologyMetaCommandTest {
     final var args = new ArrayList<String>();
     args.add("topology");
     switch (method) {
-      case "file":
-        args.addAll(List.of("-v", "--file", filePath));
-        break;
-      case "f":
-        args.addAll(List.of("-v", "-f", filePath));
-        break;
-      case "r":
-        args.addAll(List.of("-v", "-r", Path.of(filePath).getParent().toString()));
-        break;
-      case "root":
-        args.addAll(List.of("-v", "--root", Path.of(filePath).getParent().toString()));
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown method: " + method);
+      case "file" -> args.addAll(List.of("-v", "--file", filePath));
+      case "f" -> args.addAll(List.of("-v", "-f", filePath));
+      case "r" -> args.addAll(List.of("-v", "-r", Path.of(filePath).getParent().toString()));
+      case "root" -> args.addAll(List.of("-v", "--root", Path.of(filePath).getParent().toString()));
+      default -> throw new IllegalArgumentException("Unknown method: " + method);
     }
     args.addAll(Arrays.stream(extraArgs).toList());
     commandLine.execute(args.toArray(new String[0]));

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
@@ -218,20 +218,13 @@ public class DefaultClusterEventService
     eventServiceExecutor.execute(
         () -> {
           switch (event.type()) {
-            case MEMBER_ADDED:
-              updateRemoteSubscription(event);
-              break;
-            case METADATA_CHANGED:
-              updateRemoteSubscription(event);
-              break;
-            case REACHABILITY_CHANGED:
-              break;
-            case MEMBER_REMOVED:
-              removeAllSubscription(event.subject().id());
-              break;
-            default:
-              LOGGER.warn(
-                  "Unexpected membership event type {} from {}", event.type(), event.subject());
+            case MEMBER_ADDED -> updateRemoteSubscription(event);
+            case METADATA_CHANGED -> updateRemoteSubscription(event);
+            case REACHABILITY_CHANGED -> {}
+            case MEMBER_REMOVED -> removeAllSubscription(event.subject().id());
+            default ->
+                LOGGER.warn(
+                    "Unexpected membership event type {} from {}", event.type(), event.subject());
           }
         });
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV1.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV1.java
@@ -99,14 +99,9 @@ class MessageDecoderV1 extends AbstractMessageDecoder {
         }
 
         switch (type) {
-          case REQUEST:
-            currentState = DecoderState.READ_SUBJECT_LENGTH;
-            break;
-          case REPLY:
-            currentState = DecoderState.READ_STATUS;
-            break;
-          default:
-            checkState(false, "Must not be here");
+          case REQUEST -> currentState = DecoderState.READ_SUBJECT_LENGTH;
+          case REPLY -> currentState = DecoderState.READ_STATUS;
+          default -> checkState(false, "Must not be here");
         }
         break;
       default:
@@ -114,7 +109,7 @@ class MessageDecoderV1 extends AbstractMessageDecoder {
     }
 
     switch (type) {
-      case REQUEST:
+      case REQUEST -> {
         switch (currentState) {
           case READ_SUBJECT_LENGTH:
             if (buffer.readableBytes() < Short.BYTES) {
@@ -135,10 +130,10 @@ class MessageDecoderV1 extends AbstractMessageDecoder {
           default:
             break;
         }
-        break;
-      case REPLY:
+      }
+      case REPLY -> {
         switch (currentState) {
-          case READ_STATUS:
+          case READ_STATUS -> {
             if (buffer.readableBytes() < Byte.BYTES) {
               return;
             }
@@ -146,13 +141,11 @@ class MessageDecoderV1 extends AbstractMessageDecoder {
             final ProtocolReply message = new ProtocolReply(messageId, content, status);
             out.add(message);
             currentState = DecoderState.READ_TYPE;
-            break;
-          default:
-            break;
+          }
+          default -> {}
         }
-        break;
-      default:
-        checkState(false, "Must not be here");
+      }
+      default -> checkState(false, "Must not be here");
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV2.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV2.java
@@ -96,14 +96,9 @@ class MessageDecoderV2 extends AbstractMessageDecoder {
         }
 
         switch (type) {
-          case REQUEST:
-            currentState = DecoderState.READ_SUBJECT_LENGTH;
-            break;
-          case REPLY:
-            currentState = DecoderState.READ_STATUS;
-            break;
-          default:
-            checkState(false, "Must not be here");
+          case REQUEST -> currentState = DecoderState.READ_SUBJECT_LENGTH;
+          case REPLY -> currentState = DecoderState.READ_STATUS;
+          default -> checkState(false, "Must not be here");
         }
         break;
       default:
@@ -111,7 +106,7 @@ class MessageDecoderV2 extends AbstractMessageDecoder {
     }
 
     switch (type) {
-      case REQUEST:
+      case REQUEST -> {
         switch (currentState) {
           case READ_SUBJECT_LENGTH:
             if (buffer.readableBytes() < Short.BYTES) {
@@ -132,10 +127,10 @@ class MessageDecoderV2 extends AbstractMessageDecoder {
           default:
             break;
         }
-        break;
-      case REPLY:
+      }
+      case REPLY -> {
         switch (currentState) {
-          case READ_STATUS:
+          case READ_STATUS -> {
             if (buffer.readableBytes() < Byte.BYTES) {
               return;
             }
@@ -143,13 +138,11 @@ class MessageDecoderV2 extends AbstractMessageDecoder {
             final ProtocolReply message = new ProtocolReply(messageId, content, status);
             out.add(message);
             currentState = DecoderState.READ_TYPE;
-            break;
-          default:
-            break;
+          }
+          default -> {}
         }
-        break;
-      default:
-        checkState(false, "Must not be here");
+      }
+      default -> checkState(false, "Must not be here");
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -991,18 +991,16 @@ public final class NettyMessagingService implements ManagedMessagingService {
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
 
       switch (config.getCompressionAlgorithm()) {
-        case GZIP:
+        case GZIP -> {
           channel.pipeline().addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
           channel.pipeline().addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
-          break;
-        case SNAPPY:
+        }
+        case SNAPPY -> {
           channel.pipeline().addLast(new SnappyFrameEncoder());
           channel.pipeline().addLast(new SnappyFrameDecoder());
-          break;
-        case NONE:
-          break;
-        default:
-          log.debug("Unknown compression algorithm. Proceeding without compression.");
+        }
+        case NONE -> {}
+        default -> log.debug("Unknown compression algorithm. Proceeding without compression.");
       }
     }
 
@@ -1027,18 +1025,16 @@ public final class NettyMessagingService implements ManagedMessagingService {
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
 
       switch (config.getCompressionAlgorithm()) {
-        case GZIP:
+        case GZIP -> {
           channel.pipeline().addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
           channel.pipeline().addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
-          break;
-        case SNAPPY:
+        }
+        case SNAPPY -> {
           channel.pipeline().addLast(new SnappyFrameEncoder());
           channel.pipeline().addLast(new SnappyFrameDecoder());
-          break;
-        case NONE:
-          break;
-        default:
-          log.debug("Unknown compression algorithm. Proceeding without compression.");
+        }
+        case NONE -> {}
+        default -> log.debug("Unknown compression algorithm. Proceeding without compression.");
       }
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ProtocolMessage.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ProtocolMessage.java
@@ -72,14 +72,11 @@ public abstract class ProtocolMessage {
      * @return the type enum for the given ID.
      */
     public static Type forId(final int id) {
-      switch (id) {
-        case 1:
-          return REQUEST;
-        case 2:
-          return REPLY;
-        default:
-          throw new IllegalArgumentException("Unknown status ID " + id);
-      }
+      return switch (id) {
+        case 1 -> REQUEST;
+        case 2 -> REPLY;
+        default -> throw new IllegalArgumentException("Unknown status ID " + id);
+      };
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ProtocolReply.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ProtocolReply.java
@@ -86,18 +86,13 @@ public final class ProtocolReply extends ProtocolMessage {
      * @return the status enum for the given ID.
      */
     public static Status forId(final int id) {
-      switch (id) {
-        case 0:
-          return OK;
-        case 1:
-          return ERROR_NO_HANDLER;
-        case 2:
-          return ERROR_HANDLER_EXCEPTION;
-        case 3:
-          return PROTOCOL_EXCEPTION;
-        default:
-          throw new IllegalArgumentException("Unknown status ID " + id);
-      }
+      return switch (id) {
+        case 0 -> OK;
+        case 1 -> ERROR_NO_HANDLER;
+        case 2 -> ERROR_HANDLER_EXCEPTION;
+        case 3 -> PROTOCOL_EXCEPTION;
+        default -> throw new IllegalArgumentException("Unknown status ID " + id);
+      };
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -847,14 +847,9 @@ public class SwimMembershipProtocol
    */
   private void handleDiscoveryEvent(final NodeDiscoveryEvent event) {
     switch (event.type()) {
-      case JOIN:
-        handleJoinEvent(event.subject());
-        break;
-      case LEAVE:
-        handleLeaveEvent(event.subject());
-        break;
-      default:
-        throw new AssertionError();
+      case JOIN -> handleJoinEvent(event.subject());
+      case LEAVE -> handleLeaveEvent(event.subject());
+      default -> throw new AssertionError();
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -116,19 +116,17 @@ public final class RaftMemberContext {
 
   private void openReader(final RaftLog log) {
     switch (member.getType()) {
-      case PASSIVE:
+      case PASSIVE -> {
         reader = log.openCommittedReader();
         resetReaderAtEndOfLog(reader);
-        break;
-      case PROMOTABLE:
-      case ACTIVE:
+      }
+      case PROMOTABLE, ACTIVE -> {
         reader = log.openUncommittedReader();
         resetReaderAtEndOfLog(reader);
-        break;
-      default:
-        LoggerFactory.getLogger(RaftMemberContext.class)
-            .error("ResetState: No case for Member type {}", member.getType());
-        break;
+      }
+      default ->
+          LoggerFactory.getLogger(RaftMemberContext.class)
+              .error("ResetState: No case for Member type {}", member.getType());
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -794,26 +794,26 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   /** Creates an internal state for the given state type. */
   private RaftRole createRole(final Role role) {
-    switch (role) {
-      case INACTIVE:
+    return switch (role) {
+      case INACTIVE -> {
         raftRoleMetrics.becomingInactive();
-        return new InactiveRole(this);
-      case PASSIVE:
-        return new PassiveRole(this);
-      case PROMOTABLE:
-        return new PromotableRole(this);
-      case FOLLOWER:
+        yield new InactiveRole(this);
+      }
+      case PASSIVE -> new PassiveRole(this);
+      case PROMOTABLE -> new PromotableRole(this);
+      case FOLLOWER -> {
         raftRoleMetrics.becomingFollower();
-        return new FollowerRole(this, this::createElectionTimer);
-      case CANDIDATE:
+        yield new FollowerRole(this, this::createElectionTimer);
+      }
+      case CANDIDATE -> {
         raftRoleMetrics.becomingCandidate();
-        return new CandidateRole(this);
-      case LEADER:
+        yield new CandidateRole(this);
+      }
+      case LEADER -> {
         raftRoleMetrics.becomingLeader();
-        return new LeaderRole(this);
-      default:
-        throw new AssertionError();
-    }
+        yield new LeaderRole(this);
+      }
+    };
   }
 
   private ElectionTimer createElectionTimer(final Runnable triggerElection, final Logger log) {
@@ -834,26 +834,26 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   /** Transitions the server to the base state for the given member type. */
   public void transition(final Type type) {
     switch (type) {
-      case ACTIVE:
+      case ACTIVE -> {
         if (!(role instanceof ActiveRole)) {
           transition(Role.FOLLOWER);
         }
-        break;
-      case PROMOTABLE:
+      }
+      case PROMOTABLE -> {
         if (role.role() != Role.PROMOTABLE) {
           transition(Role.PROMOTABLE);
         }
-        break;
-      case PASSIVE:
+      }
+      case PASSIVE -> {
         if (role.role() != Role.PASSIVE) {
           transition(Role.PASSIVE);
         }
-        break;
-      default:
+      }
+      default -> {
         if (role.role() != Role.INACTIVE) {
           transition(Role.INACTIVE);
         }
-        break;
+      }
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/SerializerUtil.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/SerializerUtil.java
@@ -20,32 +20,21 @@ import io.atomix.raft.cluster.RaftMember;
 public class SerializerUtil {
 
   static MemberType getSBEType(final RaftMember.Type type) {
-    switch (type) {
-      case ACTIVE:
-        return MemberType.ACTIVE;
-      case PASSIVE:
-        return MemberType.PASSIVE;
-      case INACTIVE:
-        return MemberType.INACTIVE;
-      case PROMOTABLE:
-        return MemberType.PROMOTABLE;
-      default:
-        throw new IllegalStateException("Unexpected member type");
-    }
+    return switch (type) {
+      case ACTIVE -> MemberType.ACTIVE;
+      case PASSIVE -> MemberType.PASSIVE;
+      case INACTIVE -> MemberType.INACTIVE;
+      case PROMOTABLE -> MemberType.PROMOTABLE;
+    };
   }
 
   static RaftMember.Type getRaftMemberType(final MemberType type) {
-    switch (type) {
-      case ACTIVE:
-        return RaftMember.Type.ACTIVE;
-      case PASSIVE:
-        return RaftMember.Type.PASSIVE;
-      case INACTIVE:
-        return RaftMember.Type.INACTIVE;
-      case PROMOTABLE:
-        return RaftMember.Type.PROMOTABLE;
-      default:
-        throw new IllegalStateException("Unexpected member type " + type);
-    }
+    return switch (type) {
+      case ACTIVE -> RaftMember.Type.ACTIVE;
+      case PASSIVE -> RaftMember.Type.PASSIVE;
+      case INACTIVE -> RaftMember.Type.INACTIVE;
+      case PROMOTABLE -> RaftMember.Type.PROMOTABLE;
+      default -> throw new IllegalStateException("Unexpected member type " + type);
+    };
   }
 }

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableListSerializer.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableListSerializer.java
@@ -43,17 +43,16 @@ public class ImmutableListSerializer extends Serializer<ImmutableList<?>> {
   public ImmutableList<?> read(
       final Kryo kryo, final Input input, final Class<? extends ImmutableList<?>> type) {
     final int size = input.readInt();
-    switch (size) {
-      case 0:
-        return ImmutableList.of();
-      case 1:
-        return ImmutableList.of(kryo.readClassAndObject(input));
-      default:
+    return switch (size) {
+      case 0 -> ImmutableList.of();
+      case 1 -> ImmutableList.of(kryo.readClassAndObject(input));
+      default -> {
         final Object[] elms = new Object[size];
         for (int i = 0; i < size; ++i) {
           elms[i] = kryo.readClassAndObject(input);
         }
-        return ImmutableList.copyOf(elms);
-    }
+        yield ImmutableList.copyOf(elms);
+      }
+    };
   }
 }

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableMapSerializer.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableMapSerializer.java
@@ -46,18 +46,16 @@ public class ImmutableMapSerializer extends Serializer<ImmutableMap<?, ?>> {
   public ImmutableMap<?, ?> read(
       final Kryo kryo, final Input input, final Class<? extends ImmutableMap<?, ?>> type) {
     final int size = input.readInt();
-    switch (size) {
-      case 0:
-        return ImmutableMap.of();
-      case 1:
-        return ImmutableMap.of(kryo.readClassAndObject(input), kryo.readClassAndObject(input));
-
-      default:
+    return switch (size) {
+      case 0 -> ImmutableMap.of();
+      case 1 -> ImmutableMap.of(kryo.readClassAndObject(input), kryo.readClassAndObject(input));
+      default -> {
         final Builder<Object, Object> builder = ImmutableMap.builder();
         for (int i = 0; i < size; ++i) {
           builder.put(kryo.readClassAndObject(input), kryo.readClassAndObject(input));
         }
-        return builder.build();
-    }
+        yield builder.build();
+      }
+    };
   }
 }

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableSetSerializer.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/ImmutableSetSerializer.java
@@ -43,17 +43,16 @@ public class ImmutableSetSerializer extends Serializer<ImmutableSet<?>> {
   public ImmutableSet<?> read(
       final Kryo kryo, final Input input, final Class<? extends ImmutableSet<?>> type) {
     final int size = input.readInt();
-    switch (size) {
-      case 0:
-        return ImmutableSet.of();
-      case 1:
-        return ImmutableSet.of(kryo.readClassAndObject(input));
-      default:
+    return switch (size) {
+      case 0 -> ImmutableSet.of();
+      case 1 -> ImmutableSet.of(kryo.readClassAndObject(input));
+      default -> {
         final Object[] elms = new Object[size];
         for (int i = 0; i < size; ++i) {
           elms[i] = kryo.readClassAndObject(input);
         }
-        return ImmutableSet.copyOf(elms);
-    }
+        yield ImmutableSet.copyOf(elms);
+      }
+    };
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -273,36 +273,35 @@ public class CheckpointScheduleTest {
         .thenAnswer(
             invocation -> {
               final int count = callCount.incrementAndGet();
-              switch (count) {
-                case 1:
-                  // initial
-                  return CompletableFuture.completedStage(
-                      checkpointState(initTime.toEpochMilli(), latestBackupCheckpoint));
-                case 2:
-                  // after 5s
-                  return CompletableFuture.completedStage(
-                      checkpointState(
-                          initTime.plusSeconds(5).toEpochMilli(), latestBackupCheckpoint));
-                case 3:
-                  // after 10s
-                  return CompletableFuture.completedStage(
-                      checkpointState(
-                          initTime.plusSeconds(10).toEpochMilli(), latestBackupCheckpoint));
-                case 4:
-                  // after 15s
-                  return CompletableFuture.completedStage(
-                      checkpointState(
-                          initTime.plusSeconds(15).toEpochMilli(),
-                          latestBackupCheckpoint + Duration.ofSeconds(15).toMillis()));
-                case 5:
-                  // after 20s
-                  return CompletableFuture.completedStage(
-                      checkpointState(
-                          initTime.plusSeconds(25).toEpochMilli(),
-                          latestBackupCheckpoint + Duration.ofSeconds(15).toMillis()));
-                default:
-                  return null;
-              }
+              return switch (count) {
+                // initial
+                case 1 ->
+                    CompletableFuture.completedStage(
+                        checkpointState(initTime.toEpochMilli(), latestBackupCheckpoint));
+                // after 5s
+                case 2 ->
+                    CompletableFuture.completedStage(
+                        checkpointState(
+                            initTime.plusSeconds(5).toEpochMilli(), latestBackupCheckpoint));
+                // after 10s
+                case 3 ->
+                    CompletableFuture.completedStage(
+                        checkpointState(
+                            initTime.plusSeconds(10).toEpochMilli(), latestBackupCheckpoint));
+                // after 15s
+                case 4 ->
+                    CompletableFuture.completedStage(
+                        checkpointState(
+                            initTime.plusSeconds(15).toEpochMilli(),
+                            latestBackupCheckpoint + Duration.ofSeconds(15).toMillis()));
+                // after 20s
+                case 5 ->
+                    CompletableFuture.completedStage(
+                        checkpointState(
+                            initTime.plusSeconds(25).toEpochMilli(),
+                            latestBackupCheckpoint + Duration.ofSeconds(15).toMillis()));
+                default -> null;
+              };
             });
 
     for (int i = 0; i < 4; i++) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -104,15 +104,9 @@ public final class ExporterMetrics {
 
   public void initializeExporterState(final ExporterPhase state) {
     switch (state) {
-      case PAUSED:
-        setExporterPaused();
-        break;
-      case SOFT_PAUSED:
-        setExporterSoftPaused();
-        break;
-      default:
-        setExporterActive();
-        break;
+      case PAUSED -> setExporterPaused();
+      case SOFT_PAUSED -> setExporterSoftPaused();
+      default -> setExporterActive();
     }
 
     final ExtendedMeterDocumentation meterDoc = ExporterMetricsDoc.EXPORTER_STATE;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -120,22 +120,13 @@ public final class TopologyManagerImpl extends Actor
       actor.run(
           () -> {
             switch (clusterMembershipEvent.type()) {
-              case METADATA_CHANGED:
-              case MEMBER_ADDED:
-                onMetadataChanged(brokerInfo);
-                break;
-
-              case MEMBER_REMOVED:
-                onMemberRemoved(brokerInfo);
-                break;
-
-              case REACHABILITY_CHANGED:
-              default:
-                LOG.debug(
-                    "Received {} from member {}, was not handled.",
-                    clusterMembershipEvent.type(),
-                    brokerInfo.getNodeId());
-                break;
+              case METADATA_CHANGED, MEMBER_ADDED -> onMetadataChanged(brokerInfo);
+              case MEMBER_REMOVED -> onMemberRemoved(brokerInfo);
+              default ->
+                  LOG.debug(
+                      "Received {} from member {}, was not handled.",
+                      clusterMembershipEvent.type(),
+                      brokerInfo.getNodeId());
             }
           });
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -254,19 +254,9 @@ public final class ZeebePartition extends Actor
 
   private void onRoleChange(final Role newRole, final long newTerm) {
     switch (newRole) {
-      case LEADER:
-        leaderTransition(newTerm);
-        break;
-      case INACTIVE:
-        transitionToInactive();
-        break;
-      case PASSIVE:
-      case PROMOTABLE:
-      case CANDIDATE:
-      case FOLLOWER:
-      default:
-        followerTransition(newTerm);
-        break;
+      case LEADER -> leaderTransition(newTerm);
+      case INACTIVE -> transitionToInactive();
+      default -> followerTransition(newTerm);
     }
     LOG.debug("Partition role transitioning from {} to {} in term {}", raftRole, newRole, newTerm);
     raftRole = newRole;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -142,15 +142,9 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             context.setExporterDirector(director);
             // Pause/Resume here in case the state was changed after the director was created
             switch (context.getExporterPhase()) {
-              case PAUSED:
-                director.pauseExporting();
-                break;
-              case SOFT_PAUSED:
-                director.softPauseExporting();
-                break;
-              default:
-                director.resumeExporting();
-                break;
+              case PAUSED -> director.pauseExporting();
+              case SOFT_PAUSED -> director.softPauseExporting();
+              default -> director.resumeExporting();
             }
 
             // The config might have changed after ExporterDirector has created

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
@@ -122,17 +122,12 @@ public final class QueryApiRequestHandler
 
     final Optional<DirectBuffer> bpmnProcessId;
     switch (messageDecoder.valueType()) {
-      case PROCESS:
-        bpmnProcessId = queryService.getBpmnProcessIdForProcess(key);
-        break;
-      case PROCESS_INSTANCE:
-        bpmnProcessId = queryService.getBpmnProcessIdForProcessInstance(key);
-        break;
-      case JOB:
-        bpmnProcessId = queryService.getBpmnProcessIdForJob(key);
-        break;
-      default:
+      case PROCESS -> bpmnProcessId = queryService.getBpmnProcessIdForProcess(key);
+      case PROCESS_INSTANCE -> bpmnProcessId = queryService.getBpmnProcessIdForProcessInstance(key);
+      case JOB -> bpmnProcessId = queryService.getBpmnProcessIdForJob(key);
+      default -> {
         return Either.left(failOnInvalidValueType(messageDecoder, errorResponseWriter));
+      }
     }
 
     if (bpmnProcessId.isEmpty()) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -241,15 +241,11 @@ public class RandomizedPartitionTransitionTest {
 
   private TestOperation createTestOperation(
       final TestOperationKind kind, final RaftServer.Role role) {
-    switch (kind) {
-      case TRANSITION_TO_ROLE_NO_PAUSE:
-        return new RequestTransition(role, false);
-      case TRANSITION_TO_RULE_PAUSED:
-        return new RequestTransition(role, true);
-      case CATCH_UP:
-      default:
-        return new CatchUpOperation();
-    }
+    return switch (kind) {
+      case TRANSITION_TO_ROLE_NO_PAUSE -> new RequestTransition(role, false);
+      case TRANSITION_TO_RULE_PAUSED -> new RequestTransition(role, true);
+      default -> new CatchUpOperation();
+    };
   }
 
   private StreamProcessor produceMockStreamProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -165,29 +165,29 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       final ExecutableFlowElement element) {
 
     switch (intent) {
-      case ACTIVATE_ELEMENT:
+      case ACTIVATE_ELEMENT -> {
         final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
             .flatMap(ok -> processor.onActivate(element, activatingContext))
             .flatMap(ok -> afterActivating(element, processor, activatingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
-        break;
-      case COMPLETE_ELEMENT:
+      }
+      case COMPLETE_ELEMENT -> {
         final var completingContext = stateTransitionBehavior.transitionToCompleting(context);
         processor
             .onComplete(element, completingContext)
             .flatMap(ok -> afterCompleting(element, processor, completingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, completingContext));
-        break;
-      case TERMINATE_ELEMENT:
+      }
+      case TERMINATE_ELEMENT -> {
         final var terminatingContext = stateTransitionBehavior.transitionToTerminating(context);
         final var transitionOutcome = processor.onTerminate(element, terminatingContext);
         if (transitionOutcome == TransitionOutcome.CONTINUE) {
           processor.finalizeTermination(element, terminatingContext);
         }
-        break;
-      case COMPLETE_EXECUTION_LISTENER:
+      }
+      case COMPLETE_EXECUTION_LISTENER -> {
         final ProcessInstanceIntent elementState =
             stateBehavior.getElementInstance(context).getState();
         switch (elementState) {
@@ -201,16 +201,14 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
               throw new BpmnProcessingException(
                   context, String.format("Unexpected element state: '%s'", elementState));
         }
-        break;
-      case CONTINUE_TERMINATING_ELEMENT:
-        processor.finalizeTermination(element, context);
-        break;
-      default:
-        throw new BpmnProcessingException(
-            context,
-            String.format(
-                "Expected the processor '%s' to handle the event but the intent '%s' is not supported",
-                processor.getClass(), intent));
+      }
+      case CONTINUE_TERMINATING_ELEMENT -> processor.finalizeTermination(element, context);
+      default ->
+          throw new BpmnProcessingException(
+              context,
+              String.format(
+                  "Expected the processor '%s' to handle the event but the intent '%s' is not supported",
+                  processor.getClass(), intent));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
@@ -58,22 +58,13 @@ public class JobRecurAfterBackoffProcessor implements TypedRecordProcessor<JobRe
 
       jobActivationBehavior.publishWork(jobKey, recurredJob);
     } else {
-      final String textState;
-
-      switch (state) {
-        case ACTIVATABLE:
-          textState = "it is already activable";
-          break;
-        case ACTIVATED:
-          textState = "it is already activated";
-          break;
-        case ERROR_THROWN:
-          textState = "it is in error state";
-          break;
-        default:
-          textState = "no such job was found";
-          break;
-      }
+      final String textState =
+          switch (state) {
+            case ACTIVATABLE -> "it is already activable";
+            case ACTIVATED -> "it is already activated";
+            case ERROR_THROWN -> "it is in error state";
+            default -> "no such job was found";
+          };
 
       final String errorMesage = String.format(NOT_FAILED_JOB_MESSAGE, jobKey, textState);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMesage);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
@@ -159,27 +159,19 @@ final class ProcessInstanceElementActivatingV1Applier
     // sequence flow and for interrupting event sub processes we reset the count completely.
     // Furthermore some elements are special and need to be handled separately.
     switch (currentElementType) {
-      case START_EVENT:
-      case BOUNDARY_EVENT:
-        break;
-      case INTERMEDIATE_CATCH_EVENT:
-        decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
-        break;
-      case PARALLEL_GATEWAY:
-        decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
-        break;
-      case INCLUSIVE_GATEWAY:
-        decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
-        break;
-      case EVENT_SUB_PROCESS:
-        decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
-        break;
-      default:
+      case START_EVENT, BOUNDARY_EVENT -> {}
+      case INTERMEDIATE_CATCH_EVENT ->
+          decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
+      case PARALLEL_GATEWAY -> decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
+      case INCLUSIVE_GATEWAY ->
+          decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
+      case EVENT_SUB_PROCESS -> decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
+      default -> {
         if (flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
           flowScopeInstance.decrementActiveSequenceFlows();
           elementInstanceState.updateInstance(flowScopeInstance);
         }
-        break;
+      }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
@@ -166,27 +166,19 @@ final class ProcessInstanceElementActivatingV2Applier
     // sequence flow and for interrupting event sub processes we reset the count completely.
     // Furthermore some elements are special and need to be handled separately.
     switch (currentElementType) {
-      case START_EVENT:
-      case BOUNDARY_EVENT:
-        break;
-      case INTERMEDIATE_CATCH_EVENT:
-        decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
-        break;
-      case PARALLEL_GATEWAY:
-        decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
-        break;
-      case INCLUSIVE_GATEWAY:
-        decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
-        break;
-      case EVENT_SUB_PROCESS:
-        decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
-        break;
-      default:
+      case START_EVENT, BOUNDARY_EVENT -> {}
+      case INTERMEDIATE_CATCH_EVENT ->
+          decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
+      case PARALLEL_GATEWAY -> decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
+      case INCLUSIVE_GATEWAY ->
+          decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
+      case EVENT_SUB_PROCESS -> decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
+      default -> {
         if (flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
           flowScopeInstance.decrementActiveSequenceFlows();
           elementInstanceState.updateInstance(flowScopeInstance);
         }
-        break;
+      }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -105,15 +105,15 @@ public class DbMigratorImpl implements DbMigrator {
   public MigrationsPerformed runMigrations() {
     var initializationOnly = false;
     switch (checkVersionCompatibility()) {
-      case final Indeterminate.PreviousVersionUnknown unknown:
+      case final Indeterminate.PreviousVersionUnknown unknown -> {
         LOGGER.debug("Snapshot is empty, only initialization migrations will be run.");
         initializationOnly = true;
-        break;
-      case final Compatible.SameVersion compatible:
+      }
+      case final Compatible.SameVersion compatible -> {
         LOGGER.debug("No migrations to run, snapshot is the same as current version");
         return MigrationsPerformed.none();
-      default:
-        break;
+      }
+      default -> {}
     }
     logPreview(migrationTasks, initializationOnly);
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -44,16 +44,15 @@ public class MessageSubscriptionExportHandler
   @Override
   public void export(final Record<ProcessMessageSubscriptionRecordValue> record) {
     switch (record.getIntent()) {
-      case ProcessMessageSubscriptionIntent.CREATED:
-        messageSubscriptionWriter.create(map(record));
-        break;
+      case ProcessMessageSubscriptionIntent.CREATED ->
+          messageSubscriptionWriter.create(map(record));
       case ProcessMessageSubscriptionIntent.CORRELATED,
-      ProcessMessageSubscriptionIntent.DELETED,
-      ProcessMessageSubscriptionIntent.MIGRATED:
-        messageSubscriptionWriter.update(map(record));
-        break;
-      default:
+          ProcessMessageSubscriptionIntent.DELETED,
+          ProcessMessageSubscriptionIntent.MIGRATED ->
+          messageSubscriptionWriter.update(map(record));
+      default -> {
         // do nothing
+      }
     }
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -211,30 +211,13 @@ public final class GrpcErrorMapper {
     final Builder builder = Status.newBuilder().setMessage(message);
 
     switch (rejection.type()) {
-      case INVALID_ARGUMENT:
-        builder.setCode(Code.INVALID_ARGUMENT_VALUE);
-        break;
-      case NOT_FOUND:
-        builder.setCode(Code.NOT_FOUND_VALUE);
-        break;
-      case ALREADY_EXISTS:
-        builder.setCode(Code.ALREADY_EXISTS_VALUE);
-        break;
-      case INVALID_STATE:
-        builder.setCode(Code.FAILED_PRECONDITION_VALUE);
-        break;
-      case PROCESSING_ERROR:
-        builder.setCode(Code.INTERNAL_VALUE);
-        break;
-      case UNAUTHORIZED:
-      case FORBIDDEN:
-        builder.setCode(Code.PERMISSION_DENIED_VALUE);
-        break;
-      case SBE_UNKNOWN:
-      case NULL_VAL:
-      default:
-        builder.setCode(Code.UNKNOWN_VALUE);
-        break;
+      case INVALID_ARGUMENT -> builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+      case NOT_FOUND -> builder.setCode(Code.NOT_FOUND_VALUE);
+      case ALREADY_EXISTS -> builder.setCode(Code.ALREADY_EXISTS_VALUE);
+      case INVALID_STATE -> builder.setCode(Code.FAILED_PRECONDITION_VALUE);
+      case PROCESSING_ERROR -> builder.setCode(Code.INTERNAL_VALUE);
+      case UNAUTHORIZED, FORBIDDEN -> builder.setCode(Code.PERMISSION_DENIED_VALUE);
+      default -> builder.setCode(Code.UNKNOWN_VALUE);
     }
 
     return builder.build();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
@@ -63,17 +63,9 @@ public final class GatewayHealthManagerImpl implements GatewayHealthManager {
 
   private void updateGrpcHealthStatus(final Status status) {
     switch (status) {
-      case RUNNING:
-        setGrpcHealthStatus(ServingStatus.SERVING);
-        break;
-      case SHUTDOWN:
-        statusManager.enterTerminalState();
-        break;
-      case INITIAL:
-      case STARTING:
-      default:
-        setGrpcHealthStatus(ServingStatus.NOT_SERVING);
-        break;
+      case RUNNING -> setGrpcHealthStatus(ServingStatus.SERVING);
+      case SHUTDOWN -> statusManager.enterTerminalState();
+      default -> setGrpcHealthStatus(ServingStatus.NOT_SERVING);
     }
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicator.java
@@ -39,18 +39,11 @@ public class StartedHealthIndicator implements HealthIndicator {
       return Health.unknown().build();
     } else {
       final var status = optStatus.get();
-      switch (status) {
-        case INITIAL:
-        case STARTING:
-          return Health.down().build();
-        case RUNNING:
-          return Health.up().build();
-        case SHUTDOWN:
-          return Health.outOfService().build();
-        default:
-          LOG.warn("Encountered unexpected status " + status);
-          return Health.unknown().build();
-      }
+      return switch (status) {
+        case INITIAL, STARTING -> Health.down().build();
+        case RUNNING -> Health.up().build();
+        case SHUTDOWN -> Health.outOfService().build();
+      };
     }
   }
 }

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackFormat.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackFormat.java
@@ -115,70 +115,38 @@ public enum MsgPackFormat {
     if (isFixedMap(b)) {
       return FIXMAP;
     }
-    switch (b) {
-      case MsgPackCodes.NIL:
-        return NIL;
-      case MsgPackCodes.FALSE:
-      case MsgPackCodes.TRUE:
-        return BOOLEAN;
-      case MsgPackCodes.BIN8:
-        return BIN8;
-      case MsgPackCodes.BIN16:
-        return BIN16;
-      case MsgPackCodes.BIN32:
-        return BIN32;
-      case MsgPackCodes.EXT8:
-        return EXT8;
-      case MsgPackCodes.EXT16:
-        return EXT16;
-      case MsgPackCodes.EXT32:
-        return EXT32;
-      case MsgPackCodes.FLOAT32:
-        return FLOAT32;
-      case MsgPackCodes.FLOAT64:
-        return FLOAT64;
-      case MsgPackCodes.UINT8:
-        return UINT8;
-      case MsgPackCodes.UINT16:
-        return UINT16;
-      case MsgPackCodes.UINT32:
-        return UINT32;
-      case MsgPackCodes.UINT64:
-        return UINT64;
-      case MsgPackCodes.INT8:
-        return INT8;
-      case MsgPackCodes.INT16:
-        return INT16;
-      case MsgPackCodes.INT32:
-        return INT32;
-      case MsgPackCodes.INT64:
-        return INT64;
-      case MsgPackCodes.FIXEXT1:
-        return FIXEXT1;
-      case MsgPackCodes.FIXEXT2:
-        return FIXEXT2;
-      case MsgPackCodes.FIXEXT4:
-        return FIXEXT4;
-      case MsgPackCodes.FIXEXT8:
-        return FIXEXT8;
-      case MsgPackCodes.FIXEXT16:
-        return FIXEXT16;
-      case MsgPackCodes.STR8:
-        return STR8;
-      case MsgPackCodes.STR16:
-        return STR16;
-      case MsgPackCodes.STR32:
-        return STR32;
-      case MsgPackCodes.ARRAY16:
-        return ARRAY16;
-      case MsgPackCodes.ARRAY32:
-        return ARRAY32;
-      case MsgPackCodes.MAP16:
-        return MAP16;
-      case MsgPackCodes.MAP32:
-        return MAP32;
-      default:
-        return NEVER_USED;
-    }
+    return switch (b) {
+      case MsgPackCodes.NIL -> NIL;
+      case MsgPackCodes.FALSE, MsgPackCodes.TRUE -> BOOLEAN;
+      case MsgPackCodes.BIN8 -> BIN8;
+      case MsgPackCodes.BIN16 -> BIN16;
+      case MsgPackCodes.BIN32 -> BIN32;
+      case MsgPackCodes.EXT8 -> EXT8;
+      case MsgPackCodes.EXT16 -> EXT16;
+      case MsgPackCodes.EXT32 -> EXT32;
+      case MsgPackCodes.FLOAT32 -> FLOAT32;
+      case MsgPackCodes.FLOAT64 -> FLOAT64;
+      case MsgPackCodes.UINT8 -> UINT8;
+      case MsgPackCodes.UINT16 -> UINT16;
+      case MsgPackCodes.UINT32 -> UINT32;
+      case MsgPackCodes.UINT64 -> UINT64;
+      case MsgPackCodes.INT8 -> INT8;
+      case MsgPackCodes.INT16 -> INT16;
+      case MsgPackCodes.INT32 -> INT32;
+      case MsgPackCodes.INT64 -> INT64;
+      case MsgPackCodes.FIXEXT1 -> FIXEXT1;
+      case MsgPackCodes.FIXEXT2 -> FIXEXT2;
+      case MsgPackCodes.FIXEXT4 -> FIXEXT4;
+      case MsgPackCodes.FIXEXT8 -> FIXEXT8;
+      case MsgPackCodes.FIXEXT16 -> FIXEXT16;
+      case MsgPackCodes.STR8 -> STR8;
+      case MsgPackCodes.STR16 -> STR16;
+      case MsgPackCodes.STR32 -> STR32;
+      case MsgPackCodes.ARRAY16 -> ARRAY16;
+      case MsgPackCodes.ARRAY32 -> ARRAY32;
+      case MsgPackCodes.MAP16 -> MAP16;
+      case MsgPackCodes.MAP32 -> MAP32;
+      default -> NEVER_USED;
+    };
   }
 }

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
@@ -65,18 +65,15 @@ public final class MsgPackReader {
       mapSize = headerByte & (byte) 0x0F;
     } else {
       switch (headerByte) {
-        case MAP16:
+        case MAP16 -> {
           mapSize = buffer.getShort(offset, BYTE_ORDER) & 0xffff;
           offset += SIZE_OF_SHORT;
-          break;
-
-        case MAP32:
+        }
+        case MAP32 -> {
           mapSize = (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
           offset += SIZE_OF_INT;
-          break;
-
-        default:
-          throw exceptionOnUnknownHeader("map", headerByte);
+        }
+        default -> throw exceptionOnUnknownHeader("map", headerByte);
       }
     }
 
@@ -93,18 +90,15 @@ public final class MsgPackReader {
       mapSize = headerByte & (byte) 0x0F;
     } else {
       switch (headerByte) {
-        case ARRAY16:
+        case ARRAY16 -> {
           mapSize = buffer.getShort(offset, BYTE_ORDER) & 0xffff;
           offset += SIZE_OF_SHORT;
-          break;
-
-        case ARRAY32:
+        }
+        case ARRAY32 -> {
           mapSize = (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
           offset += SIZE_OF_INT;
-          break;
-
-        default:
-          throw exceptionOnUnknownHeader("array", headerByte);
+        }
+        default -> throw exceptionOnUnknownHeader("array", headerByte);
       }
     }
 
@@ -121,23 +115,19 @@ public final class MsgPackReader {
       stringLength = headerByte & (byte) 0x1F;
     } else {
       switch (headerByte) {
-        case STR8:
+        case STR8 -> {
           stringLength = buffer.getByte(offset) & 0xff;
           ++offset;
-          break;
-
-        case STR16:
+        }
+        case STR16 -> {
           stringLength = buffer.getShort(offset, BYTE_ORDER) & 0xffff;
           offset += SIZE_OF_SHORT;
-          break;
-
-        case STR32:
+        }
+        case STR32 -> {
           stringLength = (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
           offset += SIZE_OF_INT;
-          break;
-
-        default:
-          throw exceptionOnUnknownHeader("string", headerByte);
+        }
+        default -> throw exceptionOnUnknownHeader("string", headerByte);
       }
     }
     return stringLength;
@@ -150,23 +140,19 @@ public final class MsgPackReader {
     ++offset;
 
     switch (headerByte) {
-      case BIN8:
+      case BIN8 -> {
         length = buffer.getByte(offset) & 0xff;
         ++offset;
-        break;
-
-      case BIN16:
+      }
+      case BIN16 -> {
         length = buffer.getShort(offset, BYTE_ORDER) & 0xffff;
         offset += SIZE_OF_SHORT;
-        break;
-
-      case BIN32:
+      }
+      case BIN32 -> {
         length = (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
         offset += SIZE_OF_INT;
-        break;
-
-      default:
-        throw exceptionOnUnknownHeader("binary", headerByte);
+      }
+      default -> throw exceptionOnUnknownHeader("binary", headerByte);
     }
 
     return length;
@@ -187,48 +173,39 @@ public final class MsgPackReader {
       val = headerByte;
     } else {
       switch (headerByte) {
-        case UINT8:
+        case UINT8 -> {
           val = buffer.getByte(offset) & 0xffL;
           ++offset;
-          break;
-
-        case UINT16:
+        }
+        case UINT16 -> {
           val = buffer.getShort(offset, BYTE_ORDER) & 0xffffL;
           offset += 2;
-          break;
-
-        case UINT32:
+        }
+        case UINT32 -> {
           val = buffer.getInt(offset, BYTE_ORDER) & 0xffff_ffffL;
           offset += 4;
-          break;
-
-        case UINT64:
+        }
+        case UINT64 -> {
           val = ensurePositive(buffer.getLong(offset, BYTE_ORDER));
           offset += 8;
-          break;
-
-        case INT8:
+        }
+        case INT8 -> {
           val = buffer.getByte(offset);
           ++offset;
-          break;
-
-        case INT16:
+        }
+        case INT16 -> {
           val = buffer.getShort(offset, BYTE_ORDER);
           offset += 2;
-          break;
-
-        case INT32:
+        }
+        case INT32 -> {
           val = buffer.getInt(offset, BYTE_ORDER);
           offset += 4;
-          break;
-
-        case INT64:
+        }
+        case INT64 -> {
           val = buffer.getLong(offset, BYTE_ORDER);
           offset += 8;
-          break;
-
-        default:
-          throw exceptionOnUnknownHeader("long", headerByte);
+        }
+        default -> throw exceptionOnUnknownHeader("long", headerByte);
       }
     }
 
@@ -246,16 +223,15 @@ public final class MsgPackReader {
     final double value;
 
     switch (headerByte) {
-      case FLOAT32:
+      case FLOAT32 -> {
         value = buffer.getFloat(offset, BYTE_ORDER);
         offset += 4;
-        break;
-      case FLOAT64:
+      }
+      case FLOAT64 -> {
         value = buffer.getDouble(offset, BYTE_ORDER);
         offset += 8;
-        break;
-      default:
-        throw exceptionOnUnknownHeader("float", headerByte);
+      }
+      default -> throw exceptionOnUnknownHeader("float", headerByte);
     }
 
     return value;
@@ -277,47 +253,45 @@ public final class MsgPackReader {
     final MsgPackFormat format = MsgPackFormat.valueOf(b);
 
     switch (format.type) {
-      case INTEGER:
+      case INTEGER -> {
         token.setType(MsgPackType.INTEGER);
         token.setValue(readInteger());
-        break;
-      case FLOAT:
+      }
+      case FLOAT -> {
         token.setType(MsgPackType.FLOAT);
         token.setValue(readFloat());
-        break;
-      case BOOLEAN:
+      }
+      case BOOLEAN -> {
         token.setType(MsgPackType.BOOLEAN);
         token.setValue(readBoolean());
-        break;
-      case MAP:
+      }
+      case MAP -> {
         token.setType(MsgPackType.MAP);
         token.setMapHeader(readMapHeader());
-        break;
-      case ARRAY:
+      }
+      case ARRAY -> {
         token.setType(MsgPackType.ARRAY);
         token.setArrayHeader(readArrayHeader());
-        break;
-      case NIL:
+      }
+      case NIL -> {
         token.setType(MsgPackType.NIL);
         skipValue();
-        break;
-      case BINARY:
+      }
+      case BINARY -> {
         token.setType(MsgPackType.BINARY);
         final int binaryLength = readBinaryLength();
         token.setValue(buffer, offset, binaryLength);
         skipBytes(binaryLength);
-        break;
-      case STRING:
+      }
+      case STRING -> {
         token.setType(MsgPackType.STRING);
         final int stringLength = readStringLength();
         token.setValue(buffer, offset, stringLength);
         skipBytes(stringLength);
-        break;
-      case EXTENSION:
-      case NEVER_USED:
-      default:
-        throw new MsgpackReaderException(
-            String.format("Unknown token format '%s'", format.getType().name()));
+      }
+      default ->
+          throw new MsgpackReaderException(
+              String.format("Unknown token format '%s'", format.getType().name()));
     }
 
     return token;
@@ -343,102 +317,51 @@ public final class MsgPackReader {
       final MsgPackFormat f = MsgPackFormat.valueOf(b);
 
       switch (f) {
-        case POSFIXINT:
-        case NEGFIXINT:
-        case BOOLEAN:
-        case NIL:
-          break;
-        case FIXMAP:
-          {
-            final int mapLen = b & 0x0f;
-            count += mapLen * 2L;
-            break;
-          }
-        case FIXARRAY:
-          {
-            final int arrayLen = b & 0x0f;
-            count += arrayLen;
-            break;
-          }
-        case FIXSTR:
-          {
-            final int strLen = b & 0x1f;
-            offset += strLen;
-            break;
-          }
-        case INT8:
-        case UINT8:
-          ++offset;
-          break;
-        case INT16:
-        case UINT16:
-          offset += 2;
-          break;
-        case INT32:
-        case UINT32:
-        case FLOAT32:
-          offset += 4;
-          break;
-        case INT64:
-        case UINT64:
-        case FLOAT64:
-          offset += 8;
-          break;
-        case BIN8:
-        case STR8:
-          offset += 1 + Byte.toUnsignedInt(buffer.getByte(offset));
-          break;
-        case BIN16:
-        case STR16:
-          offset += 2 + Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER));
-          break;
-        case BIN32:
-        case STR32:
-          offset += 4 + (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
-          break;
-        case FIXEXT1:
-          offset += 2;
-          break;
-        case FIXEXT2:
-          offset += 3;
-          break;
-        case FIXEXT4:
-          offset += 5;
-          break;
-        case FIXEXT8:
-          offset += 9;
-          break;
-        case FIXEXT16:
-          offset += 17;
-          break;
-        case EXT8:
-          offset += 1 + 1 + Byte.toUnsignedInt(buffer.getByte(offset));
-          break;
-        case EXT16:
-          offset += 1 + 2 + Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER));
-          break;
-        case EXT32:
-          offset += 1 + 4 + (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
-          break;
-        case ARRAY16:
+        case POSFIXINT, NEGFIXINT, BOOLEAN, NIL -> {}
+        case FIXMAP -> {
+          final int mapLen = b & 0x0f;
+          count += mapLen * 2L;
+        }
+        case FIXARRAY -> {
+          final int arrayLen = b & 0x0f;
+          count += arrayLen;
+        }
+        case FIXSTR -> {
+          final int strLen = b & 0x1f;
+          offset += strLen;
+        }
+        case INT8, UINT8 -> ++offset;
+        case INT16, UINT16 -> offset += 2;
+        case INT32, UINT32, FLOAT32 -> offset += 4;
+        case INT64, UINT64, FLOAT64 -> offset += 8;
+        case BIN8, STR8 -> offset += 1 + Byte.toUnsignedInt(buffer.getByte(offset));
+        case BIN16, STR16 -> offset += 2 + Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER));
+        case BIN32, STR32 -> offset += 4 + (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
+        case FIXEXT1 -> offset += 2;
+        case FIXEXT2 -> offset += 3;
+        case FIXEXT4 -> offset += 5;
+        case FIXEXT8 -> offset += 9;
+        case FIXEXT16 -> offset += 17;
+        case EXT8 -> offset += 1 + 1 + Byte.toUnsignedInt(buffer.getByte(offset));
+        case EXT16 -> offset += 1 + 2 + Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER));
+        case EXT32 -> offset += 1 + 4 + (int) ensurePositive(buffer.getInt(offset, BYTE_ORDER));
+        case ARRAY16 -> {
           count += Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER));
           offset += 2;
-          break;
-        case ARRAY32:
+        }
+        case ARRAY32 -> {
           count += ensurePositive(buffer.getInt(offset, BYTE_ORDER));
           offset += 4;
-          break;
-        case MAP16:
+        }
+        case MAP16 -> {
           count += Short.toUnsignedInt(buffer.getShort(offset, BYTE_ORDER)) * 2L;
           offset += 2;
-          break;
-        case MAP32:
+        }
+        case MAP32 -> {
           count += ensurePositive(buffer.getInt(offset, BYTE_ORDER)) * 2L;
           offset += 4;
-          break;
-        case NEVER_USED:
-        default:
-          throw new MsgpackReaderException("Encountered 0xC1 \"NEVER_USED\" byte");
+        }
+        default -> throw new MsgpackReaderException("Encountered 0xC1 \"NEVER_USED\" byte");
       }
 
       count--;

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgPackUtil.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/MsgPackUtil.java
@@ -55,21 +55,18 @@ public final class MsgPackUtil {
   private static Object deserializeElement(final MsgPackReader reader) {
 
     final MsgPackToken token = reader.readToken();
-    switch (token.getType()) {
-      case INTEGER:
-        return token.getIntegerValue();
-      case FLOAT:
-        return token.getFloatValue();
-      case STRING:
-        return bufferAsString(token.getValueBuffer());
-      case BOOLEAN:
-        return token.getBooleanValue();
-      case BINARY:
+    return switch (token.getType()) {
+      case INTEGER -> token.getIntegerValue();
+      case FLOAT -> token.getFloatValue();
+      case STRING -> bufferAsString(token.getValueBuffer());
+      case BOOLEAN -> token.getBooleanValue();
+      case BINARY -> {
         final DirectBuffer valueBuffer = token.getValueBuffer();
         final byte[] valueArray = new byte[valueBuffer.capacity()];
         valueBuffer.getBytes(0, valueArray);
-        return valueArray;
-      case MAP:
+        yield valueArray;
+      }
+      case MAP -> {
         final Map<String, Object> valueMap = new HashMap<>();
         final int mapSize = token.getSize();
         for (int i = 0; i < mapSize; i++) {
@@ -77,17 +74,18 @@ public final class MsgPackUtil {
           final Object value = deserializeElement(reader);
           valueMap.put(key, value);
         }
-        return valueMap;
-      case ARRAY:
+        yield valueMap;
+      }
+      case ARRAY -> {
         final int size = token.getSize();
         final Object[] arr = new Object[size];
         for (int i = 0; i < size; i++) {
           arr[i] = deserializeElement(reader);
         }
-        return toString(arr);
-      default:
-        throw new RuntimeException("Not implemented yet");
-    }
+        yield toString(arr);
+      }
+      default -> throw new RuntimeException("Not implemented yet");
+    };
   }
 
   private static String toString(final Object[] arr) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -459,17 +459,12 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         (partition, role) -> {
           partitionConsumer.accept(partition);
           switch (role) {
-            case LEADER:
-              leaderPartitionConsumer.accept(partition, partitionLeaderTerms.get(partition));
-              break;
-            case FOLLOWER:
-              followerPartitionsConsumer.accept(partition);
-              break;
-            case INACTIVE:
-              inactivePartitionsConsumer.accept(partition);
-              break;
-            default:
-              LOG.warn("Failed to decode broker info, found unknown partition role: {}", role);
+            case LEADER ->
+                leaderPartitionConsumer.accept(partition, partitionLeaderTerms.get(partition));
+            case FOLLOWER -> followerPartitionsConsumer.accept(partition);
+            case INACTIVE -> inactivePartitionsConsumer.accept(partition);
+            default ->
+                LOG.warn("Failed to decode broker info, found unknown partition role: {}", role);
           }
         });
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -277,26 +277,13 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   private void updateAttribute(final String attributeName, final UserTaskRecord record) {
     switch (attributeName) {
-      case ASSIGNEE:
-        setAssignee(record.getAssigneeBuffer());
-        break;
-      case CANDIDATE_GROUPS:
-        setCandidateGroupsList(record.getCandidateGroupsList());
-        break;
-      case CANDIDATE_USERS:
-        setCandidateUsersList(record.getCandidateUsersList());
-        break;
-      case DUE_DATE:
-        dueDateProp.setValue(record.getDueDateBuffer());
-        break;
-      case FOLLOW_UP_DATE:
-        followUpDateProp.setValue(record.getFollowUpDateBuffer());
-        break;
-      case PRIORITY:
-        priorityProp.setValue(record.getPriority());
-        break;
-      default:
-        break;
+      case ASSIGNEE -> setAssignee(record.getAssigneeBuffer());
+      case CANDIDATE_GROUPS -> setCandidateGroupsList(record.getCandidateGroupsList());
+      case CANDIDATE_USERS -> setCandidateUsersList(record.getCandidateUsersList());
+      case DUE_DATE -> dueDateProp.setValue(record.getDueDateBuffer());
+      case FOLLOW_UP_DATE -> followUpDateProp.setValue(record.getFollowUpDateBuffer());
+      case PRIORITY -> priorityProp.setValue(record.getPriority());
+      default -> {}
     }
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -125,7 +125,7 @@ public class ActorTask {
       currentJob.execute(runner);
 
       switch (currentJob.schedulingState) {
-        case TERMINATED:
+        case TERMINATED -> {
           final ActorJob terminatedJob = currentJob;
           currentJob = fastLaneJobs.poll();
 
@@ -140,18 +140,13 @@ public class ActorTask {
           } else {
             runner.recycleJob(terminatedJob);
           }
-
-          break;
-
-        case QUEUED:
-          // the task is experiencing backpressure: do not retry it right now, instead re-enqueue
-          // the actor task.
-          // this allows other tasks which may be needed to unblock the backpressure to run
-          resubmit = true;
-          break;
-
-        default:
-          break;
+        }
+        case QUEUED ->
+            // the task is experiencing backpressure: do not retry it right now, instead re-enqueue
+            // the actor task.
+            // this allows other tasks which may be needed to unblock the backpressure to run
+            resubmit = true;
+        default -> {}
       }
 
       if (shouldYield) {
@@ -172,45 +167,35 @@ public class ActorTask {
     boolean resubmit = false;
 
     if (allPhaseSubscriptionsTriggered()) {
-      switch (lifecyclePhase) {
-        case STARTING:
-          lifecyclePhase = ActorLifecyclePhase.STARTED;
-          submitStartedJob();
-          startingFuture.completeWith(jobStartingTaskFuture);
-          resubmit = true;
-          break;
-
-        case CLOSING:
-          lifecyclePhase = ActorLifecyclePhase.CLOSED;
-          submitClosedJob();
-          resubmit = true;
-          break;
-
-        case STARTED:
-          resubmit = tryWait();
-          break;
-
-        case CLOSE_REQUESTED:
-          lifecyclePhase = ActorLifecyclePhase.CLOSING;
-          submitClosingJob();
-          resubmit = true;
-          break;
-
-        case CLOSED:
-          onClosed();
-          closeFuture.completeWith(jobClosingTaskFuture);
-          resubmit = false;
-          break;
-
-        case FAILED:
-          onClosed();
-          resubmit = false;
-          break;
-
-        default:
-          throw new IllegalStateException(
-              "Unexpected actor lifecycle phase " + lifecyclePhase.name());
-      }
+      resubmit =
+          switch (lifecyclePhase) {
+            case STARTING -> {
+              lifecyclePhase = ActorLifecyclePhase.STARTED;
+              submitStartedJob();
+              startingFuture.completeWith(jobStartingTaskFuture);
+              yield true;
+            }
+            case CLOSING -> {
+              lifecyclePhase = ActorLifecyclePhase.CLOSED;
+              submitClosedJob();
+              yield true;
+            }
+            case STARTED -> tryWait();
+            case CLOSE_REQUESTED -> {
+              lifecyclePhase = ActorLifecyclePhase.CLOSING;
+              submitClosingJob();
+              yield true;
+            }
+            case CLOSED -> {
+              onClosed();
+              closeFuture.completeWith(jobClosingTaskFuture);
+              yield false;
+            }
+            case FAILED -> {
+              onClosed();
+              yield false;
+            }
+          };
     } else {
       if (lifecyclePhase != ActorLifecyclePhase.CLOSED) {
         resubmit = tryWait();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -58,20 +58,11 @@ public final class StreamProcessorMetrics {
 
   public void initializeProcessorPhase(final Phase phase) {
     switch (phase) {
-      case INITIAL:
-        setStreamProcessorInitial();
-        break;
-      case REPLAY:
-        setStreamProcessorReplay();
-        break;
-      case PROCESSING:
-        setStreamProcessorProcessing();
-        break;
-      case PAUSED:
-        setStreamProcessorPaused();
-        break;
-      default:
-        setStreamProcessorFailed();
+      case INITIAL -> setStreamProcessorInitial();
+      case REPLAY -> setStreamProcessorReplay();
+      case PROCESSING -> setStreamProcessorProcessing();
+      case PAUSED -> setStreamProcessorPaused();
+      default -> setStreamProcessorFailed();
     }
   }
 


### PR DESCRIPTION
## Description

As part of https://github.com/checkstyle/checkstyle/pull/18489, we're seeking feedback on a new UseEnhancedSwitch check. I've replaced all enhanceable switches that weren't in a JDK 8 project.

In most cases this is basically just a formatting change, but there are some changes where switch expressions allowed the removal of `default` branches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
