### PR TITLE
[Backport stable/8.9] Only root process instances track business id uniqueness

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1442,7 +1442,7 @@ public final class ProcessInstanceModificationModifyProcessor
       // started by a call activity.
       final var currentElementInstanceRecord = currentElementInstance.getValue();
       if (currentElementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS
-          && currentElementInstanceRecord.hasParentProcess()) {
+          && currentElementInstanceRecord.hasParentProcessInstance()) {
         throw new TerminatedChildProcessException(
             ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED.formatted(
                 currentElementInstanceRecord.getBpmnProcessId()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV3Applier.java
@@ -61,7 +61,8 @@ final class ProcessInstanceElementActivatingV3Applier
         elementInstanceState.newInstance(
             flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       insertBusinessIdIndex(value);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCompletedV2Applier.java
@@ -64,7 +64,8 @@ final class ProcessInstanceElementCompletedV2Applier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       deleteBusinessIdIndex(value);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedV2Applier.java
@@ -48,7 +48,8 @@ final class ProcessInstanceElementTerminatedV2Applier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       deleteBusinessIdIndex(value);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -402,4 +402,64 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .describedAs("Expect two active child instances with the same business id")
         .allSatisfy(r -> assertThat(r.getValue()).hasBusinessId(businessId));
   }
+
+  @Test
+  public void shouldAllowCallActivityToCreateProcessInstanceWithBusinessIdInUse() {
+    final String processUnderTestId = helper.getBpmnProcessId() + "_underTest";
+    final String processWithCallActivityId = helper.getBpmnProcessId() + "_callActivity";
+    final String businessId = "biz-123";
+
+    // given:
+    // - two processes: process under test and call activity process
+    // - and an instance of the process under test with a business id
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processUnderTestId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processWithCallActivityId)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(processUnderTestId))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // and an already active instance of the process under test with business id
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processUnderTestId)
+            .withBusinessId(businessId)
+            .create();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(processUnderTestId)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect business id in use")
+        .hasBusinessId(businessId);
+
+    // when
+    final var callActivityInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processWithCallActivityId)
+            .withBusinessId(businessId)
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(processUnderTestId)
+                .withParentProcessInstanceKey(callActivityInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect called process instance created even with business id already in use")
+        .hasBusinessId(businessId);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -462,4 +462,65 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .describedAs("Expect called process instance created even with business id already in use")
         .hasBusinessId(businessId);
   }
+
+  @Test
+  public void shouldAllowCreateProcessInstanceWithBusinessIdInUseOnlyByChildInstance() {
+    final String processUnderTestId = helper.getBpmnProcessId() + "_underTest";
+    final String processWithCallActivityId = helper.getBpmnProcessId() + "_callActivity";
+    final String businessId = "biz-123";
+
+    // given:
+    // - two processes: process under test and call activity process
+    // - and an instance of the process under test with a business id
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processUnderTestId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processWithCallActivityId)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(processUnderTestId))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // and an instance of process under test created via a call activity with a business id
+    final var callActivityInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processWithCallActivityId)
+            .withBusinessId(businessId)
+            .create();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withParentProcessInstanceKey(callActivityInstanceKey)
+                .withBpmnProcessId(processUnderTestId)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect child instance with business id in use")
+        .hasBusinessId(businessId);
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processUnderTestId)
+            .withBusinessId(businessId)
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withBpmnProcessId(processUnderTestId)
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Allow creating process instance with business id only in use by child instance")
+        .hasBusinessId(businessId);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -386,7 +386,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .deploy();
 
     // when
-    final var parentInstanceKey =
+    final var parentProcessInstanceKey =
         ENGINE
             .processInstance()
             .ofBpmnProcessId(parentProcessId)
@@ -397,7 +397,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withBpmnProcessId(childProcessId)
-                .withParentProcessInstanceKey(parentInstanceKey)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
                 .limit(2))
         .describedAs("Expect two active child instances with the same business id")
         .allSatisfy(r -> assertThat(r.getValue()).hasBusinessId(businessId));
@@ -445,7 +445,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .hasBusinessId(businessId);
 
     // when
-    final var callActivityInstanceKey =
+    final var parentProcessInstanceKey =
         ENGINE
             .processInstance()
             .ofBpmnProcessId(processWithCallActivityId)
@@ -456,7 +456,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withBpmnProcessId(processUnderTestId)
-                .withParentProcessInstanceKey(callActivityInstanceKey)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
                 .getFirst()
                 .getValue())
         .describedAs("Expect called process instance created even with business id already in use")
@@ -489,7 +489,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
         .deploy();
 
     // and an instance of process under test created via a call activity with a business id
-    final var callActivityInstanceKey =
+    final var parentProcessInstanceKey =
         ENGINE
             .processInstance()
             .ofBpmnProcessId(processWithCallActivityId)
@@ -497,7 +497,7 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
             .create();
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withParentProcessInstanceKey(callActivityInstanceKey)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
                 .withBpmnProcessId(processUnderTestId)
                 .getFirst()
                 .getValue())

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_ACTIVATING_v3.golden
@@ -61,7 +61,8 @@ final class ProcessInstanceElementActivatingV3Applier
         elementInstanceState.newInstance(
             flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       insertBusinessIdIndex(value);
     }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMPLETED_v2.golden
@@ -64,7 +64,8 @@ final class ProcessInstanceElementCompletedV2Applier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       deleteBusinessIdIndex(value);
     }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_TERMINATED_v2.golden
@@ -48,7 +48,8 @@ final class ProcessInstanceElementTerminatedV2Applier
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && !value.hasParentProcessInstance()) {
       deleteBusinessIdIndex(value);
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -365,7 +365,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public boolean hasParentProcess() {
+  public boolean hasParentProcessInstance() {
     return getParentProcessInstanceKey() != -1L;
   }
 


### PR DESCRIPTION
# Description
Backport of #46257 to `stable/8.9`.

relates to #46112