### PR TITLE
feat: auto-generate no-op patch-to-patch upgrade plans

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlan.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlan.java
@@ -49,4 +49,16 @@ public class UpgradePlan {
   public void setFromVersion(final Semver fromVersion) {
     this.fromVersion = fromVersion;
   }
+
+  @Override
+  public String toString() {
+    return "UpgradePlan("
+        + "from="
+        + fromVersion
+        + ", to="
+        + toVersion
+        + ", steps="
+        + upgradeSteps
+        + ')';
+  }
 }

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistry.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistry.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.optimize.upgrade.plan;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.vdurmont.semver4j.Semver;
+import io.camunda.optimize.service.metadata.Version;
 import io.camunda.optimize.upgrade.exception.UpgradeRuntimeException;
 import io.camunda.optimize.upgrade.plan.factories.CurrentVersionNoOperationUpgradePlanFactory;
 import io.camunda.optimize.upgrade.plan.factories.UpgradePlanFactory;
@@ -63,10 +65,54 @@ public class UpgradePlanRegistry {
                 }
               });
     }
+
+    // Generate patch plans up to the compiled-in version. Plans beyond the actual target
+    // version (if different) are harmlessly filtered by `getSequentialUpgradePlansToTargetVersion`.
+    generateMissingPatchUpgradePlans(Version.VERSION);
   }
 
-  public UpgradePlanRegistry(final Map<Semver, UpgradePlan> upgradePlans) {
+  @VisibleForTesting
+  UpgradePlanRegistry(final Map<Semver, UpgradePlan> upgradePlans) {
     this.upgradePlans = upgradePlans;
+  }
+
+  /**
+   * Auto-generates no-op upgrade plans for missing patch-to-patch transitions within the current
+   * minor version. For example, if the current version is {@code 8.9.3}, this method ensures that
+   * plans for {@code 8.9.0 -> 8.9.1}, {@code 8.9.1 -> 8.9.2}, and {@code 8.9.2 -> 8.9.3} exist.
+   * Plans already registered by explicit {@link UpgradePlanFactory} implementations are never
+   * overwritten — only missing gaps are filled with no-op plans.
+   *
+   * <p>This eliminates the need to manually create boilerplate per-patch factory classes that
+   * contain no real migration logic.
+   *
+   * @param currentVersion the current application version string (e.g. {@code "8.9.3"})
+   */
+  @VisibleForTesting
+  void generateMissingPatchUpgradePlans(final String currentVersion) {
+    final var version = new Semver(currentVersion);
+    final int major = version.getMajor();
+    final int minor = version.getMinor();
+    final int currentPatch = version.getPatch();
+
+    if (currentPatch == 0) {
+      return;
+    }
+
+    for (int patch = 1; patch <= currentPatch; patch++) {
+      final var toVersion = new Semver(major + "." + minor + "." + patch);
+      if (!upgradePlans.containsKey(toVersion)) {
+        final var from = major + "." + minor + "." + (patch - 1);
+        final var to = major + "." + minor + "." + patch;
+        final var noOpPlan =
+            UpgradePlanBuilder.createUpgradePlan().fromVersion(from).toVersion(to).build();
+        upgradePlans.put(toVersion, noOpPlan);
+        LOG.debug(
+            "Auto-generated no-op patch upgrade plan from {} to {} (no explicit factory found).",
+            from,
+            to);
+      }
+    }
   }
 
   public List<UpgradePlan> getSequentialUpgradePlansToTargetVersion(final String targetVersion) {

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistry.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistry.java
@@ -78,10 +78,31 @@ public class UpgradePlanRegistry {
 
   /**
    * Auto-generates no-op upgrade plans for missing patch-to-patch transitions within the current
-   * minor version. For example, if the current version is {@code 8.9.3}, this method ensures that
-   * plans for {@code 8.9.0 -> 8.9.1}, {@code 8.9.1 -> 8.9.2}, and {@code 8.9.2 -> 8.9.3} exist.
-   * Plans already registered by explicit {@link UpgradePlanFactory} implementations are never
-   * overwritten — only missing gaps are filled with no-op plans.
+   * minor version, while respecting explicit version jumps.
+   *
+   * <p>The algorithm walks backwards from {@code currentPatch} down to {@code 1}. At each step it
+   * looks up whether an explicit plan already targets {@code major.minor.patch}. If one is found,
+   * the loop jumps directly to {@code fromVersion.patch}, skipping the entire covered range without
+   * generating any intermediate plans. If no plan is found, a no-op plan is inserted for that
+   * single step and the counter decrements by one.
+   *
+   * <p>For example, given an explicit jump plan {@code 8.8.2 -> 8.8.10} with current version {@code
+   * 8.8.12}, the backward walk proceeds as follows:
+   *
+   * <ul>
+   *   <li>patch 12 - no plan -> auto-generate {@code 8.8.11->8.8.12}, decrement to 11
+   *   <li>patch 11 - no plan -> auto-generate {@code 8.8.10->8.8.11}, decrement to 10
+   *   <li>patch 10 - explicit plan {@code 8.8.2->8.8.10} found → jump to patch 2
+   *   <li>patch 2 - no plan -> auto-generate {@code 8.8.1->8.8.2}, decrement to 1
+   *   <li>patch 1 - no plan -> auto-generate {@code 8.8.0->8.8.1}, decrement to 0
+   *   <li>patch 0 - loop ends
+   * </ul>
+   *
+   * <p>Patches {@code 8.8.3} through {@code 8.8.9} are never visited and no plans are generated for
+   * them.
+   *
+   * <p>Plans already registered by explicit {@link UpgradePlanFactory} implementations are never
+   * overwritten - only missing gaps are filled with no-op plans.
    *
    * <p>This eliminates the need to manually create boilerplate per-patch factory classes that
    * contain no real migration logic.
@@ -99,9 +120,23 @@ public class UpgradePlanRegistry {
       return;
     }
 
-    for (int patch = 1; patch <= currentPatch; patch++) {
+    int patch = currentPatch;
+    while (patch > 0) {
       final var toVersion = new Semver(major + "." + minor + "." + patch);
-      if (!upgradePlans.containsKey(toVersion)) {
+      final var plan = upgradePlans.get(toVersion);
+      if (plan != null) {
+        // Explicit plan found - jump to its fromVersion patch, skipping the covered range
+        LOG.debug(
+            "Explicit plan spans {}.{}.{} -> {}.{}.{}, skipping auto-generation for this range.",
+            major,
+            minor,
+            plan.getFromVersion().getPatch(),
+            major,
+            minor,
+            patch);
+        patch = plan.getFromVersion().getPatch();
+      } else {
+        // No plan for this patch - generate a no-op step and move one patch down
         final var from = major + "." + minor + "." + (patch - 1);
         final var to = major + "." + minor + "." + patch;
         final var noOpPlan =
@@ -111,6 +146,7 @@ public class UpgradePlanRegistry {
             "Auto-generated no-op patch upgrade plan from {} to {} (no explicit factory found).",
             from,
             to);
+        patch--;
       }
     }
   }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
@@ -126,6 +126,89 @@ public class UpgradePlanRegistryTest {
             plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"));
   }
 
+  @Test
+  void versionJumpSkipsUnreleasedPatches() {
+    // given: jump from 8.8.2->8.8.10
+    final var targetVersion = "8.8.12";
+    final var jumpPlan = createUpgradePlan("8.8.2", "8.8.10");
+    final var existingPlans = new HashMap<Semver, UpgradePlan>();
+    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+    final var registry = new UpgradePlanRegistry(existingPlans);
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then: no plans for 8.8.3 through 8.8.9
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as("Should generate chain with jump: auto 0->1->2, jump 2->10, auto 10->11->12")
+        .satisfiesExactly(
+            plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
+            plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
+            plan882to8810 -> {
+              assertThat(plan882to8810.getFromVersion().getOriginalValue()).isEqualTo("8.8.2");
+              assertThat(plan882to8810.getToVersion().getOriginalValue()).isEqualTo("8.8.10");
+              assertThat(plan882to8810).isSameAs(jumpPlan);
+            },
+            plan8810to8811 -> assertNoOpPlan(plan8810to8811, "8.8.10", "8.8.11"),
+            plan8811to8812 -> assertNoOpPlan(plan8811to8812, "8.8.11", "8.8.12"));
+  }
+
+  @Test
+  void jumpToCurrentVersionGeneratesNoPlansBeyondJump() {
+    // given: jump plan from 8.8.3->8.8.7
+    final var targetVersion = "8.8.7";
+    final var jumpPlan = createUpgradePlan("8.8.3", targetVersion);
+    final var existingPlans = new HashMap<Semver, UpgradePlan>();
+    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+
+    final var registry = new UpgradePlanRegistry(existingPlans);
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then: auto 0->1->2->3, jump 3->7, no 8.8.4/5/6
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as("Should generate chain ending with jump: auto 0->1->2->3, then jump 3->7")
+        .satisfiesExactly(
+            plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
+            plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
+            plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"),
+            plan883to887 -> {
+              assertThat(plan883to887.getFromVersion().getOriginalValue()).isEqualTo("8.8.3");
+              assertThat(plan883to887.getToVersion().getOriginalValue()).isEqualTo("8.8.7");
+              assertThat(plan883to887).isSameAs(jumpPlan);
+            });
+  }
+
+  @Test
+  void jumpFromPatchZeroGeneratesNoPlanBeforeJump() {
+    // given: jump plan from 8.8.0->8.8.5
+    final var targetVersion = "8.8.7";
+    final var jumpPlan = createUpgradePlan("8.8.0", "8.8.5");
+    final var existingPlans = new HashMap<Semver, UpgradePlan>();
+    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+
+    final var registry = new UpgradePlanRegistry(existingPlans);
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then: jump 0->5, auto 5->6->7, no 8.8.1/2/3/4
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as("Should generate chain starting with jump: jump 0->5, then auto 5->6->7")
+        .satisfiesExactly(
+            plan880to885 -> {
+              assertThat(plan880to885.getFromVersion().getOriginalValue()).isEqualTo("8.8.0");
+              assertThat(plan880to885.getToVersion().getOriginalValue()).isEqualTo("8.8.5");
+              assertThat(plan880to885).isSameAs(jumpPlan);
+            },
+            plan885to886 -> assertNoOpPlan(plan885to886, "8.8.5", "8.8.6"),
+            plan886to887 -> assertNoOpPlan(plan886to887, "8.8.6", "8.8.7"));
+  }
+
   private UpgradePlan createUpgradePlan(final String fromVersion, final String toVersion) {
     return UpgradePlanBuilder.createUpgradePlan()
         .fromVersion(fromVersion)

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
@@ -60,9 +60,9 @@ public class UpgradePlanRegistryTest {
   void explicitPlanInMiddleIsPreserved() {
     // given: explicit factory for 8.8.2 -> 8.8.3
     final var targetVersion = "8.8.5";
-    final var explicitPlan = createUpgradePlan("8.8.2", "8.8.3");
+    final var explicitPlan882to883 = createUpgradePlan("8.8.2", "8.8.3");
     final var existingPlans = new HashMap<Semver, UpgradePlan>();
-    existingPlans.put(explicitPlan.getToVersion(), explicitPlan);
+    existingPlans.put(explicitPlan882to883.getToVersion(), explicitPlan882to883);
 
     final var registry = new UpgradePlanRegistry(existingPlans);
 
@@ -76,10 +76,7 @@ public class UpgradePlanRegistryTest {
         .satisfiesExactly(
             plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
             plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
-            explicitPlan882to883 -> {
-              assertNoOpPlan(explicitPlan882to883, "8.8.2", "8.8.3");
-              assertThat(explicitPlan882to883).isSameAs(explicitPlan);
-            },
+            plan882to883 -> assertThat(plan882to883).isSameAs(explicitPlan882to883),
             plan883to884 -> assertNoOpPlan(plan883to884, "8.8.3", "8.8.4"),
             plan884to885 -> assertNoOpPlan(plan884to885, "8.8.4", "8.8.5"));
   }
@@ -102,9 +99,9 @@ public class UpgradePlanRegistryTest {
   void crossMinorPlanInMapIsNotAffected() {
     // given: a cross-minor plan 8.7 -> 8.8.0 already in the map
     final var targetVersion = "8.8.3";
-    final var crossMinorPlan = createUpgradePlan("8.7", "8.8.0");
+    final var crossMinorPlan87to880 = createUpgradePlan("8.7", "8.8.0");
     final var existingPlans = new HashMap<Semver, UpgradePlan>();
-    existingPlans.put(crossMinorPlan.getToVersion(), crossMinorPlan);
+    existingPlans.put(crossMinorPlan87to880.getToVersion(), crossMinorPlan87to880);
 
     final var registry = new UpgradePlanRegistry(existingPlans);
 
@@ -117,10 +114,7 @@ public class UpgradePlanRegistryTest {
         .as(
             "Should preserve the existing cross-minor plan from 8.7 to 8.8.0, and generate patch plans from 8.8.0 to 8.8.3")
         .satisfiesExactly(
-            plan87to880 -> {
-              assertNoOpPlan(plan87to880, "8.7", "8.8.0");
-              assertThat(plan87to880).isSameAs(crossMinorPlan);
-            },
+            plan87to880 -> assertThat(plan87to880).isSameAs(crossMinorPlan87to880),
             plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
             plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
             plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"));
@@ -130,9 +124,9 @@ public class UpgradePlanRegistryTest {
   void versionJumpSkipsUnreleasedPatches() {
     // given: jump from 8.8.2->8.8.10
     final var targetVersion = "8.8.12";
-    final var jumpPlan = createUpgradePlan("8.8.2", "8.8.10");
+    final var jumpPlan882to8810 = createUpgradePlan("8.8.2", "8.8.10");
     final var existingPlans = new HashMap<Semver, UpgradePlan>();
-    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+    existingPlans.put(jumpPlan882to8810.getToVersion(), jumpPlan882to8810);
     final var registry = new UpgradePlanRegistry(existingPlans);
 
     // when
@@ -145,11 +139,7 @@ public class UpgradePlanRegistryTest {
         .satisfiesExactly(
             plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
             plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
-            plan882to8810 -> {
-              assertThat(plan882to8810.getFromVersion().getOriginalValue()).isEqualTo("8.8.2");
-              assertThat(plan882to8810.getToVersion().getOriginalValue()).isEqualTo("8.8.10");
-              assertThat(plan882to8810).isSameAs(jumpPlan);
-            },
+            plan882to8810 -> assertThat(plan882to8810).isSameAs(jumpPlan882to8810),
             plan8810to8811 -> assertNoOpPlan(plan8810to8811, "8.8.10", "8.8.11"),
             plan8811to8812 -> assertNoOpPlan(plan8811to8812, "8.8.11", "8.8.12"));
   }
@@ -158,9 +148,9 @@ public class UpgradePlanRegistryTest {
   void jumpToCurrentVersionGeneratesNoPlansBeyondJump() {
     // given: jump plan from 8.8.3->8.8.7
     final var targetVersion = "8.8.7";
-    final var jumpPlan = createUpgradePlan("8.8.3", targetVersion);
+    final var jumpPlan883to887 = createUpgradePlan("8.8.3", targetVersion);
     final var existingPlans = new HashMap<Semver, UpgradePlan>();
-    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+    existingPlans.put(jumpPlan883to887.getToVersion(), jumpPlan883to887);
 
     final var registry = new UpgradePlanRegistry(existingPlans);
 
@@ -175,20 +165,16 @@ public class UpgradePlanRegistryTest {
             plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
             plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
             plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"),
-            plan883to887 -> {
-              assertThat(plan883to887.getFromVersion().getOriginalValue()).isEqualTo("8.8.3");
-              assertThat(plan883to887.getToVersion().getOriginalValue()).isEqualTo("8.8.7");
-              assertThat(plan883to887).isSameAs(jumpPlan);
-            });
+            plan883to887 -> assertThat(plan883to887).isSameAs(jumpPlan883to887));
   }
 
   @Test
   void jumpFromPatchZeroGeneratesNoPlanBeforeJump() {
     // given: jump plan from 8.8.0->8.8.5
     final var targetVersion = "8.8.7";
-    final var jumpPlan = createUpgradePlan("8.8.0", "8.8.5");
+    final var jumpPlan880to885 = createUpgradePlan("8.8.0", "8.8.5");
     final var existingPlans = new HashMap<Semver, UpgradePlan>();
-    existingPlans.put(jumpPlan.getToVersion(), jumpPlan);
+    existingPlans.put(jumpPlan880to885.getToVersion(), jumpPlan880to885);
 
     final var registry = new UpgradePlanRegistry(existingPlans);
 
@@ -203,7 +189,7 @@ public class UpgradePlanRegistryTest {
             plan880to885 -> {
               assertThat(plan880to885.getFromVersion().getOriginalValue()).isEqualTo("8.8.0");
               assertThat(plan880to885.getToVersion().getOriginalValue()).isEqualTo("8.8.5");
-              assertThat(plan880to885).isSameAs(jumpPlan);
+              assertThat(plan880to885).isSameAs(jumpPlan880to885);
             },
             plan885to886 -> assertNoOpPlan(plan885to886, "8.8.5", "8.8.6"),
             plan886to887 -> assertNoOpPlan(plan886to887, "8.8.6", "8.8.7"));

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/plan/UpgradePlanRegistryTest.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.upgrade.plan;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vdurmont.semver4j.Semver;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -36,10 +37,106 @@ public class UpgradePlanRegistryTest {
         .containsExactly("3.8.0", "3.8.1");
   }
 
+  @Test
+  void noExplicitPatchPlansGeneratesFullChain() {
+    // given: no explicit patch plans
+    final var targetVersion = "8.8.3";
+    final var registry = new UpgradePlanRegistry(new HashMap<>());
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as("Should generate a full chain of patch upgrade plans from 8.8.0 to 8.8.3")
+        .satisfiesExactly(
+            plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
+            plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
+            plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"));
+  }
+
+  @Test
+  void explicitPlanInMiddleIsPreserved() {
+    // given: explicit factory for 8.8.2 -> 8.8.3
+    final var targetVersion = "8.8.5";
+    final var explicitPlan = createUpgradePlan("8.8.2", "8.8.3");
+    final var existingPlans = new HashMap<Semver, UpgradePlan>();
+    existingPlans.put(explicitPlan.getToVersion(), explicitPlan);
+
+    final var registry = new UpgradePlanRegistry(existingPlans);
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as("Should generate patch plans for missing versions, but preserve the explicit plan")
+        .satisfiesExactly(
+            plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
+            plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
+            explicitPlan882to883 -> {
+              assertNoOpPlan(explicitPlan882to883, "8.8.2", "8.8.3");
+              assertThat(explicitPlan882to883).isSameAs(explicitPlan);
+            },
+            plan883to884 -> assertNoOpPlan(plan883to884, "8.8.3", "8.8.4"),
+            plan884to885 -> assertNoOpPlan(plan884to885, "8.8.4", "8.8.5"));
+  }
+
+  @Test
+  void patchZeroGeneratesNoPatchPlans() {
+    // given
+    final var targetVersion = "8.9.0";
+    final var registry = new UpgradePlanRegistry(new HashMap<>());
+
+    // when
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans).as("No patch plans should be generated for patch version 0").isEmpty();
+  }
+
+  @Test
+  void crossMinorPlanInMapIsNotAffected() {
+    // given: a cross-minor plan 8.7 -> 8.8.0 already in the map
+    final var targetVersion = "8.8.3";
+    final var crossMinorPlan = createUpgradePlan("8.7", "8.8.0");
+    final var existingPlans = new HashMap<Semver, UpgradePlan>();
+    existingPlans.put(crossMinorPlan.getToVersion(), crossMinorPlan);
+
+    final var registry = new UpgradePlanRegistry(existingPlans);
+
+    // when: auto-generating for version 8.8.3
+    registry.generateMissingPatchUpgradePlans(targetVersion);
+
+    // then: cross-minor plan is preserved, plus 3 auto-generated patch plans
+    final var plans = registry.getSequentialUpgradePlansToTargetVersion(targetVersion);
+    assertThat(plans)
+        .as(
+            "Should preserve the existing cross-minor plan from 8.7 to 8.8.0, and generate patch plans from 8.8.0 to 8.8.3")
+        .satisfiesExactly(
+            plan87to880 -> {
+              assertNoOpPlan(plan87to880, "8.7", "8.8.0");
+              assertThat(plan87to880).isSameAs(crossMinorPlan);
+            },
+            plan880to881 -> assertNoOpPlan(plan880to881, "8.8.0", "8.8.1"),
+            plan881to882 -> assertNoOpPlan(plan881to882, "8.8.1", "8.8.2"),
+            plan882to883 -> assertNoOpPlan(plan882to883, "8.8.2", "8.8.3"));
+  }
+
   private UpgradePlan createUpgradePlan(final String fromVersion, final String toVersion) {
     return UpgradePlanBuilder.createUpgradePlan()
         .fromVersion(fromVersion)
         .toVersion(toVersion)
         .build();
+  }
+
+  private void assertNoOpPlan(
+      final UpgradePlan plan, final String fromVersion, final String toVersion) {
+    assertThat(plan.getFromVersion().getOriginalValue()).isEqualTo(fromVersion);
+    assertThat(plan.getToVersion().getOriginalValue()).isEqualTo(toVersion);
+    assertThat(plan.getUpgradeSteps()).isEmpty();
   }
 }


### PR DESCRIPTION
## Description

Eliminate the need for manually creating boilerplate per-patch no-op `UpgradePlanFactory` classes (e.g., `Upgrade880to881PlanFactory`, `Upgrade881to882PlanFactory`, ...) by auto-generating missing patch-to-patch transitions directly in `UpgradePlanRegistry`.

### Problem

Every Optimize patch release currently requires someone to manually add a no-op factory class that simply chains versions (e.g., `fromVersion("8.8.0").toVersion("8.8.1")`). This is error-prone and slows down releases.

### Solution

After scanning explicit `UpgradePlanFactory` implementations via ClassGraph, the registry now auto-generates a chain of no-op plans from `X.Y.0` to `X.Y.currentPatch` for the current minor version.

Key behaviors:
- **Explicit factories always win** — if a factory with real migration steps exists for a given `toVersion`, it is never overwritten.
- **Version jumps are respected** — when an explicit plan spans multiple patches (e.g., `8.8.5 -> 8.8.13` for the [unified release cadence jump](https://github.com/camunda/camunda/issues/45791)), no intermediate plans are generated for unreleased versions (`8.8.6` - `8.8.12`).
- **No changes to existing behavior** — the `CurrentVersionNoOperationUpgradePlanFactory` (cross-minor plan) and `UpgradeValidationService` remain unchanged.

### What's NOT in this PR

- Removal of `PreviousVersion.java` / `project.previousVersion` POM property - separate follow-up PR

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #40258 
