### PR TITLE
fix: rate-limit job timeout re-pushes to prevent vicious circle amplification

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -88,7 +88,12 @@ public final class JobEventProcessors {
             ValueType.JOB,
             JobIntent.TIME_OUT,
             new JobTimeOutProcessor(
-                processingState, writers, jobMetrics, bpmnBehaviors.jobActivationBehavior(), clock))
+                processingState,
+                writers,
+                jobMetrics,
+                bpmnBehaviors.jobActivationBehavior(),
+                clock,
+                new JobTimeoutPushTracker()))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_RETRIES,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -34,19 +34,22 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
   private final JobProcessingMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final InstantSource clock;
+  private final JobTimeoutPushTracker pushTracker;
 
   public JobTimeOutProcessor(
       final ProcessingState state,
       final Writers writers,
       final JobProcessingMetrics jobMetrics,
       final BpmnJobActivationBehavior jobActivationBehavior,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final JobTimeoutPushTracker pushTracker) {
     jobState = state.getJobState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
     this.clock = clock;
+    this.pushTracker = pushTracker;
   }
 
   @Override
@@ -58,7 +61,13 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
     if (state == State.ACTIVATED && hasTimedOut(job)) {
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
       jobMetrics.countJobEvent(JobAction.TIMED_OUT, job.getJobKind(), job.getType());
-      jobActivationBehavior.publishWork(jobKey, job);
+
+      if (pushTracker.shouldPush(jobKey)) {
+        jobActivationBehavior.publishWork(jobKey, job);
+        pushTracker.recordPush(jobKey);
+      } else {
+        jobActivationBehavior.notifyJobAvailableAsSideEffect(job);
+      }
     } else {
       final var reason =
           switch (state) {
@@ -71,6 +80,11 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
       final String errorMessage = String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, reason);
       rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, errorMessage);
+
+      // Clean up tracking for jobs that are no longer activated
+      if (state != State.ACTIVATED) {
+        pushTracker.remove(jobKey);
+      }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutPushTracker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutPushTracker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import org.agrona.collections.LongHashSet;
+
+/**
+ * Tracks which jobs have already been re-pushed after a timeout, to prevent the "vicious circle"
+ * amplification pattern where repeated timeouts cause unbounded push growth.
+ *
+ * <p>Once a job has been re-pushed after timeout, subsequent timeouts for that job will use {@code
+ * notifyJobAvailableAsSideEffect()} instead of {@code publishWork()}, letting workers pick up the
+ * job via long-polling when they have capacity.
+ *
+ * <p>This state is transient (not persisted). On partition leader change or restart, the set is
+ * recreated empty — jobs get one fresh direct re-push. This is acceptable because the tracking is a
+ * best-effort optimization to limit amplification under backpressure.
+ *
+ * <p>Memory is bounded by {@code maxTrackedJobs}. When the set exceeds this limit, all entries are
+ * cleared — jobs get one fresh direct re-push. This prevents unbounded memory growth from completed
+ * jobs whose entries would otherwise never be cleaned up.
+ *
+ * <p>Uses Agrona's {@link LongHashSet} to store primitive longs without boxing overhead. The set
+ * uses open addressing with a 0.65 load factor, so the backing {@code long[]} array is ~1.5x the
+ * entry count (rounded to next power of 2). At the default limit of 100,000 entries, the backing
+ * array is 262,144 longs = ~2 MB — significantly less than a boxed {@code HashSet<Long>} which
+ * would use ~4-5 MB for the same number of entries.
+ */
+public final class JobTimeoutPushTracker {
+
+  private static final int DEFAULT_MAX_TRACKED_JOBS = 100_000;
+
+  private final LongHashSet pushedJobs = new LongHashSet();
+  private final int maxTrackedJobs;
+
+  public JobTimeoutPushTracker() {
+    this(DEFAULT_MAX_TRACKED_JOBS);
+  }
+
+  public JobTimeoutPushTracker(final int maxTrackedJobs) {
+    this.maxTrackedJobs = maxTrackedJobs;
+  }
+
+  /** Returns true if the job has not yet been re-pushed after a timeout. */
+  public boolean shouldPush(final long jobKey) {
+    return !pushedJobs.contains(jobKey);
+  }
+
+  /** Mark a job as having been re-pushed after timeout. */
+  public void recordPush(final long jobKey) {
+    if (pushedJobs.size() >= maxTrackedJobs) {
+      // Clear all entries to bound memory. Jobs get one fresh direct re-push.
+      // This is safe because the tracking is best-effort: the worst case is
+      // a single extra direct re-push per job until it's tracked again.
+      pushedJobs.clear();
+    }
+    pushedJobs.add(jobKey);
+  }
+
+  /** Remove tracking for a job (e.g., when the job is no longer activatable). */
+  public void remove(final long jobKey) {
+    pushedJobs.remove(jobKey);
+  }
+
+  /** Returns the number of currently tracked jobs. Intended for testing and metrics. */
+  public int size() {
+    return pushedJobs.size();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -257,6 +257,86 @@ public class ActivatableJobsPushTest {
     assertActivatedJobsPushed(jobKey, activationCount);
   }
 
+  @Test
+  public void shouldNotTimeOutYieldedJob() {
+    // given - create and activate a job
+    final long jobKey = createJob(jobType, PROCESS_ID, variables);
+    assertActivatedJobsPushed(jobKey, 1);
+
+    // when - yield the job (state → ACTIVATABLE, deadline removed from index)
+    ENGINE.job().withKey(jobKey).yield();
+    jobRecords(JobIntent.YIELDED).withType(jobType).await();
+
+    // and - advance time past the original deadline
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+
+    // then - no timeout should occur because:
+    // 1. Yield removed the deadline from the deadline column family
+    // 2. Even if a stale TIME_OUT command existed, the state check (ACTIVATABLE != ACTIVATED)
+    //    would reject it
+    //
+    // Use a second job creation as a synchronization point to ensure the timeout check has run
+    createJob(jobType, PROCESS_ID, variables);
+    await("waiting for second job to be pushed")
+        .atMost(MAX_WAIT_TIME_FOR_ACTIVATED_JOBS)
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(2));
+
+    // Verify no TIMED_OUT event was generated for the yielded job
+    assertThat(jobRecords(TIMED_OUT).withType(jobType).exists()).isFalse();
+  }
+
+  @Test
+  public void shouldLimitTimeoutRepushAmplification() {
+    // given - create 1 job, which triggers 1 push
+    final long jobKey = createJob(jobType, PROCESS_ID, variables);
+    assertActivatedJobsPushed(jobKey, 1); // 1 push for 1 creation
+
+    // when - first timeout: gets one direct re-push
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    jobRecords(TIMED_OUT).withType(jobType).limit(1).await();
+    assertActivatedJobsPushed(jobKey, 2); // creation + 1 re-push
+
+    // when - second timeout occurs
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    jobRecords(TIMED_OUT).withType(jobType).limit(2).await();
+
+    // when - third timeout occurs
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    jobRecords(TIMED_OUT).withType(jobType).limit(3).await();
+
+    // then - amplification is capped: only 2 direct pushes (creation + 1 re-push)
+    // despite 3 timeouts. Without the tracker, this would be 4 pushes.
+    assertThat(jobStream.getActivatedJobs()).hasSize(2);
+  }
+
+  @Test
+  public void shouldStopDirectPushAfterFirstTimeoutRepush() {
+    // given - create a job (1 direct push on creation)
+    final long jobKey = createJob(jobType, PROCESS_ID, variables);
+    assertActivatedJobsPushed(jobKey, 1);
+
+    // when - first timeout: job gets one direct re-push
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    jobRecords(TIMED_OUT).withType(jobType).limit(1).await();
+    assertActivatedJobsPushed(jobKey, 2); // creation + 1 re-push
+
+    // when - second timeout: should NOT produce another direct push
+    // because the job was already re-pushed once after timeout
+    ENGINE.increaseTime(
+        Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    jobRecords(TIMED_OUT).withType(jobType).limit(2).await();
+
+    // then - push count stays at 2 (no new direct push)
+    // The job was notified via notifyJobAvailableAsSideEffect instead
+    assertThat(jobStream.getActivatedJobs()).hasSize(2);
+  }
+
   private List<Long> createJobs(final int amount) {
     return IntStream.range(0, amount)
         .mapToObj(i -> createJob(jobType, PROCESS_ID, variables))


### PR DESCRIPTION


## Description
When workers can't keep up, each job timeout generates another direct push via publishWork(), creating unbounded amplification (1 job → N pushes after N-1 timeouts). This overwhelms workers further, causing more timeouts in a positive feedback loop.

Introduce JobTimeoutPushTracker (in-memory LongHashSet, per partition) that allows one direct re-push per job after timeout. Subsequent timeouts fall back to notifyJobAvailableAsSideEffect(), letting workers pick up the job via long-polling when they have capacity.

The tracker is bounded at 100K entries (~2MB) and cleared on overflow or leader change. This is a best-effort optimization — the worst case is a single extra direct re-push per job when the tracker resets.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
