### PR TITLE
refactor: retention writes deletion commands

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -10,13 +10,13 @@ package io.camunda.zeebe.backup.retention;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
-import io.camunda.zeebe.backup.api.BackupRangeMarker;
-import io.camunda.zeebe.backup.api.BackupRanges;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.client.api.BackupDeleteRequest;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.schedule.Schedule;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
@@ -36,8 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manages the retention of backups by periodically deleting old backups and their associated range
- * markers based on a configurable retention window.
+ * Manages the retention of backups by periodically identifying old backups and routing their
+ * deletion through the stream processor via {@code DELETE_BACKUP} commands.
  *
  * <h2>Retention Process</h2>
  *
@@ -49,16 +49,10 @@ import org.slf4j.LoggerFactory;
  *       store, sorted by creation time and checkpoint ID.
  *   <li><b>Filter Backups:</b> Identifies backups that fall outside the retention window (i.e.,
  *       backups older than {@code currentTime - retentionWindow}) and marks them for deletion.
- *       Determines the earliest backup checkpoint ID that should be retained.
- *   <li><b>Retrieve Range Markers:</b> Fetches all range markers for the partition and enriches the
- *       retention context. Range markers with checkpoint IDs less than the earliest retained backup
- *       are marked for deletion.
- *   <li><b>Reset Range Start:</b> If a previous start marker exists and its associated end marker
- *       has a lower checkpoint ID, the start marker is deleted and a new one is created pointing to
- *       the earliest retained backup.
- *   <li><b>Delete Markers:</b> Removes all range markers that are no longer needed (those
- *       associated with deleted backups).
- *   <li><b>Delete Backups:</b> Removes all backups identified for deletion from the backup store.
+ *   <li><b>Write Delete Commands:</b> For each deletable backup, sends a {@code DELETE_BACKUP}
+ *       request to the partition leader via the {@link BrokerClient}. The leader's stream processor
+ *       handles the actual deletion: updating the CHECKPOINTS and BACKUP_RANGES column families,
+ *       asynchronously deleting from the backup store, and syncing the JSON metadata file.
  * </ol>
  *
  * <h2>Scheduling</h2>
@@ -74,13 +68,12 @@ import org.slf4j.LoggerFactory;
  *   <li>Next scheduled execution time
  *   <li>Last execution time
  *   <li>Earliest retained backup ID
- *   <li>Number of range markers deleted
  *   <li>Number of backups deleted
  * </ul>
  *
  * @see BackupStore
  * @see Schedule
- * @see BackupRangeMarker
+ * @see BrokerClient
  */
 public class BackupRetention extends Actor {
   private static final Logger LOG = LoggerFactory.getLogger(BackupRetention.class);
@@ -105,6 +98,7 @@ public class BackupRetention extends Actor {
           });
 
   private final BackupStore backupStore;
+  private final BrokerClient brokerClient;
   private final Schedule retentionSchedule;
   private final Duration retentionWindow;
   private final BrokerTopologyManager topologyManager;
@@ -112,12 +106,14 @@ public class BackupRetention extends Actor {
 
   public BackupRetention(
       final BackupStore backupStore,
+      final BrokerClient brokerClient,
       final Schedule retentionSchedule,
       final Duration retentionWindow,
       final BrokerTopologyManager topologyManager,
       final MeterRegistry meterRegistry) {
     metrics = new RetentionMetrics(meterRegistry);
     this.backupStore = backupStore;
+    this.brokerClient = brokerClient;
     this.retentionSchedule = retentionSchedule;
     this.retentionWindow = retentionWindow;
     this.topologyManager = topologyManager;
@@ -169,9 +165,7 @@ public class BackupRetention extends Actor {
                 future ->
                     future
                         .thenApply(this::logContext, this)
-                        .andThen(this::resetRangeStart, this)
-                        .andThen(this::deleteMarkers, this)
-                        .thenApply(this::deleteBackups, this))
+                        .thenApply(this::writeDeleteCommands, this))
             .collect(new ActorFutureCollector<>(this));
 
     partitionFutures.onComplete(
@@ -189,8 +183,6 @@ public class BackupRetention extends Actor {
     LOG.atDebug()
         .addKeyValue("deletableBackups", ctx.deletableBackups)
         .addKeyValue("earliestBackupInNewRange", ctx.earliestBackupInNewRange)
-        .addKeyValue("previousStartMarker", ctx.previousStartMarker)
-        .addKeyValue("deletableRangeMarkers", ctx.deletableRangeMarkers)
         .setMessage("Determined retention context for partition " + ctx.partitionId)
         .log();
     return ctx;
@@ -199,12 +191,7 @@ public class BackupRetention extends Actor {
   private ActorFuture<RetentionContext> createRetentionContext(final int partitionId) {
     return retrieveBackups(partitionId)
         .thenApply(this::excludeBackupsWithoutTimestamps)
-        .thenApply((statuses) -> processBackups(statuses, partitionId), this)
-        .andThen(
-            (context) ->
-                retrieveRangeMarkers(partitionId)
-                    .thenApply((markers) -> enrichContextWithMarkers(context, markers), this),
-            this);
+        .thenApply((statuses) -> processBackups(statuses, partitionId), this);
   }
 
   private ActorFuture<Collection<BackupStatus>> retrieveBackups(final int partitionId) {
@@ -224,35 +211,6 @@ public class BackupRetention extends Actor {
               }
             });
     return requestFuture;
-  }
-
-  private ActorFuture<Collection<BackupRangeMarker>> retrieveRangeMarkers(final int partitionId) {
-    final ActorFuture<Collection<BackupRangeMarker>> requestFuture = createFuture();
-    backupStore
-        .rangeMarkers(partitionId)
-        .thenApply(markers -> markers.stream().sorted(BackupRanges.MARKER_ORDERING).toList())
-        .whenComplete(requestFuture);
-    return requestFuture;
-  }
-
-  private RetentionContext enrichContextWithMarkers(
-      final RetentionContext retentionContext, final Collection<BackupRangeMarker> markers) {
-    BackupRangeMarker rangeStart = null;
-    final var deletableRangeMarkers = new ArrayList<BackupRangeMarker>();
-
-    for (final BackupRangeMarker marker : markers) {
-      if (marker instanceof BackupRangeMarker.Start
-          && marker.checkpointId() <= retentionContext.earliestBackupInNewRange) {
-        rangeStart = marker;
-      }
-
-      if (marker.checkpointId() < retentionContext.earliestBackupInNewRange) {
-        deletableRangeMarkers.add(marker);
-      } else {
-        break;
-      }
-    }
-    return retentionContext.withRangeMarkerContext(rangeStart, deletableRangeMarkers);
   }
 
   private RetentionContext processBackups(
@@ -314,118 +272,65 @@ public class BackupRetention extends Actor {
     return backupTimestamp(latestCompletedBackup).minusSeconds(retentionWindow.toSeconds());
   }
 
-  private CompletableActorFuture<RetentionContext> resetRangeStart(final RetentionContext context) {
-    final CompletableActorFuture<RetentionContext> future = new CompletableActorFuture<>();
-    if (shouldResetMarker(context)) {
-      final var marker = context.previousStartMarker.get();
-      LOG.debug(
-          "Advancing range start marker for partition {} from {} to {}",
-          context.partitionId,
-          context.previousStartMarker.get(),
-          context.earliestBackupInNewRange);
-      backupStore
-          .storeRangeMarker(
-              context.partitionId, new BackupRangeMarker.Start(context.earliestBackupInNewRange))
-          .thenCompose(ignore -> backupStore.deleteRangeMarker(context.partitionId, marker))
-          .thenAccept(
-              ignore ->
-                  metrics
-                      .forPartition(context.partitionId)
-                      .setEarliestBackupId(context.earliestBackupInNewRange))
-          .thenApply(v -> context)
-          .thenAccept(future::complete)
-          .exceptionally(
-              throwable -> {
-                LOG.debug(
-                    "Failed to reset range start marker for partition {}. Marker: {}, new checkpoint id: {}",
-                    context.partitionId,
-                    marker,
-                    context.earliestBackupInNewRange,
-                    throwable);
-                future.completeExceptionally(throwable);
-                return null;
-              });
-    } else {
-      future.complete(context);
-    }
-    return future;
-  }
-
-  private boolean shouldResetMarker(final RetentionContext context) {
-    return context.previousStartMarker.isPresent()
-        && !context.deletableBackups.isEmpty()
-        && context.previousStartMarker.get().checkpointId() != context.earliestBackupInNewRange;
-  }
-
-  private CompletableActorFuture<RetentionContext> deleteMarkers(final RetentionContext context) {
-    final CompletableActorFuture<RetentionContext> future = new CompletableActorFuture<>();
-    if (context.deletableRangeMarkers.isEmpty() || context.deletableBackups.isEmpty()) {
-      future.complete(context);
-      return future;
-    }
-    LOG.debug(
-        "Deleting range markers {} for partition {}",
-        context.deletableRangeMarkers,
-        context.partitionId);
-
-    final var futures =
-        context.deletableRangeMarkers.stream()
-            .map(marker -> backupStore.deleteRangeMarker(context.partitionId, marker))
-            .toList()
-            .toArray(CompletableFuture[]::new);
-
-    CompletableFuture.allOf(futures)
-        .thenAccept(
-            ignore ->
-                metrics
-                    .forPartition(context.partitionId)
-                    .setRangesDeleted(context.deletableRangeMarkers.size()))
-        .thenApply(v -> context)
-        .thenAccept(future::complete)
-        .exceptionally(
-            throwable -> {
-              LOG.debug(
-                  "Failed to delete range markers for partition {}. Markers: {}",
-                  context.partitionId,
-                  context.deletableRangeMarkers,
-                  throwable);
-              future.completeExceptionally(throwable);
-              return null;
-            });
-    return future;
-  }
-
-  private CompletableActorFuture<Void> deleteBackups(final RetentionContext context) {
+  /**
+   * Sends a {@code DELETE_BACKUP} request to the partition leader for each deletable backup. The
+   * leader's stream processor handles the actual deletion: updating the CHECKPOINTS and
+   * BACKUP_RANGES column families, asynchronously deleting from the backup store, and syncing the
+   * JSON metadata file.
+   *
+   * <p>Multiple backup copies (from different broker nodes) for the same checkpoint ID are handled
+   * by a single {@code DELETE_BACKUP} command — the stream processor's post-commit task deletes all
+   * copies via a wildcard query.
+   */
+  private CompletableActorFuture<Void> writeDeleteCommands(final RetentionContext context) {
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     if (context.deletableBackups.isEmpty()) {
       future.complete(null);
       return future;
     }
-    LOG.debug(
-        "Deleting {} backups for partition {}", context.deletableBackups, context.partitionId);
-    final var futures =
-        context.deletableBackups.stream()
-            .map(backupStore::delete)
-            .toList()
-            .toArray(CompletableFuture[]::new);
 
-    CompletableFuture.allOf(futures)
+    // Deduplicate by checkpoint ID — a single DELETE_BACKUP command handles all node copies
+    final var uniqueCheckpointIds =
+        context.deletableBackups.stream()
+            .mapToLong(BackupIdentifier::checkpointId)
+            .distinct()
+            .toArray();
+
+    LOG.debug(
+        "Sending {} DELETE_BACKUP commands for partition {}",
+        uniqueCheckpointIds.length,
+        context.partitionId);
+
+    final var futures = new ArrayList<CompletableFuture<?>>(uniqueCheckpointIds.length);
+    for (final var checkpointId : uniqueCheckpointIds) {
+      final var request = new BackupDeleteRequest();
+      request.setPartitionId(context.partitionId);
+      request.setBackupId(checkpointId);
+      futures.add(brokerClient.sendRequestWithRetry(request));
+    }
+
+    CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
         .thenAccept(
-            ignore ->
+            ignore -> {
+              metrics
+                  .forPartition(context.partitionId)
+                  .setBackupsDeleted(uniqueCheckpointIds.length);
+              if (context.earliestBackupInNewRange > 0) {
                 metrics
                     .forPartition(context.partitionId)
-                    .setBackupsDeleted(context.deletableBackups().size()))
-        .thenAccept(future::complete)
-        .exceptionally(
-            throwable -> {
-              LOG.error(
-                  "Failed to delete backups for partition {}. Backups: {}",
-                  context.partitionId,
-                  context.deletableBackups,
-                  throwable);
-              future.completeExceptionally(throwable);
-              return null;
-            });
+                    .setEarliestBackupId(context.earliestBackupInNewRange);
+              }
+            })
+        .whenComplete(
+            (result, error) -> {
+              if (error != null) {
+                LOG.error(
+                    "Failed to send DELETE_BACKUP commands for partition {}",
+                    context.partitionId,
+                    error);
+              }
+            })
+        .whenComplete(future);
     return future;
   }
 
@@ -445,8 +350,6 @@ public class BackupRetention extends Actor {
   record RetentionContext(
       List<BackupIdentifier> deletableBackups,
       long earliestBackupInNewRange,
-      Optional<BackupRangeMarker> previousStartMarker,
-      List<BackupRangeMarker> deletableRangeMarkers,
       int partitionId,
       Instant windowBoundary) {
 
@@ -456,24 +359,7 @@ public class BackupRetention extends Actor {
         final long earliestBackupInNewRange,
         final Instant windowBoundary) {
       return new RetentionContext(
-          deletableBackups,
-          earliestBackupInNewRange,
-          Optional.empty(),
-          null,
-          partitionId,
-          windowBoundary);
-    }
-
-    RetentionContext withRangeMarkerContext(
-        final BackupRangeMarker previousStartMarker,
-        final List<BackupRangeMarker> deletableRangeMarkers) {
-      return new RetentionContext(
-          deletableBackups,
-          earliestBackupInNewRange,
-          Optional.ofNullable(previousStartMarker),
-          deletableRangeMarkers,
-          partitionId,
-          windowBoundary);
+          deletableBackups, earliestBackupInNewRange, partitionId, windowBoundary);
     }
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -19,7 +19,6 @@ public class RetentionMetrics implements CloseableSilently {
   static final String RETENTION_LAST_EXECUTION = NAMESPACE + ".last.execution.millis";
   static final String RETENTION_NEXT_EXECUTION = NAMESPACE + ".next.execution.millis";
   static final String BACKUPS_DELETED_ROUND = NAMESPACE + ".backups.deleted.round";
-  static final String RANGES_DELETED_ROUND = NAMESPACE + ".ranges.deleted.round";
   static final String EARLIEST_BACKUP_ID = NAMESPACE + ".earliest.backup.id";
   static final String PARTITION_TAG = "partition";
 
@@ -68,11 +67,6 @@ public class RetentionMetrics implements CloseableSilently {
         .description("Number of backups deleted in the last retention round")
         .tag(PARTITION_TAG, partition)
         .register(meterRegistry);
-
-    Gauge.builder(RANGES_DELETED_ROUND, () -> metrics.rangesDeleted)
-        .description("Number of ranges deleted in the last retention round")
-        .tag(PARTITION_TAG, partition)
-        .register(meterRegistry);
   }
 
   @Override
@@ -81,7 +75,6 @@ public class RetentionMetrics implements CloseableSilently {
     meterRegistry.remove(nextExecutionGauge);
     meterRegistry.find(EARLIEST_BACKUP_ID).gauges().forEach(meterRegistry::remove);
     meterRegistry.find(BACKUPS_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
-    meterRegistry.find(RANGES_DELETED_ROUND).gauges().forEach(meterRegistry::remove);
     partitionMetrics.clear();
   }
 
@@ -96,7 +89,6 @@ public class RetentionMetrics implements CloseableSilently {
   static class PartitionMetrics {
     private long earliestBackupId = 0L;
     private long backupsDeleted = 0L;
-    private long rangesDeleted = 0L;
 
     void setEarliestBackupId(final long id) {
       earliestBackupId = id;
@@ -104,10 +96,6 @@ public class RetentionMetrics implements CloseableSilently {
 
     void setBackupsDeleted(final long count) {
       backupsDeleted = count;
-    }
-
-    void setRangesDeleted(final long count) {
-      rangesDeleted = count;
     }
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/retention/RetentionTest.java
@@ -10,16 +10,12 @@ package io.camunda.zeebe.backup.retention;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.BACKUPS_DELETED_ROUND;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.EARLIEST_BACKUP_ID;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.PARTITION_TAG;
-import static io.camunda.zeebe.backup.retention.RetentionMetrics.RANGES_DELETED_ROUND;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.RETENTION_LAST_EXECUTION;
 import static io.camunda.zeebe.backup.retention.RetentionMetrics.RETENTION_NEXT_EXECUTION;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -29,18 +25,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
-import io.camunda.zeebe.backup.api.BackupRangeMarker;
-import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
-import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.client.api.BackupDeleteRequest;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.schedule.Schedule.IntervalSchedule;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.util.VersionUtil;
@@ -75,6 +72,7 @@ public class RetentionTest {
       new ControlledActorSchedulerExtension();
 
   @Mock private BackupStore backupStore;
+  @Mock private BrokerClient brokerClient;
   @Mock private BrokerTopologyManager topologyManager;
   @Mock private BrokerClusterState clusterState;
   private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -88,17 +86,11 @@ public class RetentionTest {
     doReturn(clusterState).when(topologyManager).getTopology();
     doReturn(List.of(1)).when(clusterState).getPartitions();
 
-    doReturn(CompletableFuture.completedFuture(null)).when(backupStore).delete(any());
-    doReturn(CompletableFuture.completedFuture(null))
-        .when(backupStore)
-        .storeRangeMarker(anyInt(), any());
     lenient()
         .doReturn(CompletableFuture.completedFuture(null))
-        .when(backupStore)
-        .deleteRangeMarker(anyInt(), any());
-    doReturn(CompletableFuture.completedFuture(null))
-        .when(backupStore)
-        .deleteRangeMarker(anyInt(), any());
+        .when(brokerClient)
+        .sendRequestWithRetry(any());
+
     actorScheduler.getClock().pinCurrentTime();
   }
 
@@ -107,20 +99,15 @@ public class RetentionTest {
     // given
     final var now = actorScheduler.getClock().instant();
     final List<BackupStatus> backups = createDefaultBackups(1, 1, now);
-    final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
     when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(backups));
-    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
 
     // when
     runRetentionCycle();
 
-    // then
-    verifyBackupsDeleted(backups.subList(0, 4));
-    verifyRangeMarkerStored(1, backups.get(4));
-    verifyRangeMarkerDeleted(1, backups.get(3));
-    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
-    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+    // then — first 4 backups (offsets 375, 315, 255, 195) are outside the 1-minute window
+    // They have 4 distinct checkpoint IDs, so 4 DELETE_BACKUP commands should be sent
+    verifyDeleteCommandsSent(1, backups.subList(0, 4));
   }
 
   @Test
@@ -128,18 +115,14 @@ public class RetentionTest {
     // given
     final var now = actorScheduler.getClock().instant();
     final List<BackupStatus> backups = createDefaultBackupsNoCreatedDate(1, 1, now);
-    final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
     when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(backups));
-    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
 
     // when
     runRetentionCycle();
 
     // then
-    verifyBackupsDeleted(backups.subList(0, 4));
-    verifyRangeMarkerStored(1, backups.get(4));
-    verifyRangeMarkerDeleted(1, backups.get(3));
+    verifyDeleteCommandsSent(1, backups.subList(0, 4));
   }
 
   @Test
@@ -149,112 +132,28 @@ public class RetentionTest {
     final var now = actorScheduler.getClock().instant();
     final Map<Integer, List<BackupStatus>> backupsPerPartition =
         createBackupsForPartitions(List.of(1, 2, 3), now);
-    final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
     setupBackupStoreListForPartitions(backupsPerPartition);
-    when(backupStore.rangeMarkers(anyInt())).thenReturn(CompletableFuture.completedFuture(ranges));
 
     // when
     runRetentionCycle();
 
     // then
     backupsPerPartition.forEach(
-        (partition, backups) -> verifyBackupsDeleted(backups.subList(0, 4)));
-
-    for (int partition = 1; partition <= 3; partition++) {
-      verifyRangeMarkerStored(partition, backupsPerPartition.get(partition).get(4));
-      verify(backupStore)
-          .deleteRangeMarker(eq(partition), argThat(c -> c.equals(ranges.getFirst())));
-      verify(backupStore).deleteRangeMarker(eq(partition), argThat(c -> c.equals(ranges.get(1))));
-      verifyRangeMarkerDeleted(partition, backupsPerPartition.get(1).get(3));
-    }
-  }
-
-  @Test
-  void shouldHandleNoEndMarker() {
-    // given
-    final var now = actorScheduler.getClock().instant();
-    final BackupStatus backup1 = backup(now.minusSeconds(190));
-    final BackupStatus backup2 = backup(now.minusSeconds(130));
-    final BackupStatus backup3 = backup(now.minusSeconds(10));
-
-    when(backupStore.list(any()))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
-
-    when(backupStore.rangeMarkers(1))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                List.of(
-                    new Start(now.minusSeconds(190).toEpochMilli()),
-                    new End(now.minusSeconds(140).toEpochMilli()),
-                    new Start(now.minusSeconds(130).toEpochMilli()))));
-
-    // when
-    runRetentionCycle();
-
-    // then
-    verify(backupStore).delete(backup1.id());
-    verify(backupStore).delete(backup2.id());
-    verifyRangeMarkerStored(1, backup3);
-
-    verify(backupStore, atLeast(1))
-        .deleteRangeMarker(
-            anyInt(),
-            argThat(
-                marker ->
-                    marker instanceof Start
-                        && marker.checkpointId() == now.minusSeconds(130).toEpochMilli()));
-  }
-
-  @Test
-  void shouldNotDeleteMarkerIfSameAsLastBackup() {
-    // given
-    reset(backupStore);
-    final var now = actorScheduler.getClock().instant();
-    final BackupStatus backup1 = backup(now.minusSeconds(250));
-    final BackupStatus backup2 = backup(now.minusSeconds(180));
-    final BackupStatus backup3 = backup(now.minusSeconds(110));
-
-    final List<BackupRangeMarker> ranges =
-        List.of(
-            new Start(now.minusSeconds(360).toEpochMilli()),
-            new End(now.minusSeconds(290).toEpochMilli()),
-            new Start(now.minusSeconds(110).toEpochMilli()),
-            new End(now.minusSeconds(110).toEpochMilli()));
-
-    when(backupStore.list(any()))
-        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
-
-    when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
-    doReturn(CompletableFuture.completedFuture(null))
-        .when(backupStore)
-        .deleteRangeMarker(anyInt(), any());
-
-    // when
-    runRetentionCycle();
-
-    // then
-    verify(backupStore).delete(backup1.id());
-    verify(backupStore).delete(backup2.id());
-    verify(backupStore, never()).storeRangeMarker(eq(1), any());
-    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
-    verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
+        (partition, backups) -> verifyDeleteCommandsSent(partition, backups.subList(0, 4)));
   }
 
   @Test
   void shouldHandleNoBackups() {
     // given
-    reset(backupStore);
     when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
-    when(backupStore.rangeMarkers(anyInt()))
-        .thenReturn(CompletableFuture.completedFuture(List.of()));
 
     // when
     runRetentionCycle();
 
     // then
     verify(backupStore).list(any());
-    verifyNoBackupStoreModifications();
+    verifyNoDeleteCommands();
   }
 
   @Test
@@ -265,10 +164,8 @@ public class RetentionTest {
     final var now = actorScheduler.getClock().instant();
     final Map<Integer, List<BackupStatus>> backupsPerPartition =
         createBackupsForPartitions(partitions, now);
-    final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
     setupBackupStoreListForPartitions(backupsPerPartition);
-    when(backupStore.rangeMarkers(anyInt())).thenReturn(CompletableFuture.completedFuture(ranges));
 
     // when
     runRetentionCycle();
@@ -279,7 +176,6 @@ public class RetentionTest {
     partitions.forEach(
         partition -> {
           assertThat(getGauge(BACKUPS_DELETED_ROUND, partition)).isNotNull();
-          assertThat(getGauge(RANGES_DELETED_ROUND, partition)).isNotNull();
           assertThat(getGauge(EARLIEST_BACKUP_ID, partition)).isNotNull();
         });
   }
@@ -292,10 +188,8 @@ public class RetentionTest {
     final var now = actorScheduler.getClock().instant();
     final Map<Integer, List<BackupStatus>> backupsPerPartition =
         createBackupsForPartitions(partitions, now);
-    final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
     setupBackupStoreListForPartitions(backupsPerPartition);
-    when(backupStore.rangeMarkers(anyInt())).thenReturn(CompletableFuture.completedFuture(ranges));
 
     // when
     runRetentionCycle();
@@ -312,8 +206,6 @@ public class RetentionTest {
         partition -> {
           assertThatThrownBy(() -> getGauge(BACKUPS_DELETED_ROUND, partition))
               .isInstanceOf(MeterNotFoundException.class);
-          assertThatThrownBy(() -> getGauge(RANGES_DELETED_ROUND, partition))
-              .isInstanceOf(MeterNotFoundException.class);
           assertThatThrownBy(() -> getGauge(EARLIEST_BACKUP_ID, partition))
               .isInstanceOf(MeterNotFoundException.class);
         });
@@ -323,65 +215,42 @@ public class RetentionTest {
   void shouldProgressMarkerAfterFailed() {
     // given
     final var now = actorScheduler.getClock().instant();
-    final BackupStatus backup1 = backup(now.minusSeconds(300));
-    final BackupStatus backup2 = failedBackup(now.minusSeconds(60));
-    final BackupStatus backup3 = failedBackup(now.minusSeconds(50));
-    final BackupStatus backup4 = backup(now.minusSeconds(40));
+    final var backup1 = backup(now.minusSeconds(300));
+    final var backup2 = failedBackup(now.minusSeconds(60));
+    final var backup3 = failedBackup(now.minusSeconds(50));
+    final var backup4 = backup(now.minusSeconds(40));
 
     when(backupStore.list(any()))
         .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3, backup4)));
-
-    when(backupStore.rangeMarkers(1))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                List.of(
-                    new Start(now.minusSeconds(300).toEpochMilli()),
-                    new End(now.minusSeconds(40).toEpochMilli()))));
 
     // when
     runRetentionCycle();
     actorScheduler.workUntilDone();
 
-    // then
-    verify(backupStore, times(1)).delete(any());
-    verify(backupStore, times(1))
-        .storeRangeMarker(
-            anyInt(), argThat(marker -> marker.checkpointId() == backup4.id().checkpointId()));
-    verify(backupStore, atLeast(1))
-        .deleteRangeMarker(
-            anyInt(), argThat(marker -> marker.checkpointId() == backup1.id().checkpointId()));
+    // then — only backup1 is outside the retention window (300s > 60s window relative to backup4)
+    verifyDeleteCommandSent(1, backup1.id().checkpointId());
+    verifyNoDeleteCommandSent(backup4.id().checkpointId());
   }
 
   @Test
   void shouldIgnoreLastFailedBackup() {
     // given
     final var now = actorScheduler.getClock().instant();
-    final BackupStatus backup1 = backup(now.minusSeconds(300));
-    final BackupStatus backup2 = backup(now.minusSeconds(100));
-    final BackupStatus backup3 = failedBackup(now.minusSeconds(40));
+    final var backup1 = backup(now.minusSeconds(300));
+    final var backup2 = backup(now.minusSeconds(100));
+    final var backup3 = failedBackup(now.minusSeconds(40));
 
     when(backupStore.list(any()))
         .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
-
-    when(backupStore.rangeMarkers(1))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                List.of(
-                    new Start(now.minusSeconds(300).toEpochMilli()),
-                    new End(now.minusSeconds(100).toEpochMilli()))));
 
     // when
     runRetentionCycle();
     actorScheduler.workUntilDone();
 
-    // then
-    verify(backupStore, times(1)).delete(any());
-    verify(backupStore, times(1))
-        .storeRangeMarker(
-            anyInt(), argThat(marker -> marker.checkpointId() == backup2.id().checkpointId()));
-    verify(backupStore, atLeast(1))
-        .deleteRangeMarker(
-            anyInt(), argThat(marker -> marker.checkpointId() == backup1.id().checkpointId()));
+    // then — backup1 is outside the window (300s - 100s = 200s > 60s window); backup2 is the
+    // latest completed so it's kept
+    verifyDeleteCommandSent(1, backup1.id().checkpointId());
+    verifyNoDeleteCommandSent(backup2.id().checkpointId());
   }
 
   private Gauge getGauge(final String gaugeName) {
@@ -395,6 +264,7 @@ public class RetentionTest {
   private BackupRetention createBackupRetention() {
     return new BackupRetention(
         backupStore,
+        brokerClient,
         new IntervalSchedule(Duration.ofSeconds(10)),
         Duration.ofMinutes(1),
         topologyManager,
@@ -428,18 +298,6 @@ public class RetentionTest {
         .toList();
   }
 
-  // private static final int[] DEFAULT_BACKUP_OFFSETS = {375, 315, 255, 195, 135, 75, 10};
-  // private static final int[] DEFAULT_BACKUP_OFFSETS = {360, 300, 290, 130, 110, 20, 10};
-  private List<BackupRangeMarker> createDefaultRangeMarkers(final Instant now) {
-    return List.of(
-        new Start(now.minusSeconds(375).toEpochMilli()),
-        new End(now.minusSeconds(255).toEpochMilli()),
-        new Start(now.minusSeconds(195).toEpochMilli()),
-        new End(now.minusSeconds(30).toEpochMilli()),
-        new Start(now.minusSeconds(10).toEpochMilli()),
-        new End(now.minusSeconds(10).toEpochMilli()));
-  }
-
   private Map<Integer, List<BackupStatus>> createBackupsForPartitions(
       final List<Integer> partitions, final Instant now) {
     final Map<Integer, List<BackupStatus>> backupsPerPartition = new HashMap<>();
@@ -458,34 +316,53 @@ public class RetentionTest {
                 .list(argThat(id -> id.partitionId().get() == partition)));
   }
 
-  private void verifyBackupsDeleted(final List<BackupStatus> backups) {
-    backups.forEach(backup -> verify(backupStore).delete(argThat(id -> id.equals(backup.id()))));
+  /** Verifies that DELETE_BACKUP commands were sent for each unique checkpoint ID in the list. */
+  private void verifyDeleteCommandsSent(
+      final int partitionId, final List<BackupStatus> deletedBackups) {
+    final var uniqueCheckpointIds =
+        deletedBackups.stream().mapToLong(b -> b.id().checkpointId()).distinct().toArray();
+    for (final var checkpointId : uniqueCheckpointIds) {
+      verifyDeleteCommandSent(partitionId, checkpointId);
+    }
   }
 
-  private void verifyRangeMarkerStored(final int partition, final BackupStatus backup) {
-    verify(backupStore)
-        .storeRangeMarker(
-            eq(partition),
-            argThat(
-                marker ->
-                    marker.checkpointId() == backup.id().checkpointId()
-                        && marker instanceof Start));
+  @SuppressWarnings("unchecked")
+  private void verifyDeleteCommandSent(final int partitionId, final long checkpointId) {
+    verify(brokerClient)
+        .sendRequestWithRetry(
+            (BrokerRequest<BackupStatusResponse>)
+                argThat(
+                    req ->
+                        req instanceof BackupDeleteRequest deleteReq
+                            && deleteReq.getPartitionId() == partitionId
+                            && deleteReq.getBackupId() == checkpointId));
   }
 
-  private void verifyRangeMarkerDeleted(final int partition, final BackupStatus backup) {
-    verify(backupStore, atLeast(1))
-        .deleteRangeMarker(
-            eq(partition),
-            argThat(
-                marker ->
-                    marker.checkpointId() == backup.id().checkpointId()
-                        && marker instanceof Start));
+  @SuppressWarnings("unchecked")
+  private void verifyNoDeleteCommandSent(final long checkpointId) {
+    verify(brokerClient, never())
+        .sendRequestWithRetry(
+            (BrokerRequest<BackupStatusResponse>)
+                argThat(
+                    req ->
+                        req instanceof BackupDeleteRequest deleteReq
+                            && deleteReq.getBackupId() == checkpointId));
   }
 
-  private void verifyNoBackupStoreModifications() {
-    verify(backupStore, never()).deleteRangeMarker(anyInt(), any());
-    verify(backupStore, never()).delete(any());
-    verify(backupStore, never()).storeRangeMarker(anyInt(), any());
+  @SuppressWarnings("unchecked")
+  private void verifyNoDeleteCommandSent(final int partitionId, final long checkpointId) {
+    verify(brokerClient, never())
+        .sendRequestWithRetry(
+            (BrokerRequest<BackupStatusResponse>)
+                argThat(
+                    req ->
+                        req instanceof BackupDeleteRequest deleteReq
+                            && deleteReq.getPartitionId() == partitionId
+                            && deleteReq.getBackupId() == checkpointId));
+  }
+
+  private void verifyNoDeleteCommands() {
+    verify(brokerClient, never()).sendRequestWithRetry(any());
   }
 
   private BackupStatus backup(final Instant timestamp) {
@@ -548,27 +425,8 @@ public class RetentionTest {
       // then
       actorScheduler.updateClock(Duration.ofSeconds(10));
       actorScheduler.workUntilDone();
-      verify(backupStore, org.mockito.Mockito.times(2)).list(any());
-      verifyNoBackupStoreModifications();
-    }
-
-    @Test
-    void actorShouldNotHangOnMarkerListingFailure() {
-      // given
-      reset(backupStore);
-      when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
-      when(backupStore.rangeMarkers(anyInt()))
-          .thenReturn(
-              CompletableFuture.failedFuture(new RuntimeException("Failed to list markers")));
-
-      // when
-      runRetentionCycle();
-
-      // then
-      actorScheduler.updateClock(Duration.ofSeconds(10));
-      actorScheduler.workUntilDone();
-      verify(backupStore, org.mockito.Mockito.times(2)).list(any());
-      verifyNoBackupStoreModifications();
+      verify(backupStore, times(2)).list(any());
+      verifyNoDeleteCommands();
     }
 
     @Test
@@ -578,7 +436,6 @@ public class RetentionTest {
       final var now = actorScheduler.getClock().instant();
       final Map<Integer, List<BackupStatus>> backupsPerPartition =
           createBackupsForPartitions(List.of(1, 2), now);
-      final List<BackupRangeMarker> ranges = createDefaultRangeMarkers(now);
 
       doReturn(CompletableFuture.completedFuture(backupsPerPartition.get(1)))
           .when(backupStore)
@@ -590,29 +447,17 @@ public class RetentionTest {
           .when(backupStore)
           .list(argThat(id -> id.partitionId().get() == 2));
 
-      when(backupStore.rangeMarkers(anyInt()))
-          .thenReturn(CompletableFuture.completedFuture(ranges));
-
       // when
       runRetentionCycle();
 
-      // then
-      verifyBackupsDeleted(backupsPerPartition.get(1).subList(0, 4));
+      // then — delete commands sent for partition 1 but not partition 2
+      verifyDeleteCommandsSent(1, backupsPerPartition.get(1).subList(0, 4));
 
+      // No delete commands for partition 2's backups
       backupsPerPartition
           .get(2)
           .subList(0, 4)
-          .forEach(
-              backup -> verify(backupStore, never()).delete(argThat(id -> id.equals(backup.id()))));
-
-      verifyRangeMarkerStored(1, backupsPerPartition.get(1).get(4));
-      verify(backupStore, never()).storeRangeMarker(eq(2), any());
-
-      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
-      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
-      verify(backupStore, never()).deleteRangeMarker(eq(2), any());
-
-      verifyRangeMarkerDeleted(1, backupsPerPartition.get(1).get(3));
+          .forEach(backup -> verifyNoDeleteCommandSent(2, backup.id().checkpointId()));
     }
   }
 
@@ -624,78 +469,53 @@ public class RetentionTest {
     void shouldAlwaysMaintainASingleBackup() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backup(now.minusSeconds(200));
-      final BackupStatus backup2 = backup(now.minusSeconds(140));
-      final BackupStatus backup3 = backup(now.minusSeconds(70));
+      final var backup1 = backup(now.minusSeconds(200));
+      final var backup2 = backup(now.minusSeconds(140));
+      final var backup3 = backup(now.minusSeconds(70));
       // Failed backup with older timestamp than the latest successful backup
-      final BackupStatus backup4 = failedBackup(now.minusSeconds(10));
+      final var backup4 = failedBackup(now.minusSeconds(10));
 
       when(backupStore.list(any()))
           .thenReturn(
               CompletableFuture.completedFuture(List.of(backup1, backup2, backup3, backup4)));
 
-      when(backupStore.rangeMarkers(1))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  List.of(
-                      new Start(now.minusSeconds(200).toEpochMilli()),
-                      new End(now.minusSeconds(70).toEpochMilli()))));
-
       // when
       runRetentionCycle();
 
       // then
-      verify(backupStore).delete(backup1.id());
-      verify(backupStore).delete(backup2.id());
-      verify(backupStore, never()).delete(backup4.id());
-      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
-
-      verifyRangeMarkerStored(1, backup3);
-      verifyRangeMarkerDeleted(1, backup1);
+      verifyDeleteCommandSent(1, backup1.id().checkpointId());
+      verifyDeleteCommandSent(1, backup2.id().checkpointId());
+      verifyNoDeleteCommandSent(backup4.id().checkpointId());
+      verifyNoDeleteCommandSent(backup3.id().checkpointId());
     }
 
     @Test
     void shouldAlwaysMaintainASingleBackupWhenNoDescriptor() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backupNoDescriptor(1, 1, now.minusSeconds(300));
-      final BackupStatus backup2 = backupNoDescriptor(1, 1, now.minusSeconds(200));
-      final BackupStatus backup3 = backupNoDescriptor(1, 1, now.minusSeconds(130));
+      final var backup1 = backupNoDescriptor(1, 1, now.minusSeconds(300));
+      final var backup2 = backupNoDescriptor(1, 1, now.minusSeconds(200));
+      final var backup3 = backupNoDescriptor(1, 1, now.minusSeconds(130));
 
       when(backupStore.list(any()))
           .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
-
-      when(backupStore.rangeMarkers(1))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  List.of(
-                      new Start(now.minusSeconds(300).toEpochMilli()),
-                      new End(now.minusSeconds(200).toEpochMilli()))));
 
       // when
       runRetentionCycle();
 
       // then
-      verify(backupStore).delete(backup1.id());
-      verify(backupStore).delete(backup2.id());
-      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
-
-      verifyRangeMarkerStored(1, backup3);
-      verifyRangeMarkerDeleted(1, backup1);
+      verifyDeleteCommandSent(1, backup1.id().checkpointId());
+      verifyDeleteCommandSent(1, backup2.id().checkpointId());
+      verifyNoDeleteCommandSent(backup3.id().checkpointId());
     }
 
     @Test
     void shouldNotDeleteBackupsIfOnlyOneExists() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backup(now.minusSeconds(500));
+      final var backup1 = backup(now.minusSeconds(500));
 
       when(backupStore.list(any())).thenReturn(CompletableFuture.completedFuture(List.of(backup1)));
-
-      when(backupStore.rangeMarkers(1))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  List.of(new Start(now.minusSeconds(360).toEpochMilli()))));
 
       // when multiple runs occur
       actorScheduler.submitActor(backupRetention);
@@ -708,111 +528,78 @@ public class RetentionTest {
       actorScheduler.workUntilDone();
 
       // then
-      verify(backupStore, never()).delete(any());
+      verifyNoDeleteCommands();
     }
 
     @Test
     void shouldAlwaysMaintainASingleBackupOnCheckpointId() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backup(now.minusSeconds(300));
-      final BackupStatus backup2 = backup(now.minusSeconds(200));
-      final BackupStatus backup3 = backupOnlyId(1, 1, now.minusSeconds(130));
+      final var backup1 = backup(now.minusSeconds(300));
+      final var backup2 = backup(now.minusSeconds(200));
+      final var backup3 = backupOnlyId(1, 1, now.minusSeconds(130));
 
       when(backupStore.list(any()))
           .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2, backup3)));
-
-      when(backupStore.rangeMarkers(1))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  List.of(new Start(now.minusSeconds(360).toEpochMilli()))));
 
       // when
       runRetentionCycle();
 
       // then
-      verify(backupStore).delete(backup1.id());
-      verify(backupStore).delete(backup2.id());
-      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
+      verifyDeleteCommandSent(1, backup1.id().checkpointId());
+      verifyDeleteCommandSent(1, backup2.id().checkpointId());
+      verifyNoDeleteCommandSent(backup3.id().checkpointId());
     }
 
     @Test
     void shouldNotInterfereIfLatestNotWithinWindow() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backup(now.minusSeconds(290));
-      final BackupStatus backup2 = backup(now.minusSeconds(220));
-      final BackupStatus backup3 = backup(now.minusSeconds(150));
-      final BackupStatus backup4 = backup(now.minusSeconds(100));
+      final var backup1 = backup(now.minusSeconds(290));
+      final var backup2 = backup(now.minusSeconds(220));
+      final var backup3 = backup(now.minusSeconds(150));
+      final var backup4 = backup(now.minusSeconds(100));
 
       when(backupStore.list(any()))
           .thenReturn(
               CompletableFuture.completedFuture(List.of(backup1, backup2, backup3, backup4)));
 
-      final List<BackupRangeMarker> ranges =
-          List.of(
-              new Start(now.minusSeconds(290).toEpochMilli()),
-              new End(now.minusSeconds(220).toEpochMilli()),
-              new Start(now.minusSeconds(150).toEpochMilli()),
-              new End(now.minusSeconds(100).toEpochMilli()));
-
-      when(backupStore.rangeMarkers(1)).thenReturn(CompletableFuture.completedFuture(ranges));
-
       // when
       runRetentionCycle();
 
       // then
-      verify(backupStore).delete(backup1.id());
-      verify(backupStore).delete(backup2.id());
-      verify(backupStore, never()).delete(argThat(id -> id.equals(backup3.id())));
-      verify(backupStore, never()).delete(argThat(id -> id.equals(backup4.id())));
-
-      verify(backupStore, never()).storeRangeMarker(eq(1), any());
-      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.getFirst())));
-      verify(backupStore).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(1))));
-      verify(backupStore, never()).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(2))));
-      verify(backupStore, never()).deleteRangeMarker(eq(1), argThat(c -> c.equals(ranges.get(3))));
+      verifyDeleteCommandSent(1, backup1.id().checkpointId());
+      verifyDeleteCommandSent(1, backup2.id().checkpointId());
+      verifyNoDeleteCommandSent(backup3.id().checkpointId());
+      verifyNoDeleteCommandSent(backup4.id().checkpointId());
     }
 
     @Test
     void shouldNotDeleteBackupsRelativeToLastCompleted() {
       // given
       final var now = actorScheduler.getClock().instant();
-      final BackupStatus backup1 = backup(now.minusSeconds(370));
-      final BackupStatus backup2 = backup(now.minusSeconds(340));
-      final BackupStatus backup3 = backup(now.minusSeconds(300));
-      final BackupStatus backup4 = failedBackup(now.minusSeconds(220));
-      final BackupStatus backup5 = failedBackup(now.minusSeconds(210));
+      final var backup1 = backup(now.minusSeconds(370));
+      final var backup2 = backup(now.minusSeconds(340));
+      final var backup3 = backup(now.minusSeconds(300));
+      final var backup4 = failedBackup(now.minusSeconds(220));
+      final var backup5 = failedBackup(now.minusSeconds(210));
 
       when(backupStore.list(any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   List.of(backup1, backup2, backup3, backup4, backup5)));
 
-      when(backupStore.rangeMarkers(1))
-          .thenReturn(
-              CompletableFuture.completedFuture(
-                  List.of(
-                      new Start(now.minusSeconds(300).toEpochMilli()),
-                      new End(now.minusSeconds(300).toEpochMilli()))));
-
       // when
       runRetentionCycle();
       actorScheduler.workUntilDone();
 
-      // then
-      verify(backupStore, times(1))
-          .delete(argThat(backup -> backup.checkpointId() == backup1.id().checkpointId()));
-      verify(backupStore, never())
-          .delete(argThat(backup -> backup.checkpointId() == backup2.id().checkpointId()));
-      verify(backupStore, never())
-          .delete(argThat(backup -> backup.checkpointId() == backup3.id().checkpointId()));
-      verify(backupStore, never())
-          .delete(argThat(backup -> backup.checkpointId() == backup4.id().checkpointId()));
-      verify(backupStore, never())
-          .delete(argThat(backup -> backup.checkpointId() == backup5.id().checkpointId()));
-      verify(backupStore, never()).storeRangeMarker(anyInt(), any());
-      verify(backupStore, never()).deleteRangeMarker(anyInt(), any());
+      // then — window is relative to backup3 (latest completed, 300s ago)
+      // Window bound = 300 + 60 = 360s ago; backup1 (370s) is outside
+      verifyDeleteCommandSent(1, backup1.id().checkpointId());
+      verifyNoDeleteCommandSent(backup2.id().checkpointId());
+      verifyNoDeleteCommandSent(backup3.id().checkpointId());
+      verifyNoDeleteCommandSent(backup4.id().checkpointId());
+      verifyNoDeleteCommandSent(backup5.id().checkpointId());
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -90,6 +90,7 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
       backupRetentionJob =
           new BackupRetention(
               backupStore,
+              brokerClient,
               retentionCfg.getCleanupSchedule(),
               retentionCfg.getWindow(),
               brokerClient.getTopologyManager(),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -12,8 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.configuration.Camunda;
 import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.PartitionBackupState;
-import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
-import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -25,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,7 +91,6 @@ public interface BackupRetentionAcceptance extends ClockSupport {
     assertManifestPresentInStore(thirdBackup);
     assertManifestNotFoundFromStore(firstBackup);
     assertManifestNotFoundFromStore(secondBackup);
-    assertRangeMarkerHasBeenUpdated(thirdBackup, fourthBackup);
   }
 
   default long awaitNewBackup(final long previousBackup) {
@@ -155,31 +151,6 @@ public interface BackupRetentionAcceptance extends ClockSupport {
                     .extracting(BackupStatus::statusCode)
                     .isEqualTo(BackupStatusCode.COMPLETED);
               }
-            });
-  }
-
-  default void assertRangeMarkerHasBeenUpdated(
-      final long newStartBackupId, final long expectedEndBackupId) {
-    IntStream.rangeClosed(1, PARTITION_COUNT)
-        .forEach(
-            partitionId -> {
-              final var markers = getBackupStore().rangeMarkers(partitionId).join();
-              AssertionsForClassTypes.assertThat(markers.size()).isEqualTo(2);
-              final var startMarker = markers.stream().filter(Start.class::isInstance).findFirst();
-              AssertionsForClassTypes.assertThat(startMarker)
-                  .as("Start range marker for partition %d should be present", partitionId)
-                  .isPresent();
-              AssertionsForClassTypes.assertThat(startMarker.get().checkpointId())
-                  .as("Start range marker for partition %d should be updated", partitionId)
-                  .isEqualTo(newStartBackupId);
-
-              final var endMarker = markers.stream().filter(End.class::isInstance).findFirst();
-              AssertionsForClassTypes.assertThat(endMarker)
-                  .as("End range marker for partition %d should be present", partitionId)
-                  .isPresent();
-              AssertionsForClassTypes.assertThat(endMarker.get().checkpointId())
-                  .as("End range marker for partition %d should be updated", partitionId)
-                  .isEqualTo(expectedEndBackupId);
             });
   }
 


### PR DESCRIPTION
This adjusts the retention job to delete backups via commands instead of directly in the store. Old code to update range information is removed because this is handled by the deletion processor instead.

Builds on top of #46541