### PR TITLE
[Backport stable/8.9] Add validation for processDefinitionId in document upload

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -361,7 +361,8 @@ public class RequestMapper {
               .reduce(
                   CamundaProblemDetail.forStatus(HttpStatus.BAD_REQUEST),
                   (acc, detail) -> {
-                    acc.setDetail(acc.getDetail() + ". " + detail.getDetail());
+                    final String existing = acc.getDetail();
+                    acc.setDetail((existing == null ? "" : existing + ". ") + detail.getDetail());
                     return acc;
                   });
 
@@ -414,7 +415,8 @@ public class RequestMapper {
             .reduce(
                 CamundaProblemDetail.forStatus(HttpStatus.BAD_REQUEST),
                 (acc, detail) -> {
-                  acc.setDetail(acc.getDetail() + ". " + detail.getDetail());
+                  final String existing = acc.getDetail();
+                  acc.setDetail((existing == null ? "" : existing + ". ") + detail.getDetail());
                   return acc;
                 });
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/DocumentValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/DocumentValidator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mapping.http.validator;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
@@ -17,6 +18,8 @@ import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class DocumentValidator {
+
+  static final String PROCESS_DEFINITION_ID_PATTERN = "^[a-zA-Z_][a-zA-Z0-9_\\-.]*$";
 
   public static Optional<ProblemDetail> validateDocumentMetadata(final DocumentMetadata metadata) {
     if (metadata == null) {
@@ -34,6 +37,13 @@ public class DocumentValidator {
 
           if (metadata.getExpiresAt() != null) {
             validateDate(metadata.getExpiresAt(), "expiresAt", violations);
+          }
+
+          if (metadata.getProcessDefinitionId() != null
+              && !metadata.getProcessDefinitionId().matches(PROCESS_DEFINITION_ID_PATTERN)) {
+            violations.add(
+                ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
+                    "processDefinitionId", PROCESS_DEFINITION_ID_PATTERN));
           }
         });
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/DocumentValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/DocumentValidator.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.gateway.mapping.http.validator;
 
-import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateProcessDefinitionId;
 
 import io.camunda.gateway.protocol.model.DocumentLinkRequest;
 import io.camunda.gateway.protocol.model.DocumentMetadata;
@@ -18,8 +18,6 @@ import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class DocumentValidator {
-
-  static final String PROCESS_DEFINITION_ID_PATTERN = "^[a-zA-Z_][a-zA-Z0-9_\\-.]*$";
 
   public static Optional<ProblemDetail> validateDocumentMetadata(final DocumentMetadata metadata) {
     if (metadata == null) {
@@ -39,12 +37,7 @@ public class DocumentValidator {
             validateDate(metadata.getExpiresAt(), "expiresAt", violations);
           }
 
-          if (metadata.getProcessDefinitionId() != null
-              && !metadata.getProcessDefinitionId().matches(PROCESS_DEFINITION_ID_PATTERN)) {
-            violations.add(
-                ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
-                    "processDefinitionId", PROCESS_DEFINITION_ID_PATTERN));
-          }
+          validateProcessDefinitionId(metadata.getProcessDefinitionId(), violations);
         });
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
@@ -14,6 +14,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateOperationReference;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateProcessDefinitionId;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryFilterMapper;
 import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
@@ -79,6 +80,7 @@ public class ProcessInstanceRequestValidator {
                 ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
                     List.of("processDefinitionId", "processDefinitionKey")));
           }
+          validateProcessDefinitionId(request.getProcessDefinitionId(), violations);
           validateOperationReference(request.getOperationReference(), violations);
           validateTags(request.getTags(), violations);
         });
@@ -101,6 +103,10 @@ public class ProcessInstanceRequestValidator {
             violations.add(
                 ERROR_MESSAGE_ONLY_ONE_FIELD.formatted(
                     List.of("processDefinitionId", "processDefinitionKey")));
+          }
+
+          if (byIdSet) {
+            validateProcessDefinitionId(request.getProcessDefinitionId(), violations);
           }
 
           final var versionSet =

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_DATE_PARSING;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_KEY_FORMAT;
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
@@ -22,10 +23,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 
 public final class RequestValidator {
+
+  /** Compiled pattern for a valid BPMN process definition ID, matching the OpenAPI spec. */
+  public static final Pattern PROCESS_DEFINITION_ID_PATTERN =
+      Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_\\-.]*$");
 
   public static Optional<ProblemDetail> createProblemDetail(final List<String> violations) {
     String problems = String.join(". ", violations);
@@ -92,6 +98,22 @@ public final class RequestValidator {
       final String keyValue, final String fieldName, final List<String> violations) {
     if (keyValue != null && KeyUtil.tryParseLong(keyValue).isEmpty()) {
       violations.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, keyValue));
+    }
+  }
+
+  /**
+   * Validates that a process definition ID matches the BPMN identifier pattern.
+   *
+   * @param processDefinitionId the value to validate (may be null; null is not validated)
+   * @param violations the list to add validation errors to
+   */
+  public static void validateProcessDefinitionId(
+      final String processDefinitionId, final List<String> violations) {
+    if (processDefinitionId != null
+        && !PROCESS_DEFINITION_ID_PATTERN.matcher(processDefinitionId).matches()) {
+      violations.add(
+          ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(
+              "processDefinitionId", PROCESS_DEFINITION_ID_PATTERN.pattern()));
     }
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/document-api-tests.spec.ts
@@ -111,6 +111,39 @@ test.describe.parallel('Document API Tests', () => {
     );
   });
 
+  // Regression guard for #46405 / #46407: a processDefinitionId that starts
+  // with a digit violates the BPMN identifier pattern and must be rejected.
+  test('Create Document Invalid processDefinitionId 400', async ({request}) => {
+    const form = new FormData();
+    form.append(
+      'file',
+      new File(['test content'], 'test.txt', {type: 'text/plain'}),
+    );
+    form.append(
+      'metadata',
+      new Blob(
+        [
+          JSON.stringify({
+            fileName: 'test.txt',
+            processDefinitionId: '9invalid',
+          }),
+        ],
+        {type: 'application/json'},
+      ),
+    );
+
+    const res = await request.post(buildUrl('/documents'), {
+      headers: defaultHeaders(),
+      multipart: form,
+    });
+
+    await assertBadRequest(
+      res,
+      'The provided processDefinitionId contains illegal characters',
+      'INVALID_ARGUMENT',
+    );
+  });
+
   test('Create Document', async ({request}) => {
     const payload = CREATE_TXT_DOCUMENT_REQUEST();
     const expectedPostBody = CREATE_TXT_DOC_RESPONSE_BODY('helloworld', 12);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -462,6 +462,40 @@ public class DocumentControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectDocumentWithInvalidProcessDefinitionId() {
+    // given — a processDefinitionId starting with a digit is invalid per the
+    // BPMN identifier pattern ^[a-zA-Z_][a-zA-Z0-9_\-.]*$
+    final var content = new byte[] {1, 2, 3};
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+
+    final var metadata = new DocumentMetadata();
+    metadata.setFileName("file.txt");
+    metadata.setProcessDefinitionId("9invalid");
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("file", content).contentType(contentType).filename("file.txt");
+    multipartBodyBuilder.part("metadata", metadata).contentType(MediaType.APPLICATION_JSON);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo(
+            "The provided processDefinitionId contains illegal characters. "
+                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'");
+
+    verify(documentServices, never()).createDocument(any());
+  }
+
+  @Test
   void shouldReturnBadRequestWhenMetadataListLengthMismatch() throws Exception {
     // given two files but only one metadataList entry
     final var filename1 = "file.txt";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -490,7 +490,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .jsonPath("$.detail")
         .isEqualTo(
             "The provided processDefinitionId contains illegal characters. "
-                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'");
+                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'.");
 
     verify(documentServices, never()).createDocument(any());
   }
@@ -712,7 +712,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .jsonPath("$.detail")
         .isEqualTo(
             "The provided processDefinitionId contains illegal characters. "
-                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'");
+                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'.");
 
     verify(documentServices, never()).createDocumentBatch(any());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -679,4 +679,41 @@ public class DocumentControllerTest extends RestControllerTest {
 
     verify(documentServices, never()).createDocumentBatch(any());
   }
+
+  @Test
+  void shouldRejectBatchDocumentWithInvalidProcessDefinitionId() throws Exception {
+    // given — a processDefinitionId starting with a digit is invalid per the
+    // BPMN identifier pattern ^[a-zA-Z_][a-zA-Z0-9_\-.]*$
+    final var content = new byte[] {1, 2, 3};
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var mapper = new ObjectMapper();
+
+    final var metadata = new DocumentMetadata();
+    metadata.setFileName("file.txt");
+    metadata.setProcessDefinitionId("9invalid");
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("files", content).contentType(contentType).filename("file.txt");
+    multipartBodyBuilder
+        .part("metadataList", mapper.writeValueAsString(List.of(metadata)))
+        .contentType(MediaType.APPLICATION_JSON);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL + "/batch")
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo(
+            "The provided processDefinitionId contains illegal characters. "
+                + "It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\-.]*$'");
+
+    verify(documentServices, never()).createDocumentBatch(any());
+  }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -2970,4 +2970,39 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
   }
+
+  @Test
+  void shouldRejectCreateProcessInstanceWithInvalidProcessDefinitionId() {
+    // given — processDefinitionId starting with a digit violates BPMN identifier pattern
+    final var request =
+        """
+            {
+                "processDefinitionId": "9invalid"
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"The provided processDefinitionId contains illegal characters. It must match the pattern '^[a-zA-Z_][a-zA-Z0-9_\\\\-.]*$'.",
+                "instance":"/v2/process-instances"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
 }


### PR DESCRIPTION
# Description
Backport of #46408 to `stable/8.9`.

relates to #46405