### PR TITLE
test: added json report and stable/8.9 branch

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -5,9 +5,13 @@
 ---
 name: C8 Orchestration Cluster E2E Tests Nightly
 
+#on:
+#  schedule:
+#    - cron: "0 0 * * *" # Run all tests at midnight UTC
+
 on:
-  schedule:
-    - cron: "0 0 * * *" # Run all tests at midnight UTC
+  pull_request:
+    types: [opened, edited, synchronize]  # Triggers on PR open, new comits on PR and when the PR description is edited
 
 permissions:
   contents: read
@@ -18,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, stable/8.8, main]
+        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -203,7 +207,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.6, stable/8.7, stable/8.8, main]
+        branch: [stable/8.6, stable/8.7, stable/8.8, stable/8.9, main]
         tasklist_mode: [v1, v2]
         exclude:
           # V2 mode only supported on main branch - exclude V2 for older branches
@@ -357,15 +361,15 @@ jobs:
           fi
 
           if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
-            if [[ "${{ matrix.branch }}" == "main" ]]; then
-              echo "Running all tests in V2 mode on main branch, excluding V1-specific tests"
+            if [[ "${{ matrix.branch }}" == "main" || "${{ matrix.branch }}" == "stable/8.9" ]]; then
+              echo "Running all tests in V2 mode on ${{ matrix.branch }}, excluding V1-specific tests"
               npm run test -- --project=chromium --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
             else
               echo "Running all tests in V2 mode: excluding @v1-only tests"
               npm run test -- --project=chromium --grep-invert "@v1-only"
             fi
           else
-            if [[ "${{ matrix.branch }}" == "main" ]]; then
+            if [[ "${{ matrix.branch }}" == "main" || "${{ matrix.branch }}" == "stable/8.9"]]; then
               echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
               npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/
             elif [[ "${{ matrix.branch }}" == "stable/8.8" ]]; then
@@ -398,6 +402,14 @@ jobs:
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: json-report-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          path: json-report/**
+          retention-days: 60
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -5,13 +5,9 @@
 ---
 name: C8 Orchestration Cluster E2E Tests Nightly
 
-#on:
-#  schedule:
-#    - cron: "0 0 * * *" # Run all tests at midnight UTC
-
 on:
-  pull_request:
-    types: [opened, edited, synchronize]  # Triggers on PR open, new comits on PR and when the PR description is edited
+  schedule:
+    - cron: "0 0 * * *" # Run all tests at midnight UTC
 
 permissions:
   contents: read
@@ -407,7 +403,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: json-report-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          name: json-report-nightly-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: json-report-nightly-api-${{ matrix.branch }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
@@ -409,7 +409,7 @@ jobs:
 
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: json-report-nightly-e2e-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -369,7 +369,7 @@ jobs:
               npm run test -- --project=chromium --grep-invert "@v1-only"
             fi
           else
-            if [[ "${{ matrix.branch }}" == "main" || "${{ matrix.branch }}" == "stable/8.9"]]; then
+            if [[ "${{ matrix.branch }}" == "main" || "${{ matrix.branch }}" == "stable/8.9" ]]; then
               echo "Running V1 specific tests only: common-flows/v1/ and tests/tasklist/v1/"
               npm run test -- --project=chromium tests/common-flows/v1/ tests/tasklist/v1/
             elif [[ "${{ matrix.branch }}" == "stable/8.8" ]]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -408,7 +408,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: json-report-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
-          path: json-report/**
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 
       - name: Observe build status

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -186,6 +186,14 @@ jobs:
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
 
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: json-report-nightly-api-${{ matrix.branch }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -403,7 +411,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: json-report-nightly-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          name: json-report-nightly-e2e-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -437,7 +437,7 @@ jobs:
         if: failure()
         with:
           name: C8 Orchestration Cluster E2E Test Result (Tasklist ${{ matrix.tasklist_mode }} mode)
-          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
       - name: Observe build status

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           branch="${{ github.event.inputs.branch }}"
           echo "Detecting base branch for input branch: $branch"
-          git fetch origin stable/8.6 stable/8.7 stable/8.8 main "$branch"
+          git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 main "$branch"
           base="main"
-          for candidate in stable/8.6 stable/8.7 stable/8.8 main; do
+          for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 main; do
             if git merge-base --is-ancestor origin/$candidate origin/$branch; then
               base="$candidate"
               break
@@ -194,10 +194,10 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
           fi
-          
+
           echo "Running API tests"
           npm run test -- --project=api-tests
-          
+
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
       - name: Publish test results to TestRail
@@ -389,7 +389,7 @@ jobs:
             export CORE_APPLICATION_URL="http://localhost:8080"
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
             TEST_ARGS=(--project=chromium)
-            
+
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
               echo "Running V2 mode tests"
               if [[ "${{ needs.validate-branch.outputs.base }}" == "stable/8.8" ]]; then
@@ -437,7 +437,7 @@ jobs:
         if: failure()
         with:
           name: C8 Orchestration Cluster E2E Test Result (Tasklist ${{ matrix.tasklist_mode }} mode)
-          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 10
 
       - name: Observe build status

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: json-report-release-api
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
@@ -541,7 +541,7 @@ jobs:
 
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: json-report-release-e2e-${{ needs.validate-release.outputs.release_version }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -558,51 +558,51 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  notify-result:
-    name: Send notification based on test results
-    runs-on: ubuntu-latest
-    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
-    if: always()
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-
-      - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
-                  }
-                }
-              ]
-            }
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          job_name: c8-orchestration-cluster-e2e-tests-notify-result
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+#  notify-result:
+#    name: Send notification based on test results
+#    runs-on: ubuntu-latest
+#    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
+#    if: always()
+#    timeout-minutes: 5
+#    permissions: {}
+#    steps:
+#      - name: Import Secrets
+#        id: secrets
+#        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+#        with:
+#          url: ${{ secrets.VAULT_ADDR }}
+#          method: approle
+#          roleId: ${{ secrets.VAULT_ROLE_ID }}
+#          secretId: ${{ secrets.VAULT_SECRET_ID }}
+#          exportEnv: false
+#          secrets: |
+#            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+#
+#      - name: Send Slack notification
+#        uses: slackapi/slack-github-action@v2.1.1
+#        with:
+#          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+#                  }
+#                }
+#              ]
+#            }
+#
+#      - name: Observe build status
+#        if: always()
+#        continue-on-error: true
+#        uses: ./.github/actions/observe-build-status
+#        with:
+#          build_status: ${{ job.status }}
+#          job_name: c8-orchestration-cluster-e2e-tests-notify-result
+#          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+#          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+#          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -285,6 +285,14 @@ jobs:
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: json-report-release-api
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -530,6 +538,14 @@ jobs:
           name: C8 Orchestration Cluster E2E Test Result Release v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: json-report-release-e2e${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -543,7 +543,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: json-report-release-e2e${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          name: json-report-release-e2e-${{ needs.validate-release.outputs.release_version }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 
@@ -558,51 +558,51 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-#  notify-result:
-#    name: Send notification based on test results
-#    runs-on: ubuntu-latest
-#    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
-#    if: always()
-#    timeout-minutes: 5
-#    permissions: {}
-#    steps:
-#      - name: Import Secrets
-#        id: secrets
-#        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
-#        with:
-#          url: ${{ secrets.VAULT_ADDR }}
-#          method: approle
-#          roleId: ${{ secrets.VAULT_ROLE_ID }}
-#          secretId: ${{ secrets.VAULT_SECRET_ID }}
-#          exportEnv: false
-#          secrets: |
-#            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
-#
-#      - name: Send Slack notification
-#        uses: slackapi/slack-github-action@v2.1.1
-#        with:
-#          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
-#                  }
-#                }
-#              ]
-#            }
-#
-#      - name: Observe build status
-#        if: always()
-#        continue-on-error: true
-#        uses: ./.github/actions/observe-build-status
-#        with:
-#          build_status: ${{ job.status }}
-#          job_name: c8-orchestration-cluster-e2e-tests-notify-result
-#          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-#          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-#          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+  notify-result:
+    name: Send notification based on test results
+    runs-on: ubuntu-latest
+    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                  }
+                }
+              ]
+            }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-notify-result
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/.gitignore
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 /jsonReports/
 /playwright-report/
 /html-report/
+/json-report/
 /playwright/.cache/
 .env
 .DS_Store

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -41,7 +41,7 @@ const useReportersWithSlack: any[] = [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
       slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
-      channels: ['prj-qa-sandbox'],
+      channels: ['c8-orchestration-cluster-e2e-test-results'],
       sendResults: 'always',
       showInThread: true,
       meta: [

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -33,6 +33,7 @@ const useReportersWithoutSlack: any[] = [
   ['list'],
   ['junit', testRailOptions],
   ['html', {outputFolder: 'html-report'}],
+  ['json', { outputFile: `json-report/results.json` }],
 ];
 
 const useReportersWithSlack: any[] = [
@@ -40,7 +41,7 @@ const useReportersWithSlack: any[] = [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
       slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
-      channels: ['c8-orchestration-cluster-e2e-test-results'],
+      channels: ['prj-qa-sandbox'],
       sendResults: 'always',
       showInThread: true,
       meta: [


### PR DESCRIPTION
## Description

- Added json reporting to the release run and nightly run.
- stable/8.9 branch is introduced.

I triggered [this run](https://github.com/camunda/camunda/actions/runs/22301814207/job/64511249500) and cancelled it not to send Slack messages. 8.9 tests started.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
