### PR TITLE
[Backport stable/8.9] feat: remove validation for start instructions in adhoc subprocess

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -204,7 +204,6 @@ public class ProcessInstanceCreationHelper {
     return validateHasNoneStartEventOrStartInstructions(process, startInstructions)
         .flatMap(valid -> validateElementsExist(process, startInstructions))
         .flatMap(valid -> validateElementsNotInsideMultiInstance(process, startInstructions))
-        .flatMap(valid -> validateElementsNotInsideAdHocSubProcess(process, startInstructions))
         .flatMap(valid -> validateTargetsSupportedElementType(process, startInstructions))
         .flatMap(
             valid -> validateElementNotBelongingToEventBasedGateway(process, startInstructions))
@@ -319,43 +318,6 @@ public class ProcessInstanceCreationHelper {
       return true;
     } else {
       return hasMultiInstanceScope(flowScope);
-    }
-  }
-
-  private Either<Rejection, ?> validateElementsNotInsideAdHocSubProcess(
-      final ExecutableProcess process,
-      final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions) {
-
-    return startInstructions.stream()
-        .map(ProcessInstanceCreationStartInstruction::getElementId)
-        .filter(elementId -> isElementInsideAdHocSubProcess(process, elementId))
-        .findAny()
-        .map(
-            elementId ->
-                Either.left(
-                    new Rejection(
-                        RejectionType.INVALID_ARGUMENT,
-                        "Expected to create instance of process with start instructions but the element with id '%s' is inside an ad-hoc subprocess. The creation of elements inside an ad-hoc subprocess is not supported."
-                            .formatted(elementId))))
-        .orElse(VALID);
-  }
-
-  private boolean isElementInsideAdHocSubProcess(
-      final ExecutableProcess process, final String elementId) {
-    final var element = process.getElementById(wrapString(elementId));
-    return element != null && hasAdHocSubProcessScope(element);
-  }
-
-  private boolean hasAdHocSubProcessScope(final ExecutableFlowElement flowElement) {
-    final var flowScope = flowElement.getFlowScope();
-    if (flowScope == null) {
-      return false;
-    }
-
-    if (flowScope.getElementType() == BpmnElementType.AD_HOC_SUB_PROCESS) {
-      return true;
-    } else {
-      return hasAdHocSubProcessScope(flowScope);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -14,18 +14,20 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
-import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -946,16 +948,17 @@ public class CreateProcessInstanceAnywhereTest {
   }
 
   @Test
-  public void shouldActivateWithStartInstructionInAdHocSubProcess() {
+  public void shouldActivateElementWithinAdHocSubProcess() {
     // given
     final String subProcessTaskId = "subprocessTask";
     final String adhocProcessId = "adhoc";
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .adHocSubProcess(
                 adhocProcessId, adHocSubProcess -> adHocSubProcess.task(subProcessTaskId))
-            .endEvent()
             .done();
 
     ENGINE.deployment().withXmlResource(process).deploy();
@@ -972,23 +975,35 @@ public class CreateProcessInstanceAnywhereTest {
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
-        .containsSubsequence(
+        .containsSequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsSubsequence(
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
-  public void shouldActivateWithMultipleStartInstructionsInAdHocSubProcess() {
+  public void shouldActivateMulitpleElementsWithinAdHocSubProcess() {
     // given
     final String subProcessTaskId = "subprocessTask";
     final String subProcessTaskId2 = "subprocessTask2";
     final String adhocProcessId = "adhoc";
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
@@ -996,7 +1011,7 @@ public class CreateProcessInstanceAnywhereTest {
                 adhocProcessId,
                 adHocSubProcess -> {
                   adHocSubProcess.task(subProcessTaskId);
-                  adHocSubProcess.serviceTask(subProcessTaskId2).zeebeJobType("task");
+                  adHocSubProcess.task(subProcessTaskId2);
                 })
             .endEvent()
             .done();
@@ -1012,43 +1027,48 @@ public class CreateProcessInstanceAnywhereTest {
             .withStartInstruction(subProcessTaskId2)
             .create();
 
-    // complete service task to complete the process instance
-    final long jobKey =
-        RecordingExporter.jobRecords()
-            .withElementId(subProcessTaskId2)
-            .withType("task")
-            .getFirst()
-            .getKey();
-    ENGINE.job().withKey(jobKey).complete();
-
     // then
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
-        .containsSubsequence(
+        .containsSequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsSubsequence(
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
-  public void shouldActivateWithStartInstructionInJobBasedAdHocSubProcess() {
+  public void shouldActivateElementsWithinJobBasedAdHocSubProcess() {
     // given
+    final String jobType = "task";
     final String subProcessTaskId = "subprocessTask";
     final String adhocProcessId = "adhoc";
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .adHocSubProcess(
                 adhocProcessId, adHocSubProcess -> adHocSubProcess.task(subProcessTaskId))
-            .zeebeJobType("task")
+            .zeebeJobType(jobType)
             .endEvent()
             .done();
 
@@ -1062,28 +1082,42 @@ public class CreateProcessInstanceAnywhereTest {
             .withStartInstruction(subProcessTaskId)
             .create();
 
+    completeJob(jobType, true, false);
+
     // then
-    final String adhocInnerElementId =
-        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
-        .containsSubsequence(
+        .containsSequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsSubsequence(
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
-  public void shouldActivateWithMultipleStartInstructionsInJobBasedAdHocSubProcess() {
+  public void shouldActivateMulitpleElementsWithinJobBasedAdHocSubProcess() {
     // given
+    final String jobType = "task";
     final String subProcessTaskId = "subprocessTask";
     final String subProcessTaskId2 = "subprocessTask2";
     final String adhocProcessId = "adhoc";
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
@@ -1091,9 +1125,9 @@ public class CreateProcessInstanceAnywhereTest {
                 adhocProcessId,
                 adHocSubProcess -> {
                   adHocSubProcess.task(subProcessTaskId);
-                  adHocSubProcess.userTask(subProcessTaskId2).zeebeUserTask();
+                  adHocSubProcess.task(subProcessTaskId2);
                 })
-            .zeebeJobType("task")
+            .zeebeJobType(jobType)
             .endEvent()
             .done();
 
@@ -1107,29 +1141,49 @@ public class CreateProcessInstanceAnywhereTest {
             .withStartInstruction(subProcessTaskId)
             .withStartInstruction(subProcessTaskId2)
             .create();
-    // complete user task to complete the process instance
-    final var userTaskKey =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
-            .withElementId(subProcessTaskId2)
-            .getFirst()
-            .getKey();
-    ENGINE.userTask().withKey(userTaskKey).complete();
+
+    completeJob(jobType, true, false);
 
     // then
-    final String adhocInnerElementId =
-        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
-        .containsSubsequence(
+        .containsSequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsSubsequence(
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  private void completeJob(
+      final String jobType,
+      final boolean completionConditionFulfilled,
+      final boolean cancelRemainingInstances,
+      final JobResultActivateElement... activateElements) {
+    final var jobKey =
+        ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().getFirst();
+    final var jobResult =
+        new JobResult()
+            .setActivateElements(List.of(activateElements))
+            .setCompletionConditionFulfilled(completionConditionFulfilled)
+            .setCancelRemainingInstances(cancelRemainingInstances);
+    ENGINE.job().withKey(jobKey).withResult(jobResult).complete();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -940,5 +942,83 @@ public class CreateProcessInstanceAnywhereTest {
         .doesNotContain(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldActivateProcessInstanceWithStartInstructionInAdHocSubProcess() {
+    // given
+    final String subProcessTaskId = "subprocessTask";
+    final String adhocProcessId = "adhoc";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                adhocProcessId, adHocSubProcess -> adHocSubProcess.task(subProcessTaskId))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(subProcessTaskId)
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldActivateProcessInstanceWithStartInstructionInJobBasedAdHocSubProcess() {
+    // given
+    final String subProcessTaskId = "subprocessTask";
+    final String adhocProcessId = "adhoc";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                adhocProcessId, adHocSubProcess -> adHocSubProcess.task(subProcessTaskId))
+            .zeebeJobType("task")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(subProcessTaskId)
+            .create();
+
+    // then
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
@@ -945,7 +946,7 @@ public class CreateProcessInstanceAnywhereTest {
   }
 
   @Test
-  public void shouldActivateProcessInstanceWithStartInstructionInAdHocSubProcess() {
+  public void shouldActivateWithStartInstructionInAdHocSubProcess() {
     // given
     final String subProcessTaskId = "subprocessTask";
     final String adhocProcessId = "adhoc";
@@ -983,7 +984,62 @@ public class CreateProcessInstanceAnywhereTest {
   }
 
   @Test
-  public void shouldActivateProcessInstanceWithStartInstructionInJobBasedAdHocSubProcess() {
+  public void shouldActivateWithMultipleStartInstructionsInAdHocSubProcess() {
+    // given
+    final String subProcessTaskId = "subprocessTask";
+    final String subProcessTaskId2 = "subprocessTask2";
+    final String adhocProcessId = "adhoc";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                adhocProcessId,
+                adHocSubProcess -> {
+                  adHocSubProcess.task(subProcessTaskId);
+                  adHocSubProcess.serviceTask(subProcessTaskId2).zeebeJobType("task");
+                })
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(subProcessTaskId)
+            .withStartInstruction(subProcessTaskId2)
+            .create();
+
+    // complete service task to complete the process instance
+    final long jobKey =
+        RecordingExporter.jobRecords()
+            .withElementId(subProcessTaskId2)
+            .withType("task")
+            .getFirst()
+            .getKey();
+    ENGINE.job().withKey(jobKey).complete();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldActivateWithStartInstructionInJobBasedAdHocSubProcess() {
     // given
     final String subProcessTaskId = "subprocessTask";
     final String adhocProcessId = "adhoc";
@@ -1019,6 +1075,61 @@ public class CreateProcessInstanceAnywhereTest {
             tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldActivateWithMultipleStartInstructionsInJobBasedAdHocSubProcess() {
+    // given
+    final String subProcessTaskId = "subprocessTask";
+    final String subProcessTaskId2 = "subprocessTask2";
+    final String adhocProcessId = "adhoc";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                adhocProcessId,
+                adHocSubProcess -> {
+                  adHocSubProcess.task(subProcessTaskId);
+                  adHocSubProcess.userTask(subProcessTaskId2).zeebeUserTask();
+                })
+            .zeebeJobType("task")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(subProcessTaskId)
+            .withStartInstruction(subProcessTaskId2)
+            .create();
+    // complete user task to complete the process instance
+    final var userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withElementId(subProcessTaskId2)
+            .getFirst()
+            .getKey();
+    ENGINE.userTask().withKey(userTaskKey).complete();
+
+    // then
+    final String adhocInnerElementId =
+        adhocProcessId + ZeebeConstants.AD_HOC_SUB_PROCESS_INNER_INSTANCE_ID_POSTFIX;
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(adhocProcessId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(subProcessTaskId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(subProcessTaskId2, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(adhocInnerElementId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -329,40 +329,4 @@ public class CreateProcessInstanceRejectionTest {
         .hasRejectionReason(
             "Expected to create instance of process with tags, but the number of tags exceeds the limit of 10.");
   }
-
-  @Test
-  public void shouldRejectCommandIfElementIsInsideAdHocSubProcess() {
-    // given
-    engine
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .adHocSubProcess(
-                    "adHoc",
-                    adHoc -> {
-                      adHoc.task("A");
-                    })
-                .endEvent()
-                .done())
-        .deploy();
-
-    // when
-    engine
-        .processInstance()
-        .ofBpmnProcessId(PROCESS_ID)
-        .withStartInstruction("A")
-        .expectRejection()
-        .create();
-
-    // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
-
-    assertThat(rejectionRecord)
-        .hasIntent(ProcessInstanceCreationIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            "Expected to create instance of process with start instructions but the element with id 'A' is inside an ad-hoc subprocess. The creation of elements inside an ad-hoc subprocess is not supported.");
-  }
 }


### PR DESCRIPTION
# Description
Backport of #46187 to `stable/8.9`.

relates to #44823