### PR TITLE
[Backport stable/8.9] fix: Change REST address from 8088 to 8080

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/resources/modes/self-managed.yaml
+++ b/clients/camunda-spring-boot-starter/src/main/resources/modes/self-managed.yaml
@@ -2,4 +2,4 @@ camunda:
   client:
     mode: self-managed
     grpc-address: http://localhost:26500
-    rest-address: http://localhost:8088
+    rest-address: http://localhost:8080

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesTest.java
@@ -76,7 +76,7 @@ public class CamundaClientModesTest {
     void shouldLoadDefaultsSelfManaged() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
     }
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesWithAuthMethodsTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientModesWithAuthMethodsTest.java
@@ -38,7 +38,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeNone() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.none);
     }
   }
@@ -54,7 +54,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeNone() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.none);
     }
   }
@@ -70,7 +70,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeBasic() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.basic);
       assertThat(properties.getAuth().getUsername()).isEqualTo("basic");
       assertThat(properties.getAuth().getPassword()).isEqualTo("demo");
@@ -88,7 +88,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeBasic() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.basic);
       assertThat(properties.getAuth().getUsername()).isEqualTo("demo");
       assertThat(properties.getAuth().getPassword()).isEqualTo("demo");
@@ -106,7 +106,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeOidc() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
       assertThat(properties.getAuth().getIssuerUrl())
           .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));
@@ -126,7 +126,7 @@ public class CamundaClientModesWithAuthMethodsTest {
     void shouldBeOidc() {
       assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
       assertThat(properties.getGrpcAddress().toString()).isEqualTo("http://localhost:26500");
-      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8088");
+      assertThat(properties.getRestAddress().toString()).isEqualTo("http://localhost:8080");
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.oidc);
       assertThat(properties.getAuth().getIssuerUrl())
           .isEqualTo(URI.create("http://localhost:18080/auth/realms/camunda-platform"));


### PR DESCRIPTION
# Description
Backport of #46585 to `stable/8.9`.

relates to 