### PR TITLE
ci: extend preview env smoke test to 8.10

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -94,7 +94,7 @@ jobs:
         - version: 8.9
           host: ${{ needs.deploy-8-9.outputs.host-name }}
           run: ${{ needs.deploy-8-9.result == 'success' }}
-        - version: 8.9
+        - version: 8.10
           host: ${{ needs.deploy-8-10.outputs.host-name }}
           run: ${{ needs.deploy-8-10.result == 'success' }}
         exclude:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -15,6 +15,7 @@ on:
         type: choice
         options:
         - all
+        - '8.10'
         - '8.9'
         - '8.8'
         default: all
@@ -44,7 +45,7 @@ jobs:
   deploy-8-9:
     name: Deploy 8.9 Preview Environment
     if: contains(fromJSON('["all", "8.9", ""]'), inputs.version)
-    uses: ./.github/workflows/preview-env-build-and-deploy.yml
+    uses: camunda/camunda/.github/workflows/preview-env-build-and-deploy.yml@stable/8.9
     secrets: inherit
     with:
       app-name: smoke89-${{ github.run_number }}
@@ -55,13 +56,28 @@ jobs:
       helm-extra-args: |
         --helm-set global.preview.ingress.internalAuthBypass.enabled=true
 
+  deploy-8-10:
+    name: Deploy 8.10 Preview Environment
+    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
+    uses: ./.github/workflows/preview-env-build-and-deploy.yml
+    secrets: inherit
+    with:
+      app-name: smoke810-${{ github.run_number }}
+      labels: |
+        preview=smoke-test
+        repo=camunda_camunda
+        version=8.10
+      helm-extra-args: |
+        --helm-set global.preview.ingress.internalAuthBypass.enabled=true
+
   test:
     name: Run ${{ matrix.deployment.version }} Smoke Tests
     needs:
     - deploy-8-8
     - deploy-8-9
+    - deploy-8-10
     # Run if at least one deploy succeeded
-    if: always() && (needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success')
+    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -78,6 +94,9 @@ jobs:
         - version: 8.9
           host: ${{ needs.deploy-8-9.outputs.host-name }}
           run: ${{ needs.deploy-8-9.result == 'success' }}
+        - version: 8.9
+          host: ${{ needs.deploy-8-10.outputs.host-name }}
+          run: ${{ needs.deploy-8-10.result == 'success' }}
         exclude:
         - deployment:
             run: false
@@ -109,7 +128,7 @@ jobs:
           # Use full path since sudo doesn't inherit PATH
           sudo -E "$(which tsh)" proxy app "${TELEPORT_APP}" --port 443 --debug &
           sleep 5
-          
+
           # Verify tunnel is running
           if ! nc -z 127.0.0.1 443; then
             echo "::error::Failed to start tsh proxy on port 443"
@@ -202,6 +221,7 @@ jobs:
     with:
       app-name: smoke88-${{ github.run_number }}
       ref: stable/8.8
+
   teardown-8-9:
     name: Teardown 8.9 Preview Environment
     if: >
@@ -217,6 +237,21 @@ jobs:
     with:
       app-name: smoke89-${{ github.run_number }}
 
+  teardown-8-10:
+    name: Teardown 8.10 Preview Environment
+    if: >
+      always() &&
+      needs.deploy-8-10.result == 'success' &&
+      needs.test.result == 'success' &&
+      !inputs.skip-teardown
+    needs:
+    - deploy-8-10
+    - test
+    uses: ./.github/workflows/preview-env-teardown.yml
+    secrets: inherit
+    with:
+      app-name: smoke810-${{ github.run_number }}
+
   notify-failure:
     name: Notify on Failure
     # Notify on failure for scheduled runs only
@@ -226,11 +261,13 @@ jobs:
       (
         needs.deploy-8-8.result == 'failure' ||
         needs.deploy-8-9.result == 'failure' ||
+        needs.deploy-8-10.result == 'failure' ||
         needs.test.result == 'failure'
       )
     needs:
     - deploy-8-8
     - deploy-8-9
+    - deploy-8-10
     - test
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Description

8.9 preview environments are now on `stable/8.9` and 8.10 is on `main`

Working Demo based on this PR: https://github.com/camunda/camunda/actions/runs/22436204246

This PR also includes https://github.com/camunda/camunda/pull/46667

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed as this is a scheduled job on main

## Related issues

Related #46249