### PR TITLE
feat: parameter resolver for root process instance key

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -72,7 +72,9 @@ public class AnnotationUtil {
               JobKey.class,
               ActivatedJob::getKey,
               ProcessDefinitionKey.class,
-              ActivatedJob::getProcessDefinitionKey);
+              ActivatedJob::getProcessDefinitionKey,
+              RootProcessInstanceKey.class,
+              ActivatedJob::getRootProcessInstanceKey);
 
   public static boolean isVariable(final ParameterInfo parameterInfo) {
     return parameterInfo.getParameter().isAnnotationPresent(Variable.class)

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/RootProcessInstanceKey.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/RootProcessInstanceKey.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RootProcessInstanceKey {}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -29,6 +29,7 @@ import io.camunda.client.annotation.ElementInstanceKey;
 import io.camunda.client.annotation.JobKey;
 import io.camunda.client.annotation.ProcessDefinitionKey;
 import io.camunda.client.annotation.ProcessInstanceKey;
+import io.camunda.client.annotation.RootProcessInstanceKey;
 import io.camunda.client.annotation.VariablesAsType;
 import io.camunda.client.annotation.value.DeploymentValue;
 import io.camunda.client.annotation.value.DocumentValue;
@@ -379,6 +380,19 @@ public class AnnotationUtilTest {
       assertThat(keyResolver.apply(job)).isEqualTo(123L);
     }
 
+    @Test
+    void shouldExtractRootProcessInstanceKeyResolver() {
+      // given
+      final ParameterInfo parameterInfo = parameterInfo(this, "testRootProcessInstanceKey");
+      final ActivatedJob job = mock(ActivatedJob.class);
+      when(job.getRootProcessInstanceKey()).thenReturn(123L);
+      // when
+      final Function<ActivatedJob, Long> keyResolver =
+          AnnotationUtil.getKeyResolver(parameterInfo).get();
+      // then
+      assertThat(keyResolver.apply(job)).isEqualTo(123L);
+    }
+
     public void testProcessInstanceKey(@ProcessInstanceKey final String key) {}
 
     public void testProcessDefinitionKey(@ProcessDefinitionKey final String key) {}
@@ -386,5 +400,7 @@ public class AnnotationUtilTest {
     public void testJobKey(@JobKey final String key) {}
 
     public void testElementInstanceKey(@ElementInstanceKey final String key) {}
+
+    public void testRootProcessInstanceKey(@RootProcessInstanceKey final String key) {}
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a key resolver for the parameter root process instance key.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
