### PR TITLE
feat: add JobWorker metrics API (controller + API doc)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -18,9 +18,11 @@ import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.JobTypeStatisticsSort;
 import io.camunda.security.reader.ResourceAccessChecks;
@@ -39,12 +41,19 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   private static final JobTypeStatisticsSort JOB_TYPE_STATS_FIXED_SORT =
       JobTypeStatisticsSort.of(b -> b.jobType().asc());
 
+  // Fixed sort: worker asc
+  //  private static final JobWorkerStatisticsSort JOB_WORKER_STATS_FIXED_SORT =
+  //      JobWorkerStatisticsSort.of(b -> b.worker().asc());
+
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
+
+  // private final AbstractEntityReader<JobWorkerStatisticsEntity> workerStatsReader;
 
   public JobMetricsBatchDbReader(
       final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
     super(JobTypeStatisticsColumn.values(), readerConfig);
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
+    // workerStatsReader = new WorkerStatsReader(readerConfig);
   }
 
   @Override
@@ -111,8 +120,62 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
         entities.size(), entities, convertSort(JOB_TYPE_STATS_FIXED_SORT));
   }
 
+  @Override
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    LOG.trace("[RDBMS DB] Search job worker statistics with {}", query);
+    // TODO enabled in a follow up PR
+    throw new UnsupportedOperationException("Job worker statistics is not yet supported");
+    //    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+    //      return EmptyResults.JOB_WORKER_STATISTICS;
+    //    }
+    //    final var dbSort = workerStatsReader.convertSort(JOB_WORKER_STATS_FIXED_SORT);
+    //    final var dbPage =
+    //        workerStatsReader.convertPaging(
+    //            dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+    //    final var dbQuery =
+    //        JobWorkerStatisticsDbQuery.of(
+    //            b ->
+    //                b.filter(query.filter())
+    //                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+    //                    .sort(dbSort)
+    //                    .page(dbPage));
+    //
+    //    final var results = jobMetricsBatchMapper.jobWorkerStatistics(dbQuery);
+    //    final var entities =
+    //        results.stream()
+    //            .map(
+    //                result ->
+    //                    new JobWorkerStatisticsEntity(
+    //                        result.worker(),
+    //                        new StatusMetric(
+    //                            ofNullable(result.createdCount()).orElse(0L),
+    // result.lastCreatedAt()),
+    //                        new StatusMetric(
+    //                            ofNullable(result.completedCount()).orElse(0L),
+    //                            result.lastCompletedAt()),
+    //                        new StatusMetric(
+    //                            ofNullable(result.failedCount()).orElse(0L),
+    // result.lastFailedAt())))
+    //            .toList();
+    //
+    //    return workerStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+  }
+
+  //  /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */
+  //  private static final class WorkerStatsReader
+  //      extends AbstractEntityReader<JobWorkerStatisticsEntity> {
+  //
+  //    WorkerStatsReader(final RdbmsReaderConfig readerConfig) {
+  //      super(JobWorkerStatisticsColumn.values(), readerConfig);
+  //    }
+  //  }
+
   private static final class EmptyResults {
     private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =
+        SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
+
+    private static final SearchQueryResult<JobWorkerStatisticsEntity> JOB_WORKER_STATISTICS =
         SearchQueryResult.of(f -> f.total(0L).items(Collections.emptyList()).endCursor(""));
 
     private static final GlobalJobStatisticsEntity GLOBAL_JOB_STATISTICS =

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -54,6 +54,7 @@ import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.JobTypeStatisticsFilter;
+import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.filter.MessageSubscriptionFilter;
 import io.camunda.search.filter.Operation;
@@ -441,6 +442,33 @@ public class SearchQueryFilterMapper {
     Optional.ofNullable(filter.getJobType())
         .map(mapToOperations(String.class))
         .ifPresent(builder::jobTypeOperations);
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  public static Either<List<String>, JobWorkerStatisticsFilter> toJobWorkerStatisticsFilter(
+      final io.camunda.gateway.protocol.model.JobWorkerStatisticsFilter filter) {
+    final var builder = FilterBuilders.jobWorkerStatistics();
+    final List<String> validationErrors = new ArrayList<>();
+
+    if (filter == null) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"));
+      return Either.left(validationErrors);
+    }
+
+    final var from = validateDate(filter.getFrom(), "from", validationErrors);
+    Optional.ofNullable(from).ifPresent(builder::from);
+
+    final var to = validateDate(filter.getTo(), "to", validationErrors);
+    Optional.ofNullable(to).ifPresent(builder::to);
+
+    if (filter.getJobType() == null || filter.getJobType().isBlank()) {
+      validationErrors.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("jobType"));
+    } else {
+      builder.jobType(filter.getJobType());
+    }
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -139,6 +139,15 @@ public final class SearchQueryRequestMapper {
         filter, Either.right(null), page, SearchQueryBuilders::jobTypeStatisticsSearchQuery);
   }
 
+  public static Either<ProblemDetail, io.camunda.search.query.JobWorkerStatisticsQuery>
+      toJobWorkerStatisticsQuery(
+          final io.camunda.gateway.protocol.model.JobWorkerStatisticsQuery request) {
+    final Either<List<String>, SearchQueryPage> page = toSearchQueryPage(request.getPage());
+    final var filter = SearchQueryFilterMapper.toJobWorkerStatisticsFilter(request.getFilter());
+    return buildSearchQuery(
+        filter, Either.right(null), page, SearchQueryBuilders::jobWorkerStatisticsSearchQuery);
+  }
+
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
       final io.camunda.gateway.protocol.model.simple.ProcessDefinitionSearchQuery query) {
     return toProcessDefinitionQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -79,6 +79,8 @@ import io.camunda.gateway.protocol.model.JobSearchResult;
 import io.camunda.gateway.protocol.model.JobStateEnum;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsItem;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQueryResult;
+import io.camunda.gateway.protocol.model.JobWorkerStatisticsItem;
+import io.camunda.gateway.protocol.model.JobWorkerStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.MappingRuleResult;
 import io.camunda.gateway.protocol.model.MappingRuleSearchQueryResult;
 import io.camunda.gateway.protocol.model.MatchedDecisionRuleItem;
@@ -158,6 +160,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionE
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -1573,6 +1576,30 @@ public final class SearchQueryResponseMapper {
         .completed(toStatusMetric(entity.completed()))
         .failed(toStatusMetric(entity.failed()))
         .workers(entity.workers());
+  }
+
+  public static JobWorkerStatisticsQueryResult toJobWorkerStatisticsQueryResult(
+      final SearchQueryResult<JobWorkerStatisticsEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new JobWorkerStatisticsQueryResult()
+        .page(page)
+        .items(
+            result.items().stream()
+                .map(SearchQueryResponseMapper::toJobWorkerStatisticsItem)
+                .toList());
+  }
+
+  private static JobWorkerStatisticsItem toJobWorkerStatisticsItem(
+      final JobWorkerStatisticsEntity entity) {
+    if (entity == null) {
+      return new JobWorkerStatisticsItem();
+    }
+
+    return new JobWorkerStatisticsItem()
+        .worker(entity.worker())
+        .created(toStatusMetric(entity.created()))
+        .completed(toStatusMetric(entity.completed()))
+        .failed(toStatusMetric(entity.failed()));
   }
 
   private static StatusMetric toStatusMetric(final GlobalJobStatisticsEntity.StatusMetric metric) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchDocumentReader.java
@@ -12,8 +12,10 @@ import io.camunda.search.aggregation.result.JobTypeStatisticsAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -46,5 +48,22 @@ public class JobMetricsBatchDocumentReader extends DocumentBasedReader
         aggResult.items(),
         null,
         aggResult.endCursor());
+  }
+
+  @Override
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    // TODO enabled in a follow up PR
+    throw new UnsupportedOperationException("Job worker statistics is not yet supported");
+    //    final var aggResult =
+    //        getSearchExecutor()
+    //            .aggregate(query, JobWorkerStatisticsAggregationResult.class,
+    // resourceAccessChecks);
+    //    return new SearchQueryResult<>(
+    //        aggResult.items().size(),
+    //        !aggResult.items().isEmpty(),
+    //        aggResult.items(),
+    //        null,
+    //        aggResult.endCursor());
   }
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/JobMetricsBatchReader.java
@@ -9,8 +9,10 @@ package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 
@@ -21,4 +23,7 @@ public interface JobMetricsBatchReader extends SearchClientReader {
 
   SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       JobTypeStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
+
+  SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      JobWorkerStatisticsQuery query, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -35,6 +35,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionE
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -80,6 +81,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
@@ -393,6 +395,13 @@ public class CamundaSearchClients implements SearchClientsProxy {
       final JobTypeStatisticsQuery query) {
     return doReadWithResourceAccessController(
         access -> readers.jobMetricsBatchReader().getJobTypeStatistics(query, access));
+  }
+
+  @Override
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query) {
+    return doReadWithResourceAccessController(
+        access -> readers.jobMetricsBatchReader().getJobWorkerStatistics(query, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -10,9 +10,11 @@ package io.camunda.search.clients;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
 
@@ -23,6 +25,9 @@ public interface JobSearchClient {
   GlobalJobStatisticsEntity getGlobalJobStatistics(GlobalJobStatisticsQuery query);
 
   SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(JobTypeStatisticsQuery query);
+
+  SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      JobWorkerStatisticsQuery query);
 
   JobSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -29,6 +29,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionE
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -69,6 +70,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
@@ -410,6 +412,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -31,6 +31,7 @@ import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionE
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.MessageSubscriptionEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -70,6 +71,7 @@ import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery;
@@ -412,6 +414,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
       final JobTypeStatisticsQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobWorkerStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobWorkerStatisticsEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
+
+/**
+ * Represents aggregated job statistics for a specific worker within a job type.
+ *
+ * @param worker the worker identifier
+ * @param created metrics for created jobs
+ * @param completed metrics for completed jobs
+ * @param failed metrics for failed jobs
+ */
+public record JobWorkerStatisticsEntity(
+    String worker, StatusMetric created, StatusMetric completed, StatusMetric failed) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -357,6 +357,16 @@ public final class FilterBuilders {
     return fn.apply(jobTypeStatistics()).build();
   }
 
+  public static JobWorkerStatisticsFilter.Builder jobWorkerStatistics() {
+    return new JobWorkerStatisticsFilter.Builder();
+  }
+
+  public static JobWorkerStatisticsFilter jobWorkerStatistics(
+      final Function<JobWorkerStatisticsFilter.Builder, ObjectBuilder<JobWorkerStatisticsFilter>>
+          fn) {
+    return fn.apply(jobWorkerStatistics()).build();
+  }
+
   public static GlobalListenerFilter.Builder globalListener() {
     return new GlobalListenerFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobWorkerStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobWorkerStatisticsFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Filter for job worker statistics queries.
+ *
+ * @param from start of the time window to filter metrics
+ * @param to end of the time window to filter metrics
+ * @param jobType the job type to filter worker metrics for
+ */
+public record JobWorkerStatisticsFilter(OffsetDateTime from, OffsetDateTime to, String jobType)
+    implements FilterBase {
+
+  public static JobWorkerStatisticsFilter of(
+      final Function<Builder, ObjectBuilder<JobWorkerStatisticsFilter>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobWorkerStatisticsFilter> {
+    private OffsetDateTime from;
+    private OffsetDateTime to;
+    private String jobType;
+
+    public Builder from(final OffsetDateTime from) {
+      this.from = from;
+      return this;
+    }
+
+    public Builder to(final OffsetDateTime to) {
+      this.to = to;
+      return this;
+    }
+
+    public Builder jobType(final String jobType) {
+      this.jobType = jobType;
+      return this;
+    }
+
+    @Override
+    public JobWorkerStatisticsFilter build() {
+      return new JobWorkerStatisticsFilter(
+          Objects.requireNonNull(from, "from must not be null"),
+          Objects.requireNonNull(to, "to must not be null"),
+          Objects.requireNonNull(jobType, "jobType must not be null"));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobWorkerStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobWorkerStatisticsQuery.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobWorkerStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Query for retrieving per-worker level statistics for a given job type.
+ *
+ * @param filter the filter criteria for job worker statistics
+ * @param page pagination parameters
+ */
+public record JobWorkerStatisticsQuery(JobWorkerStatisticsFilter filter, SearchQueryPage page)
+    implements TypedSearchQuery<JobWorkerStatisticsFilter, NoSort> {
+
+  public static JobWorkerStatisticsQuery of(
+      final Function<Builder, ObjectBuilder<JobWorkerStatisticsQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public NoSort sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public AggregationBase aggregation() {
+    // TODO enabled in a future PR, once the aggregation implementation is completed
+    // return new JobWorkerStatisticsAggregation(page);
+    return null;
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<JobWorkerStatisticsQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          JobWorkerStatisticsQuery,
+          JobWorkerStatisticsQuery.Builder,
+          JobWorkerStatisticsFilter,
+          NoSort> {
+
+    private JobWorkerStatisticsFilter filter;
+    private SearchQueryPage page;
+
+    @Override
+    public Builder filter(final JobWorkerStatisticsFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final NoSort value) {
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobWorkerStatisticsFilter.Builder, ObjectBuilder<JobWorkerStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobWorkerStatistics(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder page(final SearchQueryPage page) {
+      this.page = page;
+      return this;
+    }
+
+    @Override
+    public Builder page(
+        final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> fn) {
+      return page(SearchQueryPage.of(fn));
+    }
+
+    @Override
+    public JobWorkerStatisticsQuery build() {
+      return new JobWorkerStatisticsQuery(
+          Objects.requireNonNull(filter, "filter must not be null"), page);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -44,6 +44,10 @@ public final class SearchQueryBuilders {
     return new JobTypeStatisticsQuery.Builder();
   }
 
+  public static JobWorkerStatisticsQuery.Builder jobWorkerStatisticsSearchQuery() {
+    return new JobWorkerStatisticsQuery.Builder();
+  }
+
   public static ProcessInstanceQuery processInstanceSearchQuery(
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
     return fn.apply(processInstanceSearchQuery()).build();

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -13,9 +13,11 @@ import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -163,6 +165,17 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
                 .getJobTypeStatistics(query));
+  }
+
+  public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
+      final JobWorkerStatisticsQuery query) {
+    return executeSearchRequest(
+        () ->
+            jobSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .getJobWorkerStatistics(query));
   }
 
   public record ActivateJobsRequest(

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -83,6 +83,37 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
 
+  /jobs/statistics/by-workers:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Job
+      operationId: getJobWorkerStatistics
+      summary: Get job statistics by worker
+      description: |
+        Returns aggregated metrics per worker for the given jobType.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobWorkerStatisticsQuery'
+      responses:
+        "200":
+          description: The job worker statistics result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobWorkerStatisticsQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+
 ## Schema definitions
 
 components:
@@ -205,3 +236,75 @@ components:
           format: int32
           example: 5
 
+    JobWorkerStatisticsQuery:
+      description: Job worker statistics query.
+      type: object
+      required:
+        - filter
+      properties:
+        filter:
+          $ref: '#/components/schemas/JobWorkerStatisticsFilter'
+        page:
+          description: Search cursor pagination.
+          allOf:
+            - $ref: 'search-models.yaml#/components/schemas/CursorForwardPagination'
+
+    JobWorkerStatisticsFilter:
+      description: Job worker statistics search filter.
+      type: object
+      required:
+        - from
+        - to
+        - jobType
+      properties:
+        from:
+          description: |
+            Start of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-28T15:51:28.071Z"
+        to:
+          description: |
+            End of the time window to filter metrics. ISO 8601 date-time format.
+          type: string
+          format: date-time
+          example: "2024-07-29T15:51:28.071Z"
+        jobType:
+          description: Job type to return worker metrics for.
+          type: string
+          example: "fetch-customer-data"
+
+    JobWorkerStatisticsQueryResult:
+      description: Job worker statistics query result.
+      type: object
+      required:
+        - items
+        - page
+      allOf:
+        - $ref: "search-models.yaml#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The list of per-worker statistics items.
+          type: array
+          items:
+            $ref: '#/components/schemas/JobWorkerStatisticsItem'
+
+    JobWorkerStatisticsItem:
+      description: Statistics for a single worker within a job type.
+      type: object
+      required:
+        - worker
+        - created
+        - completed
+        - failed
+      properties:
+        worker:
+          description: The worker identifier.
+          type: string
+          example: "worker-1"
+        created:
+          $ref: '#/components/schemas/StatusMetric'
+        completed:
+          $ref: '#/components/schemas/StatusMetric'
+        failed:
+          $ref: '#/components/schemas/StatusMetric'

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -239,6 +239,8 @@ paths:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1global'
   /jobs/statistics/by-types:
     $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1by-types'
+  /jobs/statistics/by-workers:
+    $ref: 'job-metrics.yaml#/paths/~1jobs~1statistics~1by-workers'
 
   # License endpoints
   /license:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -27,6 +27,8 @@ import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQuery;
 import io.camunda.gateway.protocol.model.JobTypeStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
+import io.camunda.gateway.protocol.model.JobWorkerStatisticsQuery;
+import io.camunda.gateway.protocol.model.JobWorkerStatisticsQueryResult;
 import io.camunda.search.query.JobQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
@@ -128,6 +130,14 @@ public class JobController {
         .fold(RestErrorMapper::mapProblemToResponse, this::getTypeStatistics);
   }
 
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/statistics/by-workers")
+  public ResponseEntity<JobWorkerStatisticsQueryResult> getJobWorkerStatistics(
+      @RequestBody final JobWorkerStatisticsQuery request) {
+    return SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request)
+        .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
+  }
+
   private CompletableFuture<ResponseEntity<Object>> activateJobs(
       final ActivateJobsRequest activationRequest) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
@@ -225,6 +235,19 @@ public class JobController {
               .withAuthentication(authenticationProvider.getCamundaAuthentication())
               .getJobTypeStatistics(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobTypeStatisticsQueryResult(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<JobWorkerStatisticsQueryResult> getWorkerStatistics(
+      final io.camunda.search.query.JobWorkerStatisticsQuery query) {
+    try {
+      final var result =
+          jobServices
+              .withAuthentication(authenticationProvider.getCamundaAuthentication())
+              .getJobWorkerStatistics(query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toJobWorkerStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -1502,5 +1503,326 @@ public class JobControllerTest extends RestControllerTest {
     assertThat(capturedRequest.tenantIds())
         .describedAs("Tenant IDs should be empty when ASSIGNED filter is used")
         .isEmpty();
+  }
+
+  @Test
+  void shouldGetJobWorkerStatistics() {
+    // given
+    final var lastUpdatedAt = OffsetDateTime.parse("2024-07-29T15:51:28.071Z");
+    final var workerEntity1 =
+        new JobWorkerStatisticsEntity(
+            "worker-1",
+            new StatusMetric(400, lastUpdatedAt),
+            new StatusMetric(390, lastUpdatedAt),
+            new StatusMetric(2, lastUpdatedAt));
+    final var workerEntity2 =
+        new JobWorkerStatisticsEntity(
+            "worker-2",
+            new StatusMetric(350, lastUpdatedAt),
+            new StatusMetric(340, lastUpdatedAt),
+            new StatusMetric(5, lastUpdatedAt));
+
+    final var searchResult =
+        new SearchQueryResult.Builder<JobWorkerStatisticsEntity>()
+            .total(2L)
+            .items(List.of(workerEntity1, workerEntity2))
+            .build();
+
+    when(jobServices.getJobWorkerStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    final var expectedResponse =
+        """
+            {
+              "items": [
+                {
+                  "worker": "worker-1",
+                  "created": {
+                    "count": 400,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "completed": {
+                    "count": 390,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "failed": {
+                    "count": 2,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  }
+                },
+                {
+                  "worker": "worker-2",
+                  "created": {
+                    "count": 350,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "completed": {
+                    "count": 340,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "failed": {
+                    "count": 5,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  }
+                }
+              ],
+              "page": {
+                "totalItems": 2
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldGetJobWorkerStatisticsWithPagination() {
+    // given
+    final var lastUpdatedAt = OffsetDateTime.parse("2024-07-29T15:51:28.071Z");
+    final var workerEntity =
+        new JobWorkerStatisticsEntity(
+            "worker-1",
+            new StatusMetric(400, lastUpdatedAt),
+            new StatusMetric(390, lastUpdatedAt),
+            new StatusMetric(2, lastUpdatedAt));
+
+    final var searchResult =
+        new SearchQueryResult.Builder<JobWorkerStatisticsEntity>()
+            .total(1L)
+            .items(List.of(workerEntity))
+            .build();
+
+    when(jobServices.getJobWorkerStatistics(any())).thenReturn(searchResult);
+
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              },
+              "page": {
+                "limit": 1
+              }
+            }""";
+
+    final var expectedResponse =
+        """
+            {
+              "items": [
+                {
+                  "worker": "worker-1",
+                  "created": {
+                    "count": 400,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "completed": {
+                    "count": 390,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  },
+                  "failed": {
+                    "count": 2,
+                    "lastUpdatedAt": "2024-07-29T15:51:28.071Z"
+                  }
+                }
+              ],
+              "page": {
+                "totalItems": 1
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithMissingBody() {
+    // given
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "Bad Request",
+              "detail": "Required request body is missing",
+              "instance": "%s"
+            }"""
+            .formatted(JOBS_BASE_URL + "/statistics/by-workers");
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithMissingFilter() {
+    // given
+    final var request =
+        """
+            {
+              "page": {
+                "limit": 10
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithEmptyFilter() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {}
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithMissingFrom() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "to": "2024-07-29T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithMissingTo() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "jobType": "fetch-customer-data"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
+  }
+
+  @Test
+  void shouldRejectJobWorkerStatisticsWithMissingJobType() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "from": "2024-07-28T15:51:28.071Z",
+                "to": "2024-07-29T15:51:28.071Z"
+              }
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/statistics/by-workers")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+
+    verifyNoInteractions(jobServices);
   }
 }


### PR DESCRIPTION
## Description

This pull request introduces the initial support for job worker statistics queries across multiple layers of the codebase. While the actual implementation for fetching job worker statistics is not yet enabled (it throws an `UnsupportedOperationException` for now), the groundwork is laid by adding the necessary interfaces, method signatures, mappers, and response structures. This prepares the system for full support in a future update.

Key changes include:

**API and Query Layer Integration:**

- Added new methods and types for handling `JobWorkerStatisticsQuery` and `JobWorkerStatisticsEntity` in the client interfaces, service interfaces, and the main search client (`JobSearchClient`, `CamundaSearchClients`, and related proxies). [[1]](diffhunk://#diff-6bc393dbbefa998aeded55a7b52a03bf0850de6fdf891681159a773c2cdb932bR12-R15) [[2]](diffhunk://#diff-6bc393dbbefa998aeded55a7b52a03bf0850de6fdf891681159a773c2cdb932bR26-R28) [[3]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R38) [[4]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R84) [[5]](diffhunk://#diff-99616651437db17eb866f9a3b4a3ef9d0e6d75bea00465643f7204920966fa93R400-R406) [[6]](diffhunk://#diff-cb11a4b24fb6e9c25f887e4b2b02055b11b559dca7d87fdd650da35a5184df9eR13-R17) [[7]](diffhunk://#diff-cb11a4b24fb6e9c25f887e4b2b02055b11b559dca7d87fdd650da35a5184df9eR29-R31) [[8]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R32) [[9]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R73) [[10]](diffhunk://#diff-38418fdd9bb6a019d3630943518b33259023fb83352657e76a9d862394278b80R418-R423) [[11]](diffhunk://#diff-c79d6b60e20a1f39b125755908386489c3f033508a294e45ef84feed9a285b1eR34) [[12]](diffhunk://#diff-c79d6b60e20a1f39b125755908386489c3f033508a294e45ef84feed9a285b1eR74)

**Database and Reader Layer:**

- Introduced a new reader and mapping for job worker statistics in the RDBMS and document-based readers, including a stubbed implementation that throws an exception until the feature is fully enabled. Also added a fixed sort order for worker statistics. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R17-R29) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R46-R57) [[3]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R124-R181) [[4]](diffhunk://#diff-3d08ffb727a5ff5eefa4ab0d72c0e83b4d16e575b46d7532b8e324b91afc770bR15-R18) [[5]](diffhunk://#diff-3d08ffb727a5ff5eefa4ab0d72c0e83b4d16e575b46d7532b8e324b91afc770bR52-R68)

**Gateway Mapping and Filter Support:**

- Implemented filter and query mappers for job worker statistics, enabling the gateway to parse and validate incoming job worker statistics requests. [[1]](diffhunk://#diff-e1f65762c93bb5ef2c37f4c053b3bf3bd244485263d62e64276b97772981027fR57) [[2]](diffhunk://#diff-e1f65762c93bb5ef2c37f4c053b3bf3bd244485263d62e64276b97772981027fR451-R477) [[3]](diffhunk://#diff-2f50a632e9f67fa9422b16bdf13afef8966a85408cea148428ab2b763c86fefaR142-R150)

**API Response Mapping:**

- Added response mappers to convert internal job worker statistics entities into the appropriate API response models, ensuring the API can return structured results once the backend is enabled. [[1]](diffhunk://#diff-06c4e31c99d1aca6e942471bbb0c7dfdb715a4cc9535d3cbd34a982dcb3714f2R82-R83) [[2]](diffhunk://#diff-06c4e31c99d1aca6e942471bbb0c7dfdb715a4cc9535d3cbd34a982dcb3714f2R163) [[3]](diffhunk://#diff-06c4e31c99d1aca6e942471bbb0c7dfdb715a4cc9535d3cbd34a982dcb3714f2R1581-R1604)

These changes collectively set up the infrastructure for job worker statistics queries, making it easier to enable and implement the feature fully in a follow-up pull request.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43060
