### PR TITLE
Fix flaky test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -6,16 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { test } from 'fixtures';
-import { expect } from '@playwright/test';
-import { deploy, createInstances, createSingleInstance, searchByProcessInstanceKey } from 'utils/zeebeClient';
-import { captureScreenshot, captureFailureVideo } from '@setup';
-import { navigateToApp } from '@pages/UtilitiesPage';
-import { waitForAssertion } from 'utils/waitForAssertion';
-import { sleep } from 'utils/sleep';
-import { OperateOperationPanelPage } from '@pages/OperateOperationPanelPage';
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
+import {OperateOperationPanelPage} from '@pages/OperateOperationPanelPage';
 
-type ProcessInstance = { processInstanceKey: number };
+type ProcessInstance = {processInstanceKey: number};
 
 let callActivityProcessInstance: ProcessInstance;
 let orderProcessInstance: ProcessInstance;
@@ -26,6 +26,8 @@ test.beforeAll(async () => {
     './resources/processWithMultipleVersions_v_1.bpmn',
     './resources/processWithAnError.bpmn',
   ]);
+
+  await sleep(1000);
 
   await createInstances('processWithMultipleVersions', 1, 1);
   await createInstances('processWithAnError', 1, 1);
@@ -51,7 +53,7 @@ test.beforeAll(async () => {
 
   callActivityProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('CallActivityProcess', 1, { filtersTest: 456 }))
+      (await createSingleInstance('CallActivityProcess', 1, {filtersTest: 456}))
         .processInstanceKey,
     ),
   };
@@ -59,7 +61,7 @@ test.beforeAll(async () => {
   await deploy(['./resources/Variable_Process.bpmn']);
   variableProcessInstance = {
     processInstanceKey: Number(
-      (await createSingleInstance('Variable_Process', 1, { filtersTest: 604 }))
+      (await createSingleInstance('Variable_Process', 1, {filtersTest: 604}))
         .processInstanceKey,
     ),
   };
@@ -73,14 +75,14 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instances Filters', () => {
-  test.beforeEach(async ({ page, loginPage, operateHomePage }) => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });
 
-  test.afterEach(async ({ page }, testInfo) => {
+  test.afterEach(async ({page}, testInfo) => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
@@ -230,7 +232,7 @@ test.describe('Process Instances Filters', () => {
       await expect(operateFiltersPanelPage.startDateFilter).toBeHidden();
     });
 
-    await test.step('Filter by variable and assert results', async ({ }) => {
+    await test.step('Filter by variable and assert results', async ({}) => {
       await operateFiltersPanelPage.displayOptionalFilter('Variable');
       await operateFiltersPanelPage.fillVariableNameFilter('filtersTest');
       await operateFiltersPanelPage.fillVariableValueFilter('604');
@@ -258,7 +260,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with one key and assert results', async ({ }) => {
+    await test.step('Filter by process instance key with one key and assert results', async ({}) => {
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
 
@@ -282,7 +284,7 @@ test.describe('Process Instances Filters', () => {
       });
     });
 
-    await test.step('Filter by process instance key with multiple keys and assert results', async ({ }) => {
+    await test.step('Filter by process instance key with multiple keys and assert results', async ({}) => {
       const variableProcessInstanceKey =
         variableProcessInstance.processInstanceKey.toString();
       const callActivityProcessInstanceKey =
@@ -327,14 +329,14 @@ test.describe('Process Instances Filters', () => {
     await test.step('Filter by variable and operation id and assert results', async () => {
       const processToCancelMeowInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, { sound: 'meow' }))
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))
             .processInstanceKey,
         ),
       };
 
       const processToCancelGawInstance = {
         processInstanceKey: Number(
-          (await createSingleInstance('ProcessToCancel', 1, { sound: 'gaw' }))
+          (await createSingleInstance('ProcessToCancel', 1, {sound: 'gaw'}))
             .processInstanceKey,
         ),
       };
@@ -353,7 +355,9 @@ test.describe('Process Instances Filters', () => {
 
       await waitForAssertion({
         assertion: async () => {
-          await expect(page.getByText('Process Instances   -   2 results', { exact: true })).toBeVisible();
+          await expect(
+            page.getByText('Process Instances   -   2 results', {exact: true}),
+          ).toBeVisible();
         },
         onFailure: async () => {
           await page.reload();
@@ -375,7 +379,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -452,7 +456,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -476,7 +480,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -502,7 +506,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 30000 });
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
@@ -550,7 +554,7 @@ test.describe('Process Instances Filters', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({ timeout: 60000 });
+          ).toBeVisible({timeout: 60000});
         },
         onFailure: async () => {
           await page.reload();
@@ -636,11 +640,11 @@ test.describe('Process Instances Filters', () => {
             exact: true,
           },
         ),
-      ).toBeVisible({ timeout: 60000 });
+      ).toBeVisible({timeout: 60000});
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          { exact: true },
+          {exact: true},
         ),
       ).toBeHidden();
     });
@@ -667,7 +671,7 @@ test.describe('Process Instances Filters', () => {
     });
 
     await test.step('Check that process instances table is filtered correctly', async () => {
-      await expect(page.getByText('2 results')).toBeVisible({ timeout: 60000 });
+      await expect(page.getByText('2 results')).toBeVisible({timeout: 60000});
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           orderProcessInstanceKey.toString(),
@@ -679,7 +683,7 @@ test.describe('Process Instances Filters', () => {
       await expect(
         operateProcessesPage.processInstancesTable.getByText(
           callActivityProcessInstanceKey.toString(),
-          { exact: true },
+          {exact: true},
         ),
       ).toBeVisible();
     });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Test was failing as it was trying to create an instance before a process is actually deployed. Added a sleep to give the process time to be deployed.

## Testing
🧪 [Test run](https://github.com/camunda/camunda/actions/runs/22297736758/job/64497986661)
❗ Failing test is unrelated to my changes and will be investigated in a separate PR
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
