### PR TITLE
fix: update flaky test on main

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
@@ -43,7 +43,7 @@ class TaskPanelPageV1 {
     await this.availableTasks
       .getByText(name, {exact: true})
       .nth(0)
-      .click({timeout: 10000});
+      .click({timeout: 30000});
   }
 
   async filterBy(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -126,7 +126,6 @@ test.describe('task details page', () => {
   });
 
   test('assign and unassign task', async ({
-    page,
     taskPanelPageV1,
     taskDetailsPageV1,
   }) => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR fixes a flaky test by making two changes to the Tasklist V1 end-to-end tests: removing an unused parameter and increasing a timeout value to improve test reliability.

Changes:

Removed unused page parameter from the 'assign and unassign task' test fixture
Increased click timeout in TaskPanelPageV1.openTask() from 10 seconds to 30 seconds
🧪 [Test run](https://github.com/camunda/camunda/actions/runs/22344326150)
❗ Failing v2 tests are due to [this issue](https://camunda.slack.com/archives/C08MRKHJ0CD/p1771831048856029)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
