### PR TITLE
ci: revert disable Zeebe Update tests during version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,16 +748,16 @@ jobs:
             owner: "General"
             module: "Zeebe"
             test-filter: "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*$*.java"
-          # - group: qa-update
-          #   name: "Zeebe QA - Update"
-          #   maven-modules: "zeebe/qa/update-tests"
-          #   maven-build-threads: 1
-          #   maven-test-fork-count: 10
-          #   runs-on: gcp-perf-core-8-default
-          #   docker-repository: localhost:5000/camunda/zeebe
-          #   docker-file: Dockerfile
-          #   owner: "Core Features"
-          #   module: "Zeebe"
+          - group: qa-update
+            name: "Zeebe QA - Update"
+            maven-modules: "zeebe/qa/update-tests"
+            maven-build-threads: 1
+            maven-test-fork-count: 10
+            runs-on: gcp-perf-core-8-default
+            docker-repository: localhost:5000/camunda/zeebe
+            docker-file: Dockerfile
+            owner: "Core Features"
+            module: "Zeebe"
           - group: qa-camunda-process-test
             name: "Camunda Process"
             maven-modules: "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example"


### PR DESCRIPTION
## Description

This reverts commit bf724988ecf614c7950f3ca71e6dc8df85360c64 as follow-up to temporary change in https://github.com/camunda/camunda/pull/46223

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related #46249
