### PR TITLE
test: changed report name

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -186,11 +186,21 @@ jobs:
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
 
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          # Replace invalid artifact-name characters (at least '/')
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: json-report-nightly-api-${{ matrix.branch }}
+          name: json-report-nightly-api-${{ steps.sanitize.outputs.safe_branch }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 
@@ -407,11 +417,21 @@ jobs:
             --close-run \
             -f "$JUNIT_RESULTS_FILE"
 
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          # Replace invalid artifact-name characters (at least '/')
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
       - name: Upload json report to GitHub Actions Artifacts
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: json-report-nightly-e2e-${{ matrix.branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          name: json-report-nightly-e2e-${{ steps.sanitize.outputs.safe_branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -231,7 +231,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          branch="${{ matrix.branch }}"
+          branch="${{ github.event.inputs.branch }}"
           # Replace invalid artifact-name characters (at least '/')
           safe_branch="${branch//\//-}"
           echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
@@ -464,7 +464,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          branch="${{ matrix.branch }}"
+          branch="${{ github.event.inputs.branch }}"
           # Replace invalid artifact-name characters (at least '/')
           safe_branch="${branch//\//-}"
           echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -226,6 +226,25 @@ jobs:
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          # Replace invalid artifact-name characters (at least '/')
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: json-report-will-be-remoeved-nightly-api-${{ steps.sanitize.outputs.safe_branch }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -439,6 +458,24 @@ jobs:
           name: C8 Orchestration Cluster E2E Test Result (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
+
+      - name: Sanitize branch name for artifact names
+        id: sanitize
+        if: always()
+        shell: bash
+        run: |
+          branch="${{ matrix.branch }}"
+          # Replace invalid artifact-name characters (at least '/')
+          safe_branch="${branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: json-will-be-removed-report-nightly-e2e-${{ steps.sanitize.outputs.safe_branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -226,25 +226,6 @@ jobs:
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
 
-      - name: Sanitize branch name for artifact names
-        id: sanitize
-        if: always()
-        shell: bash
-        run: |
-          branch="${{ github.event.inputs.branch }}"
-          # Replace invalid artifact-name characters (at least '/')
-          safe_branch="${branch//\//-}"
-          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
-
-      - name: Upload json report to GitHub Actions Artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: json-report-will-be-remoeved-nightly-api-${{ steps.sanitize.outputs.safe_branch }}
-          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
-          retention-days: 60
-
-
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -458,24 +439,6 @@ jobs:
           name: C8 Orchestration Cluster E2E Test Result (Tasklist ${{ matrix.tasklist_mode }} mode)
           path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
           retention-days: 10
-
-      - name: Sanitize branch name for artifact names
-        id: sanitize
-        if: always()
-        shell: bash
-        run: |
-          branch="${{ github.event.inputs.branch }}"
-          # Replace invalid artifact-name characters (at least '/')
-          safe_branch="${branch//\//-}"
-          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
-
-      - name: Upload json report to GitHub Actions Artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: json-will-be-removed-report-nightly-e2e-${{ steps.sanitize.outputs.safe_branch }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
-          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
-          retention-days: 60
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

Artifact names contains branch name, which resulted in failure due to the "/" character. Changed it into the "-" character to have successful artifacts.

[Here](https://github.com/camunda/camunda/actions/runs/22339578952#artifacts) is an on-demand run. I testerd it with on-demand and rolled back changes.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
