### PR TITLE
build: module do not read files from other modules

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -113,6 +113,13 @@
       <artifactId>zeebe-gateway-grpc</artifactId>
     </dependency>
 
+    <!-- required to unpack OpenAPI specs at build time -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-protocol</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-restore</artifactId>
@@ -983,7 +990,7 @@
               <outputDirectory>${project.build.directory}/camunda-zeebe/config/openapi/v2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.basedir}/../zeebe/gateway-protocol/src/main/proto/v2</directory>
+                  <directory>${project.build.directory}/v2</directory>
                   <includes>
                     <include>**/*.yaml</include>
                   </includes>
@@ -1018,6 +1025,25 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-openapi-yaml</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <includes>v2/**</includes>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
         <configuration>
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1025,25 +1025,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-openapi-yaml</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>io.camunda</groupId>
-                  <artifactId>zeebe-gateway-protocol</artifactId>
-                  <includes>v2/**</includes>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
         <configuration>
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
@@ -1094,6 +1075,25 @@
             <dep>io.camunda.optimize:optimize-webjar</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
+        <executions>
+          <execution>
+            <id>unpack-openapi-yaml</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <includes>v2/**</includes>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -19,11 +19,13 @@
   <packaging>jar</packaging>
   <name>Camunda Gateway Model</name>
 
-  <properties>
-    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</openapi.dir>
-  </properties>
-
   <dependencies>
+    <!-- required to unpack OpenAPI specs at build time -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-protocol</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- required for OpenAPI model generation -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -82,7 +84,7 @@
               <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
               <generatorName>spring</generatorName>
               <templateDirectory>${project.basedir}/src/main/resources/templates/java-spring/advanced</templateDirectory>
-              <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
+              <inputSpec>${project.build.directory}/v2/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.gateway.protocol.model</modelPackage>
               <typeMappings>
                 <!-- map OffsetDateTime to String to avoid timezone issues and do validation manually -->
@@ -135,7 +137,7 @@
               <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
               <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md -->
               <generatorName>spring</generatorName>
-              <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
+              <inputSpec>${project.build.directory}/v2/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.gateway.protocol.model.simple</modelPackage>
               <templateDirectory>${project.basedir}/src/main/resources/templates/java-spring/simple</templateDirectory>
               <typeMappings>
@@ -271,6 +273,25 @@
             <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
           </usedDependencies>
         </configuration>
+        <executions>
+          <execution>
+            <id>unpack-openapi-specs</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <includes>v2/**</includes>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -23,7 +23,6 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <proto.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto</proto.dir>
   </properties>
 
   <dependencies>
@@ -86,12 +85,35 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-proto-sources</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.camunda</groupId>
+                  <artifactId>zeebe-gateway-protocol</artifactId>
+                  <includes>**/*.proto</includes>
+                  <outputDirectory>${project.build.directory}/proto</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- generate Java protobuf code -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
-          <protoSourceRoot>${proto.dir}</protoSourceRoot>
+          <protoSourceRoot>${project.build.directory}/proto</protoSourceRoot>
         </configuration>
       </plugin>
     </plugins>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -19,10 +19,6 @@
   <packaging>jar</packaging>
   <name>Zeebe Gateway REST API server</name>
 
-  <properties>
-    <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</openapi.dir>
-  </properties>
-
   <dependencies>
 
     <!-- required to guarantee the protocol is processed earlier during the build -->


### PR DESCRIPTION
## Description
Gateway modules were reading protobuf & openapi specs file directly from other modules source files.
This has been replaced by putting the files in the source module's jar and it being unpacked by the dependant module. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
