### PR TITLE
[Backport stable/8.9] feat: store created markers, confirmed backups and ranges in runtime state

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupConfirmedApplier.java
@@ -8,21 +8,56 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 
 public class CheckpointBackupConfirmedApplier {
   private final CheckpointState checkpointState;
+  private final DbCheckpointMetadataState checkpointMetadataState;
+  private final DbBackupRangeState backupRangeState;
 
-  public CheckpointBackupConfirmedApplier(final CheckpointState checkpointState) {
+  public CheckpointBackupConfirmedApplier(
+      final CheckpointState checkpointState,
+      final DbCheckpointMetadataState checkpointMetadataState,
+      final DbBackupRangeState backupRangeState) {
     this.checkpointState = checkpointState;
+    this.checkpointMetadataState = checkpointMetadataState;
+    this.backupRangeState = backupRangeState;
   }
 
-  public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
+  public void apply(
+      final CheckpointRecord checkpointRecord,
+      final long checkpointTimestamp,
+      final String brokerVersion) {
+    final var checkpointId = checkpointRecord.getCheckpointId();
+    final var firstLogPosition = checkpointRecord.getFirstLogPosition();
+
+    // Read pre-update state for contiguity check
+    final var latestBackupId = checkpointState.getLatestBackupId();
+    final var latestBackupPosition = checkpointState.getLatestBackupPosition();
+
+    // Update range state: extend existing range or start a new one
+    if (latestBackupId != CheckpointState.NO_CHECKPOINT
+        && firstLogPosition <= latestBackupPosition + 1) {
+      // Contiguous with previous backup — find and extend the range that contains the latest backup
+      final var existingRange = backupRangeState.findRangeContaining(latestBackupId);
+      if (existingRange.isPresent()) {
+        backupRangeState.updateRangeEnd(existingRange.get().start(), checkpointId);
+      } else {
+        // Range not found (pre-migration state) — start a new one
+        backupRangeState.startNewRange(checkpointId);
+      }
+    } else {
+      backupRangeState.startNewRange(checkpointId);
+    }
+
+    // Update the existing checkpoint state (2-entry DEFAULT CF)
+    final var checkpointPosition = checkpointRecord.getCheckpointPosition();
+    final var checkpointType = checkpointRecord.getCheckpointType();
     checkpointState.setLatestBackupInfo(
-        checkpointRecord.getCheckpointId(),
-        checkpointRecord.getCheckpointPosition(),
-        checkpointTimestamp,
-        checkpointRecord.getCheckpointType(),
-        checkpointRecord.getFirstLogPosition());
+        checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
+    checkpointMetadataState.addBackupCheckpoint(
+        checkpointId, checkpointPosition, checkpointTimestamp, checkpointType, firstLogPosition);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -24,22 +26,27 @@ public class CheckpointConfirmBackupProcessor {
 
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointConfirmBackupProcessor.class);
   private final CheckpointState checkpointState;
-  private final CheckpointBackupConfirmedApplier backupConfirmedApplier;
   private final BackupManager backupManager;
+  private final CheckpointBackupConfirmedApplier backupConfirmedApplier;
 
   public CheckpointConfirmBackupProcessor(
-      final CheckpointState checkpointState, final BackupManager backupManager) {
+      final CheckpointState checkpointState,
+      final DbCheckpointMetadataState checkpointMetadataState,
+      final DbBackupRangeState backupRangeState,
+      final BackupManager backupManager) {
     this.checkpointState = checkpointState;
-    backupConfirmedApplier = new CheckpointBackupConfirmedApplier(checkpointState);
     this.backupManager = backupManager;
+    backupConfirmedApplier =
+        new CheckpointBackupConfirmedApplier(
+            checkpointState, checkpointMetadataState, backupRangeState);
   }
 
   public ProcessingResult process(
       final TypedRecord<CheckpointRecord> record, final ProcessingResultBuilder resultBuilder) {
     final var checkpointRecord = record.getValue();
     final var checkpointId = checkpointRecord.getCheckpointId();
-    final var latestBackupId = checkpointState.getLatestBackupId();
     final var firstLogPosition = checkpointRecord.getFirstLogPosition();
+    final var latestBackupId = checkpointState.getLatestBackupId();
     if (latestBackupId < checkpointId) {
       LOG.debug("Confirming backup for checkpoint {}", checkpointId);
       if (latestBackupId != CheckpointState.NO_CHECKPOINT
@@ -48,7 +55,8 @@ public class CheckpointConfirmBackupProcessor {
       } else {
         backupManager.startNewRange(checkpointId);
       }
-      backupConfirmedApplier.apply(checkpointRecord, record.getTimestamp());
+      backupConfirmedApplier.apply(
+          checkpointRecord, record.getTimestamp(), record.getBrokerVersion());
       resultBuilder.appendRecord(
           record.getKey(),
           checkpointRecord,

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -34,6 +35,7 @@ public final class CheckpointCreateProcessor {
   public CheckpointCreateProcessor(
       final CheckpointState checkpointState,
       final BackupManager backupManager,
+      final DbCheckpointMetadataState checkpointMetadataState,
       final Set<CheckpointListener> listeners,
       final ScalingStatusSupplier scalingStatusSupplier,
       final PartitionCountSupplier partitionCountSupplier,
@@ -44,7 +46,7 @@ public final class CheckpointCreateProcessor {
     this.metrics = metrics;
     this.partitionCountSupplier = partitionCountSupplier;
     checkpointCreatedApplier =
-        new CheckpointCreatedEventApplier(checkpointState, listeners, metrics);
+        new CheckpointCreatedEventApplier(checkpointState, checkpointMetadataState, listeners);
   }
 
   public ProcessingResult process(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -8,25 +8,25 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.CheckpointListener;
-import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.util.Set;
 
 public final class CheckpointCreatedEventApplier {
 
   private final CheckpointState checkpointState;
+  private final DbCheckpointMetadataState checkpointMetadataState;
   private final Set<CheckpointListener> checkpointListeners;
-
-  private final CheckpointMetrics metrics;
 
   public CheckpointCreatedEventApplier(
       final CheckpointState checkpointState,
-      final Set<CheckpointListener> checkpointListeners,
-      final CheckpointMetrics metrics) {
+      final DbCheckpointMetadataState checkpointMetadataState,
+      final Set<CheckpointListener> checkpointListeners) {
     this.checkpointState = checkpointState;
+    this.checkpointMetadataState = checkpointMetadataState;
     this.checkpointListeners = checkpointListeners;
-    this.metrics = metrics;
   }
 
   public void apply(final CheckpointRecord checkpointRecord, final long checkpointTimestamp) {
@@ -35,6 +35,14 @@ public final class CheckpointCreatedEventApplier {
         checkpointRecord.getCheckpointPosition(),
         checkpointTimestamp,
         checkpointRecord.getCheckpointType());
+
+    if (checkpointRecord.getCheckpointType() == CheckpointType.MARKER) {
+      checkpointMetadataState.addMarkerCheckpoint(
+          checkpointRecord.getCheckpointId(),
+          checkpointRecord.getCheckpointPosition(),
+          checkpointTimestamp);
+    }
+
     checkpointListeners.forEach(
         listener ->
             listener.onNewCheckpointCreated(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -79,6 +81,13 @@ public final class CheckpointRecordsProcessor
         new DbCheckpointState(
             recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
 
+    final var checkpointMetadataState =
+        new DbCheckpointMetadataState(
+            recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
+    final var backupRangeState =
+        new DbBackupRangeState(
+            recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
+
     if (scalingInProgressSupplier == null) {
       throw new IllegalStateException("Scaling in progress supplier is not initialized.");
     }
@@ -90,16 +99,21 @@ public final class CheckpointRecordsProcessor
         new CheckpointCreateProcessor(
             checkpointState,
             backupManager,
+            checkpointMetadataState,
             checkpointListeners,
             scalingInProgressSupplier,
             partitionCountSupplier,
             metrics);
 
     checkpointConfirmBackupProcessor =
-        new CheckpointConfirmBackupProcessor(checkpointState, backupManager);
+        new CheckpointConfirmBackupProcessor(
+            checkpointState, checkpointMetadataState, backupRangeState, backupManager);
     checkpointCreatedEventApplier =
-        new CheckpointCreatedEventApplier(checkpointState, checkpointListeners, metrics);
-    checkpointBackupConfirmedApplier = new CheckpointBackupConfirmedApplier(checkpointState);
+        new CheckpointCreatedEventApplier(
+            checkpointState, checkpointMetadataState, checkpointListeners);
+    checkpointBackupConfirmedApplier =
+        new CheckpointBackupConfirmedApplier(
+            checkpointState, checkpointMetadataState, backupRangeState);
 
     final long checkpointId = checkpointState.getLatestCheckpointId();
     final var checkpointType = checkpointState.getLatestCheckpointType();
@@ -130,7 +144,9 @@ public final class CheckpointRecordsProcessor
               (CheckpointRecord) record.getValue(), record.getTimestamp());
       case CONFIRMED_BACKUP ->
           checkpointBackupConfirmedApplier.apply(
-              (CheckpointRecord) record.getValue(), record.getTimestamp());
+              (CheckpointRecord) record.getValue(),
+              record.getTimestamp(),
+              record.getBrokerVersion());
       default -> {
         // Don't apply intents CREATE and IGNORED
       }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+
+/**
+ * Full metadata for a single checkpoint, stored in the CHECKPOINTS column family. Tracks all
+ * checkpoint types (MARKER, SCHEDULED_BACKUP, MANUAL_BACKUP).
+ */
+public final class CheckpointMetadataValue extends UnpackedObject implements DbValue {
+
+  private final LongProperty checkpointPositionProperty =
+      new LongProperty("checkpointPosition", -1L);
+  private final LongProperty checkpointTimestampProperty =
+      new LongProperty("checkpointTimestamp", -1L);
+  private final EnumProperty<CheckpointType> checkpointTypeProperty =
+      new EnumProperty<>("checkpointType", CheckpointType.class, CheckpointType.MARKER);
+  private final LongProperty firstLogPositionProperty = new LongProperty("firstLogPosition", -1L);
+
+  public CheckpointMetadataValue() {
+    super(4);
+    declareProperty(checkpointPositionProperty)
+        .declareProperty(checkpointTimestampProperty)
+        .declareProperty(checkpointTypeProperty)
+        .declareProperty(firstLogPositionProperty);
+  }
+
+  public long getCheckpointPosition() {
+    return checkpointPositionProperty.getValue();
+  }
+
+  public CheckpointMetadataValue setCheckpointPosition(final long position) {
+    checkpointPositionProperty.setValue(position);
+    return this;
+  }
+
+  public long getCheckpointTimestamp() {
+    return checkpointTimestampProperty.getValue();
+  }
+
+  public CheckpointMetadataValue setCheckpointTimestamp(final long timestamp) {
+    checkpointTimestampProperty.setValue(timestamp);
+    return this;
+  }
+
+  public CheckpointType getCheckpointType() {
+    return checkpointTypeProperty.getValue();
+  }
+
+  public CheckpointMetadataValue setCheckpointType(final CheckpointType type) {
+    checkpointTypeProperty.setValue(type);
+    return this;
+  }
+
+  public long getFirstLogPosition() {
+    return firstLogPositionProperty.getValue();
+  }
+
+  public CheckpointMetadataValue setFirstLogPosition(final long firstLogPosition) {
+    firstLogPositionProperty.setValue(firstLogPosition);
+    return this;
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
@@ -24,7 +24,7 @@ public final class CheckpointMetadataValue extends UnpackedObject implements DbV
   private final LongProperty checkpointTimestampProperty =
       new LongProperty("checkpointTimestamp", -1L);
   private final EnumProperty<CheckpointType> checkpointTypeProperty =
-      new EnumProperty<>("checkpointType", CheckpointType.class, CheckpointType.MARKER);
+      new EnumProperty<>("checkpointType", CheckpointType.class);
   private final LongProperty firstLogPositionProperty = new LongProperty("firstLogPosition", -1L);
 
   public CheckpointMetadataValue() {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
@@ -118,11 +118,10 @@ public final class DbBackupRangeState {
    *
    * @param oldStart the current start key
    * @param newStart the new start key
-   * @param endCheckpointId the unchanged end of the range
    */
-  public void updateRangeStart(
-      final long oldStart, final long newStart, final long endCheckpointId) {
+  public void updateRangeStart(final long oldStart, final long newStart) {
     rangeStartKey.wrapLong(oldStart);
+    final var endCheckpointId = rangesColumnFamily.get(rangeStartKey).getValue();
     rangesColumnFamily.deleteExisting(rangeStartKey);
 
     rangeStartKey.wrapLong(newStart);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.collections.MutableLong;
+
+/**
+ * State backed by the BACKUP_RANGES column family. Maintains pre-computed contiguous backup ranges
+ * so they can be queried without scanning all checkpoints.
+ *
+ * <p>Each entry maps a range start checkpoint ID (key) to the range end checkpoint ID (value). A
+ * range [start, end] means that all backup-type checkpoints from start to end form a contiguous
+ * sequence (each checkpoint's log starts at or before the previous checkpoint's position + 1).
+ */
+public final class DbBackupRangeState {
+
+  private final DbLong rangeStartKey;
+  private final DbLong rangeEndValue;
+  private final ColumnFamily<DbLong, DbLong> rangesColumnFamily;
+
+  public DbBackupRangeState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    rangeStartKey = new DbLong();
+    rangeEndValue = new DbLong();
+    rangesColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.BACKUP_RANGES, transactionContext, rangeStartKey, rangeEndValue);
+  }
+
+  /**
+   * Starts a new range containing a single checkpoint. Inserts (checkpointId, checkpointId).
+   *
+   * @param checkpointId the checkpoint that starts (and currently ends) the new range
+   */
+  public void startNewRange(final long checkpointId) {
+    rangeStartKey.wrapLong(checkpointId);
+    rangeEndValue.wrapLong(checkpointId);
+    rangesColumnFamily.insert(rangeStartKey, rangeEndValue);
+  }
+
+  /**
+   * Finds the range that contains the given checkpoint ID. Seeks backward from checkpointId, the
+   * first entry found has the largest start <= checkpointId, then verifies that end >=
+   * checkpointId.
+   *
+   * @param checkpointId the checkpoint ID to look up
+   * @return the range containing the checkpoint, or empty if not in any range
+   */
+  public Optional<BackupRange> findRangeContaining(final long checkpointId) {
+    final var start = new MutableLong(CheckpointState.NO_CHECKPOINT);
+    final var end = new MutableLong(CheckpointState.NO_CHECKPOINT);
+
+    rangeStartKey.wrapLong(checkpointId);
+    rangesColumnFamily.whileTrueReverse(
+        rangeStartKey,
+        (key, value) -> {
+          // First entry with start <= checkpointId
+          final var startValue = key.getValue();
+          final var endValue = value.getValue();
+          if (endValue >= checkpointId) {
+            start.set(startValue);
+            end.set(endValue);
+          }
+          return false; // only need the first entry
+        });
+
+    return start.get() != CheckpointState.NO_CHECKPOINT
+        ? Optional.of(new BackupRange(start.get(), end.get()))
+        : Optional.empty();
+  }
+
+  /** Returns all ranges, ordered by start checkpoint ID ascending. */
+  public List<BackupRange> getAllRanges() {
+    final var result = new ArrayList<BackupRange>();
+    rangesColumnFamily.forEach(
+        (key, value) -> result.add(new BackupRange(key.getValue(), value.getValue())));
+    return result;
+  }
+
+  /**
+   * Deletes a range entry. Used when the only checkpoint in a range is deleted.
+   *
+   * @param startCheckpointId the start key of the range to delete
+   */
+  public void deleteRange(final long startCheckpointId) {
+    rangeStartKey.wrapLong(startCheckpointId);
+    rangesColumnFamily.deleteExisting(rangeStartKey);
+  }
+
+  /**
+   * Updates the end of a range. Used when extending a range to include a new checkpoint.
+   *
+   * @param startCheckpointId the start key of the range to extend
+   * @param newEndCheckpointId the new end checkpoint ID
+   */
+  public void updateRangeEnd(final long startCheckpointId, final long newEndCheckpointId) {
+    rangeStartKey.wrapLong(startCheckpointId);
+    rangeEndValue.wrapLong(newEndCheckpointId);
+    rangesColumnFamily.update(rangeStartKey, rangeEndValue);
+  }
+
+  /**
+   * Updates the start of a range. Deletes the old entry and inserts a new one with the updated
+   * start. Used when deleting the first checkpoint in a range.
+   *
+   * @param oldStart the current start key
+   * @param newStart the new start key
+   * @param endCheckpointId the unchanged end of the range
+   */
+  public void updateRangeStart(
+      final long oldStart, final long newStart, final long endCheckpointId) {
+    rangeStartKey.wrapLong(oldStart);
+    rangesColumnFamily.deleteExisting(rangeStartKey);
+
+    rangeStartKey.wrapLong(newStart);
+    rangeEndValue.wrapLong(endCheckpointId);
+    rangesColumnFamily.insert(rangeStartKey, rangeEndValue);
+  }
+
+  /**
+   * Splits a range into two sub-ranges around a deleted checkpoint. Removes the old range and
+   * inserts two new ones: [oldStart, predecessorId] and [successorId, oldEnd].
+   *
+   * @param oldStart the original range start
+   * @param oldEnd the original range end
+   * @param predecessorId the last checkpoint before the deleted one (becomes end of left sub-range)
+   * @param successorId the first checkpoint after the deleted one (becomes start of right
+   *     sub-range)
+   */
+  public void splitRange(
+      final long oldStart, final long oldEnd, final long predecessorId, final long successorId) {
+    // Delete the original range
+    rangeStartKey.wrapLong(oldStart);
+    rangesColumnFamily.deleteExisting(rangeStartKey);
+
+    // Insert left sub-range: [oldStart, predecessorId]
+    rangeStartKey.wrapLong(oldStart);
+    rangeEndValue.wrapLong(predecessorId);
+    rangesColumnFamily.insert(rangeStartKey, rangeEndValue);
+
+    // Insert right sub-range: [successorId, oldEnd]
+    rangeStartKey.wrapLong(successorId);
+    rangeEndValue.wrapLong(oldEnd);
+    rangesColumnFamily.insert(rangeStartKey, rangeEndValue);
+  }
+
+  /** Immutable representation of a backup range [start, end]. */
+  public record BackupRange(long start, long end) {}
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -41,6 +41,7 @@ public final class DbCheckpointMetadataState {
   public void addMarkerCheckpoint(
       final long checkpointId, final long checkpointPosition, final long timestamp) {
     checkpointIdKey.wrapLong(checkpointId);
+    metadataValue.reset();
     metadataValue
         .setCheckpointPosition(checkpointPosition)
         .setCheckpointTimestamp(timestamp)
@@ -56,6 +57,7 @@ public final class DbCheckpointMetadataState {
       final CheckpointType checkpointType,
       final long firstLogPosition) {
     checkpointIdKey.wrapLong(checkpointId);
+    metadataValue.reset();
     metadataValue
         .setCheckpointPosition(checkpointPosition)
         .setCheckpointTimestamp(checkpointTimestamp)

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.collections.MutableLong;
+
+/**
+ * State backed by the CHECKPOINTS column family. Stores full metadata for every created markers and
+ * confirmed backups. Keyed by checkpoint ID.
+ */
+public final class DbCheckpointMetadataState {
+
+  private final DbLong checkpointIdKey;
+  private final CheckpointMetadataValue metadataValue;
+  private final ColumnFamily<DbLong, CheckpointMetadataValue> checkpointsColumnFamily;
+
+  public DbCheckpointMetadataState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    checkpointIdKey = new DbLong();
+    metadataValue = new CheckpointMetadataValue();
+    checkpointsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.CHECKPOINTS, transactionContext, checkpointIdKey, metadataValue);
+  }
+
+  /** Adds a new checkpoint entry when marker checkpoints are created. */
+  public void addMarkerCheckpoint(
+      final long checkpointId, final long checkpointPosition, final long timestamp) {
+    checkpointIdKey.wrapLong(checkpointId);
+    metadataValue
+        .setCheckpointPosition(checkpointPosition)
+        .setCheckpointTimestamp(timestamp)
+        .setCheckpointType(CheckpointType.MARKER);
+    checkpointsColumnFamily.insert(checkpointIdKey, metadataValue);
+  }
+
+  /** Adds a new checkpoint entry when a backup is created. */
+  public void addBackupCheckpoint(
+      final long checkpointId,
+      final long checkpointPosition,
+      final long checkpointTimestamp,
+      final CheckpointType checkpointType,
+      final long firstLogPosition) {
+    checkpointIdKey.wrapLong(checkpointId);
+    metadataValue
+        .setCheckpointPosition(checkpointPosition)
+        .setCheckpointTimestamp(checkpointTimestamp)
+        .setCheckpointType(checkpointType)
+        .setFirstLogPosition(firstLogPosition);
+    checkpointsColumnFamily.insert(checkpointIdKey, metadataValue);
+  }
+
+  /** Removes a checkpoint entry (used during backup deletion). */
+  public void removeCheckpoint(final long checkpointId) {
+    checkpointIdKey.wrapLong(checkpointId);
+    checkpointsColumnFamily.deleteIfExists(checkpointIdKey);
+  }
+
+  /** Point lookup for a single checkpoint. Returns null if not found. */
+  public CheckpointMetadataValue getCheckpoint(final long checkpointId) {
+    checkpointIdKey.wrapLong(checkpointId);
+    return checkpointsColumnFamily.get(checkpointIdKey);
+  }
+
+  /** Returns all checkpoint entries, ordered by checkpoint ID ascending. */
+  public List<CheckpointEntry> getAllCheckpoints() {
+    final var result = new ArrayList<CheckpointEntry>();
+    checkpointsColumnFamily.forEach(
+        (key, value) ->
+            result.add(
+                new CheckpointEntry(
+                    key.getValue(),
+                    value.getCheckpointPosition(),
+                    value.getCheckpointTimestamp(),
+                    value.getCheckpointType(),
+                    value.getFirstLogPosition())));
+    return result;
+  }
+
+  /** Returns true if no checkpoint entries exist (for migration detection). */
+  public boolean isEmpty() {
+    return checkpointsColumnFamily.isEmpty();
+  }
+
+  /**
+   * Finds the predecessor backup-type checkpoint by iterating backward from {@code checkpointId -
+   * 1}. Skips MARKER-type checkpoints since only backup-type checkpoints form ranges.
+   *
+   * @return the checkpoint ID of the nearest predecessor backup, or empty if none exists
+   */
+  public Optional<Long> findPredecessorBackupCheckpoint(final long checkpointId) {
+    final var result = new MutableLong(CheckpointState.NO_CHECKPOINT);
+
+    checkpointIdKey.wrapLong(checkpointId - 1);
+    checkpointsColumnFamily.whileTrueReverse(
+        checkpointIdKey,
+        (key, value) -> {
+          if (value.getCheckpointType().shouldCreateBackup()) {
+            result.set(key.getValue());
+            return false; // stop iteration
+          }
+          return true; // skip MARKERs, continue backward
+        });
+
+    return result.get() != CheckpointState.NO_CHECKPOINT
+        ? Optional.of(result.get())
+        : Optional.empty();
+  }
+
+  /**
+   * Finds the successor backup-type checkpoint by iterating forward from {@code checkpointId + 1}.
+   * Skips MARKER-type checkpoints since only backup-type checkpoints form ranges.
+   *
+   * @return the checkpoint ID of the nearest successor backup, or empty if none exists
+   */
+  public Optional<Long> findSuccessorBackupCheckpoint(final long checkpointId) {
+    final var result = new MutableLong(CheckpointState.NO_CHECKPOINT);
+
+    checkpointIdKey.wrapLong(checkpointId + 1);
+    checkpointsColumnFamily.whileTrue(
+        checkpointIdKey,
+        (key, value) -> {
+          if (value.getCheckpointType().shouldCreateBackup()) {
+            result.set(key.getValue());
+            return false; // stop iteration
+          }
+          return true; // skip MARKERs, continue forward
+        });
+
+    return result.get() != CheckpointState.NO_CHECKPOINT
+        ? Optional.of(result.get())
+        : Optional.empty();
+  }
+
+  /** Immutable snapshot of a checkpoint entry for external consumption. */
+  public record CheckpointEntry(
+      long checkpointId,
+      long checkpointPosition,
+      long checkpointTimestamp,
+      CheckpointType checkpointType,
+      long firstLogPosition) {}
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.processing.MockProcessingResult.Event;
 import io.camunda.zeebe.backup.processing.MockProcessingResult.MockProcessingResultBuilder;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
@@ -63,6 +65,7 @@ final class CheckpointRecordsProcessorTest {
   private ProcessingResultBuilder resultBuilder;
   // Used for verifying state in the tests
   private CheckpointState state;
+  private DbBackupRangeState backupRangeState;
   private ZeebeDb zeebedb;
   private final AtomicBoolean scalingInProgress = new AtomicBoolean(false);
   private final AtomicInteger dynamicPartitionCount =
@@ -87,6 +90,7 @@ final class CheckpointRecordsProcessorTest {
     processor.init(context);
 
     state = new DbCheckpointState(zeebedb, zeebedb.createContext());
+    backupRangeState = new DbBackupRangeState(zeebedb, zeebedb.createContext());
   }
 
   private RecordProcessorContextImpl createContext(
@@ -535,18 +539,21 @@ final class CheckpointRecordsProcessorTest {
     // when
     processor.process(record, resultBuilder);
 
-    // then
-    verify(backupManager, times(1)).startNewRange(newCheckpointId);
+    // then — a new range [5, 5] is created in the backup ranges CF
+    assertThat(backupRangeState.getAllRanges())
+        .containsExactly(new BackupRange(newCheckpointId, newCheckpointId));
   }
 
   @Test
   void shouldExtendRangeWhenSubsequentBackupConfirmed() {
-    // given
+    // given — first backup creates a range [5, 5]
     final var currentBackupId = 5;
     final var currentBackupPosition = 50;
     final var timestamp = Instant.now().toEpochMilli();
     state.setLatestBackupInfo(
         currentBackupId, currentBackupPosition, timestamp, CheckpointType.MANUAL_BACKUP, -1L);
+    // Seed the range state so the extend can find the existing range
+    backupRangeState.startNewRange(currentBackupId);
 
     final var newCheckpointId = 10;
     final var newCheckpointPosition = 100;
@@ -563,8 +570,9 @@ final class CheckpointRecordsProcessorTest {
     // when
     processor.process(record, resultBuilder);
 
-    // then
-    verify(backupManager, times(1)).extendRange(currentBackupId, newCheckpointId);
+    // then — the range is extended to [5, 10]
+    assertThat(backupRangeState.getAllRanges())
+        .containsExactly(new BackupRange(currentBackupId, newCheckpointId));
   }
 
   @Test

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class DbBackupRangeStateTest {
+
+  @TempDir Path database;
+  private ZeebeDb<ZbColumnFamilies> zeebedb;
+  private DbBackupRangeState state;
+
+  @BeforeEach
+  void before() {
+    zeebedb =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+                new RocksDbConfiguration(),
+                new ConsistencyChecksSettings(true, true),
+                new AccessMetricsConfiguration(Kind.NONE, 1),
+                SimpleMeterRegistry::new)
+            .createDb(database.toFile());
+    state = new DbBackupRangeState(zeebedb, zeebedb.createContext());
+  }
+
+  @AfterEach
+  void closeDb() throws Exception {
+    zeebedb.close();
+  }
+
+  // --- startNewRange ---
+
+  @Test
+  void shouldStartNewRange() {
+    // when
+    state.startNewRange(5L);
+
+    // then
+    final var ranges = state.getAllRanges();
+    assertThat(ranges).containsExactly(new BackupRange(5L, 5L));
+  }
+
+  @Test
+  void shouldStartMultipleRanges() {
+    // when
+    state.startNewRange(1L);
+    state.startNewRange(10L);
+
+    // then
+    final var ranges = state.getAllRanges();
+    assertThat(ranges).containsExactly(new BackupRange(1L, 1L), new BackupRange(10L, 10L));
+  }
+
+  // --- extendRange ---
+
+  @Test
+  void shouldUpdateRangeEnd() {
+    // given
+    state.startNewRange(1L);
+
+    // when
+    state.updateRangeEnd(1L, 5L);
+
+    // then
+    final var ranges = state.getAllRanges();
+    assertThat(ranges).containsExactly(new BackupRange(1L, 5L));
+  }
+
+  @Test
+  void shouldUpdateRangeEndMultipleTimes() {
+    // given
+    state.startNewRange(1L);
+
+    // when
+    state.updateRangeEnd(1L, 3L);
+    state.updateRangeEnd(1L, 7L);
+
+    // then
+    final var ranges = state.getAllRanges();
+    assertThat(ranges).containsExactly(new BackupRange(1L, 7L));
+  }
+
+  // --- findRangeContaining ---
+
+  @Test
+  void shouldFindRangeContainingStartCheckpoint() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    final var result = state.findRangeContaining(1L);
+
+    // then
+    assertThat(result).isPresent().contains(new BackupRange(1L, 5L));
+  }
+
+  @Test
+  void shouldFindRangeContainingEndCheckpoint() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    final var result = state.findRangeContaining(5L);
+
+    // then
+    assertThat(result).isPresent().contains(new BackupRange(1L, 5L));
+  }
+
+  @Test
+  void shouldFindRangeContainingMiddleCheckpoint() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    final var result = state.findRangeContaining(3L);
+
+    // then
+    assertThat(result).isPresent().contains(new BackupRange(1L, 5L));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenCheckpointNotInAnyRange() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    final var result = state.findRangeContaining(6L);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoRangesExist() {
+    // when
+    final var result = state.findRangeContaining(1L);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldFindCorrectRangeAmongMultiple() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 3L);
+    state.startNewRange(10L);
+    state.updateRangeEnd(10L, 15L);
+
+    // when/then — checkpoint in first range
+    assertThat(state.findRangeContaining(2L)).isPresent().contains(new BackupRange(1L, 3L));
+
+    // when/then — checkpoint in second range
+    assertThat(state.findRangeContaining(12L)).isPresent().contains(new BackupRange(10L, 15L));
+
+    // when/then — checkpoint between ranges
+    assertThat(state.findRangeContaining(5L)).isEmpty();
+  }
+
+  @Test
+  void shouldFindSingleCheckpointRange() {
+    // given — a range with start == end
+    state.startNewRange(5L);
+
+    // when
+    final var result = state.findRangeContaining(5L);
+
+    // then
+    assertThat(result).isPresent().contains(new BackupRange(5L, 5L));
+  }
+
+  // --- deleteRange ---
+
+  @Test
+  void shouldDeleteRange() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    state.deleteRange(1L);
+
+    // then
+    assertThat(state.getAllRanges()).isEmpty();
+  }
+
+  @Test
+  void shouldDeleteOnlyTargetRange() {
+    // given
+    state.startNewRange(1L);
+    state.startNewRange(10L);
+
+    // when
+    state.deleteRange(1L);
+
+    // then
+    assertThat(state.getAllRanges()).containsExactly(new BackupRange(10L, 10L));
+  }
+
+  // --- advanceRangeStart ---
+
+  @Test
+  void shouldUpdateRangeStart() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    state.updateRangeStart(1L, 2L, 5L);
+
+    // then
+    assertThat(state.getAllRanges()).containsExactly(new BackupRange(2L, 5L));
+  }
+
+  @Test
+  void shouldNotAffectOtherRangesWhenAdvancing() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+    state.startNewRange(10L);
+    state.updateRangeEnd(10L, 15L);
+
+    // when
+    state.updateRangeStart(1L, 3L, 5L);
+
+    // then
+    assertThat(state.getAllRanges())
+        .containsExactly(new BackupRange(3L, 5L), new BackupRange(10L, 15L));
+  }
+
+  // --- shrinkRangeEnd ---
+
+  @Test
+  void shouldShrinkRangeEnd() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 5L);
+
+    // when
+    state.updateRangeEnd(1L, 4L);
+
+    // then
+    assertThat(state.getAllRanges()).containsExactly(new BackupRange(1L, 4L));
+  }
+
+  // --- splitRange ---
+
+  @Test
+  void shouldSplitRangeIntoTwo() {
+    // given — range [1, 10]
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 10L);
+
+    // when — delete checkpoint 5, predecessor=4, successor=6
+    state.splitRange(1L, 10L, 4L, 6L);
+
+    // then — two sub-ranges: [1, 4] and [6, 10]
+    assertThat(state.getAllRanges())
+        .containsExactly(new BackupRange(1L, 4L), new BackupRange(6L, 10L));
+  }
+
+  @Test
+  void shouldSplitRangeNearStart() {
+    // given — range [1, 10]
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 10L);
+
+    // when — delete checkpoint 2, predecessor=1, successor=3
+    state.splitRange(1L, 10L, 1L, 3L);
+
+    // then — [1, 1] and [3, 10]
+    assertThat(state.getAllRanges())
+        .containsExactly(new BackupRange(1L, 1L), new BackupRange(3L, 10L));
+  }
+
+  @Test
+  void shouldSplitRangeNearEnd() {
+    // given — range [1, 10]
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 10L);
+
+    // when — delete checkpoint 9, predecessor=8, successor=10
+    state.splitRange(1L, 10L, 8L, 10L);
+
+    // then — [1, 8] and [10, 10]
+    assertThat(state.getAllRanges())
+        .containsExactly(new BackupRange(1L, 8L), new BackupRange(10L, 10L));
+  }
+
+  @Test
+  void shouldNotAffectOtherRangesWhenSplitting() {
+    // given
+    state.startNewRange(1L);
+    state.updateRangeEnd(1L, 10L);
+    state.startNewRange(20L);
+    state.updateRangeEnd(20L, 30L);
+
+    // when
+    state.splitRange(1L, 10L, 4L, 6L);
+
+    // then
+    assertThat(state.getAllRanges())
+        .containsExactly(
+            new BackupRange(1L, 4L), new BackupRange(6L, 10L), new BackupRange(20L, 30L));
+  }
+
+  // --- getAllRanges ---
+
+  @Test
+  void shouldReturnEmptyListWhenNoRanges() {
+    // when/then
+    assertThat(state.getAllRanges()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnRangesInOrder() {
+    // given — insert out of order (ranges are still keyed by start ID)
+    state.startNewRange(10L);
+    state.startNewRange(1L);
+    state.startNewRange(5L);
+
+    // when
+    final var ranges = state.getAllRanges();
+
+    // then — ordered by start checkpoint ID
+    assertThat(ranges)
+        .containsExactly(
+            new BackupRange(1L, 1L), new BackupRange(5L, 5L), new BackupRange(10L, 10L));
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeStateTest.java
@@ -229,7 +229,7 @@ final class DbBackupRangeStateTest {
     state.updateRangeEnd(1L, 5L);
 
     // when
-    state.updateRangeStart(1L, 2L, 5L);
+    state.updateRangeStart(1L, 2L);
 
     // then
     assertThat(state.getAllRanges()).containsExactly(new BackupRange(2L, 5L));
@@ -244,7 +244,7 @@ final class DbBackupRangeStateTest {
     state.updateRangeEnd(10L, 15L);
 
     // when
-    state.updateRangeStart(1L, 3L, 5L);
+    state.updateRangeStart(1L, 3L);
 
     // then
     assertThat(state.getAllRanges())

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataStateTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class DbCheckpointMetadataStateTest {
+
+  @TempDir Path database;
+  private ZeebeDb<ZbColumnFamilies> zeebedb;
+  private DbCheckpointMetadataState state;
+
+  @BeforeEach
+  void before() {
+    zeebedb =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+                new RocksDbConfiguration(),
+                new ConsistencyChecksSettings(true, true),
+                new AccessMetricsConfiguration(Kind.NONE, 1),
+                SimpleMeterRegistry::new)
+            .createDb(database.toFile());
+    state = new DbCheckpointMetadataState(zeebedb, zeebedb.createContext());
+  }
+
+  @AfterEach
+  void closeDb() throws Exception {
+    zeebedb.close();
+  }
+
+  @Test
+  void shouldAddMarkerCheckpoint() {
+    // when
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+
+    // then
+    final var checkpoint = state.getCheckpoint(1L);
+    assertThat(checkpoint).isNotNull();
+    assertThat(checkpoint.getCheckpointPosition()).isEqualTo(100L);
+    assertThat(checkpoint.getCheckpointTimestamp()).isEqualTo(1000L);
+    assertThat(checkpoint.getCheckpointType()).isEqualTo(CheckpointType.MARKER);
+    assertThat(checkpoint.getFirstLogPosition()).isEqualTo(-1L);
+  }
+
+  @Test
+  void shouldAddMultipleCheckpoints() {
+    // when
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+    state.addMarkerCheckpoint(3L, 300L, 3000L);
+
+    // then
+    final var all = state.getAllCheckpoints();
+    assertThat(all).hasSize(3);
+    assertThat(all.get(0).checkpointId()).isEqualTo(1L);
+    assertThat(all.get(1).checkpointId()).isEqualTo(2L);
+    assertThat(all.get(2).checkpointId()).isEqualTo(3L);
+  }
+
+  @Test
+  void shouldAddBackupCheckpoint() {
+    // when
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+
+    // then
+    final var checkpoint = state.getCheckpoint(1L);
+    assertThat(checkpoint).isNotNull();
+    assertThat(checkpoint.getFirstLogPosition()).isEqualTo(50L);
+    assertThat(checkpoint.getCheckpointPosition()).isEqualTo(100L);
+    assertThat(checkpoint.getCheckpointTimestamp()).isEqualTo(1000L);
+    assertThat(checkpoint.getCheckpointType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
+  }
+
+  @Test
+  void shouldRemoveCheckpoint() {
+    // given
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+
+    // when
+    state.removeCheckpoint(1L);
+
+    // then
+    assertThat(state.getCheckpoint(1L)).isNull();
+  }
+
+  @Test
+  void shouldRemoveNonExistentCheckpointSafely() {
+    // when/then — should not throw
+    state.removeCheckpoint(99L);
+  }
+
+  @Test
+  void shouldReturnNullForNonExistentCheckpoint() {
+    // when/then
+    assertThat(state.getCheckpoint(99L)).isNull();
+  }
+
+  @Test
+  void shouldReportEmptyWhenNoCheckpoints() {
+    // when/then
+    assertThat(state.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldReportNotEmptyAfterAddingCheckpoint() {
+    // given
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+
+    // when/then
+    assertThat(state.isEmpty()).isFalse();
+  }
+
+  @Test
+  void shouldFindPredecessorBackupCheckpoint() {
+    // given — 3 backups with a MARKER in between
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+    state.addBackupCheckpoint(3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 150L);
+
+    // when — looking for predecessor of checkpoint 3
+    final var predecessor = state.findPredecessorBackupCheckpoint(3L);
+
+    // then — should skip MARKER (2) and return SCHEDULED_BACKUP (1)
+    assertThat(predecessor).isPresent().hasValue(1L);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoPredecessor() {
+    // given
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+
+    // when
+    final var predecessor = state.findPredecessorBackupCheckpoint(1L);
+
+    // then
+    assertThat(predecessor).isEmpty();
+  }
+
+  @Test
+  void shouldSkipMarkersWhenFindingPredecessor() {
+    // given — all MARKERs before the target
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+    state.addBackupCheckpoint(3L, 300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 100L);
+
+    // when
+    final var predecessor = state.findPredecessorBackupCheckpoint(3L);
+
+    // then — no backup-type predecessors
+    assertThat(predecessor).isEmpty();
+  }
+
+  @Test
+  void shouldFindSuccessorBackupCheckpoint() {
+    // given — 3 checkpoints with MARKER in between
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+    state.addBackupCheckpoint(3L, 300L, 3000L, CheckpointType.MANUAL_BACKUP, 250L);
+
+    // when — looking for successor of checkpoint 1
+    final var successor = state.findSuccessorBackupCheckpoint(1L);
+
+    // then — should skip MARKER (2) and return MANUAL_BACKUP (3)
+    assertThat(successor).isPresent().hasValue(3L);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoSuccessor() {
+    // given
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+
+    // when
+    final var successor = state.findSuccessorBackupCheckpoint(1L);
+
+    // then
+    assertThat(successor).isEmpty();
+  }
+
+  @Test
+  void shouldSkipMarkersWhenFindingSuccessor() {
+    // given — all MARKERs after the target
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+    state.addMarkerCheckpoint(3L, 300L, 3000L);
+
+    // when
+    final var successor = state.findSuccessorBackupCheckpoint(1L);
+
+    // then — no backup-type successors
+    assertThat(successor).isEmpty();
+  }
+
+  @Test
+  void shouldGetAllCheckpointsInOrder() {
+    // given
+    state.addMarkerCheckpoint(3L, 300L, 3000L);
+    state.addMarkerCheckpoint(1L, 100L, 1000L);
+    state.addMarkerCheckpoint(2L, 200L, 2000L);
+
+    // when
+    final var all = state.getAllCheckpoints();
+
+    // then — ordered by checkpoint ID (key ordering)
+    assertThat(all).hasSize(3);
+    assertThat(all.get(0).checkpointId()).isEqualTo(1L);
+    assertThat(all.get(1).checkpointId()).isEqualTo(2L);
+    assertThat(all.get(2).checkpointId()).isEqualTo(3L);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoCheckpoints() {
+    // when/then
+    assertThat(state.getAllCheckpoints()).isEmpty();
+  }
+
+  @Test
+  void shouldPreserveAllFieldsInGetAllCheckpoints() {
+    // given
+    state.addBackupCheckpoint(1L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+
+    // when
+    final var all = state.getAllCheckpoints();
+
+    // then
+    assertThat(all).hasSize(1);
+    final var entry = all.get(0);
+    assertThat(entry.checkpointId()).isEqualTo(1L);
+    assertThat(entry.checkpointPosition()).isEqualTo(100L);
+    assertThat(entry.checkpointTimestamp()).isEqualTo(1000L);
+    assertThat(entry.checkpointType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
+    assertThat(entry.firstLogPosition()).isEqualTo(50L);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -269,7 +269,11 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
 
   CONDITIONAL_SUBSCRIPTION_BY_TENANT_ID(138, PARTITION_LOCAL),
 
-  PROCESS_INSTANCE_KEY_BY_BUSINESS_ID(139, PARTITION_LOCAL);
+  PROCESS_INSTANCE_KEY_BY_BUSINESS_ID(139, PARTITION_LOCAL),
+
+  // backup range tracking
+  CHECKPOINTS(140, PARTITION_LOCAL),
+  BACKUP_RANGES(141, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
# Description
Backport of #46457 to `stable/8.9`.

relates to #46441