### PR TITLE
fix: decided optimize docker tag via generate-snapshot-docker-tag-and-concurrency-group.yml

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -10,6 +10,8 @@ fi
 
 if [ "${IS_MAIN}" = "true" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8-SNAPSHOT")
+elif [ -n "${DOCKER_HUB_SNAPSHOT_TAG}" ]; then
+    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${DOCKER_HUB_SNAPSHOT_TAG}")
 fi
 
 printf -v tag_arguments -- "-t %s " "${tags[@]}"

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -7,13 +7,24 @@ on:
   workflow_call:
 
 jobs:
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  utils-get-snapshot-docker-tag:
+    uses: ./.github/workflows/generate-snapshot-docker-tag-and-concurrency-group.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      job_to_run: 'snapshot-tag'
+
   deploy-artifacts:
     name: Deploy Artifacts
+    needs: [ utils-get-snapshot-docker-tag ]
     runs-on: gcp-core-4-default
     timeout-minutes: 30
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize
+      DOCKER_HUB_SNAPSHOT_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - name: Install common tooling (buildx)  # required on self-hosted runners
@@ -42,6 +53,7 @@ jobs:
           echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_stable_branch }}"
           echo "IS_MAIN=${{ steps.define-values.outputs.is_main_branch }}"
           echo "REVISION=${{ steps.define-values.outputs.git_commit_hash }}"
+          echo "DOCKER_HUB_SNAPSHOT_TAG=${DOCKER_HUB_SNAPSHOT_TAG}"
         } >> "$GITHUB_ENV"
     # Generating a production build
     - name: Setup Maven


### PR DESCRIPTION

## Description

This pull request updates the Docker image tagging strategy in the deployment workflow to support dynamically generated snapshot tags based on the branch name, improving flexibility and automation. The main changes involve calling a utility workflow to generate the Docker tag, updating environment variables, and modifying the image tagging logic to use the new tag.

**Workflow enhancements:**

* Added a new job `utils-get-snapshot-docker-tag` in `.github/workflows/optimize-deploy-artifacts.yml` to dynamically generate the Docker tag (e.g., `SNAPSHOT` or `X.Y-SNAPSHOT`) based on the branch name by calling a reusable workflow.
* Updated the `deploy-artifacts` job to depend on the new utility job and set the `DOCKER_HUB_SNAPSHOT_TAG` environment variable using the generated output.

**Docker image tagging logic:**

* Changed `.github/optimize/scripts/build-docker-image.sh` to use the new `DOCKER_HUB_SNAPSHOT_TAG` variable for tagging Docker images, instead of hardcoding `8-SNAPSHOT` for the main branch.
* Ensured the new `DOCKER_HUB_SNAPSHOT_TAG` environment variable is exported in the workflow for use in subsequent steps.

Related to this issue reported in `stable/8.9`
https://github.com/camunda/camunda/issues/46249#issuecomment-3946889541
As a follow up of https://github.com/camunda/camunda/issues/30477
An actual fix for https://github.com/camunda/camunda/pull/37551

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
