### PR TITLE
feat: add reverse iteration support to ColumnFamily abstraction

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -151,6 +151,20 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
       DbKey keyPrefix, KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
 
   /**
+   * Visits the key-value pairs in reverse order, which are stored in the column family. The visitor
+   * can indicate via the return value, whether the iteration should continue or not. This means if
+   * the visitor returns false the iteration will stop.
+   *
+   * <p>The given {@code startAtKey} indicates where the iteration should start. If the key exists,
+   * the first key-value-pair will contain the equal key as {@code startAtKey}. If the key doesn't
+   * exist it will start at the key just before it.
+   *
+   * @param startAtKey indicates on which key the reverse iteration should start
+   * @param visitor the visitor which visits the key-value pairs
+   */
+  void whileTrueReverse(KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
+
+  /**
    * Deletes the key-value pair with the given key if it exists in the column family
    *
    * @throws IllegalStateException if the key does not exist

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -248,6 +248,13 @@ class TransactionalColumnFamily<
   }
 
   @Override
+  public void whileTrueReverse(
+      final KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+    ensureInOpenTransaction(
+        transaction -> forEachInPrefixReverse(startAtKey, new DbNullKey(), visitor));
+  }
+
+  @Override
   public void deleteExisting(final KeyType key) {
     try (final var timer = metrics.measureDeleteLatency()) {
       ensureInOpenTransaction(
@@ -428,6 +435,49 @@ class TransactionalColumnFamily<
               for (iterator.seek(columnFamilyContext.keyWithColumnFamily(seekTarget));
                   iterator.isValid() && shouldVisitNext;
                   iterator.next()) {
+                final byte[] keyBytes = iterator.key();
+                if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length)) {
+                  break;
+                }
+
+                shouldVisitNext = visit(keyInstance, valueInstance, visitor, iterator);
+              }
+            }
+          });
+    }
+  }
+
+  /**
+   * Reverse counterpart of {@link #forEachInPrefix(DbKey, DbKey, KeyValuePairVisitor)}. Iterates
+   * backward over key-value pairs within the given prefix.
+   *
+   * @param startAt seek to this key before starting reverse iteration.
+   * @param prefix of all keys that are iterated over.
+   * @param visitor called for all kv pairs where the key matches the given prefix. The visitor can
+   *     indicate whether iteration should continue or not, see {@link KeyValuePairVisitor}.
+   */
+  private void forEachInPrefixReverse(
+      final DbKey startAt,
+      final DbKey prefix,
+      final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+    try (final var timer = metrics.measureIterateLatency()) {
+      Objects.requireNonNull(startAt);
+      Objects.requireNonNull(prefix);
+      Objects.requireNonNull(visitor);
+
+      columnFamilyContext.withPrefixKey(
+          prefix,
+          (prefixKey, prefixLength) -> {
+            try (final RocksIterator iterator =
+                newIterator(context, transactionDb.getPrefixReadOptions())) {
+
+              final var seekTarget = columnFamilyContext.keyWithColumnFamily(startAt);
+
+              boolean shouldVisitNext = true;
+
+              for (iterator.seekForPrev(seekTarget);
+                  iterator.isValid() && shouldVisitNext;
+                  iterator.prev()) {
                 final byte[] keyBytes = iterator.key();
                 if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length)) {
                   break;

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -521,6 +521,106 @@ public final class ColumnFamilyTest {
     assertThat(result2.getValue()).isEqualTo(4);
   }
 
+  @Test
+  public void shouldUseWhileTrueReverse() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(6734);
+    columnFamily.whileTrueReverse(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+          return key.getValue() != 1213;
+        });
+
+    // then — reverse from 6734: 6734, 4567, 1213 (stops because visitor returns false)
+    assertThat(keys).containsExactly(6734L, 4567L, 1213L);
+    assertThat(values).containsExactly(921L, 123L, 255L);
+  }
+
+  @Test
+  public void shouldUseWhileTrueReverseWithMissingKey() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when — start at 5000 which doesn't exist, seekForPrev lands on 4567
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(5000);
+    columnFamily.whileTrueReverse(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+          return true;
+        });
+
+    // then — reverse from 4567: 4567, 1213, 1
+    assertThat(keys).containsExactly(4567L, 1213L, 1L);
+    assertThat(values).containsExactly(123L, 255L, (long) Short.MAX_VALUE);
+  }
+
+  @Test
+  public void shouldUseWhileTrueReverseAll() {
+    // given
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
+
+    // when — start at Long.MAX_VALUE to iterate all in reverse
+    final List<Long> keys = new ArrayList<>();
+    final List<Long> values = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(Long.MAX_VALUE);
+    columnFamily.whileTrueReverse(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          values.add(value.getValue());
+          return true;
+        });
+
+    // then — all keys in reverse order
+    assertThat(keys).containsExactly((long) Short.MAX_VALUE, 6734L, 4567L, 1213L, 1L);
+    assertThat(values).containsExactly(1L, 921L, 123L, 255L, (long) Short.MAX_VALUE);
+  }
+
+  @Test
+  public void shouldReturnEmptyOnWhileTrueReverseWithNoEntries() {
+    // given — empty CF
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    final var startAt = new DbLong();
+    startAt.wrapLong(100);
+    columnFamily.whileTrueReverse(
+        startAt,
+        (key, value) -> {
+          keys.add(key.getValue());
+          return true;
+        });
+
+    // then
+    assertThat(keys).isEmpty();
+  }
+
   private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);


### PR DESCRIPTION
Add whileTrueReverse for reverse iteration across the whole column family. The implementation mirrors the existing forEachInPrefix pattern, using RocksDB's seekForPrev()/prev() instead of seek()/next().