### PR TITLE
ci: use database name for the test report artifact

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         description: The database docker image version to be used during the tests. Will be set as env variable IMAGE_VERSION. If not set, the default value from the docker-compose file will be used.
+      database-name:
+        required: true
+        type: string
+        description: The display name of the database, used in test artifact names and notifications.
       maven-profiles:
         required: false
         type: string
@@ -111,7 +115,7 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[IT] ${{inputs.test-type-label}} - ${{inputs.database-type}}"
+          name: "[IT] ${{inputs.test-type-label}} - ${{inputs.database-name}}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -153,12 +157,12 @@ jobs:
           webhook-type: webhook-trigger
           # For posting a rich message using Block Kit
           payload: |
-            text: "Scheduled Database Integration Tests for ${{inputs.database-type}} failed or were cancelled"
+            text: "Scheduled Database Integration Tests for ${{inputs.database-name}} failed or were cancelled"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "Scheduled Database Integration Tests for **${{inputs.database-type}}** FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  text: "Scheduled Database Integration Tests for **${{inputs.database-name}}** FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       # Send metrics about CI health
       - name: Observe build status
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,7 @@ jobs:
     with:
       database-type: "elasticsearch"
       database-image-version: "8.18.4"
+      database-name: "Elasticsearch 8"
       it-database-type: "es"
 
   elasticsearch9-integration-tests:
@@ -513,6 +514,7 @@ jobs:
     with:
       database-type: "elasticsearch"
       database-image-version: "9.2.4"
+      database-name: "Elasticsearch 9"
       it-database-type: "es"
       job-name-suffix: "9"
 
@@ -525,6 +527,7 @@ jobs:
     with:
       database-type: "opensearch"
       database-image-version: "2.17.0"
+      database-name: "OpenSearch 2"
       it-database-type: "os"
 
   rdbms-h2-integration-tests:
@@ -536,6 +539,7 @@ jobs:
     with:
       database-type: "h2"
       it-database-type: "rdbms_h2"
+      database-name: "H2"
 
   elasticsearch-history-tests:
     name: "History Integration Tests / Elasticsearch"
@@ -546,6 +550,7 @@ jobs:
     with:
       database-type: "elasticsearch"
       database-image-version: "8.18.4"
+      database-name: "Elasticsearch 8"
       it-database-type: "es"
       maven-profiles: "history"
       test-type-label: "History"
@@ -560,6 +565,7 @@ jobs:
     with:
       database-type: "opensearch"
       database-image-version: "2.17.0"
+      database-name: "OpenSearch 2"
       it-database-type: "os"
       maven-profiles: "history"
       test-type-label: "History"
@@ -574,6 +580,7 @@ jobs:
     with:
       database-type: "h2"
       it-database-type: "rdbms_h2"
+      database-name: "H2"
       maven-profiles: "history"
       test-type-label: "History"
       job-name-suffix: "-history"

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -93,5 +93,6 @@ jobs:
     with:
       database-type: ${{ matrix.database-type }}
       database-image-version: ${{ matrix.database-image-version }}
+      database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -65,6 +65,7 @@ jobs:
     with:
       database-type: ${{ matrix.database-type }}
       database-image-version: ${{ matrix.database-image-version }}
+      database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
       job-name-suffix: ${{ matrix.job-name-suffix || '' }}
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[Context](https://camunda.slack.com/archives/C08NQKV761G/p1771829591655829)
when nightly RDBMS jobs are flaky for multiple version of the same database type, the job fails with 
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
Using the database name, that includes the version, to avoid the conflict

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
