### PR TITLE
feat: route backup deletion through stream processor

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -50,6 +50,8 @@ public interface BackupManager {
    * @param checkpointId id of the backup to delete
    * @return future which will be completed after the backup is deleted.
    */
+  ActorFuture<Void> requestBackupDeletion(long checkpointId);
+
   ActorFuture<Void> deleteBackup(long checkpointId);
 
   /** Close Backup manager */

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -169,11 +169,16 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   @Override
+  public ActorFuture<Void> requestBackupDeletion(final long checkpointId) {
+    return internalBackupManager.writeBackupDeletionCommand(checkpointId, actor);
+  }
+
+  @Override
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
     final var operationMetrics = metrics.startDeleting();
 
-    final var backupDeleted = internalBackupManager.deleteBackup(partitionId, checkpointId, actor);
-
+    final var backupDeleted =
+        internalBackupManager.deleteBackupIfExists(partitionId, checkpointId, actor);
     backupDeleted.onComplete(operationMetrics::complete);
     backupDeleted.onComplete(
         (ignore, error) -> {
@@ -181,7 +186,6 @@ public final class BackupService extends Actor implements BackupManager {
             LOG.warn("Failed to delete backup {}", checkpointId, error);
           }
         });
-
     return backupDeleted;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -318,59 +318,70 @@ final class BackupServiceImpl {
             });
   }
 
-  ActorFuture<Void> deleteBackup(
-      final int partitionId, final long checkpointId, final ConcurrencyControl executor) {
+  ActorFuture<Void> writeBackupDeletionCommand(
+      final long checkpointId, final ConcurrencyControl executor) {
     final ActorFuture<Void> deleteCompleted = executor.createFuture();
-    final var searchPattern =
-        new BackupIdentifierWildcardImpl(
-            Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId));
-    LOG.atDebug()
-        .addKeyValue("pattern", searchPattern)
-        .setMessage("Deleting matching backups")
-        .log();
-    executor.run(
-        () ->
-            backupStore
-                .list(
-                    new BackupIdentifierWildcardImpl(
-                        Optional.empty(),
-                        Optional.of(partitionId),
-                        CheckpointPattern.of(checkpointId)))
-                .thenCompose(
-                    backups ->
-                        CompletableFuture.allOf(
-                            backups.stream()
-                                .map(this::deleteBackupIfExists)
-                                .toArray(CompletableFuture[]::new)))
-                .thenAccept(ignore -> deleteCompleted.complete(null))
-                .exceptionally(
-                    error -> {
-                      deleteCompleted.completeExceptionally(error);
-                      return null;
-                    }));
+    final var deleteWritten =
+        logStreamWriter.tryWrite(
+            WriteContext.internal(),
+            LogAppendEntry.of(
+                new RecordMetadata()
+                    .recordType(RecordType.COMMAND)
+                    .valueType(ValueType.CHECKPOINT)
+                    .intent(CheckpointIntent.DELETE_BACKUP),
+                new CheckpointRecord().setCheckpointId(checkpointId)));
+    switch (deleteWritten) {
+      case Either.Left(final var error) ->
+          deleteCompleted.completeExceptionally(
+              new RuntimeException("Failed to write DELETE_BACKUP command: " + error));
+      case final Either.Right<WriteFailure, Long> ignoredPosition -> deleteCompleted.complete(null);
+    }
     return deleteCompleted;
   }
 
-  private CompletableFuture<Void> deleteBackupIfExists(final BackupStatus backupStatus) {
-    LOG.atInfo().addKeyValue("backup", backupStatus.id()).setMessage("Deleting backup").log();
-    final CompletableFuture<Void> preparationStep;
-    if (backupStatus.statusCode() == BackupStatusCode.IN_PROGRESS) {
-      // In progress backups cannot be deleted. So first mark it as failed
-      preparationStep =
-          backupStore
-              .markFailed(backupStatus.id(), "The backup is going to be deleted.")
-              .thenApply(ignored -> null);
-    } else {
-      preparationStep = CompletableFuture.completedFuture(null);
-    }
+  ActorFuture<Void> deleteBackupIfExists(
+      final int partitionId, final long checkpointId, final ConcurrencyControl executor) {
+    final var result = executor.<Void>createFuture();
+    final var pattern =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId));
 
-    return preparationStep
+    backupStore
+        .list(pattern)
         .thenCompose(
-            ignored ->
-                backupStore.storeRangeMarker(
-                    backupStatus.id().partitionId(),
-                    new Deletion(backupStatus.id().checkpointId())))
-        .thenCompose(ignored -> backupStore.delete(backupStatus.id()));
+            backups ->
+                CompletableFuture.allOf(
+                    backups.stream()
+                        .map(
+                            backup -> {
+                              final CompletableFuture<Void> preparationStep;
+                              if (backup.statusCode() == BackupStatusCode.IN_PROGRESS) {
+                                preparationStep =
+                                    backupStore
+                                        .markFailed(backup.id(), "The backup is being deleted.")
+                                        .thenApply(ignored -> null);
+                              } else {
+                                preparationStep = CompletableFuture.completedFuture(null);
+                              }
+                              return preparationStep
+                                  .thenCompose(
+                                      ignored ->
+                                          backupStore.storeRangeMarker(
+                                              backup.id().partitionId(),
+                                              new Deletion(checkpointId)))
+                                  .thenCompose(ignored -> backupStore.delete(backup.id()));
+                            })
+                        .toArray(CompletableFuture[]::new)))
+        .exceptionally(
+            error -> {
+              LOG.warn(
+                  "Failed to delete backup for checkpoint {} from backup store",
+                  checkpointId,
+                  error);
+              return null;
+            })
+        .whenComplete(result);
+    return result;
   }
 
   ActorFuture<Collection<BackupStatus>> listBackups(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -52,6 +52,12 @@ public class NoopBackupManager implements BackupManager {
   }
 
   @Override
+  public ActorFuture<Void> requestBackupDeletion(final long checkpointId) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMessage));
+  }
+
+  @Override
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
     return CompletableActorFuture.completedExceptionally(
         new UnsupportedOperationException(errorMessage));

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -26,10 +26,7 @@ public class CheckpointBackupConfirmedApplier {
     this.backupRangeState = backupRangeState;
   }
 
-  public void apply(
-      final CheckpointRecord checkpointRecord,
-      final long checkpointTimestamp,
-      final String brokerVersion) {
+  public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
     final var checkpointId = checkpointRecord.getCheckpointId();
     final var firstLogPosition = checkpointRecord.getFirstLogPosition();
 
@@ -45,7 +42,7 @@ public class CheckpointBackupConfirmedApplier {
       if (existingRange.isPresent()) {
         backupRangeState.updateRangeEnd(existingRange.get().start(), checkpointId);
       } else {
-        // Range not found (pre-migration state) — start a new one
+        // Range not found — start a new one
         backupRangeState.startNewRange(checkpointId);
       }
     } else {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
@@ -118,64 +118,76 @@ public final class CheckpointBackupDeletedApplier {
       backupRangeState.deleteRange(range.start());
       LOG.debug("Deleted single-entry range [{}, {}]", range.start(), range.end());
     } else if (isStart) {
-      // Deleting from the start — advance start to successor
-      final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
-      if (successor.isPresent()) {
-        backupRangeState.updateRangeStart(range.start(), successor.get());
-        LOG.debug(
-            "Advanced range start from {} to {} (range end: {})",
-            range.start(),
-            successor.get(),
-            range.end());
-      } else {
-        // No successor found — should not happen for a range with start != end
-        LOG.warn(
-            "No successor found for start checkpoint {} in range [{}, {}], deleting range",
-            checkpointId,
-            range.start(),
-            range.end());
-        backupRangeState.deleteRange(range.start());
-      }
+      updateRangeStart(checkpointId, range);
     } else if (isEnd) {
-      // Deleting from the end — shrink end to predecessor
-      final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
-      if (predecessor.isPresent()) {
-        backupRangeState.updateRangeEnd(range.start(), predecessor.get());
-        LOG.debug(
-            "Shrunk range end from {} to {} (range start: {})",
-            range.end(),
-            predecessor.get(),
-            range.start());
-      } else {
-        // No predecessor found — should not happen for a range with start != end
-        LOG.warn(
-            "No predecessor found for end checkpoint {} in range [{}, {}], deleting range",
-            checkpointId,
-            range.start(),
-            range.end());
-        backupRangeState.deleteRange(range.start());
-      }
+      updateRangeEnd(checkpointId, range);
     } else {
-      // Deleting from the middle — split the range
-      final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
-      final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
-      if (predecessor.isPresent() && successor.isPresent()) {
-        backupRangeState.splitRange(range.start(), range.end(), predecessor.get(), successor.get());
-        LOG.debug(
-            "Split range [{}, {}] into [{}, {}] and [{}, {}]",
-            range.start(),
-            range.end(),
-            range.start(),
-            predecessor.get(),
-            successor.get(),
-            range.end());
-      } else {
-        LOG.warn(
-            "Could not find predecessor/successor for interior checkpoint {} in range [{}, {}]",
-            checkpointId,
-            range.start(),
-            range.end());
-      }
+      splitRange(checkpointId, range);
+    }
+  }
+
+  private void updateRangeStart(final long checkpointId, final BackupRange range) {
+    // Deleting from the start — advance start to successor
+    final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
+    if (successor.isPresent()) {
+      backupRangeState.updateRangeStart(range.start(), successor.get());
+      LOG.debug(
+          "Advanced range start from {} to {} (range end: {})",
+          range.start(),
+          successor.get(),
+          range.end());
+    } else {
+      // No successor found — should not happen for a range with start != end
+      LOG.warn(
+          "No successor found for start checkpoint {} in range [{}, {}], deleting range",
+          checkpointId,
+          range.start(),
+          range.end());
+      backupRangeState.deleteRange(range.start());
+    }
+  }
+
+  private void updateRangeEnd(final long checkpointId, final BackupRange range) {
+    // Deleting from the end — shrink end to predecessor
+    final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
+    if (predecessor.isPresent()) {
+      backupRangeState.updateRangeEnd(range.start(), predecessor.get());
+      LOG.debug(
+          "Shrunk range end from {} to {} (range start: {})",
+          range.end(),
+          predecessor.get(),
+          range.start());
+    } else {
+      // No predecessor found — should not happen for a range with start != end
+      LOG.warn(
+          "No predecessor found for end checkpoint {} in range [{}, {}], deleting range",
+          checkpointId,
+          range.start(),
+          range.end());
+      backupRangeState.deleteRange(range.start());
+    }
+  }
+
+  private void splitRange(final long checkpointId, final BackupRange range) {
+    // Deleting from the middle — split the range
+    final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
+    final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
+    if (predecessor.isPresent() && successor.isPresent()) {
+      backupRangeState.splitRange(range.start(), range.end(), predecessor.get(), successor.get());
+      LOG.debug(
+          "Split range [{}, {}] into [{}, {}] and [{}, {}]",
+          range.start(),
+          range.end(),
+          range.start(),
+          predecessor.get(),
+          successor.get(),
+          range.end());
+    } else {
+      LOG.warn(
+          "Could not find predecessor/successor for interior checkpoint {} in range [{}, {}]",
+          checkpointId,
+          range.start(),
+          range.end());
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
@@ -56,8 +56,10 @@ public final class CheckpointBackupDeletedApplier {
       LOG.debug("Checkpoint {} is not in any range, skipping range maintenance", checkpointId);
     }
 
-    // Remove the checkpoint from latest checkpoint info
-    updateLatestCheckpointInfo(checkpointId);
+    if (checkpointState.getLatestBackupId() == checkpointId) {
+      // Remove the checkpoint from latest checkpoint info
+      updateLatestCheckpointInfo(checkpointId);
+    }
   }
 
   private void removeUncoveredMarkers() {
@@ -79,10 +81,6 @@ public final class CheckpointBackupDeletedApplier {
    * the predecessor backup if one exists or clears the latest backup info entirely.
    */
   private void updateLatestCheckpointInfo(final long checkpointId) {
-    if (checkpointState.getLatestBackupId() != checkpointId) {
-      return;
-    }
-
     final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
     if (predecessor.isPresent()) {
       final var predecessorMetadata = checkpointMetadataState.getCheckpoint(predecessor.get());

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies BACKUP_DELETED events during both processing and replay. Performs the state mutations:
+ * removes the checkpoint from the CHECKPOINTS CF and maintains the BACKUP_RANGES CF.
+ */
+public final class CheckpointBackupDeletedApplier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointBackupDeletedApplier.class);
+
+  private final DbCheckpointMetadataState checkpointMetadataState;
+  private final DbBackupRangeState backupRangeState;
+
+  public CheckpointBackupDeletedApplier(
+      final DbCheckpointMetadataState checkpointMetadataState,
+      final DbBackupRangeState backupRangeState) {
+    this.checkpointMetadataState = checkpointMetadataState;
+    this.backupRangeState = backupRangeState;
+  }
+
+  /**
+   * Applies the deletion of a backup checkpoint. Removes the checkpoint entry from the CHECKPOINTS
+   * CF and updates the BACKUP_RANGES CF according to the deletion scenario.
+   *
+   * @param checkpointRecord the record containing the checkpoint ID to delete
+   */
+  public void apply(final CheckpointRecord checkpointRecord) {
+    final var checkpointId = checkpointRecord.getCheckpointId();
+    // Remove the checkpoint from the CHECKPOINTS CF
+    checkpointMetadataState.removeCheckpoint(checkpointId);
+
+    // Update range state based on deletion scenario
+    final var range = backupRangeState.findRangeContaining(checkpointId);
+    if (range.isPresent()) {
+      updateRangeOnDeletion(checkpointId, range.get());
+      removeUncoveredMarkers();
+    } else {
+      LOG.debug("Checkpoint {} is not in any range, skipping range maintenance", checkpointId);
+    }
+  }
+
+  private void removeUncoveredMarkers() {
+    final var firstRange = backupRangeState.getFirstRange();
+    if (firstRange.isEmpty()) {
+      // No ranges exist, keep any existing checkpoints because they might get included in the next
+      // backup.
+      return;
+    }
+    final var firstLogPosition =
+        checkpointMetadataState
+            .getCheckpoint(firstRange.orElseThrow().start())
+            .getFirstLogPosition();
+    checkpointMetadataState.removeCheckpointsUntil(firstLogPosition);
+  }
+
+  private void updateRangeOnDeletion(final long checkpointId, final BackupRange range) {
+    final var isStart = range.start() == checkpointId;
+    final var isEnd = range.end() == checkpointId;
+
+    if (isStart && isEnd) {
+      // Only checkpoint in the range — delete the entire range
+      backupRangeState.deleteRange(range.start());
+      LOG.debug("Deleted single-entry range [{}, {}]", range.start(), range.end());
+    } else if (isStart) {
+      // Deleting from the start — advance start to successor
+      final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
+      if (successor.isPresent()) {
+        backupRangeState.updateRangeStart(range.start(), successor.get());
+        LOG.debug(
+            "Advanced range start from {} to {} (range end: {})",
+            range.start(),
+            successor.get(),
+            range.end());
+      } else {
+        // No successor found — should not happen for a range with start != end
+        LOG.warn(
+            "No successor found for start checkpoint {} in range [{}, {}], deleting range",
+            checkpointId,
+            range.start(),
+            range.end());
+        backupRangeState.deleteRange(range.start());
+      }
+    } else if (isEnd) {
+      // Deleting from the end — shrink end to predecessor
+      final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
+      if (predecessor.isPresent()) {
+        backupRangeState.updateRangeEnd(range.start(), predecessor.get());
+        LOG.debug(
+            "Shrunk range end from {} to {} (range start: {})",
+            range.end(),
+            predecessor.get(),
+            range.start());
+      } else {
+        // No predecessor found — should not happen for a range with start != end
+        LOG.warn(
+            "No predecessor found for end checkpoint {} in range [{}, {}], deleting range",
+            checkpointId,
+            range.start(),
+            range.end());
+        backupRangeState.deleteRange(range.start());
+      }
+    } else {
+      // Deleting from the middle — split the range
+      final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
+      final var successor = checkpointMetadataState.findSuccessorBackupCheckpoint(checkpointId);
+      if (predecessor.isPresent() && successor.isPresent()) {
+        backupRangeState.splitRange(range.start(), range.end(), predecessor.get(), successor.get());
+        LOG.debug(
+            "Split range [{}, {}] into [{}, {}] and [{}, {}]",
+            range.start(),
+            range.end(),
+            range.start(),
+            predecessor.get(),
+            successor.get(),
+            range.end());
+      } else {
+        LOG.warn(
+            "Could not find predecessor/successor for interior checkpoint {} in range [{}, {}]",
+            checkpointId,
+            range.start(),
+            range.end());
+      }
+    }
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
@@ -24,12 +25,15 @@ public final class CheckpointBackupDeletedApplier {
 
   private final DbCheckpointMetadataState checkpointMetadataState;
   private final DbBackupRangeState backupRangeState;
+  private final CheckpointState checkpointState;
 
   public CheckpointBackupDeletedApplier(
       final DbCheckpointMetadataState checkpointMetadataState,
-      final DbBackupRangeState backupRangeState) {
+      final DbBackupRangeState backupRangeState,
+      final CheckpointState checkpointState) {
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupRangeState = backupRangeState;
+    this.checkpointState = checkpointState;
   }
 
   /**
@@ -51,6 +55,9 @@ public final class CheckpointBackupDeletedApplier {
     } else {
       LOG.debug("Checkpoint {} is not in any range, skipping range maintenance", checkpointId);
     }
+
+    // Remove the checkpoint from latest checkpoint info
+    updateLatestCheckpointInfo(checkpointId);
   }
 
   private void removeUncoveredMarkers() {
@@ -65,6 +72,41 @@ public final class CheckpointBackupDeletedApplier {
             .getCheckpoint(firstRange.orElseThrow().start())
             .getFirstLogPosition();
     checkpointMetadataState.removeCheckpointsUntil(firstLogPosition);
+  }
+
+  /**
+   * Updates the DbCheckpointState when the deleted checkpoint is the latest backup. Rolls back to
+   * the predecessor backup if one exists or clears the latest backup info entirely.
+   */
+  private void updateLatestCheckpointInfo(final long checkpointId) {
+    if (checkpointState.getLatestBackupId() != checkpointId) {
+      return;
+    }
+
+    final var predecessor = checkpointMetadataState.findPredecessorBackupCheckpoint(checkpointId);
+    if (predecessor.isPresent()) {
+      final var predecessorMetadata = checkpointMetadataState.getCheckpoint(predecessor.get());
+      if (predecessorMetadata != null) {
+        checkpointState.setLatestBackupInfo(
+            predecessor.get(),
+            predecessorMetadata.getCheckpointPosition(),
+            predecessorMetadata.getCheckpointTimestamp(),
+            predecessorMetadata.getCheckpointType(),
+            predecessorMetadata.getFirstLogPosition());
+        LOG.debug(
+            "Rolled back latest backup from {} to predecessor {}", checkpointId, predecessor.get());
+      } else {
+        LOG.warn(
+            "Predecessor checkpoint {} found but metadata missing, clearing latest backup info",
+            predecessor.get());
+        checkpointState.clearLatestBackupInfo();
+      }
+    } else {
+      LOG.debug(
+          "No predecessor backup found for deleted checkpoint {}, clearing latest backup info",
+          checkpointId);
+      checkpointState.clearLatestBackupInfo();
+    }
   }
 
   private void updateRangeOnDeletion(final long checkpointId, final BackupRange range) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -55,8 +55,7 @@ public class CheckpointConfirmBackupProcessor {
       } else {
         backupManager.startNewRange(checkpointId);
       }
-      backupConfirmedApplier.apply(
-          checkpointRecord, record.getTimestamp(), record.getBrokerVersion());
+      backupConfirmedApplier.apply(checkpointRecord, record.getTimestamp());
       resultBuilder.appendRecord(
           record.getKey(),
           checkpointRecord,

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -69,8 +69,7 @@ public final class CheckpointDeleteBackupProcessor {
         new RecordMetadata()
             .recordType(RecordType.EVENT)
             .valueType(ValueType.CHECKPOINT)
-            .intent(CheckpointIntent.BACKUP_DELETED));
-
+            .intent(CheckpointIntent.DELETED_BACKUP));
     resultBuilder.appendPostCommitTask(
         () -> {
           backupManager.deleteBackup(checkpointId);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.stream.api.ProcessingResult;
@@ -57,24 +56,6 @@ public final class CheckpointDeleteBackupProcessor {
       final TypedRecord<CheckpointRecord> record, final ProcessingResultBuilder resultBuilder) {
     final var checkpointRecord = record.getValue();
     final var checkpointId = checkpointRecord.getCheckpointId();
-
-    // Validate that the checkpoint exists
-    final var metadata = checkpointMetadataState.getCheckpoint(checkpointId);
-    if (metadata == null) {
-      LOG.debug(
-          "Rejecting DELETE_BACKUP for checkpoint {} — checkpoint not found in state",
-          checkpointId);
-      return resultBuilder
-          .appendRecord(
-              record.getKey(),
-              checkpointRecord,
-              new RecordMetadata()
-                  .recordType(RecordType.COMMAND_REJECTION)
-                  .rejectionType(RejectionType.NOT_FOUND)
-                  .valueType(ValueType.CHECKPOINT)
-                  .intent(record.getIntent()))
-          .build();
-    }
 
     LOG.debug("Deleting backup for checkpoint {}", checkpointId);
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -43,11 +44,13 @@ public final class CheckpointDeleteBackupProcessor {
   public CheckpointDeleteBackupProcessor(
       final DbCheckpointMetadataState checkpointMetadataState,
       final DbBackupRangeState backupRangeState,
+      final CheckpointState checkpointState,
       final BackupManager backupManager) {
     this.checkpointMetadataState = checkpointMetadataState;
     this.backupManager = backupManager;
     backupDeletedApplier =
-        new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
+        new CheckpointBackupDeletedApplier(
+            checkpointMetadataState, backupRangeState, checkpointState);
   }
 
   public ProcessingResult process(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Processes DELETE_BACKUP commands. Validates the checkpoint exists, applies state mutations
+ * (removes checkpoint from CHECKPOINTS CF, updates BACKUP_RANGES CF), appends a BACKUP_DELETED
+ * follow-up event, and schedules async side-effects for backup store deletion and JSON sync.
+ */
+public final class CheckpointDeleteBackupProcessor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointDeleteBackupProcessor.class);
+
+  private final DbCheckpointMetadataState checkpointMetadataState;
+  private final CheckpointBackupDeletedApplier backupDeletedApplier;
+  private final BackupManager backupManager;
+
+  /**
+   * @param checkpointMetadataState the checkpoint metadata CF state
+   * @param backupRangeState the backup ranges CF state
+   * @param backupManager the backup manager for async deletion (nullable)
+   */
+  public CheckpointDeleteBackupProcessor(
+      final DbCheckpointMetadataState checkpointMetadataState,
+      final DbBackupRangeState backupRangeState,
+      final BackupManager backupManager) {
+    this.checkpointMetadataState = checkpointMetadataState;
+    this.backupManager = backupManager;
+    backupDeletedApplier =
+        new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
+  }
+
+  public ProcessingResult process(
+      final TypedRecord<CheckpointRecord> record, final ProcessingResultBuilder resultBuilder) {
+    final var checkpointRecord = record.getValue();
+    final var checkpointId = checkpointRecord.getCheckpointId();
+
+    // Validate that the checkpoint exists
+    final var metadata = checkpointMetadataState.getCheckpoint(checkpointId);
+    if (metadata == null) {
+      LOG.debug(
+          "Rejecting DELETE_BACKUP for checkpoint {} — checkpoint not found in state",
+          checkpointId);
+      return resultBuilder
+          .appendRecord(
+              record.getKey(),
+              checkpointRecord,
+              new RecordMetadata()
+                  .recordType(RecordType.COMMAND_REJECTION)
+                  .rejectionType(RejectionType.NOT_FOUND)
+                  .valueType(ValueType.CHECKPOINT)
+                  .intent(record.getIntent()))
+          .build();
+    }
+
+    LOG.debug("Deleting backup for checkpoint {}", checkpointId);
+
+    // Apply state mutations (remove checkpoint + update ranges)
+    backupDeletedApplier.apply(checkpointRecord);
+
+    // Append BACKUP_DELETED follow-up event
+    resultBuilder.appendRecord(
+        record.getKey(),
+        checkpointRecord,
+        new RecordMetadata()
+            .recordType(RecordType.EVENT)
+            .valueType(ValueType.CHECKPOINT)
+            .intent(CheckpointIntent.BACKUP_DELETED));
+
+    resultBuilder.appendPostCommitTask(
+        () -> {
+          backupManager.deleteBackup(checkpointId);
+          return true;
+        });
+
+    return resultBuilder.build();
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -113,7 +113,7 @@ public final class CheckpointRecordsProcessor
 
     checkpointDeleteBackupProcessor =
         new CheckpointDeleteBackupProcessor(
-            checkpointMetadataState, backupRangeState, backupManager);
+            checkpointMetadataState, backupRangeState, checkpointState, backupManager);
 
     checkpointCreatedEventApplier =
         new CheckpointCreatedEventApplier(
@@ -122,7 +122,8 @@ public final class CheckpointRecordsProcessor
         new CheckpointBackupConfirmedApplier(
             checkpointState, checkpointMetadataState, backupRangeState);
     checkpointBackupDeletedApplier =
-        new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
+        new CheckpointBackupDeletedApplier(
+            checkpointMetadataState, backupRangeState, checkpointState);
 
     final long checkpointId = checkpointState.getLatestCheckpointId();
     final var checkpointType = checkpointState.getLatestCheckpointType();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -161,7 +161,7 @@ public final class CheckpointRecordsProcessor
       case CONFIRMED_BACKUP ->
           checkpointBackupConfirmedApplier.apply(
               (CheckpointRecord) record.getValue(), record.getTimestamp());
-      case BACKUP_DELETED ->
+      case DELETED_BACKUP ->
           checkpointBackupDeletedApplier.apply((CheckpointRecord) record.getValue());
       case IGNORED -> {}
       default ->

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -42,8 +42,10 @@ public final class CheckpointRecordsProcessor
   private final BackupManager backupManager;
   private CheckpointCreateProcessor checkpointCreateProcessor;
   private CheckpointConfirmBackupProcessor checkpointConfirmBackupProcessor;
+  private CheckpointDeleteBackupProcessor checkpointDeleteBackupProcessor;
   private CheckpointCreatedEventApplier checkpointCreatedEventApplier;
   private CheckpointBackupConfirmedApplier checkpointBackupConfirmedApplier;
+  private CheckpointBackupDeletedApplier checkpointBackupDeletedApplier;
 
   //  Can be accessed concurrently by other threads to add new listeners. Hence we have to use a
   // thread safe collection
@@ -108,12 +110,19 @@ public final class CheckpointRecordsProcessor
     checkpointConfirmBackupProcessor =
         new CheckpointConfirmBackupProcessor(
             checkpointState, checkpointMetadataState, backupRangeState, backupManager);
+
+    checkpointDeleteBackupProcessor =
+        new CheckpointDeleteBackupProcessor(
+            checkpointMetadataState, backupRangeState, backupManager);
+
     checkpointCreatedEventApplier =
         new CheckpointCreatedEventApplier(
             checkpointState, checkpointMetadataState, checkpointListeners);
     checkpointBackupConfirmedApplier =
         new CheckpointBackupConfirmedApplier(
             checkpointState, checkpointMetadataState, backupRangeState);
+    checkpointBackupDeletedApplier =
+        new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
 
     final long checkpointId = checkpointState.getLatestCheckpointId();
     final var checkpointType = checkpointState.getLatestCheckpointType();
@@ -137,6 +146,12 @@ public final class CheckpointRecordsProcessor
       // Should never reach here. StreamProcessor must choose the right processor always.
       throw new IllegalArgumentException("Unknown record");
     }
+    if (!record.getIntent().isEvent()) {
+      throw new IllegalArgumentException(
+          "Expected to replay event but got non-event with intent: %s"
+              .formatted(record.getIntent()));
+    }
+
     final CheckpointIntent intent = (CheckpointIntent) record.getIntent();
     switch (intent) {
       case CREATED ->
@@ -144,30 +159,39 @@ public final class CheckpointRecordsProcessor
               (CheckpointRecord) record.getValue(), record.getTimestamp());
       case CONFIRMED_BACKUP ->
           checkpointBackupConfirmedApplier.apply(
-              (CheckpointRecord) record.getValue(),
-              record.getTimestamp(),
-              record.getBrokerVersion());
-      default -> {
-        // Don't apply intents CREATE and IGNORED
-      }
+              (CheckpointRecord) record.getValue(), record.getTimestamp());
+      case BACKUP_DELETED ->
+          checkpointBackupDeletedApplier.apply((CheckpointRecord) record.getValue());
+      case IGNORED -> {}
+      default ->
+          throw new IllegalStateException(
+              "Unknown checkpoint intent: %s".formatted(record.getIntent()));
     }
   }
 
   @Override
   public ProcessingResult process(
       final TypedRecord record, final ProcessingResultBuilder resultBuilder) {
-    if (record.getValueType() == ValueType.CHECKPOINT
-        && record.getIntent() == CheckpointIntent.CREATE) {
-      return checkpointCreateProcessor.process(record, resultBuilder);
+    if (record.getValueType() != ValueType.CHECKPOINT) {
+      throw new IllegalArgumentException(
+          "Unknown value type %s for record %s".formatted(record.getValueType(), record));
     }
 
-    if (record.getValueType() == ValueType.CHECKPOINT
-        && record.getIntent() == CheckpointIntent.CONFIRM_BACKUP) {
-      return checkpointConfirmBackupProcessor.process(record, resultBuilder);
+    if (!(record.getIntent() instanceof final CheckpointIntent checkpointIntent)) {
+      throw new IllegalArgumentException(
+          "Unknown checkpoint intent %s".formatted(record.getIntent()));
     }
 
-    // Should never reach here. StreamProcessor must choose the right processor always.
-    throw new IllegalArgumentException("Unknown record");
+    return switch (checkpointIntent) {
+      case CheckpointIntent.CREATE -> checkpointCreateProcessor.process(record, resultBuilder);
+      case CheckpointIntent.CONFIRM_BACKUP ->
+          checkpointConfirmBackupProcessor.process(record, resultBuilder);
+      case CheckpointIntent.DELETE_BACKUP ->
+          checkpointDeleteBackupProcessor.process(record, resultBuilder);
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown checkpoint intent %s".formatted(record.getIntent()));
+    };
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -76,4 +76,10 @@ public interface CheckpointState {
 
   /** Returns the first log position of the last checkpoint with a successful backup. */
   long getLatestBackupFirstLogPosition();
+
+  /**
+   * Clears the latest backup info, resetting it to the initial state (no backup). Used when the
+   * latest backup is deleted and there is no predecessor backup.
+   */
+  void clearLatestBackupInfo();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
+import java.util.SequencedCollection;
 import org.agrona.collections.MutableLong;
 
 /**
@@ -83,11 +83,25 @@ public final class DbBackupRangeState {
   }
 
   /** Returns all ranges, ordered by start checkpoint ID ascending. */
-  public List<BackupRange> getAllRanges() {
+  public SequencedCollection<BackupRange> getAllRanges() {
     final var result = new ArrayList<BackupRange>();
     rangesColumnFamily.forEach(
         (key, value) -> result.add(new BackupRange(key.getValue(), value.getValue())));
     return result;
+  }
+
+  public Optional<BackupRange> getFirstRange() {
+    final var startValue = new MutableLong(CheckpointState.NO_CHECKPOINT);
+    final var endValue = new MutableLong(CheckpointState.NO_CHECKPOINT);
+    rangesColumnFamily.whileTrue(
+        (start, end) -> {
+          startValue.set(start.getValue());
+          endValue.set(end.getValue());
+          return false;
+        });
+    return startValue.get() != CheckpointState.NO_CHECKPOINT
+        ? Optional.of(new BackupRange(startValue.get(), endValue.get()))
+        : Optional.empty();
   }
 
   /**

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -153,8 +153,10 @@ public final class DbCheckpointMetadataState {
         (checkpointId, checkpointMetadataValue) -> {
           if (checkpointMetadataValue.getFirstLogPosition() < firstLogPosition) {
             checkpointsColumnFamily.deleteExisting(checkpointId);
+            return true;
+          } else {
+            return false;
           }
-          return true;
         });
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -148,6 +148,16 @@ public final class DbCheckpointMetadataState {
         : Optional.empty();
   }
 
+  public void removeCheckpointsUntil(final long firstLogPosition) {
+    checkpointsColumnFamily.whileTrue(
+        (checkpointId, checkpointMetadataValue) -> {
+          if (checkpointMetadataValue.getFirstLogPosition() < firstLogPosition) {
+            checkpointsColumnFamily.deleteExisting(checkpointId);
+          }
+          return true;
+        });
+  }
+
   /** Immutable snapshot of a checkpoint entry for external consumption. */
   public record CheckpointEntry(
       long checkpointId,

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -108,6 +108,12 @@ public final class DbCheckpointState implements CheckpointState {
     return getFirstLogPosition(LATEST_BACKUP_KEY);
   }
 
+  @Override
+  public void clearLatestBackupInfo() {
+    checkpointInfoKey.wrapString(LATEST_BACKUP_KEY);
+    checkpointColumnFamily.deleteIfExists(checkpointInfoKey);
+  }
+
   private long getCheckpointId(final String key) {
     checkpointInfoKey.wrapString(key);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
-import io.camunda.zeebe.backup.api.BackupRangeMarker.Deletion;
 import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
 import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
 import io.camunda.zeebe.backup.api.BackupStatus;
@@ -364,61 +363,49 @@ class BackupServiceImplTest {
   }
 
   @Test
-  void shouldDeleteAllExistingBackupWithSameCheckpointId() {
+  void shouldWriteRequestBackupDeletionCommandToLog() {
     // given
-    final int partitionId = 1;
     final long checkpointId = 2L;
-    final BackupStatus backupNode1 = mock(BackupStatus.class);
-    when(backupNode1.statusCode()).thenReturn(BackupStatusCode.COMPLETED);
-    when(backupNode1.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, checkpointId));
-
-    final BackupStatus backupNode2 = mock(BackupStatus.class);
-    when(backupNode2.statusCode()).thenReturn(BackupStatusCode.COMPLETED);
-    when(backupNode2.id()).thenReturn(new BackupIdentifierImpl(2, partitionId, checkpointId));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backupNode1, backupNode2)));
-
-    when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
-    when(backupStore.storeRangeMarker(anyInt(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
-    backupService.deleteBackup(partitionId, checkpointId, concurrencyControl).join();
+    backupService.writeBackupDeletionCommand(checkpointId, concurrencyControl).join();
 
     // then
-    verify(backupStore).delete(backupNode1.id());
-    verify(backupStore).delete(backupNode2.id());
+    verify(logStreamWriter)
+        .tryWrite(
+            eq(WriteContext.internal()),
+            assertArg(
+                (final LogAppendEntry entry) -> {
+                  assertThat(entry.recordMetadata().getRecordType()).isEqualTo(RecordType.COMMAND);
+                  assertThat(entry.recordMetadata().getIntent())
+                      .isEqualTo(CheckpointIntent.DELETE_BACKUP);
+                  assertThat(entry.recordValue())
+                      .isInstanceOfSatisfying(
+                          CheckpointRecord.class,
+                          checkpointRecord ->
+                              assertThat(checkpointRecord.getCheckpointId())
+                                  .isEqualTo(checkpointId));
+                }));
+    // deleteBackup no longer calls backupStore directly — the stream processor handles that
+    verify(backupStore, never()).delete(any());
   }
 
   @Test
-  void shouldDeleteInProgressBackup() {
+  void shouldFailRequestBackupDeletionWhenLogWriteFails() {
     // given
-    final int partitionId = 1;
     final long checkpointId = 2L;
-    final BackupStatus backup = mock(BackupStatus.class);
-    when(backup.statusCode()).thenReturn(BackupStatusCode.IN_PROGRESS);
-    when(backup.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, checkpointId));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup)));
-
-    when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
-    when(backupStore.markFailed(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(BackupStatusCode.FAILED));
-    when(backupStore.storeRangeMarker(anyInt(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
+    when(logStreamWriter.tryWrite(any(), any(LogAppendEntry.class)))
+        .thenReturn(Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED));
 
     // when
-    backupService.deleteBackup(partitionId, checkpointId, concurrencyControl).join();
+    final var result = backupService.writeBackupDeletionCommand(checkpointId, concurrencyControl);
 
     // then
-    verify(backupStore).markFailed(eq(backup.id()), anyString());
-    verify(backupStore).delete(backup.id());
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Failed to write DELETE_BACKUP command");
+    verify(backupStore, never()).delete(any());
   }
 
   @Test
@@ -504,60 +491,18 @@ class BackupServiceImplTest {
   }
 
   @Test
-  void shouldStoreDeletionMarkerWhenDeletingCompletedBackup() {
+  void shouldNotInteractWithBackupStoreOnRequestBackupDeletion() {
     // given
-    final int partitionId = 1;
     final long checkpointId = 5L;
-    final BackupStatus backup = mock(BackupStatus.class);
-    when(backup.statusCode()).thenReturn(BackupStatusCode.COMPLETED);
-    when(backup.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, checkpointId));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup)));
-
-    when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
-    when(backupStore.storeRangeMarker(anyInt(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
-    backupService.deleteBackup(partitionId, checkpointId, concurrencyControl).join();
+    backupService.writeBackupDeletionCommand(checkpointId, concurrencyControl).join();
 
-    // then - verify storeRangeMarker is called before delete
-    final var inOrder = inOrder(backupStore);
-    inOrder.verify(backupStore).storeRangeMarker(partitionId, new Deletion(checkpointId));
-    inOrder.verify(backupStore).delete(backup.id());
-  }
-
-  @Test
-  void shouldStoreDeletionMarkerBeforeDeletingInProgressBackup() {
-    // given
-    final int partitionId = 1;
-    final long checkpointId = 5L;
-    final BackupStatus backup = mock(BackupStatus.class);
-    when(backup.statusCode()).thenReturn(BackupStatusCode.IN_PROGRESS);
-    when(backup.id()).thenReturn(new BackupIdentifierImpl(1, partitionId, checkpointId));
-
-    when(backupStore.list(
-            new BackupIdentifierWildcardImpl(
-                Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(checkpointId))))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup)));
-
-    when(backupStore.delete(any())).thenReturn(CompletableFuture.completedFuture(null));
-    when(backupStore.markFailed(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(BackupStatusCode.FAILED));
-    when(backupStore.storeRangeMarker(anyInt(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    // when
-    backupService.deleteBackup(partitionId, checkpointId, concurrencyControl).join();
-
-    // then - verify markFailed is called first, then storeRangeMarker, then delete
-    final var inOrder = inOrder(backupStore);
-    inOrder.verify(backupStore).markFailed(eq(backup.id()), anyString());
-    inOrder.verify(backupStore).storeRangeMarker(partitionId, new Deletion(checkpointId));
-    inOrder.verify(backupStore).delete(backup.id());
+    // then — deleteBackup only writes to the log; the stream processor does the rest
+    verify(logStreamWriter).tryWrite(eq(WriteContext.internal()), any(LogAppendEntry.class));
+    verify(backupStore, never()).delete(any());
+    verify(backupStore, never()).storeRangeMarker(anyInt(), any());
+    verify(backupStore, never()).markFailed(any(), anyString());
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
@@ -76,12 +76,15 @@ final class CheckpointBackupDeletedApplierTest {
     checkpointMetadataState.addBackupCheckpoint(
         1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
     backupRangeState.startNewRange(1L);
+    assertThat(checkpointMetadataState.getCheckpoint(1L)).isNotNull();
 
     // when
     applier.apply(checkpointRecord(1L));
 
     // then — range is deleted
     assertThat(backupRangeState.getAllRanges()).isEmpty();
+    // then - checkpoint is removed
+    assertThat(checkpointMetadataState.getCheckpoint(1L)).isNull();
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class CheckpointBackupDeletedApplierTest {
+
+  @TempDir Path database;
+  private ZeebeDb<ZbColumnFamilies> zeebedb;
+  private DbCheckpointMetadataState checkpointMetadataState;
+  private DbBackupRangeState backupRangeState;
+  private CheckpointBackupDeletedApplier applier;
+
+  @BeforeEach
+  void before() {
+    zeebedb =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+                new RocksDbConfiguration(),
+                new ConsistencyChecksSettings(true, true),
+                new AccessMetricsConfiguration(Kind.NONE, 1),
+                SimpleMeterRegistry::new)
+            .createDb(database.toFile());
+    final var context = zeebedb.createContext();
+    checkpointMetadataState = new DbCheckpointMetadataState(zeebedb, context);
+    backupRangeState = new DbBackupRangeState(zeebedb, context);
+    applier = new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
+  }
+
+  @AfterEach
+  void closeDb() throws Exception {
+    zeebedb.close();
+  }
+
+  @Test
+  void shouldRemoveCheckpointFromState() {
+    // given
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    backupRangeState.startNewRange(1L);
+
+    // when
+    applier.apply(checkpointRecord(1L));
+
+    // then
+    assertThat(checkpointMetadataState.getCheckpoint(1L)).isNull();
+  }
+
+  @Test
+  void shouldDeleteSingleEntryRange() {
+    // given — single checkpoint in a range
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    backupRangeState.startNewRange(1L);
+
+    // when
+    applier.apply(checkpointRecord(1L));
+
+    // then — range is deleted
+    assertThat(backupRangeState.getAllRanges()).isEmpty();
+  }
+
+  @Test
+  void shouldAdvanceRangeStartWhenDeletingFirstCheckpoint() {
+    // given — range [1, 3] with checkpoints 1, 2, 3
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    checkpointMetadataState.addBackupCheckpoint(
+        3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 200L);
+    backupRangeState.startNewRange(1L);
+    backupRangeState.updateRangeEnd(1L, 3L);
+
+    // when — delete checkpoint 1
+    applier.apply(checkpointRecord(1L));
+
+    // then — range advanced to [2, 3]
+    assertThat(backupRangeState.getAllRanges()).containsExactly(new BackupRange(2L, 3L));
+  }
+
+  @Test
+  void shouldShrinkRangeEndWhenDeletingLastCheckpoint() {
+    // given — range [1, 3] with checkpoints 1, 2, 3
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    checkpointMetadataState.addBackupCheckpoint(
+        3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 200L);
+    backupRangeState.startNewRange(1L);
+    backupRangeState.updateRangeEnd(1L, 3L);
+
+    // when — delete checkpoint 3
+    applier.apply(checkpointRecord(3L));
+
+    // then — range shrunk to [1, 2]
+    assertThat(backupRangeState.getAllRanges()).containsExactly(new BackupRange(1L, 2L));
+  }
+
+  @Test
+  void shouldSplitRangeWhenDeletingMiddleCheckpoint() {
+    // given — range [1, 3] with checkpoints 1, 2, 3
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    checkpointMetadataState.addBackupCheckpoint(
+        3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 200L);
+    backupRangeState.startNewRange(1L);
+    backupRangeState.updateRangeEnd(1L, 3L);
+
+    // when — delete checkpoint 2
+    applier.apply(checkpointRecord(2L));
+
+    // then — split into [1, 1] and [3, 3]
+    assertThat(backupRangeState.getAllRanges())
+        .containsExactly(new BackupRange(1L, 1L), new BackupRange(3L, 3L));
+  }
+
+  @Test
+  void shouldSkipRangeMaintenanceWhenCheckpointNotInAnyRange() {
+    // given — checkpoint exists but is not in any range
+    checkpointMetadataState.addBackupCheckpoint(
+        5L, 500L, 5000L, CheckpointType.SCHEDULED_BACKUP, 400L);
+
+    // when — delete checkpoint not in any range
+    applier.apply(checkpointRecord(5L));
+
+    // then — checkpoint removed, no range changes
+    assertThat(checkpointMetadataState.getCheckpoint(5L)).isNull();
+    assertThat(backupRangeState.getAllRanges()).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveUncoveredMarkersAfterDeletion() {
+    // given — marker with low log position, then backup checkpoints in a range
+    checkpointMetadataState.addMarkerCheckpoint(1L, 50L, 500L); // firstLogPosition = -1
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        3L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    backupRangeState.startNewRange(2L);
+    backupRangeState.updateRangeEnd(2L, 3L);
+
+    // when — delete checkpoint 2 (start of range), range advances to [3, 3]
+    applier.apply(checkpointRecord(2L));
+
+    // then — marker (checkpoint 1) with firstLogPosition -1 < 100 is removed
+    assertThat(checkpointMetadataState.getCheckpoint(1L)).isNull();
+    // checkpoint 3 remains
+    assertThat(checkpointMetadataState.getCheckpoint(3L)).isNotNull();
+  }
+
+  @Test
+  void shouldRemoveCheckpointBeforeRangeUpdate() {
+    // given — range [1, 1] with single checkpoint
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    backupRangeState.startNewRange(1L);
+
+    // when — apply deletion
+    applier.apply(checkpointRecord(1L));
+
+    // then — both checkpoint and range are cleaned up
+    assertThat(checkpointMetadataState.getCheckpoint(1L)).isNull();
+    assertThat(backupRangeState.getAllRanges()).isEmpty();
+  }
+
+  private static CheckpointRecord checkpointRecord(final long checkpointId) {
+    return new CheckpointRecord().setCheckpointId(checkpointId);
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 final class CheckpointBackupDeletedApplierTest {
 
   @TempDir Path database;
-  private ZeebeDb<ZbColumnFamilies> zeebedb;
+  @AutoClose private ZeebeDb<ZbColumnFamilies> zeebedb;
   private DbCheckpointMetadataState checkpointMetadataState;
   private DbBackupRangeState backupRangeState;
   private CheckpointBackupDeletedApplier applier;
@@ -54,11 +54,6 @@ final class CheckpointBackupDeletedApplierTest {
     applier =
         new CheckpointBackupDeletedApplier(
             checkpointMetadataState, backupRangeState, checkpointState);
-  }
-
-  @AfterEach
-  void closeDb() throws Exception {
-    zeebedb.close();
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplierTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
@@ -35,6 +36,7 @@ final class CheckpointBackupDeletedApplierTest {
   private DbCheckpointMetadataState checkpointMetadataState;
   private DbBackupRangeState backupRangeState;
   private CheckpointBackupDeletedApplier applier;
+  private DbCheckpointState checkpointState;
 
   @BeforeEach
   void before() {
@@ -48,7 +50,10 @@ final class CheckpointBackupDeletedApplierTest {
     final var context = zeebedb.createContext();
     checkpointMetadataState = new DbCheckpointMetadataState(zeebedb, context);
     backupRangeState = new DbBackupRangeState(zeebedb, context);
-    applier = new CheckpointBackupDeletedApplier(checkpointMetadataState, backupRangeState);
+    checkpointState = new DbCheckpointState(zeebedb, context);
+    applier =
+        new CheckpointBackupDeletedApplier(
+            checkpointMetadataState, backupRangeState, checkpointState);
   }
 
   @AfterEach
@@ -189,6 +194,59 @@ final class CheckpointBackupDeletedApplierTest {
     // then — both checkpoint and range are cleaned up
     assertThat(checkpointMetadataState.getCheckpoint(1L)).isNull();
     assertThat(backupRangeState.getAllRanges()).isEmpty();
+  }
+
+  @Test
+  void shouldClearLatestBackupInfoWhenDeletingLatestWithNoPredecessor() {
+    // given — single checkpoint that is also the latest backup
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    backupRangeState.startNewRange(1L);
+    checkpointState.setLatestBackupInfo(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+
+    // when
+    applier.apply(checkpointRecord(1L));
+
+    // then — latest backup info is cleared
+    assertThat(checkpointState.getLatestBackupId()).isEqualTo(-1L);
+  }
+
+  @Test
+  void shouldRollBackLatestBackupInfoToPredecessor() {
+    // given — two checkpoints, latest backup points to checkpoint 2
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    backupRangeState.startNewRange(1L);
+    backupRangeState.updateRangeEnd(1L, 2L);
+    checkpointState.setLatestBackupInfo(2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+
+    // when — delete checkpoint 2 (the latest)
+    applier.apply(checkpointRecord(2L));
+
+    // then — latest backup info rolled back to checkpoint 1
+    assertThat(checkpointState.getLatestBackupId()).isEqualTo(1L);
+    assertThat(checkpointState.getLatestBackupPosition()).isEqualTo(100L);
+    assertThat(checkpointState.getLatestBackupFirstLogPosition()).isEqualTo(50L);
+  }
+
+  @Test
+  void shouldNotChangeLatestBackupInfoWhenDeletingNonLatestCheckpoint() {
+    // given — two checkpoints, latest backup points to checkpoint 2
+    checkpointMetadataState.addBackupCheckpoint(
+        1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    checkpointMetadataState.addBackupCheckpoint(
+        2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+    backupRangeState.startNewRange(1L);
+    backupRangeState.updateRangeEnd(1L, 2L);
+    checkpointState.setLatestBackupInfo(2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+
+    // when — delete checkpoint 1 (not the latest)
+    applier.apply(checkpointRecord(1L));
+
+    // then — latest backup info unchanged
+    assertThat(checkpointState.getLatestBackupId()).isEqualTo(2L);
   }
 
   private static CheckpointRecord checkpointRecord(final long checkpointId) {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.backup.processing.MockProcessingResult.MockProcessingRes
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
@@ -65,6 +66,7 @@ final class CheckpointRecordsProcessorTest {
   private ProcessingResultBuilder resultBuilder;
   // Used for verifying state in the tests
   private CheckpointState state;
+  private DbCheckpointMetadataState checkpointMetadataState;
   private DbBackupRangeState backupRangeState;
   private ZeebeDb zeebedb;
   private final AtomicBoolean scalingInProgress = new AtomicBoolean(false);
@@ -90,6 +92,7 @@ final class CheckpointRecordsProcessorTest {
     processor.init(context);
 
     state = new DbCheckpointState(zeebedb, zeebedb.createContext());
+    checkpointMetadataState = new DbCheckpointMetadataState(zeebedb, zeebedb.createContext());
     backupRangeState = new DbBackupRangeState(zeebedb, zeebedb.createContext());
   }
 
@@ -792,5 +795,90 @@ final class CheckpointRecordsProcessorTest {
 
     // then
     verify(backupManager, times(1)).takeBackup(eq(backupId), any());
+  }
+
+  @Test
+  void shouldClearLatestBackupOnDeletionOfOnlyBackup() {
+    // given — checkpoint 5 is the only and latest backup
+    final var checkpointId = 5L;
+    final var timestamp = Instant.now().toEpochMilli();
+    checkpointMetadataState.addBackupCheckpoint(
+        checkpointId, 50, timestamp, CheckpointType.MANUAL_BACKUP, 40);
+    backupRangeState.startNewRange(checkpointId);
+    state.setLatestBackupInfo(checkpointId, 50, timestamp, CheckpointType.MANUAL_BACKUP, 40);
+
+    final var value = new CheckpointRecord().setCheckpointId(checkpointId);
+    final var record =
+        new MockTypedCheckpointRecord(
+            60, 0, CheckpointIntent.DELETE_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    processor.process(record, resultBuilder);
+
+    // then — latest backup is cleared (no predecessor exists)
+    assertThat(state.getLatestBackupId()).isEqualTo(CheckpointState.NO_CHECKPOINT);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(CheckpointState.NO_CHECKPOINT);
+  }
+
+  @Test
+  void shouldRollBackToPredecessorOnDeletionOfLatestBackup() {
+    // given — two backups: 5 (older) and 10 (latest)
+    final var firstId = 5L;
+    final var secondId = 10L;
+    final var firstTimestamp = Instant.now().toEpochMilli();
+    final var secondTimestamp = firstTimestamp + 1000;
+    checkpointMetadataState.addBackupCheckpoint(
+        firstId, 50, firstTimestamp, CheckpointType.MANUAL_BACKUP, 40);
+    checkpointMetadataState.addBackupCheckpoint(
+        secondId, 100, secondTimestamp, CheckpointType.SCHEDULED_BACKUP, 50);
+    backupRangeState.startNewRange(firstId);
+    backupRangeState.updateRangeEnd(firstId, secondId);
+    state.setLatestBackupInfo(secondId, 100, secondTimestamp, CheckpointType.SCHEDULED_BACKUP, 50);
+
+    final var value = new CheckpointRecord().setCheckpointId(secondId);
+    final var record =
+        new MockTypedCheckpointRecord(
+            110, 0, CheckpointIntent.DELETE_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    processor.process(record, resultBuilder);
+
+    // then — latest backup rolled back to predecessor (checkpoint 5)
+    assertThat(state.getLatestBackupId()).isEqualTo(firstId);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(50);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(firstTimestamp);
+    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.MANUAL_BACKUP);
+    assertThat(state.getLatestBackupFirstLogPosition()).isEqualTo(40);
+  }
+
+  @Test
+  void shouldNotAffectLatestBackupOnDeletionOfOlderBackup() {
+    // given — two backups: 5 (older) and 10 (latest), delete 5
+    final var firstId = 5L;
+    final var secondId = 10L;
+    final var firstTimestamp = Instant.now().toEpochMilli();
+    final var secondTimestamp = firstTimestamp + 1000;
+    checkpointMetadataState.addBackupCheckpoint(
+        firstId, 50, firstTimestamp, CheckpointType.MANUAL_BACKUP, 40);
+    checkpointMetadataState.addBackupCheckpoint(
+        secondId, 100, secondTimestamp, CheckpointType.SCHEDULED_BACKUP, 50);
+    backupRangeState.startNewRange(firstId);
+    backupRangeState.updateRangeEnd(firstId, secondId);
+    state.setLatestBackupInfo(secondId, 100, secondTimestamp, CheckpointType.SCHEDULED_BACKUP, 50);
+
+    final var value = new CheckpointRecord().setCheckpointId(firstId);
+    final var record =
+        new MockTypedCheckpointRecord(
+            110, 0, CheckpointIntent.DELETE_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    processor.process(record, resultBuilder);
+
+    // then — latest backup is unchanged (deleted backup was not the latest)
+    assertThat(state.getLatestBackupId()).isEqualTo(secondId);
+    assertThat(state.getLatestBackupPosition()).isEqualTo(100);
+    assertThat(state.getLatestBackupTimestamp()).isEqualTo(secondTimestamp);
+    assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
+    assertThat(state.getLatestBackupFirstLogPosition()).isEqualTo(50);
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -838,7 +838,7 @@ final class CheckpointRecordsProcessorTest {
     assertThat(processingResult.records())
         .singleElement()
         .satisfies(
-            record -> assertThat(record).returns(CheckpointIntent.BACKUP_DELETED, Event::intent));
+            record -> assertThat(record).returns(CheckpointIntent.DELETED_BACKUP, Event::intent));
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -821,6 +821,27 @@ final class CheckpointRecordsProcessorTest {
   }
 
   @Test
+  void shouldDeleteNonExistingBackup() {
+    // when
+    final MockProcessingResult processingResult =
+        (MockProcessingResult)
+            processor.process(
+                new MockTypedCheckpointRecord(
+                    60,
+                    0,
+                    CheckpointIntent.DELETE_BACKUP,
+                    RecordType.COMMAND,
+                    new CheckpointRecord().setCheckpointId(100)),
+                resultBuilder);
+
+    // then - processing is successful
+    assertThat(processingResult.records())
+        .singleElement()
+        .satisfies(
+            record -> assertThat(record).returns(CheckpointIntent.BACKUP_DELETED, Event::intent));
+  }
+
+  @Test
   void shouldRollBackToPredecessorOnDeletionOfLatestBackup() {
     // given — two backups: 5 (older) and 10 (latest)
     final var firstId = 5L;

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
@@ -327,6 +327,42 @@ final class DbBackupRangeStateTest {
             new BackupRange(1L, 4L), new BackupRange(6L, 10L), new BackupRange(20L, 30L));
   }
 
+  // --- getFirstRange ---
+
+  @Test
+  void shouldReturnEmptyWhenNoRangesForGetFirstRange() {
+    // when/then
+    assertThat(state.getFirstRange()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnFirstRangeWhenSingleRangeExists() {
+    // given
+    state.startNewRange(5L);
+    state.updateRangeEnd(5L, 10L);
+
+    // when
+    final var result = state.getFirstRange();
+
+    // then
+    assertThat(result).isPresent().contains(new BackupRange(5L, 10L));
+  }
+
+  @Test
+  void shouldReturnFirstRangeWhenMultipleRangesExist() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+    state.startNewRange(10L);
+    state.updateRangeEnd(10L, 15L);
+
+    // when
+    final var result = state.getFirstRange();
+
+    // then — should return the range with the smallest start key
+    assertThat(result).isPresent().contains(new BackupRange(1L, 5L));
+  }
+
   // --- getAllRanges ---
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataStateTest.java
@@ -249,4 +249,57 @@ final class DbCheckpointMetadataStateTest {
     assertThat(entry.checkpointType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
     assertThat(entry.firstLogPosition()).isEqualTo(50L);
   }
+
+  // --- removeCheckpointsUntil ---
+
+  @Test
+  void shouldRemoveCheckpointsWithLogPositionBeforeThreshold() {
+    // given — checkpoints with different firstLogPositions
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 10L);
+    state.addBackupCheckpoint(2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 20L);
+    state.addBackupCheckpoint(3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+
+    // when — remove all with firstLogPosition < 50
+    state.removeCheckpointsUntil(50L);
+
+    // then — only checkpoint 3 remains
+    final var all = state.getAllCheckpoints();
+    assertThat(all).hasSize(1);
+    assertThat(all.get(0).checkpointId()).isEqualTo(3L);
+  }
+
+  @Test
+  void shouldNotRemoveCheckpointsAtOrAboveThreshold() {
+    // given
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    state.addBackupCheckpoint(2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+
+    // when — threshold equals the first checkpoint's log position
+    state.removeCheckpointsUntil(50L);
+
+    // then — both remain (50 is not < 50)
+    assertThat(state.getAllCheckpoints()).hasSize(2);
+  }
+
+  @Test
+  void shouldHandleEmptyStateForRemoveCheckpointsUntil() {
+    // when/then — should not throw
+    state.removeCheckpointsUntil(100L);
+    assertThat(state.getAllCheckpoints()).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveMarkersWithLogPositionBeforeThreshold() {
+    // given — markers have firstLogPosition of -1
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+    state.addBackupCheckpoint(2L, 200L, 2000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+
+    // when — remove all with firstLogPosition < 50 (marker has -1)
+    state.removeCheckpointsUntil(50L);
+
+    // then — marker removed, backup remains
+    final var all = state.getAllCheckpoints();
+    assertThat(all).hasSize(1);
+    assertThat(all.get(0).checkpointId()).isEqualTo(2L);
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -199,7 +199,7 @@ public final class BackupApiRequestHandler
         new CompletableActorFuture<>();
     final var backupId = requestReader.backupId();
     backupManager
-        .deleteBackup(backupId)
+        .requestBackupDeletion(backupId)
         .onComplete(
             (ignore, error) -> {
               if (error == null) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -391,7 +391,8 @@ final class BackupApiRequestHandlerTest {
     // given
     final var request = new BackupRequest().setType(BackupRequestType.DELETE).setPartitionId(1);
 
-    when(backupManager.deleteBackup(anyLong())).thenReturn(CompletableActorFuture.completed(null));
+    when(backupManager.requestBackupDeletion(anyLong()))
+        .thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final BackupStatusResponse statusResponse = new BackupStatusResponse();
@@ -408,7 +409,7 @@ final class BackupApiRequestHandlerTest {
     // given
     final var request = new BackupRequest().setType(BackupRequestType.DELETE).setPartitionId(1);
 
-    when(backupManager.deleteBackup(anyLong()))
+    when(backupManager.requestBackupDeletion(anyLong()))
         .thenReturn(
             CompletableActorFuture.completedExceptionally(
                 new RuntimeException("Expected failure")));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -24,7 +24,7 @@ public enum CheckpointIntent implements Intent {
   CONFIRM_BACKUP(3),
   CONFIRMED_BACKUP(4),
   DELETE_BACKUP(5),
-  BACKUP_DELETED(6);
+  DELETED_BACKUP(6);
 
   private final short value;
 
@@ -43,7 +43,7 @@ public enum CheckpointIntent implements Intent {
       case CREATED:
       case IGNORED:
       case CONFIRMED_BACKUP:
-      case BACKUP_DELETED:
+      case DELETED_BACKUP:
         return true;
       default:
         return false;
@@ -65,7 +65,7 @@ public enum CheckpointIntent implements Intent {
       case 5:
         return DELETE_BACKUP;
       case 6:
-        return BACKUP_DELETED;
+        return DELETED_BACKUP;
       default:
         return UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -22,7 +22,9 @@ public enum CheckpointIntent implements Intent {
   CREATED(1),
   IGNORED(2),
   CONFIRM_BACKUP(3),
-  CONFIRMED_BACKUP(4);
+  CONFIRMED_BACKUP(4),
+  DELETE_BACKUP(5),
+  BACKUP_DELETED(6);
 
   private final short value;
 
@@ -41,6 +43,7 @@ public enum CheckpointIntent implements Intent {
       case CREATED:
       case IGNORED:
       case CONFIRMED_BACKUP:
+      case BACKUP_DELETED:
         return true;
       default:
         return false;
@@ -59,6 +62,10 @@ public enum CheckpointIntent implements Intent {
         return CONFIRM_BACKUP;
       case 4:
         return CONFIRMED_BACKUP;
+      case 5:
+        return DELETE_BACKUP;
+      case 6:
+        return BACKUP_DELETED;
       default:
         return UNKNOWN;
     }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -106,6 +106,32 @@ public interface BackupCompatibilityAcceptance {
     verifyRestoredJobCanBeCompleted(restoredDataDir);
   }
 
+  @Test
+  default void shouldDeleteBackupFromPreviousVersion() {
+    // given
+    final var backupId = 1L;
+    try (final var broker = createOldBroker()) {
+      broker.start();
+      createProcessInstanceWithJob(broker);
+      takeBackup(broker, backupId);
+    }
+
+    try (final var broker =
+        new TestStandaloneBroker().withUnifiedConfig(this::configureCurrentBackupStore)) {
+      broker.start();
+      final var backupActuator = BackupActuator.of(broker);
+      assertThat(backupActuator.list()).singleElement().returns(backupId, BackupInfo::getBackupId);
+
+      // when -- delete backup from previous version
+      backupActuator.delete(backupId);
+
+      // then
+      Awaitility.await("until backup is deleted")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertThat(backupActuator.list()).isEmpty());
+    }
+  }
+
   /**
    * Starts a current-version broker on the restored data directory and verifies that the service
    * task job created before the backup can be activated and completed.


### PR DESCRIPTION
With this change, we now write deletion commands and events to the log stream to trigger the actual deletion. This is used to update the runtime state introduced in #46457.

Builds on top of #46457