### PR TITLE
[Backport stable/8.9] fix: add missing type to incident enum schemas

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -293,6 +293,7 @@ components:
 
     IncidentErrorTypeEnum:
       description: Incident error type with a defined set of values.
+      type: string
       enum:
         - AD_HOC_SUB_PROCESS_NO_RETRIES
         - CALLED_DECISION_ERROR
@@ -353,6 +354,7 @@ components:
 
     IncidentStateEnum:
       description: Incident states with a defined set of values.
+      type: string
       enum:
         - ACTIVE
         - MIGRATED


### PR DESCRIPTION
# Description
Backport of #46426 to `stable/8.9`.

relates to #30674