### PR TITLE
fix(load-tests): add nodeSelector and tolerations for storage pods

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -361,6 +361,10 @@ jobs:
           git config user.name ${{ github.actor }}
           # Create the namespace for the load test
           ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          # Annotate namespace with the workflow run URL for traceability
+          kubectl annotate namespace ${{ env.NAMESPACE }} \
+            "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --overwrite
       - name: Install latest Camunda Platform
         run: |
           cd load-tests/setup/${{ env.NAMESPACE }}

--- a/load-tests/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/camunda-platform-values-elasticsearch.yaml
@@ -75,10 +75,10 @@ elasticsearch:
       accessModes: ["ReadWriteOnce"]
     resources:
       requests:
-        cpu: 3
+        cpu: 3000m
         memory: 3Gi
       limits:
-        cpu: 3
+        cpu: 3000m
         memory: 6Gi
     nodeSelector:
       cloud.google.com/gke-nodepool: n2-standard-4

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -75,10 +75,10 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 3400m # max on n2-standard-4 due to other overhead
+      cpu: 3000m
       memory: 2Gi
     limits:
-      cpu: 3400m # max on n2-standard-4 due to other overhead
+      cpu: 3000m
       memory: 2Gi
 
   nodeSelector:

--- a/load-tests/secondary-storage-values-opensearch.yaml
+++ b/load-tests/secondary-storage-values-opensearch.yaml
@@ -34,16 +34,25 @@ sysctlVmMaxMapCount: 262144
 
 resources:
   requests:
-    cpu: 3
+    cpu: 3000m
     memory: 4Gi
   limits:
-    cpu: 6
+    cpu: 3000m
     memory: 10Gi
 
 persistence:
   enabled: true
   size: 128Gi
   storageClass: "ssd"
+
+nodeSelector:
+  cloud.google.com/gke-nodepool: n2-standard-4
+
+tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4
+    effect: NoSchedule
 
 antiAffinity: "hard"
 

--- a/load-tests/secondary-storage-values-postgresql.yaml
+++ b/load-tests/secondary-storage-values-postgresql.yaml
@@ -14,8 +14,17 @@ primary:
       memory: 4Gi
       cpu: 3000m
     limits:
+      cpu: 3000m
       memory: 6Gi
-      cpu: 6000m
+
+  nodeSelector:
+    cloud.google.com/gke-nodepool: n2-standard-4
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
 
   persistence:
     size: 128Gi


### PR DESCRIPTION
## Problem

Load test deployments using PostgreSQL or OpenSearch as secondary storage fail to schedule pods, and don't trigger cluster autoscaler scaleups.

**Root cause:** The `n2-standard-4` nodepool has a taint `nodepool=n2-standard-4:NoSchedule`, but the PostgreSQL and OpenSearch Helm values were missing both `nodeSelector` and `tolerations`. Without these, pods either:
- Can't land on `n2-standard-4` nodes (untolerated taint)
- Can't fit on the small `n2-standard-2` nodes (insufficient CPU/memory)
- Don't trigger scaleups (no nodepool matches all constraints)

The Elasticsearch values already had correct `nodeSelector` + `tolerations` under `elasticsearch.master`, so ES-based deployments were not affected for the storage layer.

## Changes

### Storage scheduling fix
- **`secondary-storage-values-postgresql.yaml`**: Added `primary.nodeSelector` and `primary.tolerations` for `n2-standard-4`
- **`secondary-storage-values-opensearch.yaml`**: Added top-level `nodeSelector` and `tolerations` for `n2-standard-4`

### Resource limits
- Set explicit CPU limits equal to CPU requests (`3000m`) across all values files (orchestration, elasticsearch, postgresql, opensearch) to ensure consistent Guaranteed QoS class and prevent implicit defaults from upstream Helm charts

### Traceability
- **`camunda-load-test.yml`**: Added a namespace annotation `github.com/workflow-run-url` pointing to the triggering GitHub Actions run, making it easy to trace any load test deployment back to its origin workflow run