### PR TITLE
fix: use local fonts for offline setup

### DIFF
--- a/optimize/c4/src/index.scss
+++ b/optimize/c4/src/index.scss
@@ -1,3 +1,3 @@
 @use "@carbon/react" as * with (
-	$font-path: "https://fonts.camunda.io"
+	$font-path: '@ibm/plex'
 );

--- a/optimize/client/src/style.scss
+++ b/optimize/client/src/style.scss
@@ -1,5 +1,5 @@
 @use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: "@ibm/plex"
 );
 
 @use '@carbon/react/scss/fonts/sans';


### PR DESCRIPTION
## Description

Use fonts bundled in `@ibm` package to avoid issues downloading assets from `fonts.camunda.io` when no internet connection is available

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45970 
