### PR TITLE
feat: clean up audit log cleanup after retention period es os

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/AuditLogCleanupTransformer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/AuditLogCleanupTransformer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.historydeletion;
+
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
+import java.util.List;
+import java.util.Set;
+
+public final class AuditLogCleanupTransformer {
+
+  public static final String AUDIT_LOG_CLEANUP_ID = "%s-%s";
+
+  private AuditLogCleanupTransformer() {
+    // Utility class
+  }
+
+  /**
+   * Builds the list of {@link AuditLogCleanupEntity} entries for the resources that were
+   * successfully deleted. These entries are written to the audit log cleanup index so that the
+   * audit log archiver can later purge the corresponding audit log records.
+   *
+   * @param historyDeletionEntities The history deletion entities that were processed
+   * @param deletedHistoryDeletionIds The history-deletion document IDs that were successfully
+   *     processed
+   * @return The list of cleanup entities to index
+   */
+  public static List<AuditLogCleanupEntity> buildAuditLogCleanupEntries(
+      final List<HistoryDeletionEntity> historyDeletionEntities,
+      final Set<String> deletedHistoryDeletionIds) {
+    return historyDeletionEntities.stream()
+        .filter(entity -> deletedHistoryDeletionIds.contains(entity.getId()))
+        .map(AuditLogCleanupTransformer::toAuditLogCleanupEntity)
+        .toList();
+  }
+
+  /**
+   * Converts a {@link HistoryDeletionEntity} to an {@link AuditLogCleanupEntity}.
+   *
+   * @param entity The history deletion entity to convert
+   * @return The audit log cleanup entity
+   */
+  private static AuditLogCleanupEntity toAuditLogCleanupEntity(final HistoryDeletionEntity entity) {
+    final String keyField =
+        switch (entity.getResourceType()) {
+          case PROCESS_INSTANCE -> AuditLogTemplate.PROCESS_INSTANCE_KEY;
+          case PROCESS_DEFINITION -> AuditLogTemplate.PROCESS_DEFINITION_KEY;
+          case DECISION_INSTANCE -> AuditLogTemplate.DECISION_EVALUATION_KEY;
+          case DECISION_REQUIREMENTS -> AuditLogTemplate.DECISION_REQUIREMENTS_KEY;
+        };
+    final var id =
+        AUDIT_LOG_CLEANUP_ID.formatted(entity.getBatchOperationKey(), entity.getResourceKey());
+    // avoid setting entityType so job later deletes only by key
+    return new AuditLogCleanupEntity()
+        .setId(id)
+        .setKey(String.valueOf(entity.getResourceKey()))
+        .setKeyField(keyField)
+        .setEntityType(null)
+        .setPartitionId((int) entity.getPartitionId());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -18,8 +18,10 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +37,7 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
     implements HistoryDeletionRepository {
 
   private final IndexDescriptor indexDescriptor;
+  private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
   private final HistoryDeletionConfiguration config;
 
@@ -52,6 +55,12 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
             .findFirst()
             .orElseThrow(
                 () -> new IllegalStateException("No HistoryDeletionIndex descriptor found"));
+    auditLogCleanupIndex =
+        resourceProvider.getIndexDescriptors().stream()
+            .filter(AuditLogCleanupIndex.class::isInstance)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException("No AuditLogCleanupIndex descriptor found"));
     this.partitionId = partitionId;
     this.config = config;
   }
@@ -147,6 +156,40 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
               }
               final var deleted = response.items().size();
               return CompletableFuture.completedFuture(deleted);
+            },
+            executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> createAuditLogCleanupEntries(
+      final List<AuditLogCleanupEntity> entries) {
+    if (entries.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final var targetIndexName = auditLogCleanupIndex.getFullQualifiedName();
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+
+    entries.forEach(
+        entry ->
+            bulkRequestBuilder.operations(
+                op -> op.index(i -> i.index(targetIndexName).id(entry.getId()).document(entry))));
+
+    return client
+        .bulk(bulkRequestBuilder.build())
+        .thenComposeAsync(
+            response -> {
+              if (response.errors()) {
+                final var errorMessage =
+                    "Bulk indexing audit log cleanup entries to index '%s' failed with errors: %s"
+                        .formatted(targetIndexName, response.items());
+                logger.error(errorMessage);
+                return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+              }
+              logger.debug(
+                  "Indexed {} audit log cleanup entries to index '{}'",
+                  entries.size(),
+                  targetIndexName);
+              return CompletableFuture.completedFuture(null);
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -21,10 +21,11 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
-import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
@@ -161,11 +162,15 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
   }
 
   @Override
-  public CompletableFuture<Void> createAuditLogCleanupEntries(
-      final List<AuditLogCleanupEntity> entries) {
-    if (entries.isEmpty()) {
+  public CompletionStage<Void> createAuditLogCleanupEntries(
+      final List<HistoryDeletionEntity> historyDeletionEntities,
+      final Set<String> deletedResources) {
+    if (deletedResources.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
+    final var entries =
+        AuditLogCleanupTransformer.buildAuditLogCleanupEntries(
+            historyDeletionEntities, deletedResources);
     final var targetIndexName = auditLogCleanupIndex.getFullQualifiedName();
     final var bulkRequestBuilder = new BulkRequest.Builder();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -18,6 +18,8 @@ import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -37,6 +39,8 @@ import org.slf4j.Logger;
  * balanced processing.
  */
 public class HistoryDeletionJob implements BackgroundTask {
+
+  public static final String AUDIT_LOG_CLEANUP_ID = "%s-%s";
   private final List<ProcessInstanceDependant> processInstanceDependants;
   private final Executor executor;
   private final HistoryDeletionRepository deleterRepository;
@@ -137,7 +141,24 @@ public class HistoryDeletionJob implements BackgroundTask {
               final var deletedResources = new ArrayList<String>();
               deletedResources.addAll(deleteProcessInstancesAndDefinitionsFuture.join());
               deletedResources.addAll(deleteDecisionInstancesAndRequirementsFuture.join());
-              return deleteFromHistoryDeletionIndex(deletedResources);
+
+              if (deletedResources.isEmpty()) {
+                return CompletableFuture.completedFuture(0);
+              }
+
+              final var cleanupEntries = buildAuditLogCleanupEntries(batch, deletedResources);
+              return deleterRepository
+                  .createAuditLogCleanupEntries(cleanupEntries)
+                  .thenCompose(v -> deleteFromHistoryDeletionIndex(deletedResources))
+                  .exceptionally(
+                      ex -> {
+                        logger.warn(
+                            "Failed to create audit log cleanup entries for batch: {}. "
+                                + "Skipping deletion from history deletion index to allow retry.",
+                            batch,
+                            ex);
+                        return 0;
+                      });
             });
   }
 
@@ -260,6 +281,43 @@ public class HistoryDeletionJob implements BackgroundTask {
               ids.addAll(batch.getHistoryDeletionIds(HistoryDeletionType.DECISION_REQUIREMENTS));
               return ids;
             });
+  }
+
+  /**
+   * Builds the list of {@link AuditLogCleanupEntity} entries for the resources that were
+   * successfully deleted. These entries are written to the audit log cleanup index so that the
+   * audit log archiver can later purge the corresponding audit log records.
+   *
+   * @param batch The batch that was processed
+   * @param deletedHistoryDeletionIds The history-deletion document IDs that were successfully
+   *     processed
+   * @return The list of cleanup entities to index
+   */
+  private List<AuditLogCleanupEntity> buildAuditLogCleanupEntries(
+      final HistoryDeletionBatch batch, final List<String> deletedHistoryDeletionIds) {
+    return batch.historyDeletionEntities().stream()
+        .filter(entity -> deletedHistoryDeletionIds.contains(entity.getId()))
+        .map(this::toAuditLogCleanupEntity)
+        .toList();
+  }
+
+  private AuditLogCleanupEntity toAuditLogCleanupEntity(final HistoryDeletionEntity entity) {
+    final String keyField =
+        switch (entity.getResourceType()) {
+          case PROCESS_INSTANCE -> AuditLogTemplate.PROCESS_INSTANCE_KEY;
+          case PROCESS_DEFINITION -> AuditLogTemplate.PROCESS_DEFINITION_KEY;
+          case DECISION_INSTANCE -> AuditLogTemplate.DECISION_EVALUATION_KEY;
+          case DECISION_REQUIREMENTS -> AuditLogTemplate.DECISION_REQUIREMENTS_KEY;
+        };
+    final var id =
+        AUDIT_LOG_CLEANUP_ID.formatted(entity.getBatchOperationKey(), entity.getResourceKey());
+    // avoid setting entityType so job later deletes only by key
+    return new AuditLogCleanupEntity()
+        .setId(id)
+        .setKey(String.valueOf(entity.getResourceKey()))
+        .setKeyField(keyField)
+        .setEntityType(null)
+        .setPartitionId((int) entity.getPartitionId());
   }
 
   private CompletionStage<Integer> deleteFromHistoryDeletionIndex(final List<String> ids) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -18,11 +18,10 @@ import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
-import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
-import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -40,7 +39,6 @@ import org.slf4j.Logger;
  */
 public class HistoryDeletionJob implements BackgroundTask {
 
-  public static final String AUDIT_LOG_CLEANUP_ID = "%s-%s";
   private final List<ProcessInstanceDependant> processInstanceDependants;
   private final Executor executor;
   private final HistoryDeletionRepository deleterRepository;
@@ -138,18 +136,14 @@ public class HistoryDeletionJob implements BackgroundTask {
             deleteDecisionInstancesAndRequirementsFuture)
         .thenCompose(
             ignored -> {
-              final var deletedResources = new ArrayList<String>();
+              final var deletedResources = new HashSet<String>();
               deletedResources.addAll(deleteProcessInstancesAndDefinitionsFuture.join());
               deletedResources.addAll(deleteDecisionInstancesAndRequirementsFuture.join());
 
-              if (deletedResources.isEmpty()) {
-                return CompletableFuture.completedFuture(0);
-              }
-
-              final var cleanupEntries = buildAuditLogCleanupEntries(batch, deletedResources);
               return deleterRepository
-                  .createAuditLogCleanupEntries(cleanupEntries)
-                  .thenCompose(v -> deleteFromHistoryDeletionIndex(deletedResources));
+                  .createAuditLogCleanupEntries(batch.historyDeletionEntities(), deletedResources)
+                  .thenCompose(
+                      v -> deleteFromHistoryDeletionIndex(new ArrayList<>(deletedResources)));
             });
   }
 
@@ -272,43 +266,6 @@ public class HistoryDeletionJob implements BackgroundTask {
               ids.addAll(batch.getHistoryDeletionIds(HistoryDeletionType.DECISION_REQUIREMENTS));
               return ids;
             });
-  }
-
-  /**
-   * Builds the list of {@link AuditLogCleanupEntity} entries for the resources that were
-   * successfully deleted. These entries are written to the audit log cleanup index so that the
-   * audit log archiver can later purge the corresponding audit log records.
-   *
-   * @param batch The batch that was processed
-   * @param deletedHistoryDeletionIds The history-deletion document IDs that were successfully
-   *     processed
-   * @return The list of cleanup entities to index
-   */
-  private List<AuditLogCleanupEntity> buildAuditLogCleanupEntries(
-      final HistoryDeletionBatch batch, final List<String> deletedHistoryDeletionIds) {
-    return batch.historyDeletionEntities().stream()
-        .filter(entity -> deletedHistoryDeletionIds.contains(entity.getId()))
-        .map(this::toAuditLogCleanupEntity)
-        .toList();
-  }
-
-  private AuditLogCleanupEntity toAuditLogCleanupEntity(final HistoryDeletionEntity entity) {
-    final String keyField =
-        switch (entity.getResourceType()) {
-          case PROCESS_INSTANCE -> AuditLogTemplate.PROCESS_INSTANCE_KEY;
-          case PROCESS_DEFINITION -> AuditLogTemplate.PROCESS_DEFINITION_KEY;
-          case DECISION_INSTANCE -> AuditLogTemplate.DECISION_EVALUATION_KEY;
-          case DECISION_REQUIREMENTS -> AuditLogTemplate.DECISION_REQUIREMENTS_KEY;
-        };
-    final var id =
-        AUDIT_LOG_CLEANUP_ID.formatted(entity.getBatchOperationKey(), entity.getResourceKey());
-    // avoid setting entityType so job later deletes only by key
-    return new AuditLogCleanupEntity()
-        .setId(id)
-        .setKey(String.valueOf(entity.getResourceKey()))
-        .setKeyField(keyField)
-        .setEntityType(null)
-        .setPartitionId((int) entity.getPartitionId());
   }
 
   private CompletionStage<Integer> deleteFromHistoryDeletionIndex(final List<String> ids) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -149,16 +149,7 @@ public class HistoryDeletionJob implements BackgroundTask {
               final var cleanupEntries = buildAuditLogCleanupEntries(batch, deletedResources);
               return deleterRepository
                   .createAuditLogCleanupEntries(cleanupEntries)
-                  .thenCompose(v -> deleteFromHistoryDeletionIndex(deletedResources))
-                  .exceptionally(
-                      ex -> {
-                        logger.warn(
-                            "Failed to create audit log cleanup entries for batch: {}. "
-                                + "Skipping deletion from history deletion index to allow retry.",
-                            batch,
-                            ex);
-                        return 0;
-                      });
+                  .thenCompose(v -> deleteFromHistoryDeletionIndex(deletedResources));
             });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
+import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -47,6 +48,16 @@ public interface HistoryDeletionRepository extends AutoCloseable {
   CompletableFuture<Integer> deleteDocumentsById(
       final String sourceIndexName, final List<String> ids);
 
+  /**
+   * Creates audit log cleanup entries in the audit log cleanup index. These entries are used by the
+   * audit log cleanup job to determine which audit logs to delete after the retention period has
+   * expired for the deleted resources.
+   *
+   * @param entries The list of {@link AuditLogCleanupEntity} entries to create
+   * @return a {@link CompletableFuture} that completes when all entries have been indexed
+   */
+  CompletableFuture<Void> createAuditLogCleanupEntries(final List<AuditLogCleanupEntity> entries);
+
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
     public CompletableFuture<HistoryDeletionBatch> getNextBatch() {
@@ -63,6 +74,12 @@ public interface HistoryDeletionRepository extends AutoCloseable {
     public CompletableFuture<Integer> deleteDocumentsById(
         final String sourceIndexName, final List<String> ids) {
       return CompletableFuture.completedFuture(0);
+    }
+
+    @Override
+    public CompletableFuture<Void> createAuditLogCleanupEntries(
+        final List<AuditLogCleanupEntity> entries) {
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.exporter.tasks.historydeletion;
 
-import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
+import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /** Repository for querying and managing history deletion requests. */
 public interface HistoryDeletionRepository extends AutoCloseable {
@@ -53,10 +55,13 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    * audit log cleanup job to determine which audit logs to delete after the retention period has
    * expired for the deleted resources.
    *
-   * @param entries The list of {@link AuditLogCleanupEntity} entries to create
-   * @return a {@link CompletableFuture} that completes when all entries have been indexed
+   * @param historyDeletionEntities The history deletion entities that were processed
+   * @param deletedResources The deleted resource IDs for which to create cleanup entries
+   * @return a {@link CompletionStage} that completes when all entries have been indexed
    */
-  CompletableFuture<Void> createAuditLogCleanupEntries(final List<AuditLogCleanupEntity> entries);
+  CompletionStage<Void> createAuditLogCleanupEntries(
+      final List<HistoryDeletionEntity> historyDeletionEntities,
+      final Set<String> deletedResources);
 
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
@@ -77,8 +82,9 @@ public interface HistoryDeletionRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletableFuture<Void> createAuditLogCleanupEntries(
-        final List<AuditLogCleanupEntity> entries) {
+    public CompletionStage<Void> createAuditLogCleanupEntries(
+        final List<HistoryDeletionEntity> historyDeletionEntities,
+        final Set<String> deletedResources) {
       return CompletableFuture.completedFuture(null);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -10,8 +10,10 @@ package io.camunda.exporter.tasks.historydeletion;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.io.IOException;
@@ -37,6 +39,7 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
     implements HistoryDeletionRepository {
 
   private final IndexDescriptor indexDescriptor;
+  private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
   private final HistoryDeletionConfiguration config;
 
@@ -54,6 +57,12 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
             .findFirst()
             .orElseThrow(
                 () -> new IllegalStateException("No HistoryDeletionIndex descriptor found"));
+    auditLogCleanupIndex =
+        resourceProvider.getIndexDescriptors().stream()
+            .filter(AuditLogCleanupIndex.class::isInstance)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException("No AuditLogCleanupIndex descriptor found"));
     this.partitionId = partitionId;
     this.config = config;
   }
@@ -153,6 +162,42 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
                       }
                       final var deleted = response.items().size();
                       return CompletableFuture.completedFuture(deleted);
+                    },
+                    executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> createAuditLogCleanupEntries(
+      final List<AuditLogCleanupEntity> entries) {
+    if (entries.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final var targetIndexName = auditLogCleanupIndex.getFullQualifiedName();
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+
+    entries.forEach(
+        entry ->
+            bulkRequestBuilder.operations(
+                op -> op.index(i -> i.index(targetIndexName).id(entry.getId()).document(entry))));
+
+    return sendRequestAsync(
+        () ->
+            client
+                .bulk(bulkRequestBuilder.build())
+                .thenComposeAsync(
+                    response -> {
+                      if (response.errors()) {
+                        final var errorMessage =
+                            "Bulk indexing audit log cleanup entries to index '%s' failed with errors: %s"
+                                .formatted(targetIndexName, response.items());
+                        logger.error(errorMessage);
+                        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                      }
+                      logger.debug(
+                          "Indexed {} audit log cleanup entries to index '{}'",
+                          entries.size(),
+                          targetIndexName);
+                      return CompletableFuture.completedFuture(null);
                     },
                     executor));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -13,12 +13,13 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
-import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -167,11 +168,15 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<Void> createAuditLogCleanupEntries(
-      final List<AuditLogCleanupEntity> entries) {
-    if (entries.isEmpty()) {
+  public CompletionStage<Void> createAuditLogCleanupEntries(
+      final List<HistoryDeletionEntity> historyDeletionEntities,
+      final Set<String> deletedResources) {
+    if (deletedResources.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
+    final var entries =
+        AuditLogCleanupTransformer.buildAuditLogCleanupEntries(
+            historyDeletionEntities, deletedResources);
     final var targetIndexName = auditLogCleanupIndex.getFullQualifiedName();
     final var bulkRequestBuilder = new BulkRequest.Builder();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -24,6 +24,7 @@ import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
@@ -66,7 +67,7 @@ final class CamundaExporterTest {
     mockedClientAdapterFactory
         .when(() -> ClientAdapter.of(configuration.getConnect()))
         .thenReturn(stubbedClientAdapterInUse);
-    doReturn(List.of(new HistoryDeletionIndex("", true)))
+    doReturn(List.of(new HistoryDeletionIndex("", true), new AuditLogCleanupIndex("", true)))
         .when(resourceProvider)
         .getIndexDescriptors();
     doReturn(emptyList()).when(resourceProvider).getIndexTemplateDescriptors();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
@@ -54,4 +54,10 @@ public class ElasticsearchHistoryDeletionRepositoryIT extends HistoryDeletionRep
         .join();
     client.indices().refresh(r -> r.index(historyDeletionIndex.getFullQualifiedName())).join();
   }
+
+  @Override
+  protected long countAuditLogCleanupEntries() {
+    client.indices().refresh(r -> r.index(auditLogCleanupIndex.getFullQualifiedName())).join();
+    return client.count(c -> c.index(auditLogCleanupIndex.getFullQualifiedName())).join().count();
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
@@ -71,6 +72,8 @@ final class HistoryDeletionJobTest {
         resourceProvider.getIndexDescriptor(DecisionRequirementsIndex.class);
     decisionIndex = resourceProvider.getIndexDescriptor(DecisionIndex.class);
     job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
+    when(repository.createAuditLogCleanupEntries(anyList()))
+        .thenReturn(CompletableFuture.completedFuture(null));
   }
 
   @Test
@@ -692,5 +695,267 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .deleteDocumentsById(
             historyDeletionIndex.getFullQualifiedName(), List.of(decisionInstanceEntity.getId()));
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntriesWhenDeletingFromHistoryDeletionIndex() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(42L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then: audit log cleanup entry is created and history deletion index is cleaned up
+    verify(repository).createAuditLogCleanupEntries(anyList());
+    verify(repository)
+        .deleteDocumentsById(historyDeletionIndex.getFullQualifiedName(), List.of(entity.getId()));
+  }
+
+  @Test
+  void shouldNotDeleteFromHistoryDeletionIndexIfAuditLogCleanupEntryCreationFails() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(42L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+    when(repository.createAuditLogCleanupEntries(anyList()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new RuntimeException("Failed to create audit log cleanup entry")));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then: history deletion index is NOT cleaned up so the job retries next cycle
+    verify(repository, never())
+        .deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any());
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntryWithCorrectKeyFieldForProcessInstance() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(100L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(3);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(
+                entries ->
+                    entries.size() == 1
+                        && entries.getFirst().getKey().equals("100")
+                        && entries
+                            .getFirst()
+                            .getKeyField()
+                            .equals(AuditLogTemplate.PROCESS_INSTANCE_KEY)
+                        && entries.getFirst().getEntityType() == null
+                        && entries.getFirst().getPartitionId() == 3));
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntryWithCorrectKeyFieldForProcessDefinition() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(200L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(
+                entries ->
+                    entries.size() == 1
+                        && entries.getFirst().getKey().equals("200")
+                        && entries
+                            .getFirst()
+                            .getKeyField()
+                            .equals(AuditLogTemplate.PROCESS_DEFINITION_KEY)
+                        && entries.getFirst().getEntityType() == null
+                        && entries.getFirst().getPartitionId() == 1));
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntryWithCorrectKeyFieldForDecisionInstance() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(300L)
+            .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(2);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(
+                entries ->
+                    entries.size() == 1
+                        && entries.getFirst().getKey().equals("300")
+                        && entries
+                            .getFirst()
+                            .getKeyField()
+                            .equals(AuditLogTemplate.DECISION_EVALUATION_KEY)
+                        && entries.getFirst().getEntityType() == null
+                        && entries.getFirst().getPartitionId() == 2));
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntryWithCorrectKeyFieldForDecisionRequirements() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(400L)
+            .setResourceType(HistoryDeletionType.DECISION_REQUIREMENTS)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(
+                entries ->
+                    entries.size() == 1
+                        && entries.getFirst().getKey().equals("400")
+                        && entries
+                            .getFirst()
+                            .getKeyField()
+                            .equals(AuditLogTemplate.DECISION_REQUIREMENTS_KEY)
+                        && entries.getFirst().getEntityType() == null
+                        && entries.getFirst().getPartitionId() == 1));
+  }
+
+  @Test
+  void shouldOnlyCreateCleanupEntriesForSuccessfullyDeletedResources() {
+    // given: one process instance (succeeds) and one process definition (fails to delete)
+    final var processInstanceEntity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var processDefinitionEntity =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(2L)
+            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new HistoryDeletionBatch(List.of(processInstanceEntity, processDefinitionEntity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+    when(repository.deleteDocumentsById(eq(processIndex.getFullQualifiedName()), anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed deleting")));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then: only the process instance cleanup entry is created (definition failed)
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(
+                entries ->
+                    entries.size() == 1
+                        && entries
+                            .getFirst()
+                            .getKeyField()
+                            .equals(AuditLogTemplate.PROCESS_INSTANCE_KEY)));
+  }
+
+  @Test
+  void shouldUseIdempotentIdForAuditLogCleanupEntry() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(42L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(3);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then: ID is deterministic: {batchOperationKey}-{resourceKey}
+    verify(repository)
+        .createAuditLogCleanupEntries(
+            argThat(entries -> entries.size() == 1 && entries.getFirst().getId().equals("2-42")));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.historydeletion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,6 +34,7 @@ import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -740,16 +742,45 @@ final class HistoryDeletionJobTest {
     when(repository.deleteDocumentsById(anyString(), anyList()))
         .thenReturn(CompletableFuture.completedFuture(0));
     when(repository.createAuditLogCleanupEntries(anyList()))
-        .thenReturn(
-            CompletableFuture.failedFuture(
-                new RuntimeException("Failed to create audit log cleanup entry")));
+        .thenThrow(new RuntimeException("Failed to create audit log cleanup entry"));
 
-    // when
-    job.execute().toCompletableFuture().join();
+    // when/then
+    assertThatThrownBy(() -> job.execute().toCompletableFuture().join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(RuntimeException.class)
+        .hasRootCauseMessage("Failed to create audit log cleanup entry");
 
     // then: history deletion index is NOT cleaned up so the job retries next cycle
     verify(repository, never())
         .deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any());
+  }
+
+  @Test
+  void shouldFailFutureIfHistoryDeletionFails() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(42L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+    when(repository.createAuditLogCleanupEntries(anyList()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(repository.deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any()))
+        .thenThrow(new RuntimeException("Failed to delete from history deletion index"));
+
+    // when/then
+    assertThatThrownBy(() -> job.execute().toCompletableFuture().join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(RuntimeException.class)
+        .hasRootCauseMessage("Failed to delete from history deletion index");
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -74,7 +74,7 @@ final class HistoryDeletionJobTest {
         resourceProvider.getIndexDescriptor(DecisionRequirementsIndex.class);
     decisionIndex = resourceProvider.getIndexDescriptor(DecisionIndex.class);
     job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
-    when(repository.createAuditLogCleanupEntries(anyList()))
+    when(repository.createAuditLogCleanupEntries(anyList(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
   }
 
@@ -137,7 +137,13 @@ final class HistoryDeletionJobTest {
             List.of(entity1.getResourceKey(), entity2.getResourceKey()));
     verify(repository)
         .deleteDocumentsById(
-            historyDeletionIndex.getFullQualifiedName(), List.of(entity1.getId(), entity2.getId()));
+            eq(historyDeletionIndex.getFullQualifiedName()),
+            argThat(
+                ids ->
+                    ids != null
+                        && ids.size() == 2
+                        && ids.contains(entity1.getId())
+                        && ids.contains(entity2.getId())));
   }
 
   @Test
@@ -381,7 +387,13 @@ final class HistoryDeletionJobTest {
             List.of(entity1.getResourceKey(), entity2.getResourceKey()));
     verify(repository)
         .deleteDocumentsById(
-            historyDeletionIndex.getFullQualifiedName(), List.of(entity1.getId(), entity2.getId()));
+            eq(historyDeletionIndex.getFullQualifiedName()),
+            argThat(
+                ids ->
+                    ids != null
+                        && ids.size() == 2
+                        && ids.contains(entity1.getId())
+                        && ids.contains(entity2.getId())));
   }
 
   @Test
@@ -542,7 +554,13 @@ final class HistoryDeletionJobTest {
                 String.valueOf(entity2.getResourceKey())));
     verify(repository)
         .deleteDocumentsById(
-            historyDeletionIndex.getFullQualifiedName(), List.of(entity1.getId(), entity2.getId()));
+            eq(historyDeletionIndex.getFullQualifiedName()),
+            argThat(
+                ids ->
+                    ids != null
+                        && ids.size() == 2
+                        && ids.contains(entity1.getId())
+                        && ids.contains(entity2.getId())));
   }
 
   @Test
@@ -720,7 +738,7 @@ final class HistoryDeletionJobTest {
     job.execute().toCompletableFuture().join();
 
     // then: audit log cleanup entry is created and history deletion index is cleaned up
-    verify(repository).createAuditLogCleanupEntries(anyList());
+    verify(repository).createAuditLogCleanupEntries(anyList(), any());
     verify(repository)
         .deleteDocumentsById(historyDeletionIndex.getFullQualifiedName(), List.of(entity.getId()));
   }
@@ -741,7 +759,7 @@ final class HistoryDeletionJobTest {
         .thenReturn(CompletableFuture.completedFuture(List.of()));
     when(repository.deleteDocumentsById(anyString(), anyList()))
         .thenReturn(CompletableFuture.completedFuture(0));
-    when(repository.createAuditLogCleanupEntries(anyList()))
+    when(repository.createAuditLogCleanupEntries(anyList(), any()))
         .thenThrow(new RuntimeException("Failed to create audit log cleanup entry"));
 
     // when/then
@@ -771,7 +789,7 @@ final class HistoryDeletionJobTest {
         .thenReturn(CompletableFuture.completedFuture(List.of()));
     when(repository.deleteDocumentsById(anyString(), anyList()))
         .thenReturn(CompletableFuture.completedFuture(0));
-    when(repository.createAuditLogCleanupEntries(anyList()))
+    when(repository.createAuditLogCleanupEntries(anyList(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(repository.deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any()))
         .thenThrow(new RuntimeException("Failed to delete from history deletion index"));
@@ -807,15 +825,15 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .createAuditLogCleanupEntries(
             argThat(
-                entries ->
-                    entries.size() == 1
-                        && entries.getFirst().getKey().equals("100")
-                        && entries
-                            .getFirst()
-                            .getKeyField()
-                            .equals(AuditLogTemplate.PROCESS_INSTANCE_KEY)
-                        && entries.getFirst().getEntityType() == null
-                        && entries.getFirst().getPartitionId() == 3));
+                entities ->
+                    entities.size() == 1
+                        && entities.getFirst().getId().equals("id1")
+                        && entities.getFirst().getResourceKey() == 100L
+                        && entities.getFirst().getResourceType()
+                            == HistoryDeletionType.PROCESS_INSTANCE),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 
   @Test
@@ -840,15 +858,15 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .createAuditLogCleanupEntries(
             argThat(
-                entries ->
-                    entries.size() == 1
-                        && entries.getFirst().getKey().equals("200")
-                        && entries
-                            .getFirst()
-                            .getKeyField()
-                            .equals(AuditLogTemplate.PROCESS_DEFINITION_KEY)
-                        && entries.getFirst().getEntityType() == null
-                        && entries.getFirst().getPartitionId() == 1));
+                entities ->
+                    entities.size() == 1
+                        && entities.getFirst().getId().equals("id1")
+                        && entities.getFirst().getResourceKey() == 200L
+                        && entities.getFirst().getResourceType()
+                            == HistoryDeletionType.PROCESS_DEFINITION),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 
   @Test
@@ -875,15 +893,15 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .createAuditLogCleanupEntries(
             argThat(
-                entries ->
-                    entries.size() == 1
-                        && entries.getFirst().getKey().equals("300")
-                        && entries
-                            .getFirst()
-                            .getKeyField()
-                            .equals(AuditLogTemplate.DECISION_EVALUATION_KEY)
-                        && entries.getFirst().getEntityType() == null
-                        && entries.getFirst().getPartitionId() == 2));
+                entities ->
+                    entities.size() == 1
+                        && entities.getFirst().getId().equals("id1")
+                        && entities.getFirst().getResourceKey() == 300L
+                        && entities.getFirst().getResourceType()
+                            == HistoryDeletionType.DECISION_INSTANCE),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 
   @Test
@@ -910,15 +928,15 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .createAuditLogCleanupEntries(
             argThat(
-                entries ->
-                    entries.size() == 1
-                        && entries.getFirst().getKey().equals("400")
-                        && entries
-                            .getFirst()
-                            .getKeyField()
-                            .equals(AuditLogTemplate.DECISION_REQUIREMENTS_KEY)
-                        && entries.getFirst().getEntityType() == null
-                        && entries.getFirst().getPartitionId() == 1));
+                entities ->
+                    entities.size() == 1
+                        && entities.getFirst().getId().equals("id1")
+                        && entities.getFirst().getResourceKey() == 400L
+                        && entities.getFirst().getResourceType()
+                            == HistoryDeletionType.DECISION_REQUIREMENTS),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 
   @Test
@@ -956,12 +974,17 @@ final class HistoryDeletionJobTest {
     verify(repository)
         .createAuditLogCleanupEntries(
             argThat(
-                entries ->
-                    entries.size() == 1
-                        && entries
-                            .getFirst()
-                            .getKeyField()
-                            .equals(AuditLogTemplate.PROCESS_INSTANCE_KEY)));
+                entities ->
+                    entities.size() == 2
+                        && entities.stream()
+                            .anyMatch(
+                                e ->
+                                    e.getId().equals("id1")
+                                        && e.getResourceType()
+                                            == HistoryDeletionType.PROCESS_INSTANCE)),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 
   @Test
@@ -987,6 +1010,14 @@ final class HistoryDeletionJobTest {
     // then: ID is deterministic: {batchOperationKey}-{resourceKey}
     verify(repository)
         .createAuditLogCleanupEntries(
-            argThat(entries -> entries.size() == 1 && entries.getFirst().getId().equals("2-42")));
+            argThat(
+                entities ->
+                    entities.size() == 1
+                        && entities.getFirst().getId().equals("id1")
+                        && entities.getFirst().getBatchOperationKey() == 2L
+                        && entities.getFirst().getResourceKey() == 42L),
+            argThat(
+                deletedResources ->
+                    deletedResources.size() == 1 && deletedResources.contains("id1")));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepositoryIT.java
@@ -17,12 +17,14 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -39,6 +41,7 @@ abstract class HistoryDeletionRepositoryIT {
   @RegisterExtension protected static SearchDBExtension searchDB = create();
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   protected final HistoryDeletionIndex historyDeletionIndex;
+  protected final AuditLogCleanupIndex auditLogCleanupIndex;
   @AutoClose protected final ClientAdapter clientAdapter;
   protected final SearchEngineClient engineClient;
   protected final ExporterConfiguration config;
@@ -57,11 +60,13 @@ abstract class HistoryDeletionRepositoryIT {
     engineClient = clientAdapter.getSearchEngineClient();
 
     historyDeletionIndex = new HistoryDeletionIndex(indexPrefix, isElastic);
+    auditLogCleanupIndex = new AuditLogCleanupIndex(indexPrefix, isElastic);
   }
 
   @BeforeEach
   void beforeEach() {
     engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
+    engineClient.createIndex(auditLogCleanupIndex, new IndexConfiguration());
     repository = createRepository(indexPrefix, PARTITION_ID);
   }
 
@@ -69,6 +74,8 @@ abstract class HistoryDeletionRepositoryIT {
   void afterEach() {
     engineClient.deleteIndex(historyDeletionIndex.getFullQualifiedName());
     engineClient.createIndex(historyDeletionIndex, new IndexConfiguration());
+    engineClient.deleteIndex(auditLogCleanupIndex.getFullQualifiedName());
+    engineClient.createIndex(auditLogCleanupIndex, new IndexConfiguration());
   }
 
   protected abstract HistoryDeletionRepository createRepository(
@@ -90,6 +97,8 @@ abstract class HistoryDeletionRepositoryIT {
   }
 
   protected abstract void index(final HistoryDeletionEntity entity) throws IOException;
+
+  protected abstract long countAuditLogCleanupEntries() throws IOException;
 
   @Test
   void shouldGetEmptyListWhenNoEntitiesToDelete() {
@@ -181,5 +190,27 @@ abstract class HistoryDeletionRepositoryIT {
                     .extracting(HistoryDeletionBatch::historyDeletionEntities)
                     .asInstanceOf(InstanceOfAssertFactories.list(HistoryDeletionEntity.class))
                     .isEmpty());
+  }
+
+  @Test
+  void shouldCreateAuditLogCleanupEntries() throws IOException {
+    // given
+    final var entity1 = createHistoryDeletionEntity();
+    final var entity2 = createHistoryDeletionEntity();
+    final var deletedResourceIds = Set.of(entity1.getId(), entity2.getId());
+
+    // when
+    repository
+        .createAuditLogCleanupEntries(List.of(entity1, entity2), deletedResourceIds)
+        .toCompletableFuture()
+        .join();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final long auditLogCount = countAuditLogCleanupEntries();
+              assertThat(auditLogCount).isEqualTo(2);
+            });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
@@ -48,4 +48,10 @@ public class OpenSearchHistoryDeletionIT extends HistoryDeletionRepositoryIT {
         .join();
     client.indices().refresh(r -> r.index(historyDeletionIndex.getFullQualifiedName())).join();
   }
+
+  @Override
+  protected long countAuditLogCleanupEntries() throws IOException {
+    client.indices().refresh(r -> r.index(auditLogCleanupIndex.getFullQualifiedName())).join();
+    return client.count(c -> c.index(auditLogCleanupIndex.getFullQualifiedName())).join().count();
+  }
 }


### PR DESCRIPTION
## Description

✅Tested locally :
1. After deleting resources, add to `camunda-audit-log-cleanup-8.9.0` index
2. remove from `camunda-history-deletion-8.9.0`
3. `AuditLogArchiverJob` runs and fetches next `AuditLogCleanupBatch`
4. moves selected audit logs from `camunda-audit-log-8.9.0` to `camunda-audit-log-8.9.0_2026-02-23`
5. Removes from `camunda-audit-log-cleanup-8.9.0`

Case wanted to cover in `qa/acceptance-tests`:
1. Deploy process
2. Await for process to be deployed
3. Start process instance
4. Await process instance to be created
5. Await audit logs for this process instance to be created - by processInstanceKey
6. Delete process instance using camunda client
7. Assert once batch request is created
8. Await for batch operation to be completed
	- should add to audit log cleanup index (is there a way to test this) before completed
	- Should add to history deletion index (is there a way to test this) before completed
9. AuditLogArchiverJob should run
	- pick up entries from audit log cleanup index, (do some irrelevant work for this test case) and remove actual audit log index (is there a way to test this)
10. Await this process instance's audit log are not searchable


I am trying to find a way to work with retention in test and delete `camunda-audit-log-8.9.0_2026-02-23` since audit logs are still searchable

## Related issues

closes #45979 