### PR TITLE
fix: job worker change sets reset tenant filter as well

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerChangeSet.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerChangeSet.java
@@ -150,7 +150,8 @@ public sealed interface JobWorkerChangeSet {
                   jobWorkerValue::setForceFetchAllVariables),
               reset(jobWorkerValue.getStreamEnabled(), jobWorkerValue::setStreamEnabled),
               reset(jobWorkerValue.getStreamTimeout(), jobWorkerValue::setStreamTimeout),
-              reset(jobWorkerValue.getMaxRetries(), jobWorkerValue::setMaxRetries))
+              reset(jobWorkerValue.getMaxRetries(), jobWorkerValue::setMaxRetries),
+              reset(jobWorkerValue.getTenantFilter(), jobWorkerValue::setTenantFilter))
           .reduce(false, Boolean::logicalOr);
     }
   }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerChangeSetTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerChangeSetTest.java
@@ -22,6 +22,7 @@ import io.camunda.client.annotation.value.SourceAware.Empty;
 import io.camunda.client.annotation.value.SourceAware.FromAnnotation;
 import io.camunda.client.annotation.value.SourceAware.FromOverrideProperty;
 import io.camunda.client.annotation.value.SourceAware.FromRuntimeOverride;
+import io.camunda.client.api.command.enums.TenantFilter;
 import io.camunda.client.jobhandling.JobWorkerChangeSet.FetchVariablesChangeSet;
 import io.camunda.client.jobhandling.JobWorkerChangeSet.ForceFetchAllVariablesChangeSet;
 import io.camunda.client.jobhandling.JobWorkerChangeSet.MaxJobsActiveChangeSet;
@@ -160,5 +161,17 @@ public class JobWorkerChangeSetTest {
     changeSet1.applyChanges(jobWorkerValue);
     assertThat(jobWorkerValue.getTenantIds())
         .isEqualTo(List.of(new FromRuntimeOverride<>("xyz", new FromAnnotation<>("abc"))));
+  }
+
+  @Test
+  void shouldResetTenantFilter() {
+    final JobWorkerValue jobWorkerValue = new JobWorkerValue();
+    jobWorkerValue.setTenantFilter(
+        new FromRuntimeOverride<>(
+            TenantFilter.ASSIGNED, new FromAnnotation<>(TenantFilter.PROVIDED)));
+    final ResetChangeSet resetChangeSet = new ResetChangeSet();
+    resetChangeSet.applyChanges(jobWorkerValue);
+    assertThat(jobWorkerValue.getTenantFilter())
+        .isEqualTo(new FromAnnotation<>(TenantFilter.PROVIDED));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR enables the reset change set to reset the tenant filter runtime override

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
