### PR TITLE
ci: include stable/8.9 in release dry-runs

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -11,6 +11,19 @@ on:
     - cron: '0 2 * * 1-5'
 
 jobs:
+  dry-run-release-89:
+    name: "Release from stable/8.9"
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.9
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: stable/8.9
+      # Uses fake tag for dry run testing without affecting real releases
+      releaseVersion: 0.0.0-dryrun-89
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: true
+      dryRun: true
   dry-run-release-88:
     name: "Release from stable/8.8"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.8
@@ -54,7 +67,7 @@ jobs:
   notify-camunda:
     name: Send Slack notification for 8.6+
     runs-on: ubuntu-latest
-    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88]
+    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88, dry-run-release-89]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -73,7 +86,7 @@ jobs:
 
       - name: Send failure Slack notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success') && github.event_name == 'schedule' }}
+        if: ${{ (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success' || needs.dry-run-release-89.result != 'success') && github.event_name == 'schedule' }}
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

As part of https://github.com/camunda/camunda/issues/46249 allow us to test that releases from the new stable branch would work.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related #46249
