### PR TITLE
43190 add global listeners to camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -40,6 +40,7 @@ import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
 import io.camunda.client.api.command.CreateDocumentCommandStep1;
 import io.camunda.client.api.command.CreateDocumentLinkCommandStep1;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.CreateGroupCommandStep1;
 import io.camunda.client.api.command.CreateMappingRuleCommandStep1;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
@@ -49,6 +50,7 @@ import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDecisionInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
+import io.camunda.client.api.command.DeleteGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
 import io.camunda.client.api.command.DeleteProcessInstanceCommandStep1;
@@ -93,6 +95,7 @@ import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
+import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
 import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
@@ -113,6 +116,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetRequest;
 import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
+import io.camunda.client.api.fetch.GlobalTaskListenerGetRequest;
 import io.camunda.client.api.fetch.GloballyScopedClusterVariableGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
@@ -146,6 +150,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.GlobalTaskListenerSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
@@ -3293,4 +3298,82 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a resource content
    */
   ResourceContentGetRequest newResourceContentGetRequest(long resourceKey);
+
+  /**
+   * Creates a request to create a new global task listener.
+   *
+   * <pre>
+   *   GlobalTaskListenerResponse response = camundaClient
+   *       .newCreateGlobalTaskListenerRequest()
+   *       .id("my-listener")
+   *       .type("my-job-type")
+   *       .eventTypes(GlobalTaskListenerEventType.ALL)
+   *       .send()
+   *       .join();
+   * </pre>
+   *
+   * @return a builder for creating a global task listener
+   */
+  CreateGlobalTaskListenerCommandStep1 newCreateGlobalTaskListenerRequest();
+
+  /**
+   * Creates a request to update an existing global task listener.
+   *
+   * <pre>
+   *   GlobalTaskListenerResponse response = camundaClient
+   *       .newUpdateGlobalTaskListenerRequest("my-listener")
+   *       .type("my-job-type")
+   *       .eventTypes(GlobalTaskListenerEventType.ALL)
+   *       .send()
+   *       .join();
+   * </pre>
+   *
+   * @param id the id of the global listener to update
+   * @return a builder for updating a global task listener
+   */
+  UpdateGlobalTaskListenerCommandStep1 newUpdateGlobalTaskListenerRequest(final String id);
+
+  /**
+   * Creates a request to delete a global task listener.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newDeleteGlobalTaskListenerRequest("my-listener")
+   *       .send();
+   * </pre>
+   *
+   * @param id the id of the global listener to delete
+   * @return a builder for deleting a global task listener
+   */
+  DeleteGlobalTaskListenerCommandStep1 newDeleteGlobalTaskListenerRequest(final String id);
+
+  /**
+   * Creates a request to fetch a global task listener by id.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newGlobalTaskListenerGetRequest("my-listener")
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for fetching a global task listener
+   */
+  GlobalTaskListenerGetRequest newGlobalTaskListenerGetRequest(final String id);
+
+  /**
+   * Creates a request to search for global task listeners.
+   *
+   * <p>Global task listeners can be searched with filtering and sorting capabilities:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newGlobalTaskListenerSearchRequest()
+   *       .filter(f -> f.source(GlobalListenerSource.CONFIGURATION))
+   *       .sort(s -> s.priority().desc())
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for searching global task listeners
+   */
+  GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateGlobalTaskListenerCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateGlobalTaskListenerCommandStep1.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.GlobalTaskListenerResponse;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import java.util.List;
+
+/**
+ * Represents a request to create a global task listener.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   GlobalTaskListenerResponse response = camundaClient
+ *       .newCreateGlobalTaskListenerRequest()
+ *       .id("my-listener")
+ *       .type("my-job-type")
+ *       .eventTypes(GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface CreateGlobalTaskListenerCommandStep1 {
+
+  /**
+   * Sets the ID of the global listener.
+   *
+   * @param id the ID of the global listener. Must not be null or empty.
+   * @return this builder for method chaining
+   */
+  CreateGlobalTaskListenerCommandStep2 id(String id);
+
+  interface CreateGlobalTaskListenerCommandStep2 {
+    /**
+     * Sets the job type of the global listener.
+     *
+     * @param type the name of the job type, used as a reference to specify which job workers
+     *     request the respective listener job. Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep3 type(String type);
+  }
+
+  interface CreateGlobalTaskListenerCommandStep3 {
+
+    /**
+     * Sets the user task event types supported by the global listener.
+     *
+     * @param eventTypes list of user task event types that trigger the listener. Must not be null
+     *     or empty.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 eventTypes(List<GlobalTaskListenerEventType> eventTypes);
+
+    /**
+     * Sets the user task event types supported by the global listener.
+     *
+     * @param eventTypes list of user task event types that trigger the listener. Must not be null
+     *     or empty.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 eventTypes(GlobalTaskListenerEventType... eventTypes);
+
+    /**
+     * Adds support for a user task event type to the global listener.
+     *
+     * @param eventType user task event types that should trigger the listener. Must not be null.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 eventType(GlobalTaskListenerEventType eventType);
+  }
+
+  interface CreateGlobalTaskListenerCommandStep4
+      extends CreateGlobalTaskListenerCommandStep1,
+          CreateGlobalTaskListenerCommandStep2,
+          CreateGlobalTaskListenerCommandStep3,
+          FinalCommandStep<GlobalTaskListenerResponse> {
+
+    // Optional parameters
+    /**
+     * Sets the number of retries for the global listener.
+     *
+     * @param retries maximum number of retries attempted by the listener job in case of failure.
+     *     Must be an integer greater or equal to 1.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 retries(Integer retries);
+
+    /**
+     * Sets whether the global listener should be executed before or after the model-level ones.
+     *
+     * @param afterNonGlobal if true, the global listener is executed after the model-level ones. If
+     *     false, it is executed before. Defaults to false if not set.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 afterNonGlobal(Boolean afterNonGlobal);
+
+    /**
+     * Sets that the global listener should be executed before the model-level ones.
+     *
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 beforeNonGlobal();
+
+    /**
+     * Sets that the global listener should be executed after the model-level ones.
+     *
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 afterNonGlobal();
+
+    /**
+     * Sets the priority of the global listener.
+     *
+     * <p>Global task listeners with higher priority are executed first.
+     *
+     * @param priority the priority of the global listener. Must be an integer between 0 and 100
+     *     included.
+     * @return this builder for method chaining
+     */
+    CreateGlobalTaskListenerCommandStep4 priority(Integer priority);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteGlobalTaskListenerCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteGlobalTaskListenerCommandStep1.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteGlobalTaskListenerResponse;
+
+/**
+ * Represents a request to delete a global task listener.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   camundaClient
+ *       .newDeleteGlobalTaskListenerRequest("my-listener")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface DeleteGlobalTaskListenerCommandStep1
+    extends FinalCommandStep<DeleteGlobalTaskListenerResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateGlobalTaskListenerCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateGlobalTaskListenerCommandStep1.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.GlobalTaskListenerResponse;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import java.util.List;
+
+/**
+ * Represents a request to update a global task listener.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   GlobalTaskListenerResponse response = camundaClient
+ *       .newUpdateGlobalTaskListenerRequest("my-listener")
+ *       .type("my-job-type")
+ *       .eventTypes(GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface UpdateGlobalTaskListenerCommandStep1 {
+
+  /**
+   * Sets the job type of the global listener.
+   *
+   * @param type the name of the job type, used as a reference to specify which job workers request
+   *     the respective listener job. Must not be null or empty.
+   * @return this builder for method chaining
+   */
+  UpdateGlobalTaskListenerCommandStep2 type(String type);
+
+  interface UpdateGlobalTaskListenerCommandStep2 {
+
+    /**
+     * Sets the user task event types supported by the global listener.
+     *
+     * @param eventTypes list of user task event types that trigger the listener. Must not be null
+     *     or empty.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 eventTypes(List<GlobalTaskListenerEventType> eventTypes);
+
+    /**
+     * Sets the user task event types supported by the global listener.
+     *
+     * @param eventTypes list of user task event types that trigger the listener. Must not be null
+     *     or empty.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 eventTypes(GlobalTaskListenerEventType... eventTypes);
+
+    /**
+     * Adds support for a user task event type to the global listener.
+     *
+     * @param eventType user task event types that should trigger the listener. Must not be null.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 eventType(GlobalTaskListenerEventType eventType);
+  }
+
+  interface UpdateGlobalTaskListenerCommandStep3
+      extends UpdateGlobalTaskListenerCommandStep1,
+          UpdateGlobalTaskListenerCommandStep2,
+          FinalCommandStep<GlobalTaskListenerResponse> {
+
+    // Optional parameters
+    /**
+     * Sets the number of retries for the global listener.
+     *
+     * @param retries maximum number of retries attempted by the listener job in case of failure.
+     *     Must be an integer greater or equal to 1.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 retries(Integer retries);
+
+    /**
+     * Sets whether the global listener should be executed before or after the model-level ones.
+     *
+     * @param afterNonGlobal if true, the global listener is executed after the model-level ones. If
+     *     false, it is executed before. Defaults to false if not set.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 afterNonGlobal(Boolean afterNonGlobal);
+
+    /**
+     * Sets that the global listener should be executed before the model-level ones.
+     *
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 beforeNonGlobal();
+
+    /**
+     * Sets that the global listener should be executed after the model-level ones.
+     *
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 afterNonGlobal();
+
+    /**
+     * Sets the priority of the global listener.
+     *
+     * <p>Global task listeners with higher priority are executed first.
+     *
+     * @param priority the priority of the global listener. Must be an integer between 0 and 100
+     *     included.
+     * @return this builder for method chaining
+     */
+    UpdateGlobalTaskListenerCommandStep3 priority(Integer priority);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/GlobalTaskListenerGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/GlobalTaskListenerGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+
+public interface GlobalTaskListenerGetRequest extends FinalCommandStep<GlobalTaskListener> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteGlobalTaskListenerResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteGlobalTaskListenerResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface DeleteGlobalTaskListenerResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/GlobalTaskListenerResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/GlobalTaskListenerResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import java.util.List;
+
+public interface GlobalTaskListenerResponse {
+  String getId();
+
+  String getType();
+
+  Integer getRetries();
+
+  List<GlobalTaskListenerEventType> getEventTypes();
+
+  Boolean getAfterNonGlobal();
+
+  Integer getPriority();
+
+  GlobalListenerSource getSource();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/GlobalListenerSource.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/GlobalListenerSource.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum GlobalListenerSource {
+  CONFIGURATION,
+  API,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/GlobalTaskListenerEventType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/GlobalTaskListenerEventType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum GlobalTaskListenerEventType {
+  ALL,
+  CREATING,
+  ASSIGNING,
+  UPDATING,
+  COMPLETING,
+  CANCELING,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GlobalTaskListenerFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GlobalTaskListenerFilter.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.api.search.filter.builder.GlobalListenerSourceProperty;
+import io.camunda.client.api.search.filter.builder.GlobalTaskListenerEventTypeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface GlobalTaskListenerFilter extends SearchRequestFilter {
+
+  /**
+   * Filter global listeners by the ID.
+   *
+   * @param id the ID of the global listener
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter id(String id);
+
+  /**
+   * Filter global listeners by the ID using {@link StringProperty} consumer.
+   *
+   * @param fn the ID filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter id(Consumer<StringProperty> fn);
+
+  /**
+   * Filter global listeners by the job type.
+   *
+   * @param type the name of the job type, used as a reference to specify which job workers request
+   *     the respective listener job
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter type(String type);
+
+  /**
+   * Filter global listeners by the job type using {@link StringProperty} consumer.
+   *
+   * @param fn the type filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter type(Consumer<StringProperty> fn);
+
+  /**
+   * Filter global listeners by a list of supported user task event types.
+   *
+   * @param eventTypes list of user task event types that trigger the listener
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter eventTypes(List<GlobalTaskListenerEventType> eventTypes);
+
+  /**
+   * Filter global listeners by a list of supported user task event types.
+   *
+   * @param eventTypes list of user task event types that trigger the listener
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter eventTypes(GlobalTaskListenerEventType... eventTypes);
+
+  /**
+   * Filter global listeners by supported user task event types using {@link
+   * GlobalTaskListenerEventTypeProperty} consumer
+   *
+   * @param fn the event types filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter eventTypes(Consumer<GlobalTaskListenerEventTypeProperty> fn);
+
+  /**
+   * Filter global listeners by a supported user task event type.
+   *
+   * @param eventType user task event types that should trigger the listener
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter eventType(GlobalTaskListenerEventType eventType);
+
+  /**
+   * Filter global listeners by the number of retries.
+   *
+   * @param retries maximum number of retries attempted by the listener job in case of failure
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter retries(Integer retries);
+
+  /**
+   * Filter global listeners by the number of retries using {@link IntegerProperty} consumer.
+   *
+   * @param fn the retries filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter retries(Consumer<IntegerProperty> fn);
+
+  /**
+   * Filter global listeners by whether the global listener should be executed before or after the
+   * model-level ones.
+   *
+   * @param afterNonGlobal if true, match global listeners executed after the model-level ones. If
+   *     false, the ones executed before
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter afterNonGlobal(Boolean afterNonGlobal);
+
+  /**
+   * Filter global listeners that are executed before the model-level ones.
+   *
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter beforeNonGlobal();
+
+  /**
+   * Filter global listeners that are executed after the model-level ones.
+   *
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter afterNonGlobal();
+
+  /**
+   * Filter global listeners by the priority.
+   *
+   * @param priority the priority of the global listener
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter priority(Integer priority);
+
+  /**
+   * Filter global listeners by the priority using {@link IntegerProperty} consumer.
+   *
+   * @param fn the priority filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter priority(Consumer<IntegerProperty> fn);
+
+  /**
+   * Filter global listeners by the source.
+   *
+   * @param source how the global listener was configured (i.e. in the configuration file or via
+   *     API)
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter source(GlobalListenerSource source);
+
+  /**
+   * Filter global listeners by the source using {@link GlobalListenerSourceProperty} consumer.
+   *
+   * @param fn the source filter consumer
+   * @return the updated filter
+   */
+  GlobalTaskListenerFilter source(Consumer<GlobalListenerSourceProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/GlobalListenerSourceProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/GlobalListenerSourceProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+
+public interface GlobalListenerSourceProperty
+    extends LikeProperty<GlobalListenerSource, String, GlobalListenerSourceProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/GlobalTaskListenerEventTypeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/GlobalTaskListenerEventTypeProperty.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+
+public interface GlobalTaskListenerEventTypeProperty
+    extends LikeProperty<
+        GlobalTaskListenerEventType, String, GlobalTaskListenerEventTypeProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GlobalTaskListenerSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GlobalTaskListenerSearchRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.GlobalTaskListenerFilter;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+import io.camunda.client.api.search.sort.GlobalTaskListenerSort;
+
+public interface GlobalTaskListenerSearchRequest
+    extends TypedSearchRequest<
+            GlobalTaskListenerFilter, GlobalTaskListenerSort, GlobalTaskListenerSearchRequest>,
+        TypedPageableRequest<GlobalTaskListenerSearchRequest>,
+        FinalSearchRequestStep<GlobalTaskListener> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.filter.GlobalTaskListenerFilter;
 import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.JobFilter;
@@ -52,6 +53,7 @@ import io.camunda.client.api.search.sort.DecisionDefinitionSort;
 import io.camunda.client.api.search.sort.DecisionInstanceSort;
 import io.camunda.client.api.search.sort.DecisionRequirementsSort;
 import io.camunda.client.api.search.sort.ElementInstanceSort;
+import io.camunda.client.api.search.sort.GlobalTaskListenerSort;
 import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.api.search.sort.IncidentSort;
@@ -79,6 +81,7 @@ import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.client.impl.search.filter.ElementInstanceFilterImpl;
+import io.camunda.client.impl.search.filter.GlobalTaskListenerFilterImpl;
 import io.camunda.client.impl.search.filter.GroupFilterImpl;
 import io.camunda.client.impl.search.filter.IncidentFilterImpl;
 import io.camunda.client.impl.search.filter.JobFilterImpl;
@@ -107,6 +110,7 @@ import io.camunda.client.impl.search.sort.DecisionDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
 import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
 import io.camunda.client.impl.search.sort.ElementInstanceSortImpl;
+import io.camunda.client.impl.search.sort.GlobalTaskListenerSortImpl;
 import io.camunda.client.impl.search.sort.GroupSortImpl;
 import io.camunda.client.impl.search.sort.GroupUserSortImpl;
 import io.camunda.client.impl.search.sort.IncidentSortImpl;
@@ -487,6 +491,20 @@ public final class SearchRequestBuilders {
     final UserTaskAuditLogFilter filter = new UserTaskAuditLogFilterImpl();
     fn.accept(filter);
     return filter;
+  }
+
+  public static GlobalTaskListenerFilter globalTaskListenerFilter(
+      final Consumer<GlobalTaskListenerFilter> fn) {
+    final GlobalTaskListenerFilter filter = new GlobalTaskListenerFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static GlobalTaskListenerSort globalTaskListenerSort(
+      final Consumer<GlobalTaskListenerSort> fn) {
+    final GlobalTaskListenerSort sort = new GlobalTaskListenerSortImpl();
+    fn.accept(sort);
+    return sort;
   }
 
   public static SearchRequestOffsetPage offsetPage(final Consumer<SearchRequestOffsetPage> fn) {

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/GlobalTaskListener.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/GlobalTaskListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import java.util.List;
+
+public interface GlobalTaskListener {
+  String getId();
+
+  String getType();
+
+  Integer getRetries();
+
+  List<GlobalTaskListenerEventType> getEventTypes();
+
+  Boolean getAfterNonGlobal();
+
+  Integer getPriority();
+
+  GlobalListenerSource getSource();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/GlobalTaskListenerSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/GlobalTaskListenerSort.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface GlobalTaskListenerSort extends SearchRequestSort<GlobalTaskListenerSort> {
+  GlobalTaskListenerSort id();
+
+  GlobalTaskListenerSort type();
+
+  GlobalTaskListenerSort afterNonGlobal();
+
+  GlobalTaskListenerSort priority();
+
+  GlobalTaskListenerSort source();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -48,6 +48,7 @@ import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
 import io.camunda.client.api.command.CreateDocumentCommandStep1;
 import io.camunda.client.api.command.CreateDocumentLinkCommandStep1;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.CreateGroupCommandStep1;
 import io.camunda.client.api.command.CreateMappingRuleCommandStep1;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
@@ -57,6 +58,7 @@ import io.camunda.client.api.command.CreateUserCommandStep1;
 import io.camunda.client.api.command.DeleteAuthorizationCommandStep1;
 import io.camunda.client.api.command.DeleteDecisionInstanceCommandStep1;
 import io.camunda.client.api.command.DeleteDocumentCommandStep1;
+import io.camunda.client.api.command.DeleteGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteMappingRuleCommandStep1;
 import io.camunda.client.api.command.DeleteProcessInstanceCommandStep1;
@@ -104,6 +106,7 @@ import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
+import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.client.api.command.UpdateJobCommandStep1;
 import io.camunda.client.api.command.UpdateMappingRuleCommandStep1;
@@ -124,6 +127,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetRequest;
 import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
+import io.camunda.client.api.fetch.GlobalTaskListenerGetRequest;
 import io.camunda.client.api.fetch.GloballyScopedClusterVariableGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
@@ -157,6 +161,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.GlobalTaskListenerSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
 import io.camunda.client.api.search.request.GroupsSearchRequest;
@@ -219,6 +224,7 @@ import io.camunda.client.impl.command.CreateBatchOperationCommandImpl.CreateBatc
 import io.camunda.client.impl.command.CreateDocumentBatchCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentLinkCommandImpl;
+import io.camunda.client.impl.command.CreateGlobalTaskListenerCommandImpl;
 import io.camunda.client.impl.command.CreateGroupCommandImpl;
 import io.camunda.client.impl.command.CreateMappingRuleCommandImpl;
 import io.camunda.client.impl.command.CreateProcessInstanceCommandImpl;
@@ -228,6 +234,7 @@ import io.camunda.client.impl.command.CreateUserCommandImpl;
 import io.camunda.client.impl.command.DeleteAuthorizationCommandImpl;
 import io.camunda.client.impl.command.DeleteDecisionInstanceCommandImpl;
 import io.camunda.client.impl.command.DeleteDocumentCommandImpl;
+import io.camunda.client.impl.command.DeleteGlobalTaskListenerCommandImpl;
 import io.camunda.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.client.impl.command.DeleteMappingRuleCommandImpl;
 import io.camunda.client.impl.command.DeleteProcessInstanceCommandImpl;
@@ -275,6 +282,7 @@ import io.camunda.client.impl.command.UnassignUserFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
+import io.camunda.client.impl.command.UpdateGlobalTaskListenerCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
 import io.camunda.client.impl.command.UpdateJobCommandImpl;
 import io.camunda.client.impl.command.UpdateMappingRuleCommandImpl;
@@ -292,6 +300,7 @@ import io.camunda.client.impl.fetch.DecisionRequirementsGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionRequirementsGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.DocumentContentGetRequestImpl;
 import io.camunda.client.impl.fetch.ElementInstanceGetRequestImpl;
+import io.camunda.client.impl.fetch.GlobalTaskListenerGetRequestImpl;
 import io.camunda.client.impl.fetch.GloballyScopedClusterVariableGetRequestImpl;
 import io.camunda.client.impl.fetch.GroupGetRequestImpl;
 import io.camunda.client.impl.fetch.IncidentGetRequestImpl;
@@ -325,6 +334,7 @@ import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
+import io.camunda.client.impl.search.request.GlobalTaskListenerSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByTenantSearchRequestImpl;
@@ -1636,6 +1646,31 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ResourceContentGetRequest newResourceContentGetRequest(final long resourceKey) {
     return new ResourceContentGetRequestImpl(httpClient, resourceKey);
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep1 newCreateGlobalTaskListenerRequest() {
+    return new CreateGlobalTaskListenerCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep1 newUpdateGlobalTaskListenerRequest(final String id) {
+    return new UpdateGlobalTaskListenerCommandImpl(httpClient, jsonMapper, id);
+  }
+
+  @Override
+  public DeleteGlobalTaskListenerCommandStep1 newDeleteGlobalTaskListenerRequest(final String id) {
+    return new DeleteGlobalTaskListenerCommandImpl(httpClient, id);
+  }
+
+  @Override
+  public GlobalTaskListenerGetRequest newGlobalTaskListenerGetRequest(final String id) {
+    return new GlobalTaskListenerGetRequestImpl(httpClient, id);
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest() {
+    return new GlobalTaskListenerSearchRequestImpl(httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateGlobalTaskListenerCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateGlobalTaskListenerCommandImpl.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1.CreateGlobalTaskListenerCommandStep2;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1.CreateGlobalTaskListenerCommandStep3;
+import io.camunda.client.api.command.CreateGlobalTaskListenerCommandStep1.CreateGlobalTaskListenerCommandStep4;
+import io.camunda.client.api.response.GlobalTaskListenerResponse;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.GlobalTaskListenerResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.CreateGlobalTaskListenerRequest;
+import io.camunda.client.protocol.rest.GlobalTaskListenerEventTypeEnum;
+import io.camunda.client.protocol.rest.GlobalTaskListenerResult;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CreateGlobalTaskListenerCommandImpl
+    implements CreateGlobalTaskListenerCommandStep1,
+        CreateGlobalTaskListenerCommandStep2,
+        CreateGlobalTaskListenerCommandStep3,
+        CreateGlobalTaskListenerCommandStep4 {
+
+  private final CreateGlobalTaskListenerRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CreateGlobalTaskListenerCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new CreateGlobalTaskListenerRequest();
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep2 id(final String id) {
+    ArgumentUtil.ensureNotNullNorEmpty("id", id);
+    request.id(id);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep3 type(final String type) {
+    ArgumentUtil.ensureNotNullNorEmpty("type", type);
+    request.type(type);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 eventTypes(
+      final List<GlobalTaskListenerEventType> eventTypes) {
+    ArgumentUtil.ensureNotNullOrEmpty("eventTypes", eventTypes);
+    eventTypes.forEach(this::eventType);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 eventTypes(
+      final GlobalTaskListenerEventType... eventTypes) {
+    eventTypes(Arrays.asList(eventTypes));
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 eventType(
+      final GlobalTaskListenerEventType eventType) {
+    ArgumentUtil.ensureNotNull("eventType", eventType);
+    request.addEventTypesItem(EnumUtil.convert(eventType, GlobalTaskListenerEventTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 retries(final Integer retries) {
+    request.setRetries(retries);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 afterNonGlobal(final Boolean afterNonGlobal) {
+    request.setAfterNonGlobal(afterNonGlobal);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 beforeNonGlobal() {
+    return afterNonGlobal(false);
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 afterNonGlobal() {
+    return afterNonGlobal(true);
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 priority(final Integer priority) {
+    request.setPriority(priority);
+    return this;
+  }
+
+  @Override
+  public CreateGlobalTaskListenerCommandStep4 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<GlobalTaskListenerResponse> send() {
+    final HttpCamundaFuture<GlobalTaskListenerResponse> result = new HttpCamundaFuture<>();
+    final GlobalTaskListenerResponseImpl response = new GlobalTaskListenerResponseImpl();
+    final String path = "/global-task-listeners";
+    httpClient.post(
+        path,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GlobalTaskListenerResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGlobalTaskListenerCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGlobalTaskListenerCommandImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.DeleteGlobalTaskListenerCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteGlobalTaskListenerResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.DeleteGlobalTaskListenerResponseImpl;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteGlobalTaskListenerCommandImpl implements DeleteGlobalTaskListenerCommandStep1 {
+
+  private final String listenerId;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteGlobalTaskListenerCommandImpl(final HttpClient httpClient, final String listenerId) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    ArgumentUtil.ensureNotNullNorEmpty("id", listenerId);
+    this.listenerId = listenerId;
+  }
+
+  @Override
+  public FinalCommandStep<DeleteGlobalTaskListenerResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteGlobalTaskListenerResponse> send() {
+    final HttpCamundaFuture<DeleteGlobalTaskListenerResponse> result = new HttpCamundaFuture<>();
+    httpClient.delete(
+        "/global-task-listeners/" + listenerId,
+        httpRequestConfig.build(),
+        DeleteGlobalTaskListenerResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateGlobalTaskListenerCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateGlobalTaskListenerCommandImpl.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
+import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1.UpdateGlobalTaskListenerCommandStep2;
+import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1.UpdateGlobalTaskListenerCommandStep3;
+import io.camunda.client.api.response.GlobalTaskListenerResponse;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.GlobalTaskListenerResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.GlobalTaskListenerEventTypeEnum;
+import io.camunda.client.protocol.rest.GlobalTaskListenerResult;
+import io.camunda.client.protocol.rest.UpdateGlobalTaskListenerRequest;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UpdateGlobalTaskListenerCommandImpl
+    implements UpdateGlobalTaskListenerCommandStep1,
+        UpdateGlobalTaskListenerCommandStep2,
+        UpdateGlobalTaskListenerCommandStep3 {
+
+  private final String listenerId;
+  private final UpdateGlobalTaskListenerRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public UpdateGlobalTaskListenerCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String id) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new UpdateGlobalTaskListenerRequest();
+    ArgumentUtil.ensureNotNullNorEmpty("id", id);
+    listenerId = id;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep2 type(final String type) {
+    ArgumentUtil.ensureNotNullNorEmpty("type", type);
+    request.type(type);
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 eventTypes(
+      final List<GlobalTaskListenerEventType> eventTypes) {
+    ArgumentUtil.ensureNotNullOrEmpty("eventTypes", eventTypes);
+    eventTypes.forEach(this::eventType);
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 eventTypes(
+      final GlobalTaskListenerEventType... eventTypes) {
+    eventTypes(Arrays.asList(eventTypes));
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 eventType(
+      final GlobalTaskListenerEventType eventType) {
+    ArgumentUtil.ensureNotNull("eventType", eventType);
+    request.addEventTypesItem(EnumUtil.convert(eventType, GlobalTaskListenerEventTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 retries(final Integer retries) {
+    request.setRetries(retries);
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 afterNonGlobal(final Boolean afterNonGlobal) {
+    request.setAfterNonGlobal(afterNonGlobal);
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 beforeNonGlobal() {
+    return afterNonGlobal(false);
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 afterNonGlobal() {
+    return afterNonGlobal(true);
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 priority(final Integer priority) {
+    request.setPriority(priority);
+    return this;
+  }
+
+  @Override
+  public UpdateGlobalTaskListenerCommandStep3 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<GlobalTaskListenerResponse> send() {
+    final HttpCamundaFuture<GlobalTaskListenerResponse> result = new HttpCamundaFuture<>();
+    final GlobalTaskListenerResponseImpl response = new GlobalTaskListenerResponseImpl();
+    final String path = "/global-task-listeners/" + listenerId;
+    httpClient.put(
+        path,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GlobalTaskListenerResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/GlobalTaskListenerGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/GlobalTaskListenerGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.GlobalTaskListenerGetRequest;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.GlobalTaskListenerImpl;
+import io.camunda.client.protocol.rest.GlobalTaskListenerResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GlobalTaskListenerGetRequestImpl implements GlobalTaskListenerGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String listenerId;
+
+  public GlobalTaskListenerGetRequestImpl(final HttpClient httpClient, final String listenerId) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    ArgumentUtil.ensureNotNullNorEmpty("id", listenerId);
+    this.listenerId = listenerId;
+  }
+
+  @Override
+  public FinalCommandStep<GlobalTaskListener> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<GlobalTaskListener> send() {
+    final HttpCamundaFuture<GlobalTaskListener> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        "/global-task-listeners/" + listenerId,
+        httpRequestConfig.build(),
+        GlobalTaskListenerResult.class,
+        GlobalTaskListenerImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeleteGlobalTaskListenerResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeleteGlobalTaskListenerResponseImpl.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.DeleteGlobalTaskListenerResponse;
+
+public class DeleteGlobalTaskListenerResponseImpl implements DeleteGlobalTaskListenerResponse {
+  public DeleteGlobalTaskListenerResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/GlobalTaskListenerResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/GlobalTaskListenerResponseImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.GlobalTaskListenerResponse;
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.GlobalTaskListenerResult;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlobalTaskListenerResponseImpl implements GlobalTaskListenerResponse {
+  private String id;
+  private String type;
+  private Integer retries;
+  private List<GlobalTaskListenerEventType> eventTypes;
+  private Boolean afterNonGlobal;
+  private Integer priority;
+  private GlobalListenerSource source;
+
+  public GlobalTaskListenerResponse setResponse(
+      final GlobalTaskListenerResult globalTaskListenerResult) {
+    id = globalTaskListenerResult.getId();
+    type = globalTaskListenerResult.getType();
+    retries = globalTaskListenerResult.getRetries();
+    eventTypes =
+        globalTaskListenerResult.getEventTypes() != null
+            ? globalTaskListenerResult.getEventTypes().stream()
+                .map(et -> EnumUtil.convert(et, GlobalTaskListenerEventType.class))
+                .collect(Collectors.toList())
+            : null;
+    afterNonGlobal = globalTaskListenerResult.getAfterNonGlobal();
+    priority = globalTaskListenerResult.getPriority();
+    source = EnumUtil.convert(globalTaskListenerResult.getSource(), GlobalListenerSource.class);
+    return this;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public Integer getRetries() {
+    return retries;
+  }
+
+  @Override
+  public List<GlobalTaskListenerEventType> getEventTypes() {
+    return eventTypes;
+  }
+
+  @Override
+  public Boolean getAfterNonGlobal() {
+    return afterNonGlobal;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
+  }
+
+  @Override
+  public GlobalListenerSource getSource() {
+    return source;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GlobalTaskListenerFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GlobalTaskListenerFilterImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.api.search.filter.GlobalTaskListenerFilter;
+import io.camunda.client.api.search.filter.builder.GlobalListenerSourceProperty;
+import io.camunda.client.api.search.filter.builder.GlobalTaskListenerEventTypeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.GlobalListenerSourcePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.GlobalTaskListenerEventTypePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.GlobalTaskListenerSearchQueryFilterRequest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class GlobalTaskListenerFilterImpl
+    extends TypedSearchRequestPropertyProvider<GlobalTaskListenerSearchQueryFilterRequest>
+    implements GlobalTaskListenerFilter {
+
+  private final GlobalTaskListenerSearchQueryFilterRequest filter;
+
+  public GlobalTaskListenerFilterImpl() {
+    filter = new GlobalTaskListenerSearchQueryFilterRequest();
+  }
+
+  @Override
+  protected GlobalTaskListenerSearchQueryFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter id(final String id) {
+    return id(f -> f.eq(id));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter id(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter type(final String type) {
+    return type(f -> f.eq(type));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter type(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter eventTypes(final List<GlobalTaskListenerEventType> eventTypes) {
+    eventTypes.forEach(this::eventType);
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter eventTypes(final GlobalTaskListenerEventType... eventTypes) {
+    return eventTypes(Arrays.asList(eventTypes));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter eventTypes(
+      final Consumer<GlobalTaskListenerEventTypeProperty> fn) {
+    final GlobalTaskListenerEventTypeProperty property =
+        new GlobalTaskListenerEventTypePropertyImpl();
+    fn.accept(property);
+    filter.addEventTypesItem(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter eventType(final GlobalTaskListenerEventType eventType) {
+    return eventTypes(f -> f.eq(eventType));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter retries(final Integer retries) {
+    return retries(f -> f.eq(retries));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter retries(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setRetries(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter afterNonGlobal(final Boolean afterNonGlobal) {
+    filter.afterNonGlobal(afterNonGlobal);
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter beforeNonGlobal() {
+    return afterNonGlobal(false);
+  }
+
+  @Override
+  public GlobalTaskListenerFilter afterNonGlobal() {
+    return afterNonGlobal(true);
+  }
+
+  @Override
+  public GlobalTaskListenerFilter priority(final Integer priority) {
+    return priority(f -> f.eq(priority));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter priority(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setPriority(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerFilter source(final GlobalListenerSource source) {
+    return source(f -> f.eq(source));
+  }
+
+  @Override
+  public GlobalTaskListenerFilter source(final Consumer<GlobalListenerSourceProperty> fn) {
+    final GlobalListenerSourceProperty property = new GlobalListenerSourcePropertyImpl();
+    fn.accept(property);
+    filter.source(provideSearchRequestProperty(property));
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/GlobalListenerSourcePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/GlobalListenerSourcePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.filter.builder.GlobalListenerSourceProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.GlobalListenerSourceEnum;
+import io.camunda.client.protocol.rest.GlobalListenerSourceFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlobalListenerSourcePropertyImpl
+    extends TypedSearchRequestPropertyProvider<GlobalListenerSourceFilterProperty>
+    implements GlobalListenerSourceProperty {
+
+  private final GlobalListenerSourceFilterProperty filterProperty =
+      new GlobalListenerSourceFilterProperty();
+
+  @Override
+  public GlobalListenerSourceProperty eq(final GlobalListenerSource value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, GlobalListenerSourceEnum.class));
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSourceProperty neq(final GlobalListenerSource value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, GlobalListenerSourceEnum.class));
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSourceProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSourceProperty in(final List<GlobalListenerSource> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> (EnumUtil.convert(source, GlobalListenerSourceEnum.class)))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public GlobalListenerSourceProperty in(final GlobalListenerSource... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected GlobalListenerSourceFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public GlobalListenerSourceProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/GlobalTaskListenerEventTypePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/GlobalTaskListenerEventTypePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.api.search.filter.builder.GlobalTaskListenerEventTypeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.GlobalTaskListenerEventTypeEnum;
+import io.camunda.client.protocol.rest.GlobalTaskListenerEventTypeFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlobalTaskListenerEventTypePropertyImpl
+    extends TypedSearchRequestPropertyProvider<GlobalTaskListenerEventTypeFilterProperty>
+    implements GlobalTaskListenerEventTypeProperty {
+
+  private final GlobalTaskListenerEventTypeFilterProperty filterProperty =
+      new GlobalTaskListenerEventTypeFilterProperty();
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty eq(final GlobalTaskListenerEventType value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, GlobalTaskListenerEventTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty neq(final GlobalTaskListenerEventType value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, GlobalTaskListenerEventTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty in(final List<GlobalTaskListenerEventType> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> (EnumUtil.convert(source, GlobalTaskListenerEventTypeEnum.class)))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty in(final GlobalTaskListenerEventType... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected GlobalTaskListenerEventTypeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public GlobalTaskListenerEventTypeProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GlobalTaskListenerSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GlobalTaskListenerSearchRequestImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.globalTaskListenerFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.globalTaskListenerSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.GlobalTaskListenerFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.GlobalTaskListenerSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.GlobalTaskListenerSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GlobalTaskListenerSearchQueryRequest;
+import io.camunda.client.protocol.rest.GlobalTaskListenerSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GlobalTaskListenerSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<GlobalTaskListenerSearchQueryRequest>
+    implements GlobalTaskListenerSearchRequest {
+
+  private final GlobalTaskListenerSearchQueryRequest request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public GlobalTaskListenerSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new GlobalTaskListenerSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<GlobalTaskListener> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<GlobalTaskListener>> send() {
+    final HttpCamundaFuture<SearchResponse<GlobalTaskListener>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/global-task-listeners/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GlobalTaskListenerSearchQueryResult.class,
+        SearchResponseMapper::toGlobalTaskListenerSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest filter(final GlobalTaskListenerFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest filter(final Consumer<GlobalTaskListenerFilter> fn) {
+    return filter(globalTaskListenerFilter(fn));
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest sort(final GlobalTaskListenerSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toGlobalTaskListenerSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerSearchRequest sort(final Consumer<GlobalTaskListenerSort> fn) {
+    return sort(globalTaskListenerSort(fn));
+  }
+
+  @Override
+  protected GlobalTaskListenerSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -630,6 +630,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<GlobalTaskListenerSearchQuerySortRequest>
+      toGlobalTaskListenerSearchQuerySortRequest(final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final GlobalTaskListenerSearchQuerySortRequest request =
+                  new GlobalTaskListenerSearchQuerySortRequest();
+              request.setField(
+                  GlobalTaskListenerSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   private static SearchRequestSort createFrom(final Object field, final SortOrderEnum order) {
     final SearchRequestSort request = new SearchRequestSort();
     request.setField(field.toString());

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/GlobalTaskListenerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/GlobalTaskListenerImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.GlobalTaskListenerResult;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlobalTaskListenerImpl implements GlobalTaskListener {
+  private final String id;
+  private final String type;
+  private final Integer retries;
+  private final List<GlobalTaskListenerEventType> eventTypes;
+  private final Boolean afterNonGlobal;
+  private final Integer priority;
+  private final GlobalListenerSource source;
+
+  public GlobalTaskListenerImpl(final GlobalTaskListenerResult globalTaskListenerResult) {
+    id = globalTaskListenerResult.getId();
+    type = globalTaskListenerResult.getType();
+    retries = globalTaskListenerResult.getRetries();
+    eventTypes =
+        globalTaskListenerResult.getEventTypes() != null
+            ? globalTaskListenerResult.getEventTypes().stream()
+                .map(et -> EnumUtil.convert(et, GlobalTaskListenerEventType.class))
+                .collect(Collectors.toList())
+            : null;
+    afterNonGlobal = globalTaskListenerResult.getAfterNonGlobal();
+    priority = globalTaskListenerResult.getPriority();
+    source = EnumUtil.convert(globalTaskListenerResult.getSource(), GlobalListenerSource.class);
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public Integer getRetries() {
+    return retries;
+  }
+
+  @Override
+  public List<GlobalTaskListenerEventType> getEventTypes() {
+    return eventTypes;
+  }
+
+  @Override
+  public Boolean getAfterNonGlobal() {
+    return afterNonGlobal;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
+  }
+
+  @Override
+  public GlobalListenerSource getSource() {
+    return source;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -32,6 +32,7 @@ import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.GlobalTaskListener;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.Incident;
@@ -446,6 +447,14 @@ public final class SearchResponseMapper {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<AuditLogResult> instances =
         toSearchResponseInstances(response.getItems(), AuditLogResultImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<GlobalTaskListener> toGlobalTaskListenerSearchResponse(
+      final GlobalTaskListenerSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<GlobalTaskListener> instances =
+        toSearchResponseInstances(response.getItems(), GlobalTaskListenerImpl::new);
     return new SearchResponseImpl<>(instances, page);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/GlobalTaskListenerSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/GlobalTaskListenerSortImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.GlobalTaskListenerSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class GlobalTaskListenerSortImpl extends SearchRequestSortBase<GlobalTaskListenerSort>
+    implements GlobalTaskListenerSort {
+
+  @Override
+  protected GlobalTaskListenerSort self() {
+    return this;
+  }
+
+  @Override
+  public GlobalTaskListenerSort id() {
+    return field("id");
+  }
+
+  @Override
+  public GlobalTaskListenerSort type() {
+    return field("type");
+  }
+
+  @Override
+  public GlobalTaskListenerSort afterNonGlobal() {
+    return field("afterNonGlobal");
+  }
+
+  @Override
+  public GlobalTaskListenerSort priority() {
+    return field("priority");
+  }
+
+  @Override
+  public GlobalTaskListenerSort source() {
+    return field("source");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerCommandIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerCommandIT.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import java.util.ArrayList;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class GlobalTaskListenerCommandIT {
+
+  private static CamundaClient camundaClient;
+
+  // ============ CREATE TESTS ============
+
+  @Test
+  void shouldCreateGlobalTaskListenerWithMinimalData() {
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+    final var response =
+        camundaClient
+            .newCreateGlobalTaskListenerRequest()
+            .id(listenerId)
+            .type("my-job")
+            .eventTypes(
+                GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+            .send()
+            .join();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(listenerId);
+    assertThat(response.getType()).isEqualTo("my-job");
+    assertThat(response.getEventTypes())
+        .containsExactlyInAnyOrder(
+            GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING);
+    assertThat(response.getRetries()).isEqualTo(GlobalListenerRecordValue.DEFAULT_RETRIES);
+    assertThat(response.getAfterNonGlobal()).isFalse();
+    assertThat(response.getPriority()).isEqualTo(GlobalListenerRecordValue.DEFAULT_PRIORITY);
+    assertThat(response.getSource()).isEqualTo(GlobalListenerSource.API);
+  }
+
+  @Test
+  void shouldCreateGlobalTaskListenerWithFullData() {
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+    final var response =
+        camundaClient
+            .newCreateGlobalTaskListenerRequest()
+            .id(listenerId)
+            .type("my-job")
+            .eventTypes(
+                GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+            .afterNonGlobal(true)
+            .retries(5)
+            .priority(70)
+            .send()
+            .join();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(listenerId);
+    assertThat(response.getType()).isEqualTo("my-job");
+    assertThat(response.getEventTypes())
+        .containsExactlyInAnyOrder(
+            GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING);
+    assertThat(response.getRetries()).isEqualTo(5);
+    assertThat(response.getAfterNonGlobal()).isTrue();
+    assertThat(response.getPriority()).isEqualTo(70);
+    assertThat(response.getSource()).isEqualTo(GlobalListenerSource.API);
+  }
+
+  @Test
+  void shouldRejectCreationIfIdIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(null)
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be null");
+  }
+
+  @Test
+  void shouldRejectCreationIfIdIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id("")
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be empty");
+  }
+
+  @Test
+  void shouldRejectCreationIfTypeIsNull() {
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type(null)
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("type must not be null");
+  }
+
+  @Test
+  void shouldRejectCreationIfTypeIsEmpty() {
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type("")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("type must not be empty");
+  }
+
+  @Test
+  void shouldRejectCreationIfEventTypesIsEmpty() {
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type("my-job")
+                    .eventTypes(new ArrayList<>())
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("eventTypes must not be empty");
+  }
+
+  @Test
+  void shouldRejectCreationIfDuplicateGlobalListener() {
+    // given
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("my-job")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type("my-other-job")
+                    .eventTypes(GlobalTaskListenerEventType.CREATING)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 409: 'Conflict'");
+  }
+
+  // ============ DELETE TESTS ============
+  @Test
+  void shouldDeleteGlobalTaskListener() {
+    // given
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("my-job")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+
+    // when
+    camundaClient.newDeleteGlobalTaskListenerRequest(listenerId).send().join();
+
+    // then - verify deletion by attempting to recreate
+    assertThatCode(
+            () ->
+                camundaClient
+                    .newCreateGlobalTaskListenerRequest()
+                    .id(listenerId)
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectDeletionIfListenerIdIsNull() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newDeleteGlobalTaskListenerRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be null");
+  }
+
+  @Test
+  void shouldRejectDeletionIfListenerIdIsEmpty() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newDeleteGlobalTaskListenerRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be empty");
+  }
+
+  @Test
+  void shouldRejectDeletionIfGlobalListenerDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newDeleteGlobalTaskListenerRequest("my-non-existent-listener")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  // ============ UPDATE TESTS ============
+
+  @Test
+  void shouldUpdateGlobalTaskListener() {
+    // given
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("my-job")
+        .eventTypes(GlobalTaskListenerEventType.ALL)
+        .send()
+        .join();
+
+    // when
+    final var response =
+        camundaClient
+            .newUpdateGlobalTaskListenerRequest(listenerId)
+            .type("my-other-job")
+            .eventTypes(
+                GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+            .afterNonGlobal(true)
+            .retries(5)
+            .priority(70)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(listenerId);
+    assertThat(response.getType()).isEqualTo("my-other-job");
+    assertThat(response.getEventTypes())
+        .containsExactlyInAnyOrder(
+            GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING);
+    assertThat(response.getRetries()).isEqualTo(5);
+    assertThat(response.getAfterNonGlobal()).isTrue();
+    assertThat(response.getPriority()).isEqualTo(70);
+    assertThat(response.getSource()).isEqualTo(GlobalListenerSource.API);
+  }
+
+  @Test
+  void shouldRejectUpdateIfListenerIdIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateGlobalTaskListenerRequest(null)
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be null");
+  }
+
+  @Test
+  void shouldRejectUpdateIfListenerIdIsEmpty() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateGlobalTaskListenerRequest("")
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be empty");
+  }
+
+  @Test
+  void shouldRejectUpdateIfGlobalListenerDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateGlobalTaskListenerRequest("my-non-existent-listener")
+                    .type("my-job")
+                    .eventTypes(GlobalTaskListenerEventType.ALL)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerFetchIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.GlobalListenerSource;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.protocol.record.value.GlobalListenerRecordValue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class GlobalTaskListenerFetchIT {
+
+  private static CamundaClient camundaClient;
+
+  // ============ GET TESTS ============
+  @Test
+  void shouldGetGlobalTaskListener() {
+    // given
+    final String listenerId = "my-listener-" + UUID.randomUUID();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(listenerId)
+        .type("my-job")
+        .eventTypes(GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+        .send()
+        .join();
+
+    // wait for data to be indexed
+    TestHelper.waitForGlobalTaskListenerToBeIndexed(camundaClient, listenerId);
+
+    // when
+    final var response = camundaClient.newGlobalTaskListenerGetRequest(listenerId).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(listenerId);
+    assertThat(response.getType()).isEqualTo("my-job");
+    assertThat(response.getEventTypes())
+        .containsExactlyInAnyOrder(
+            GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING);
+    assertThat(response.getRetries()).isEqualTo(GlobalListenerRecordValue.DEFAULT_RETRIES);
+    assertThat(response.getAfterNonGlobal()).isFalse();
+    assertThat(response.getPriority()).isEqualTo(GlobalListenerRecordValue.DEFAULT_PRIORITY);
+    assertThat(response.getSource()).isEqualTo(GlobalListenerSource.API);
+  }
+
+  @Test
+  void shouldRejectGetIfIdIsNull() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGlobalTaskListenerGetRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be null");
+  }
+
+  @Test
+  void shouldRejectGetIfIdIsEmpty() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newGlobalTaskListenerGetRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id must not be empty");
+  }
+
+  @Test
+  void shouldRejectGetIfGlobalTaskListenerNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newGlobalTaskListenerGetRequest("non-existent-listener")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalTaskListenerSearchIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.client.api.search.response.GlobalTaskListener;
+import io.camunda.it.util.TestHelper;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class GlobalTaskListenerSearchIT {
+
+  private static CamundaClient camundaClient;
+
+  // Test data - Global scoped variables
+  private static String globalListenerId1;
+  private static String globalListenerId2;
+  private static String globalListenerId3;
+  private static String globalListenerId4;
+
+  @BeforeAll
+  static void setupGlobalTaskListeners() {
+    // Setup global scoped variables
+    globalListenerId1 = "listener-search-1-" + UUID.randomUUID();
+    globalListenerId2 = "listener-search-2-" + UUID.randomUUID();
+    globalListenerId3 = "listener-search-3-" + UUID.randomUUID();
+    globalListenerId4 = "listener-search-4-" + UUID.randomUUID();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(globalListenerId1)
+        .type("my-job-22")
+        .eventTypes(GlobalTaskListenerEventType.CREATING, GlobalTaskListenerEventType.COMPLETING)
+        .afterNonGlobal(false)
+        .retries(3)
+        .priority(50)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(globalListenerId2)
+        .type("my-job-20")
+        .eventTypes(GlobalTaskListenerEventType.CREATING)
+        .afterNonGlobal(true)
+        .retries(4)
+        .priority(30)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(globalListenerId3)
+        .type("my-job-12")
+        .eventTypes(GlobalTaskListenerEventType.COMPLETING)
+        .afterNonGlobal(false)
+        .retries(5)
+        .priority(50)
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id(globalListenerId4)
+        .type("my-job-13")
+        .eventTypes(GlobalTaskListenerEventType.ASSIGNING)
+        .afterNonGlobal(true)
+        .retries(6)
+        .priority(70)
+        .send()
+        .join();
+
+    // Wait for all variables to be indexed
+    TestHelper.waitForGlobalTaskListenerToBeIndexed(
+        camundaClient,
+        List.of(globalListenerId1, globalListenerId2, globalListenerId3, globalListenerId4));
+  }
+
+  // ============ SEARCH TESTS ============
+
+  @Test
+  void shouldSearchGlobalTaskListeners() {
+    // when
+    final var response = camundaClient.newGlobalTaskListenerSearchRequest().send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    // order: by afterNonGlobal (false before true), then by priority desc, then by name asc
+    assertThat(response.items().stream().map(GlobalTaskListener::getId).toList())
+        .containsExactly(
+            globalListenerId1, globalListenerId3, globalListenerId4, globalListenerId2);
+  }
+
+  // SORTING TESTS
+
+  @Test
+  void shouldSearchSortGlobalTaskListenersById() {
+    // when
+    final var response =
+        camundaClient.newGlobalTaskListenerSearchRequest().sort(s -> s.id().asc()).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items().stream().map(GlobalTaskListener::getId).toList())
+        .containsExactly(
+            globalListenerId1, globalListenerId2, globalListenerId3, globalListenerId4);
+  }
+
+  @Test
+  void shouldSearchSortGlobalTaskListenersByType() {
+    // when
+    final var response =
+        camundaClient.newGlobalTaskListenerSearchRequest().sort(s -> s.type().asc()).send().join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items().stream().map(GlobalTaskListener::getId).toList())
+        .containsExactly(
+            globalListenerId3, globalListenerId4, globalListenerId2, globalListenerId1);
+  }
+
+  @Test
+  void shouldSearchSortGlobalTaskListenersByPriority() {
+    // when
+    final var response =
+        camundaClient
+            .newGlobalTaskListenerSearchRequest()
+            .sort(s -> s.priority().asc())
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.items()).isNotEmpty();
+    assertThat(response.items().stream().map(GlobalTaskListener::getId).toList())
+        .containsExactly(
+            globalListenerId2, globalListenerId1, globalListenerId3, globalListenerId4);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -1726,4 +1726,47 @@ public final class TestHelper {
         "sequence flow",
         () -> client.newProcessInstanceSequenceFlowsRequest(processInstanceKey).send().join());
   }
+
+  /**
+   * Waits for a global user task listener to be indexed in Elasticsearch/OpenSearch after creation.
+   *
+   * @param camundaClient CamundaClient
+   * @param listenerId the id of the global listener to retrieve
+   */
+  public static void waitForGlobalTaskListenerToBeIndexed(
+      final CamundaClient camundaClient, final String listenerId) {
+    Awaitility.await("should index global task listener")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient.newGlobalTaskListenerGetRequest(listenerId).execute();
+              assertThat(result).isNotNull();
+            });
+  }
+
+  /**
+   * Waits for multiple global user task listeners to be indexed in Elasticsearch/OpenSearch after
+   * creation.
+   *
+   * @param camundaClient CamundaClient
+   * @param listenerIds the ids of the global listeners to retrieve
+   */
+  public static void waitForGlobalTaskListenerToBeIndexed(
+      final CamundaClient camundaClient, final List<String> listenerIds) {
+    Awaitility.await("should index global task listeners")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newGlobalTaskListenerSearchRequest()
+                      .filter(f -> f.id(id -> id.in(listenerIds)))
+                      .page(p -> p.limit(listenerIds.size()))
+                      .execute();
+              assertThat(result.items()).hasSize(listenerIds.size());
+            });
+  }
 }


### PR DESCRIPTION
## Description

This pull request adds comprehensive support for managing global task listeners in the Camunda Java client. It introduces new API command interfaces, response types, enums, and request builders to allow users to create, update, delete, fetch, and search for global task listeners. These changes make it possible to programmatically handle global task listeners with full type safety and builder-pattern convenience.

The PR additionally includes `@MultiDbTest` tests ensuring global listeners are correctly managed regardless of the secondary storage used.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #43190
