### PR TITLE
fix: add missing type to incident enum schemas

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -293,6 +293,7 @@ components:
 
     IncidentErrorTypeEnum:
       description: Incident error type with a defined set of values.
+      type: string
       enum:
         - AD_HOC_SUB_PROCESS_NO_RETRIES
         - CALLED_DECISION_ERROR
@@ -353,6 +354,7 @@ components:
 
     IncidentStateEnum:
       description: Incident states with a defined set of values.
+      type: string
       enum:
         - ACTIVE
         - MIGRATED


### PR DESCRIPTION
## Description

Adds the missing `type: string` to `IncidentErrorTypeEnum` and `IncidentStateEnum` component schemas in the OpenAPI spec.

These were the only two enum schemas under `zeebe/gateway-protocol/src/main/proto/v2/` lacking an explicit `type`, making them ambiguous per the OpenAPI specification.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

fixes #30674