### PR TITLE
feat: store checkpoint and range metadata in backup store

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.backup.common.Manifest;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -260,6 +261,33 @@ public final class AzureBackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    return CompletableFuture.runAsync(
+        () -> {
+          assureContainerCreated();
+          final var blobName = backupMetadataPath(partitionId);
+          final var blobClient = blobContainerClient.getBlobClient(blobName);
+          blobClient.upload(BinaryData.fromBytes(content), true);
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          assureContainerCreated();
+          final var blobName = backupMetadataPath(partitionId);
+          final var blobClient = blobContainerClient.getBlobClient(blobName);
+          if (!blobClient.exists()) {
+            return Optional.empty();
+          }
+          return Optional.of(blobClient.downloadContent().toBytes());
+        },
+        executor);
+  }
+
+  @Override
   public CompletableFuture<Void> closeAsync() {
     return CompletableFuture.runAsync(
         () -> {
@@ -279,6 +307,10 @@ public final class AzureBackupStore implements BackupStore {
 
   private String rangeMarkersPrefix(final int partitionId) {
     return "ranges/" + partitionId + "/";
+  }
+
+  private String backupMetadataPath(final int partitionId) {
+    return "metadata/" + partitionId + "/metadata.json";
   }
 
   private void assureContainerCreated() {

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -50,6 +50,7 @@ public final class AzureBackupStore implements BackupStore {
       "Expected to restore from completed backup with id '%s', but was in state '%s'";
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
+  public static final String METADATA_OBJECT_NAME = "metadata.json";
   private static final Logger LOG = LoggerFactory.getLogger(AzureBackupStore.class);
   private final ExecutorService executor;
   private final FileSetManager fileSetManager;
@@ -310,7 +311,7 @@ public final class AzureBackupStore implements BackupStore {
   }
 
   private String backupMetadataPath(final int partitionId) {
-    return "metadata/" + partitionId + "/metadata.json";
+    return "metadata/%d/%s".formatted(partitionId, METADATA_OBJECT_NAME);
   }
 
   private void assureContainerCreated() {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -53,11 +54,13 @@ public final class FilesystemBackupStore implements BackupStore {
   private static final String CONTENTS_PATH = "contents";
   private static final String MANIFESTS_PATH = "manifests";
   private static final String RANGES_PATH = "ranges";
+  private static final String METADATA_PATH = "metadata";
 
   private final ExecutorService executor;
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
   private final Path rangesDir;
+  private final Path metadataBaseDir;
 
   FilesystemBackupStore(final FilesystemBackupConfig config) {
     this(config, Executors.newVirtualThreadPerTaskExecutor());
@@ -71,10 +74,12 @@ public final class FilesystemBackupStore implements BackupStore {
     final var contentsDir = Path.of(config.basePath()).resolve(CONTENTS_PATH);
     final var manifestsDir = Path.of(config.basePath()).resolve(MANIFESTS_PATH);
     rangesDir = Path.of(config.basePath()).resolve(RANGES_PATH);
+    metadataBaseDir = Path.of(config.basePath()).resolve(METADATA_PATH);
     try {
       FileUtil.ensureDirectoryExists(contentsDir);
       FileUtil.ensureDirectoryExists(manifestsDir);
       FileUtil.ensureDirectoryExists(rangesDir);
+      FileUtil.ensureDirectoryExists(metadataBaseDir);
     } catch (final IOException e) {
       throw new UncheckedIOException(
           "Unable to create backup directory structure; do you have the right permissions or configuration?",
@@ -223,6 +228,41 @@ public final class FilesystemBackupStore implements BackupStore {
             if (Files.deleteIfExists(markerPath)) {
               FileUtil.flushDirectory(partitionDir);
             }
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    return CompletableFuture.runAsync(
+        () -> {
+          final var metadataDir = metadataBaseDir.resolve(String.valueOf(partitionId));
+          final var metadataPath = metadataDir.resolve("metadata.json");
+          try {
+            FileUtil.ensureDirectoryExists(metadataDir);
+            Files.write(metadataPath, content);
+            FileUtil.flushDirectory(metadataDir);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var metadataDir = metadataBaseDir.resolve(String.valueOf(partitionId));
+          final var metadataPath = metadataDir.resolve("metadata.json");
+          if (!Files.exists(metadataPath)) {
+            return Optional.empty();
+          }
+          try {
+            return Optional.of(Files.readAllBytes(metadataPath));
           } catch (final IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -55,6 +55,7 @@ public final class FilesystemBackupStore implements BackupStore {
   private static final String MANIFESTS_PATH = "manifests";
   private static final String RANGES_PATH = "ranges";
   private static final String METADATA_PATH = "metadata";
+  private static final String METADATA_FILE = "metadata.json";
 
   private final ExecutorService executor;
   private final FileSetManager fileSetManager;
@@ -240,7 +241,7 @@ public final class FilesystemBackupStore implements BackupStore {
     return CompletableFuture.runAsync(
         () -> {
           final var metadataDir = metadataBaseDir.resolve(String.valueOf(partitionId));
-          final var metadataPath = metadataDir.resolve("metadata.json");
+          final var metadataPath = metadataDir.resolve(METADATA_FILE);
           try {
             FileUtil.ensureDirectoryExists(metadataDir);
             Files.write(metadataPath, content);
@@ -257,7 +258,7 @@ public final class FilesystemBackupStore implements BackupStore {
     return CompletableFuture.supplyAsync(
         () -> {
           final var metadataDir = metadataBaseDir.resolve(String.valueOf(partitionId));
-          final var metadataPath = metadataDir.resolve("metadata.json");
+          final var metadataPath = metadataDir.resolve(METADATA_FILE);
           if (!Files.exists(metadataPath)) {
             return Optional.empty();
           }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -46,6 +46,7 @@ public final class GcsBackupStore implements BackupStore {
   public static final String ERROR_VALIDATION_FAILED =
       "Invalid configuration for GcsBackupStore: %s";
   private static final Logger LOG = LoggerFactory.getLogger(GcsBackupStore.class);
+  private static final String METADATA_OBJECT_NAME = "metadata.json";
   private final ExecutorService executor;
   private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
@@ -297,7 +298,8 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   private BlobInfo backupMetadataBlobInfo(final int partitionId) {
-    return BlobInfo.newBuilder(bucketInfo, basePath + "metadata/" + partitionId + "/metadata.json")
+    return BlobInfo.newBuilder(
+            bucketInfo, "%smetadata/%d/%s".formatted(basePath, partitionId, METADATA_OBJECT_NAME))
         .build();
   }
 

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -246,6 +246,30 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    return CompletableFuture.runAsync(
+        () -> {
+          final var blobInfo = backupMetadataBlobInfo(partitionId);
+          client.create(blobInfo, content);
+        },
+        executor);
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var blobId = backupMetadataBlobInfo(partitionId).getBlobId();
+          final var blob = client.get(blobId);
+          if (blob == null || !blob.exists()) {
+            return Optional.empty();
+          }
+          return Optional.of(blob.getContent());
+        },
+        executor);
+  }
+
+  @Override
   public CompletableFuture<Void> closeAsync() {
     return CompletableFuture.runAsync(
         () -> {
@@ -269,6 +293,11 @@ public final class GcsBackupStore implements BackupStore {
   private BlobInfo rangeMarkerBlobInfo(final int partitionId, final BackupRangeMarker marker) {
     return BlobInfo.newBuilder(
             bucketInfo, rangeMarkersPrefix(partitionId) + BackupRangeMarker.toName(marker))
+        .build();
+  }
+
+  private BlobInfo backupMetadataBlobInfo(final int partitionId) {
+    return BlobInfo.newBuilder(bucketInfo, basePath + "metadata/" + partitionId + "/metadata.json")
         .build();
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -80,6 +80,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  * </ol>
  */
 public final class S3BackupStore implements BackupStore {
+
   static final ObjectMapper MAPPER =
       new ObjectMapper()
           .registerModule(new Jdk8Module())
@@ -88,6 +89,7 @@ public final class S3BackupStore implements BackupStore {
   static final String SNAPSHOT_PREFIX = "snapshot/";
   static final String SEGMENTS_PREFIX = "segments/";
   static final String MANIFEST_OBJECT_KEY = "manifest.json";
+  static final String METADATA_OBJECT_NAME = "metadata.json";
   private static final Logger LOG = LoggerFactory.getLogger(S3BackupStore.class);
   private static final int SCAN_PARALLELISM = 16;
   private final Pattern backupIdentifierPattern;
@@ -371,19 +373,11 @@ public final class S3BackupStore implements BackupStore {
   }
 
   private String backupMetadataKey(final int partitionId) {
-    return config.basePath().map(base -> base + "/").orElse("")
-        + "metadata/"
-        + partitionId
-        + "/metadata.json";
-  }
-
-  private CompletableFuture<List<ObjectIdentifier>> listBackupObjects(final Manifest manifest) {
-    return listObjects(manifest, Directory.CONTENTS);
-  }
-
-  private CompletableFuture<List<ObjectIdentifier>> listBackupManifestObjects(
-      final Manifest manifest) {
-    return listObjects(manifest, Directory.MANIFESTS);
+    return "%smetadata/%d/%s"
+        .formatted(
+            config.basePath().map(base -> base + "/").orElse(""),
+            partitionId,
+            METADATA_OBJECT_NAME);
   }
 
   private CompletableFuture<List<ObjectIdentifier>> listObjects(

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -336,6 +336,31 @@ public final class S3BackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    final var key = backupMetadataKey(partitionId);
+    return client
+        .putObject(
+            req -> req.bucket(config.bucketName()).key(key), AsyncRequestBody.fromBytes(content))
+        .thenApply(resp -> null);
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    final var key = backupMetadataKey(partitionId);
+    return client
+        .getObject(
+            req -> req.bucket(config.bucketName()).key(key), AsyncResponseTransformer.toBytes())
+        .thenApply(response -> Optional.of(response.asByteArray()))
+        .exceptionally(
+            throwable -> {
+              if (throwable.getCause() instanceof NoSuchKeyException) {
+                return Optional.empty();
+              }
+              throw new RuntimeException(throwable);
+            });
+  }
+
+  @Override
   public CompletableFuture<Void> closeAsync() {
     client.close();
     return CompletableFuture.completedFuture(null);
@@ -343,6 +368,13 @@ public final class S3BackupStore implements BackupStore {
 
   private String rangeMarkersPrefix(final int partitionId) {
     return config.basePath().map(base -> base + "/").orElse("") + "ranges/" + partitionId + "/";
+  }
+
+  private String backupMetadataKey(final int partitionId) {
+    return config.basePath().map(base -> base + "/").orElse("")
+        + "metadata/"
+        + partitionId
+        + "/metadata.json";
   }
 
   private CompletableFuture<List<ObjectIdentifier>> listBackupObjects(final Manifest manifest) {

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
@@ -18,7 +18,8 @@ public interface BackupStoreTestKit
         UpdatingBackupStatus,
         QueryingBackupStatus,
         ListingBackups,
-        StoringRangeMarkers {
+        StoringRangeMarkers,
+        StoringBackupMetadata {
 
   static Stream<? extends Arguments> provideBackups() throws Exception {
     return TestBackupProvider.provideArguments();

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/StoringBackupMetadata.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/StoringBackupMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public interface StoringBackupMetadata {
+  BackupStore getStore();
+
+  @Test
+  default void shouldStoreAndLoadMetadata() {
+    // given
+    final var store = getStore();
+    final var content = "content".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    assertThat(store.storeBackupMetadata(1, content)).succeedsWithin(Duration.ofSeconds(10));
+
+    // then
+    final var loaded = store.loadBackupMetadata(1).join();
+    assertThat(loaded).isPresent();
+    assertThat(loaded.get()).isEqualTo(content);
+  }
+
+  @Test
+  default void shouldReturnEmptyWhenNoMetadataExists() {
+    // given
+    final var store = getStore();
+
+    // when
+    final var loaded = store.loadBackupMetadata(1).join();
+
+    // then
+    assertThat(loaded).isEmpty();
+  }
+
+  @Test
+  default void shouldOverwriteExistingMetadata() {
+    // given
+    final var store = getStore();
+    final var original = "original".getBytes(StandardCharsets.UTF_8);
+    final var updated = "updated".getBytes(StandardCharsets.UTF_8);
+    store.storeBackupMetadata(1, original).join();
+
+    // when
+    assertThat(store.storeBackupMetadata(1, updated)).succeedsWithin(Duration.ofSeconds(10));
+
+    // then
+    final var loaded = store.loadBackupMetadata(1).join();
+    assertThat(loaded).isPresent();
+    assertThat(loaded.get()).isEqualTo(updated);
+  }
+
+  @Test
+  default void shouldIsolateMetadataBetweenPartitions() {
+    // given
+    final var store = getStore();
+    final var content1 = "content1".getBytes(StandardCharsets.UTF_8);
+    final var content2 = "content2".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    store.storeBackupMetadata(1, content1).join();
+    store.storeBackupMetadata(2, content2).join();
+
+    // then
+    final var loaded1 = store.loadBackupMetadata(1).join();
+    final var loaded2 = store.loadBackupMetadata(2).join();
+    assertThat(loaded1).isPresent();
+    assertThat(loaded1.get()).isEqualTo(content1);
+    assertThat(loaded2).isPresent();
+    assertThat(loaded2.get()).isEqualTo(content2);
+  }
+}

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -101,6 +101,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
     </dependency>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.api;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /** A store where the backup is stored * */
@@ -47,6 +48,24 @@ public interface BackupStore {
 
   /** Deletes a given {@link BackupRangeMarker} for the given partition. */
   CompletableFuture<Void> deleteRangeMarker(int partitionId, BackupRangeMarker marker);
+
+  /**
+   * Stores backup metadata content for the given partition. The content is an opaque byte array
+   * (JSON).
+   *
+   * @param partitionId the partition this metadata belongs to
+   * @param content the serialized metadata content
+   */
+  CompletableFuture<Void> storeBackupMetadata(int partitionId, byte[] content);
+
+  /**
+   * Loads backup metadata content for the given partition. Returns empty if the slot does not exist
+   * (fresh deployment or pre-migration).
+   *
+   * @param partitionId the partition this metadata belongs to
+   * @return the serialized metadata content, or empty if not found
+   */
+  CompletableFuture<Optional<byte[]>> loadBackupMetadata(int partitionId);
 
   CompletableFuture<Void> closeAsync();
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupMetadata.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupMetadata.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Per-partition JSON manifest containing checkpoint metadata and pre-computed backup ranges. Synced
+ * to the backup store on every mutation (backup confirmation, deletion).
+ */
+public record BackupMetadata(
+    @JsonProperty("version") int version,
+    @JsonProperty("partitionId") int partitionId,
+    @JsonProperty("lastUpdated") Instant lastUpdated,
+    @JsonProperty("checkpoints") List<CheckpointEntry> checkpoints,
+    @JsonProperty("ranges") List<RangeEntry> ranges) {
+
+  public static final int VERSION = 1;
+
+  /** A single checkpoint entry with full metadata. */
+  public record CheckpointEntry(
+      @JsonProperty("checkpointId") long checkpointId,
+      @JsonProperty("checkpointPosition") long checkpointPosition,
+      @JsonProperty("checkpointTimestamp") Instant checkpointTimestamp,
+      @JsonProperty("checkpointType") CheckpointType checkpointType,
+      @JsonProperty("firstLogPosition") long firstLogPosition) {}
+
+  /** A contiguous backup range [start, end]. */
+  public record RangeEntry(@JsonProperty("start") long start, @JsonProperty("end") long end) {}
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupMetadataSyncer.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupMetadataSyncer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.management;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupMetadata;
+import io.camunda.zeebe.backup.common.BackupMetadata.CheckpointEntry;
+import io.camunda.zeebe.backup.common.BackupMetadata.RangeEntry;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.SequencedCollection;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Syncs checkpoint metadata and backup ranges from RocksDB column families to a per-partition JSON
+ * file in the backup store.
+ */
+public final class BackupMetadataSyncer {
+
+  static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(new JavaTimeModule())
+          .disable(WRITE_DATES_AS_TIMESTAMPS);
+  private static final Logger LOG = LoggerFactory.getLogger(BackupMetadataSyncer.class);
+  private final int partitionId;
+  private final BackupStore backupStore;
+
+  public BackupMetadataSyncer(final int partitionId, final BackupStore backupStore) {
+    this.partitionId = partitionId;
+    this.backupStore = backupStore;
+  }
+
+  /**
+   * Syncs the current state of the given column families to the backup store for the specified
+   * partition. Reads all checkpoints and ranges, serializes them to JSON, and writes to the next
+   * slot.
+   *
+   * @param checkpoints source of checkpoint metadata
+   * @param ranges source of backup ranges
+   * @return a future that completes when the sync is done
+   */
+  public CompletableFuture<Void> store(
+      final SequencedCollection<DbCheckpointMetadataState.CheckpointEntry> checkpoints,
+      final SequencedCollection<BackupRange> ranges) {
+
+    final var manifest =
+        new BackupMetadata(
+            BackupMetadata.VERSION,
+            partitionId,
+            Instant.now(),
+            checkpoints.stream()
+                .map(
+                    entry ->
+                        new CheckpointEntry(
+                            entry.checkpointId(),
+                            entry.checkpointPosition(),
+                            Instant.ofEpochMilli(entry.checkpointTimestamp()),
+                            entry.checkpointType(),
+                            entry.firstLogPosition()))
+                .toList(),
+            ranges.stream().map(range -> new RangeEntry(range.start(), range.end())).toList());
+
+    try {
+      final var content = MAPPER.writeValueAsBytes(manifest);
+      return backupStore
+          .storeBackupMetadata(partitionId, content)
+          .whenComplete(
+              (result, error) -> {
+                if (error != null) {
+                  LOG.warn("Failed to sync backup metadata", error);
+                } else {
+                  LOG.debug("Synced backup metadata");
+                }
+              });
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize backup metadata", e);
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  /**
+   * Loads the most recent valid backup metadata manifest for the given partition. Reads both slots
+   * and returns the one with the higher valid sequence number.
+   *
+   * @param partitionId the partition to load metadata for
+   * @return the manifest, or empty if no valid metadata exists
+   */
+  public CompletableFuture<Optional<BackupMetadata>> load(final int partitionId) {
+    return backupStore
+        .loadBackupMetadata(partitionId)
+        .thenApply(
+            optBytes ->
+                optBytes.flatMap(
+                    bytes -> {
+                      try {
+                        return Optional.of(MAPPER.readValue(bytes, BackupMetadata.class));
+                      } catch (final IOException e) {
+                        LOG.warn("Failed to parse backup metadata", e);
+                        return Optional.empty();
+                      }
+                    }))
+        .exceptionally(
+            error -> {
+              LOG.warn("Failed to load backup metadata", error);
+              return Optional.empty();
+            });
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointConfirmBackupProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.management.BackupMetadataSyncer;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
@@ -28,14 +29,21 @@ public class CheckpointConfirmBackupProcessor {
   private final CheckpointState checkpointState;
   private final BackupManager backupManager;
   private final CheckpointBackupConfirmedApplier backupConfirmedApplier;
+  private final DbCheckpointMetadataState checkpointMetadataState;
+  private final DbBackupRangeState backupRangeState;
+  private final BackupMetadataSyncer syncer;
 
   public CheckpointConfirmBackupProcessor(
       final CheckpointState checkpointState,
       final DbCheckpointMetadataState checkpointMetadataState,
       final DbBackupRangeState backupRangeState,
-      final BackupManager backupManager) {
+      final BackupManager backupManager,
+      final BackupMetadataSyncer syncer) {
     this.checkpointState = checkpointState;
     this.backupManager = backupManager;
+    this.checkpointMetadataState = checkpointMetadataState;
+    this.backupRangeState = backupRangeState;
+    this.syncer = syncer;
     backupConfirmedApplier =
         new CheckpointBackupConfirmedApplier(
             checkpointState, checkpointMetadataState, backupRangeState);
@@ -63,6 +71,14 @@ public class CheckpointConfirmBackupProcessor {
               .recordType(RecordType.EVENT)
               .valueType(ValueType.CHECKPOINT)
               .intent(CheckpointIntent.CONFIRMED_BACKUP));
+
+      final var checkpoints = checkpointMetadataState.getAllCheckpoints();
+      final var ranges = backupRangeState.getAllRanges();
+      resultBuilder.appendPostCommitTask(
+          () -> {
+            syncer.store(checkpoints, ranges);
+            return true;
+          });
     } else {
       LOG.debug(
           "Ignoring backup for checkpoint {} as it is older than the latest backup {}",

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointDeleteBackupProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.management.BackupMetadataSyncer;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
 import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
@@ -32,8 +33,10 @@ public final class CheckpointDeleteBackupProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointDeleteBackupProcessor.class);
 
   private final DbCheckpointMetadataState checkpointMetadataState;
+  private final DbBackupRangeState backupRangeState;
   private final CheckpointBackupDeletedApplier backupDeletedApplier;
   private final BackupManager backupManager;
+  private final BackupMetadataSyncer syncer;
 
   /**
    * @param checkpointMetadataState the checkpoint metadata CF state
@@ -44,9 +47,12 @@ public final class CheckpointDeleteBackupProcessor {
       final DbCheckpointMetadataState checkpointMetadataState,
       final DbBackupRangeState backupRangeState,
       final CheckpointState checkpointState,
-      final BackupManager backupManager) {
+      final BackupManager backupManager,
+      final BackupMetadataSyncer syncer) {
     this.checkpointMetadataState = checkpointMetadataState;
+    this.backupRangeState = backupRangeState;
     this.backupManager = backupManager;
+    this.syncer = syncer;
     backupDeletedApplier =
         new CheckpointBackupDeletedApplier(
             checkpointMetadataState, backupRangeState, checkpointState);
@@ -70,6 +76,13 @@ public final class CheckpointDeleteBackupProcessor {
             .recordType(RecordType.EVENT)
             .valueType(ValueType.CHECKPOINT)
             .intent(CheckpointIntent.DELETED_BACKUP));
+    final var checkpoints = checkpointMetadataState.getAllCheckpoints();
+    final var ranges = backupRangeState.getAllRanges();
+    resultBuilder.appendPostCommitTask(
+        () -> {
+          syncer.store(checkpoints, ranges);
+          return true;
+        });
     resultBuilder.appendPostCommitTask(
         () -> {
           backupManager.deleteBackup(checkpointId);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.api.CheckpointListener;
+import io.camunda.zeebe.backup.management.BackupMetadataSyncer;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
@@ -50,16 +52,23 @@ public final class CheckpointRecordsProcessor
   //  Can be accessed concurrently by other threads to add new listeners. Hence we have to use a
   // thread safe collection
   private final Set<CheckpointListener> checkpointListeners = new CopyOnWriteArraySet<>();
+  private final BackupMetadataSyncer syncer;
   private final CheckpointMetrics metrics;
   private DbCheckpointState checkpointState;
+  private DbCheckpointMetadataState checkpointMetadataState;
+  private DbBackupRangeState backupRangeState;
   private ProcessingScheduleService executor;
   private ScalingStatusSupplier scalingInProgressSupplier;
   private PartitionCountSupplier partitionCountSupplier;
 
   public CheckpointRecordsProcessor(
-      final BackupManager backupManager, final int partitionId, final MeterRegistry registry) {
+      final BackupManager backupManager,
+      final int partitionId,
+      final BackupStore backupStore,
+      final MeterRegistry registry) {
     this.backupManager = backupManager;
     metrics = new CheckpointMetrics(registry);
+    syncer = new BackupMetadataSyncer(partitionId, backupStore);
   }
 
   public void setScalingInProgressSupplier(final ScalingStatusSupplier scalingInProgressSupplier) {
@@ -83,10 +92,10 @@ public final class CheckpointRecordsProcessor
         new DbCheckpointState(
             recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
 
-    final var checkpointMetadataState =
+    checkpointMetadataState =
         new DbCheckpointMetadataState(
             recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
-    final var backupRangeState =
+    backupRangeState =
         new DbBackupRangeState(
             recordProcessorContext.getZeebeDb(), recordProcessorContext.getTransactionContext());
 
@@ -109,11 +118,11 @@ public final class CheckpointRecordsProcessor
 
     checkpointConfirmBackupProcessor =
         new CheckpointConfirmBackupProcessor(
-            checkpointState, checkpointMetadataState, backupRangeState, backupManager);
+            checkpointState, checkpointMetadataState, backupRangeState, backupManager, syncer);
 
     checkpointDeleteBackupProcessor =
         new CheckpointDeleteBackupProcessor(
-            checkpointMetadataState, backupRangeState, checkpointState, backupManager);
+            checkpointMetadataState, backupRangeState, checkpointState, backupManager, syncer);
 
     checkpointCreatedEventApplier =
         new CheckpointCreatedEventApplier(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupMetadataSyncerTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupMetadataSyncerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupMetadata;
+import io.camunda.zeebe.backup.common.BackupMetadata.CheckpointEntry;
+import io.camunda.zeebe.backup.common.BackupMetadata.RangeEntry;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class BackupMetadataSyncerTest {
+
+  @Mock private BackupStore backupStore;
+
+  private BackupMetadataSyncer syncer;
+
+  @BeforeEach
+  void setUp() {
+    syncer = new BackupMetadataSyncer(1, backupStore);
+  }
+
+  @Test
+  void shouldSerializeCheckpointsAndRanges() throws Exception {
+    // given
+    final var checkpointEntry =
+        new DbCheckpointMetadataState.CheckpointEntry(
+            10L, 100L, 1000L, CheckpointType.SCHEDULED_BACKUP, 50L);
+    final var range = new BackupRange(10L, 20L);
+
+    final var contentCaptor = ArgumentCaptor.forClass(byte[].class);
+    when(backupStore.storeBackupMetadata(eq(1), contentCaptor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    syncer.store(List.of(checkpointEntry), List.of(range)).join();
+
+    // then - verify the content is valid JSON that deserializes correctly
+    final var manifest =
+        BackupMetadataSyncer.MAPPER.readValue(contentCaptor.getValue(), BackupMetadata.class);
+    assertThat(manifest.partitionId()).isEqualTo(1);
+    assertThat(manifest.checkpoints()).hasSize(1);
+    assertThat(manifest.checkpoints().getFirst().checkpointId()).isEqualTo(10L);
+    assertThat(manifest.checkpoints().getFirst().checkpointPosition()).isEqualTo(100L);
+    assertThat(manifest.checkpoints().getFirst().checkpointType())
+        .isEqualTo(CheckpointType.SCHEDULED_BACKUP);
+    assertThat(manifest.checkpoints().getFirst().firstLogPosition()).isEqualTo(50L);
+    assertThat(manifest.ranges()).hasSize(1);
+    assertThat(manifest.ranges().getFirst().start()).isEqualTo(10L);
+    assertThat(manifest.ranges().getFirst().end()).isEqualTo(20L);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenMissingFromStore() {
+    // given
+    when(backupStore.loadBackupMetadata(1))
+        .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+    // when
+    final var result = syncer.load(1).join();
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldLoadManifestWithCheckpointsAndRanges() {
+    // given
+    final var checkpoints =
+        List.of(
+            new CheckpointEntry(
+                1L, 100L, Instant.ofEpochMilli(1000), CheckpointType.SCHEDULED_BACKUP, 50L),
+            new CheckpointEntry(
+                2L, 200L, Instant.ofEpochMilli(2000), CheckpointType.MANUAL_BACKUP, 150L));
+    final var ranges = List.of(new RangeEntry(1L, 2L));
+    final var manifest =
+        new BackupMetadata(BackupMetadata.VERSION, 1, Instant.now(), checkpoints, ranges);
+    final var bytes = serializeManifest(manifest);
+
+    when(backupStore.loadBackupMetadata(1))
+        .thenReturn(CompletableFuture.completedFuture(Optional.of(bytes)));
+
+    // when
+    final var result = syncer.load(1).join();
+
+    // then
+    assertThat(result).isPresent();
+    final var loaded = result.get();
+    assertThat(loaded.checkpoints()).hasSize(2);
+    assertThat(loaded.checkpoints().get(0).checkpointId()).isEqualTo(1L);
+    assertThat(loaded.checkpoints().get(1).checkpointId()).isEqualTo(2L);
+    assertThat(loaded.ranges()).hasSize(1);
+    assertThat(loaded.ranges().getFirst().start()).isEqualTo(1L);
+    assertThat(loaded.ranges().getFirst().end()).isEqualTo(2L);
+  }
+
+  private static byte[] serializeManifest(final BackupMetadata manifest) {
+    try {
+      return BackupMetadataSyncer.MAPPER.writeValueAsBytes(manifest);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -9,14 +9,17 @@ package io.camunda.zeebe.backup.processing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.processing.MockProcessingResult.Event;
 import io.camunda.zeebe.backup.processing.MockProcessingResult.MockProcessingResultBuilder;
@@ -37,6 +40,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
@@ -45,6 +49,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.InstantSource;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -85,7 +90,7 @@ final class CheckpointRecordsProcessorTest {
     final RecordProcessorContextImpl context = createContext(executor, zeebedb);
 
     resultBuilder = new MockProcessingResultBuilder();
-    processor = new CheckpointRecordsProcessor(backupManager, 1, context.getMeterRegistry());
+    processor = new CheckpointRecordsProcessor(backupManager, 1, null, context.getMeterRegistry());
 
     processor.setScalingInProgressSupplier(scalingInProgress::get);
     processor.setPartitionCountSupplier(() -> (int) dynamicPartitionCount.get());
@@ -350,7 +355,7 @@ final class CheckpointRecordsProcessorTest {
   void shouldNotifyListenerOnInit() {
     // given
     final RecordProcessorContextImpl context = createContext(null, zeebedb);
-    processor = new CheckpointRecordsProcessor(backupManager, 1, context.getMeterRegistry());
+    processor = new CheckpointRecordsProcessor(backupManager, 1, null, context.getMeterRegistry());
     processor.setScalingInProgressSupplier(scalingInProgress::get);
     processor.setPartitionCountSupplier(dynamicPartitionCount::get);
     final long checkpointId = 3;
@@ -901,5 +906,87 @@ final class CheckpointRecordsProcessorTest {
     assertThat(state.getLatestBackupTimestamp()).isEqualTo(secondTimestamp);
     assertThat(state.getLatestBackupType()).isEqualTo(CheckpointType.SCHEDULED_BACKUP);
     assertThat(state.getLatestBackupFirstLogPosition()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldScheduleSyncPostCommitTaskOnConfirmBackup() {
+    // given — a processor with a real backup store
+    final var backupStore = mock(BackupStore.class);
+    when(backupStore.storeBackupMetadata(any(int.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final var context = createContext(executor, zeebedb);
+    final var syncProcessor =
+        new CheckpointRecordsProcessor(backupManager, 1, backupStore, context.getMeterRegistry());
+    syncProcessor.setScalingInProgressSupplier(scalingInProgress::get);
+    syncProcessor.setPartitionCountSupplier(dynamicPartitionCount::get);
+    syncProcessor.init(context);
+
+    final var checkpointId = 5;
+    final var checkpointPosition = 50;
+    final var value =
+        new CheckpointRecord()
+            .setCheckpointId(checkpointId)
+            .setCheckpointPosition(checkpointPosition)
+            .setCheckpointType(CheckpointType.MANUAL_BACKUP);
+    final var record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition + 10, 0, CheckpointIntent.CONFIRM_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    final var result =
+        (MockProcessingResult) syncProcessor.process(record, new MockProcessingResultBuilder());
+
+    // then — a post-commit task is registered
+    assertThat(result.postCommitTasks()).hasSize(1);
+
+    // when — the post-commit task is executed
+    final var success = result.executePostCommitTasks();
+
+    // then — task succeeds (fire-and-forget) and store metadata is called
+    assertThat(success).isTrue();
+    verify(backupStore).storeBackupMetadata(eq(1), any());
+  }
+
+  @Test
+  void shouldNotScheduleSyncPostCommitTaskOnRejection() {
+    // given — a processor with a backup store and an existing newer backup
+    final var backupStore = mock(BackupStore.class);
+    final var context = createContext(executor, zeebedb);
+    final var syncProcessor =
+        new CheckpointRecordsProcessor(backupManager, 1, backupStore, context.getMeterRegistry());
+    syncProcessor.setScalingInProgressSupplier(scalingInProgress::get);
+    syncProcessor.setPartitionCountSupplier(dynamicPartitionCount::get);
+    syncProcessor.init(context);
+
+    // Set a newer backup ID so the command will be rejected
+    state.setLatestBackupInfo(
+        10, 100, Instant.now().toEpochMilli(), CheckpointType.MANUAL_BACKUP, -1L);
+
+    final var oldCheckpointId = 5;
+    final var value = new CheckpointRecord().setCheckpointId(oldCheckpointId);
+    final var record =
+        new MockTypedCheckpointRecord(
+            50, 0, CheckpointIntent.CONFIRM_BACKUP, RecordType.COMMAND, value);
+
+    // when
+    final var result =
+        (MockProcessingResult) syncProcessor.process(record, new MockProcessingResultBuilder());
+
+    // then — no post-commit task (command was rejected)
+    assertThat(result.postCommitTasks()).isEmpty();
+  }
+
+  @Test
+  void shouldNotSyncOnRecoveryWhenNoBackupStore() {
+    // given — no backup store (the default processor in setup)
+    final var readonlyContext = mock(ReadonlyStreamProcessorContext.class);
+    when(readonlyContext.getPartitionId()).thenReturn(1);
+
+    // when — should not throw
+    processor.onRecovered(readonlyContext);
+
+    // then — no exception, backup manager still called for fail in-progress
+    verify(backupManager).failInProgressBackup(anyLong());
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-record MockProcessingResult(List<Event> records, Response response) implements ProcessingResult {
+record MockProcessingResult(
+    List<Event> records, Response response, List<PostCommitTask> postCommitTasks)
+    implements ProcessingResult {
 
   @Override
   public ImmutableRecordBatch getRecordBatch() {
@@ -39,7 +41,11 @@ record MockProcessingResult(List<Event> records, Response response) implements P
 
   @Override
   public boolean executePostCommitTasks() {
-    return false;
+    var result = true;
+    for (final var task : postCommitTasks) {
+      result = result && task.flush();
+    }
+    return result;
   }
 
   @Override
@@ -61,6 +67,7 @@ record MockProcessingResult(List<Event> records, Response response) implements P
   static class MockProcessingResultBuilder implements ProcessingResultBuilder {
 
     final List<Event> followupRecords = new ArrayList<>();
+    final List<PostCommitTask> postCommitTasks = new ArrayList<>();
     Response response;
 
     final @Override public Either<RuntimeException, ProcessingResultBuilder>
@@ -97,17 +104,19 @@ record MockProcessingResult(List<Event> records, Response response) implements P
 
     @Override
     public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask task) {
-      return null;
+      postCommitTasks.add(task);
+      return this;
     }
 
     @Override
     public ProcessingResultBuilder resetPostCommitTasks() {
-      return null;
+      postCommitTasks.clear();
+      return this;
     }
 
     @Override
     public ProcessingResult build() {
-      return new MockProcessingResult(followupRecords, response);
+      return new MockProcessingResult(followupRecords, response, List.copyOf(postCommitTasks));
     }
 
     @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -130,7 +130,10 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
       final PartitionTransitionContext context, final BackupManager backupManager) {
     final CheckpointRecordsProcessor checkpointRecordsProcessor =
         new CheckpointRecordsProcessor(
-            backupManager, context.getPartitionId(), context.getPartitionTransitionMeterRegistry());
+            backupManager,
+            context.getPartitionId(),
+            context.getBackupStore(),
+            context.getPartitionTransitionMeterRegistry());
     context.setCheckpointProcessor(checkpointRecordsProcessor);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -91,6 +92,16 @@ public class InMemoryMockBackupStore implements BackupStore, AutoCloseable {
   public CompletableFuture<Void> deleteRangeMarker(
       final int partitionId, final BackupRangeMarker marker) {
     throw new UnsupportedOperationException("Range markers are not yet supported");
+  }
+
+  @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    throw new UnsupportedOperationException("Backup metadata is not yet supported");
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    throw new UnsupportedOperationException("Backup metadata is not yet supported");
   }
 
   @Override

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/BackupRangeResolverTest.java
@@ -626,6 +626,17 @@ final class BackupRangeResolverTest {
     }
 
     @Override
+    public CompletableFuture<Void> storeBackupMetadata(
+        final int partitionId, final byte[] content) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
     public CompletableFuture<Void> closeAsync() {
       return CompletableFuture.completedFuture(null);
     }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -182,6 +182,16 @@ final class TestRestorableBackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<Void> storeBackupMetadata(final int partitionId, final byte[] content) {
+    throw new UnsupportedOperationException("Backup metadata is not yet supported");
+  }
+
+  @Override
+  public CompletableFuture<Optional<byte[]>> loadBackupMetadata(final int partitionId) {
+    throw new UnsupportedOperationException("Backup metadata is not yet supported");
+  }
+
+  @Override
   public CompletableFuture<Void> closeAsync() {
     waiters
         .values()


### PR DESCRIPTION
Defines a JSON file format for writing checkpoints and ranges to the backup store. This is done as post-commit tasks on backup confirmation and deletion. Marker checkpoints will only be added on the next backup, before that they aren't available anyway.

Builds on top of #46479