### PR TITLE
refactor: make isApplicableFor and configureFor public on AbstractCamundaAnnotationProcessor

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
@@ -31,9 +31,9 @@ public abstract class AbstractCamundaAnnotationProcessor
     this.applicationContext = applicationContext;
   }
 
-  protected abstract boolean isApplicableFor(final BeanInfo beanInfo);
+  public abstract boolean isApplicableFor(final BeanInfo beanInfo);
 
-  protected abstract void configureFor(final BeanInfo beanInfo);
+  public abstract void configureFor(final BeanInfo beanInfo);
 
   protected abstract void start(CamundaClient client);
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorAopCompatibilityTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorAopCompatibilityTest.java
@@ -96,12 +96,12 @@ public class CamundaAnnotationProcessorAopCompatibilityTest {
     BeanInfo beanInfo;
 
     @Override
-    protected boolean isApplicableFor(final BeanInfo beanInfo) {
+    public boolean isApplicableFor(final BeanInfo beanInfo) {
       return beanInfo.getTargetClass().equals(MyWorker.class);
     }
 
     @Override
-    protected void configureFor(final BeanInfo beanInfo) {
+    public void configureFor(final BeanInfo beanInfo) {
       this.beanInfo = beanInfo;
     }
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorPrototypeBeanCompatibilityTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/processor/CamundaAnnotationProcessorPrototypeBeanCompatibilityTest.java
@@ -64,12 +64,12 @@ public class CamundaAnnotationProcessorPrototypeBeanCompatibilityTest {
     private boolean configured = false;
 
     @Override
-    protected boolean isApplicableFor(final BeanInfo beanInfo) {
+    public boolean isApplicableFor(final BeanInfo beanInfo) {
       return beanInfo.getTargetClass().equals(SomeBean.class);
     }
 
     @Override
-    protected void configureFor(final BeanInfo beanInfo) {
+    public void configureFor(final BeanInfo beanInfo) {
       configured = true;
     }
 


### PR DESCRIPTION
## Description

These methods need to be accessible from the zeebe-process-test module so that the test execution listener can explicitly feed the test class into annotation processors. Test classes are not registered as Spring bean definitions and are therefore not discovered by onStart() which iterates getBeanDefinitionNames(). Making these methods public allows the test support to configure processors for the test class before the CamundaClientCreatedSpringEvent is published.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #46557
