### PR TITLE
fix: change links from wiki to camunda.github.io

### DIFF
--- a/.ci/scripts/renovate-assignments.py
+++ b/.ci/scripts/renovate-assignments.py
@@ -34,7 +34,7 @@ COMMENT_TEMPLATE = (
     "Hi @{assignee},\n\n"
     "You have been " + COMMENT_TEMPLATE_DETECTION_LINE + ". "
     "Please review and process it according to our Renovate PR Handling policy: "
-    "https://github.com/camunda/camunda/wiki/Renovate-PR-Handling#dri-responsibilities\n\n"
+    "https://camunda.github.io/camunda/renovate-pr-handling/#dri-responsibilities\n\n"
     "Thank you!"
 )
 
@@ -45,7 +45,7 @@ REMINDER_COMMENT_TEMPLATE = (
     "Hi @{assignee},\n\n"
     "This is a friendly " + REMINDER_COMMENT_DETECTION_LINE + " that has been assigned for at least " + str(REMINDER_DAYS_THRESHOLD) + " days. "
     "Please make sure to work on it according to our Renovate PR Handling policy soon: "
-    "https://github.com/camunda/camunda/wiki/Renovate-PR-Handling#dri-responsibilities\n\n"
+    "https://camunda.github.io/camunda/renovate-pr-handling/#dri-responsibilities\n\n"
     "Thank you!"
 )
 


### PR DESCRIPTION
## Description
This pull request makes a minor update to the Renovate assignment script by correcting the URLs in notification messages to point to the new location of the Renovate PR Handling policy documentation. As discussed on https://github.com/camunda/camunda/issues/36946?reload=1

- Updated policy documentation links in assignment and reminder messages to use the new `camunda.github.io` URL instead of the old GitHub wiki URL in `.ci/scripts/renovate-assignments.py`. [[1]](diffhunk://#diff-e539f43bb43e7486ff6dabdb66db6eaf99fdce7ad2a944db888eba13b9892ed5L37-R37) [[2]](diffhunk://#diff-e539f43bb43e7486ff6dabdb66db6eaf99fdce7ad2a944db888eba13b9892ed5L48-R48)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
