### PR TITLE
feat: validate dmn decision table content length #45681

### DIFF
--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecision.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecision.java
@@ -17,12 +17,19 @@ package io.camunda.zeebe.dmn;
 public interface ParsedDecision {
 
   /**
+   * @return the id of the decision
+   */
+  String getId();
+
+  /**
    * @return the name of the decision
    */
   String getName();
 
   /**
-   * @return the id of the decision
+   * @return the decision table of the decision if the decision logic is a decision table; otherwise
+   *     {@code null} (for example, when the decision uses a literal expression or context instead
+   *     of a decision table)
    */
-  String getId();
+  ParsedDecisionTable getDecisionTable();
 }

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionInput.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionInput.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn;
+
+public interface ParsedDecisionInput {
+  String getId();
+
+  String getName();
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionOutput.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionOutput.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn;
+
+public interface ParsedDecisionOutput {
+  String getId();
+
+  String getName();
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionRule.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionRule.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn;
+
+public interface ParsedDecisionRule {
+  String getId();
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionTable.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionTable.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn;
+
+import java.util.List;
+
+public interface ParsedDecisionTable {
+
+  List<? extends ParsedDecisionInput> getInputs();
+
+  List<? extends ParsedDecisionOutput> getOutputs();
+
+  List<? extends ParsedDecisionRule> getRules();
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecision.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecision.java
@@ -8,15 +8,24 @@
 package io.camunda.zeebe.dmn.impl;
 
 import io.camunda.zeebe.dmn.ParsedDecision;
+import io.camunda.zeebe.dmn.ParsedDecisionTable;
 
 public final class ParsedDmnScalaDecision implements ParsedDecision {
 
   private final String decisionId;
   private final String decisionName;
+  private final ParsedDecisionTable decisionTable;
 
-  public ParsedDmnScalaDecision(final String decisionId, final String decisionName) {
+  public ParsedDmnScalaDecision(
+      final String decisionId, final String decisionName, final ParsedDecisionTable decisionTable) {
     this.decisionId = decisionId;
     this.decisionName = decisionName;
+    this.decisionTable = decisionTable;
+  }
+
+  @Override
+  public String getId() {
+    return decisionId;
   }
 
   @Override
@@ -25,7 +34,7 @@ public final class ParsedDmnScalaDecision implements ParsedDecision {
   }
 
   @Override
-  public String getId() {
-    return decisionId;
+  public ParsedDecisionTable getDecisionTable() {
+    return decisionTable;
   }
 }

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionInput.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionInput.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecisionInput;
+
+public class ParsedDmnScalaDecisionInput implements ParsedDecisionInput {
+
+  private final String id;
+  private final String name;
+
+  public ParsedDmnScalaDecisionInput(final String id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionOutput.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionOutput.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecisionOutput;
+
+public class ParsedDmnScalaDecisionOutput implements ParsedDecisionOutput {
+
+  private final String id;
+  private final String name;
+
+  public ParsedDmnScalaDecisionOutput(final String id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionRule.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionRule.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecisionRule;
+
+public class ParsedDmnScalaDecisionRule implements ParsedDecisionRule {
+
+  private final String id;
+
+  public ParsedDmnScalaDecisionRule(final String id) {
+    this.id = id;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionTable.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecisionTable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecisionInput;
+import io.camunda.zeebe.dmn.ParsedDecisionOutput;
+import io.camunda.zeebe.dmn.ParsedDecisionRule;
+import io.camunda.zeebe.dmn.ParsedDecisionTable;
+import java.util.List;
+
+public class ParsedDmnScalaDecisionTable implements ParsedDecisionTable {
+
+  private final List<ParsedDecisionInput> inputs;
+  private final List<ParsedDecisionOutput> outputs;
+  private final List<ParsedDecisionRule> rules;
+
+  public ParsedDmnScalaDecisionTable(
+      final List<ParsedDecisionInput> inputs,
+      final List<ParsedDecisionOutput> outputs,
+      final List<ParsedDecisionRule> rules) {
+    this.inputs = inputs;
+    this.outputs = outputs;
+    this.rules = rules;
+  }
+
+  @Override
+  public List<ParsedDecisionInput> getInputs() {
+    return inputs;
+  }
+
+  @Override
+  public List<ParsedDecisionOutput> getOutputs() {
+    return outputs;
+  }
+
+  @Override
+  public List<ParsedDecisionRule> getRules() {
+    return rules;
+  }
+}

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDrg.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDrg.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.dmn.impl;
 
 import io.camunda.zeebe.dmn.ParsedDecision;
+import io.camunda.zeebe.dmn.ParsedDecisionInput;
+import io.camunda.zeebe.dmn.ParsedDecisionOutput;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.dmn.ParsedDecisionRule;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Definitions;
+import org.camunda.dmn.parser.ParsedDecisionTable;
 import org.camunda.dmn.parser.ParsedDmn;
 
 public final class ParsedDmnScalaDrg implements ParsedDecisionRequirementsGraph {
@@ -38,16 +42,6 @@ public final class ParsedDmnScalaDrg implements ParsedDecisionRequirementsGraph 
   }
 
   @Override
-  public boolean isValid() {
-    return true;
-  }
-
-  @Override
-  public String getFailureMessage() {
-    return null;
-  }
-
-  @Override
   public String getId() {
     return decisionRequirementsId;
   }
@@ -65,6 +59,16 @@ public final class ParsedDmnScalaDrg implements ParsedDecisionRequirementsGraph 
   @Override
   public Collection<ParsedDecision> getDecisions() {
     return decisions;
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return null;
   }
 
   public ParsedDmn getParsedDmn() {
@@ -90,10 +94,29 @@ public final class ParsedDmnScalaDrg implements ParsedDecisionRequirementsGraph 
         .decisions()
         .foreach(
             decision -> {
-              final var parsedDecision = new ParsedDmnScalaDecision(decision.id(), decision.name());
+              final var parsedDecision =
+                  new ParsedDmnScalaDecision(
+                      decision.id(), decision.name(), getParsedDecisionTable(decision));
               return decisions.add(parsedDecision);
             });
 
     return decisions;
+  }
+
+  private static ParsedDmnScalaDecisionTable getParsedDecisionTable(
+      final org.camunda.dmn.parser.ParsedDecision parsedDecision) {
+    if (!(parsedDecision.logic() instanceof final ParsedDecisionTable table)) {
+      return null;
+    }
+
+    final List<ParsedDecisionInput> inputs = new ArrayList<>();
+    final List<ParsedDecisionOutput> outputs = new ArrayList<>();
+    final List<ParsedDecisionRule> rules = new ArrayList<>();
+
+    table.inputs().foreach(i -> inputs.add(new ParsedDmnScalaDecisionInput(i.id(), i.name())));
+    table.outputs().foreach(i -> outputs.add(new ParsedDmnScalaDecisionOutput(i.id(), i.name())));
+    table.rules().foreach(i -> rules.add(new ParsedDmnScalaDecisionRule(i.id())));
+
+    return new ParsedDmnScalaDecisionTable(inputs, outputs, rules);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -275,8 +275,7 @@ public class DecisionBehavior {
       return ruleId;
     }
 
-    return SYNTHESIZED_RULE_ID_TEMPLATE.formatted(
-        SYNTHESIZED_RULE_ID_PREFIX, decisionId, decisionVersion, rule.ruleIndex());
+    return synthesizeRuleId(decisionId, decisionVersion, rule.ruleIndex());
   }
 
   private void addInputToEvaluationEvent(
@@ -305,6 +304,12 @@ public class DecisionBehavior {
     if (evaluatedOutput.outputName() != null) {
       outputRecord.setOutputName(evaluatedOutput.outputName());
     }
+  }
+
+  public static String synthesizeRuleId(
+      final String decisionId, final int decisionVersion, final int ruleIndex) {
+    return SYNTHESIZED_RULE_ID_TEMPLATE.formatted(
+        SYNTHESIZED_RULE_ID_PREFIX, decisionId, decisionVersion, ruleIndex);
   }
 
   private record DecisionInfo(long key, int version) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -71,7 +71,8 @@ public final class DeploymentTransformer {
             stateWriter,
             checksumGenerator,
             processingState.getDecisionState(),
-            config);
+            config.getMaxIdFieldLength(),
+            config.getMaxNameFieldLength());
 
     final var formResourceTransformer =
         new FormResourceTransformer(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -321,24 +321,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     return NO_VALIDATION_ERROR;
   }
 
-  private Either<Failure, ?> checkDecisionIdLength(
-      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
-    return checkFieldLength(
-        parsedDrg.getDecisions().stream().map(ParsedDecision::getId),
-        engineConfiguration.getMaxIdFieldLength(),
-        "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
-        resource);
-  }
-
-  private Either<Failure, ?> checkDecisionNameLength(
-      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
-    return checkFieldLength(
-        parsedDrg.getDecisions().stream().map(ParsedDecision::getName),
-        engineConfiguration.getMaxNameFieldLength(),
-        "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
-        resource);
-  }
-
   private static Either<Failure, ?> checkFieldLength(
       final String value,
       final int maxLength,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -12,7 +12,10 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.dmn.ParsedDecision;
+import io.camunda.zeebe.dmn.ParsedDecisionInput;
+import io.camunda.zeebe.dmn.ParsedDecisionOutput;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.dmn.ParsedDecisionRule;
 import io.camunda.zeebe.dmn.impl.ParsedDmnScalaDrg;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -38,6 +41,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.agrona.DirectBuffer;
 import org.camunda.bpm.model.dmn.instance.ExtensionElements;
 
@@ -82,8 +86,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     if (parsedDrg.isValid()) {
       return checkForDuplicateIds(resource, parsedDrg, deployment)
           .flatMap(valid -> checkDrdIdNameLength(resource, parsedDrg))
-          .flatMap(valid -> checkDecisionIdLength(resource, parsedDrg))
-          .flatMap(valid -> checkDecisionNameLength(resource, parsedDrg))
+          .flatMap(valid -> checkDecisions(resource, parsedDrg))
           .map(
               valid -> {
                 appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
@@ -231,62 +234,131 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     final var decisionRequirementsId = parsedDrg.getId();
     final var decisionRequirementsName = parsedDrg.getName();
 
-    if (decisionRequirementsId != null
-        && decisionRequirementsId.length() > engineConfiguration.getMaxIdFieldLength()) {
-      final var failureMessage =
-          String.format(
-              "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
-              engineConfiguration.getMaxIdFieldLength(),
-              decisionRequirementsId,
-              resource.getResourceName());
-      return Either.left(new Failure(failureMessage));
-    } else if (decisionRequirementsName != null
-        && decisionRequirementsName.length() > engineConfiguration.getMaxNameFieldLength()) {
-      final var failureMessage =
-          String.format(
-              "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was '%s' in DRG '%s'",
-              engineConfiguration.getMaxNameFieldLength(),
-              decisionRequirementsName,
-              resource.getResourceName());
-      return Either.left(new Failure(failureMessage));
-    } else {
+    return checkFieldLength(
+            Stream.of(decisionRequirementsId),
+            engineConfiguration.getMaxIdFieldLength(),
+            "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+            resource)
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    Stream.of(decisionRequirementsName),
+                    engineConfiguration.getMaxNameFieldLength(),
+                    "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was '%s' in DRG '%s'",
+                    resource));
+  }
+
+  private Either<Failure, ?> checkDecision(
+      final DeploymentResource resource, final ParsedDecision decision) {
+    return checkFieldLength(
+            decision.getId(),
+            engineConfiguration.getMaxIdFieldLength(),
+            "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+            resource)
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    decision.getName(),
+                    engineConfiguration.getMaxNameFieldLength(),
+                    "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
+                    resource))
+        .flatMap(valid -> checkDecisionTable(resource, decision));
+  }
+
+  private Either<Failure, ?> checkDecisionTable(
+      final DeploymentResource resource, final ParsedDecision decision) {
+    if (decision.getDecisionTable() == null) {
       return NO_VALIDATION_ERROR;
     }
+
+    return checkFieldLength(
+            decision.getDecisionTable().getInputs().stream().map(ParsedDecisionInput::getId),
+            engineConfiguration.getMaxIdFieldLength(),
+            "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+            resource)
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    decision.getDecisionTable().getInputs().stream()
+                        .map(ParsedDecisionInput::getName),
+                    engineConfiguration.getMaxNameFieldLength(),
+                    "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
+                    resource))
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    decision.getDecisionTable().getOutputs().stream()
+                        .map(ParsedDecisionOutput::getId),
+                    engineConfiguration.getMaxIdFieldLength(),
+                    "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+                    resource))
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    decision.getDecisionTable().getOutputs().stream()
+                        .map(ParsedDecisionOutput::getName),
+                    engineConfiguration.getMaxNameFieldLength(),
+                    "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
+                    resource))
+        .flatMap(
+            valid ->
+                checkFieldLength(
+                    decision.getDecisionTable().getRules().stream().map(ParsedDecisionRule::getId),
+                    engineConfiguration.getMaxIdFieldLength(),
+                    "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+                    resource));
+  }
+
+  private Either<Failure, ?> checkDecisions(
+      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
+    for (final var decision : parsedDrg.getDecisions()) {
+      final var validation = checkDecision(resource, decision);
+      if (validation.isLeft()) {
+        return validation;
+      }
+    }
+
+    return NO_VALIDATION_ERROR;
   }
 
   private Either<Failure, ?> checkDecisionIdLength(
       final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
-    return parsedDrg.getDecisions().stream()
-        .map(ParsedDecision::getId)
-        .filter(id -> id != null && id.length() > engineConfiguration.getMaxIdFieldLength())
-        .findFirst()
-        .map(
-            id ->
-                Either.left(
-                    new Failure(
-                        String.format(
-                            "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
-                            engineConfiguration.getMaxIdFieldLength(),
-                            id,
-                            resource.getResourceName()))))
-        .orElse(NO_VALIDATION_ERROR);
+    return checkFieldLength(
+        parsedDrg.getDecisions().stream().map(ParsedDecision::getId),
+        engineConfiguration.getMaxIdFieldLength(),
+        "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
+        resource);
   }
 
   private Either<Failure, ?> checkDecisionNameLength(
       final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
-    return parsedDrg.getDecisions().stream()
-        .map(ParsedDecision::getName)
-        .filter(name -> name != null && name.length() > engineConfiguration.getMaxNameFieldLength())
+    return checkFieldLength(
+        parsedDrg.getDecisions().stream().map(ParsedDecision::getName),
+        engineConfiguration.getMaxNameFieldLength(),
+        "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
+        resource);
+  }
+
+  private static Either<Failure, ?> checkFieldLength(
+      final String value,
+      final int maxLength,
+      final String message,
+      final DeploymentResource resource) {
+    return checkFieldLength(Stream.of(value), maxLength, message, resource);
+  }
+
+  private static Either<Failure, ?> checkFieldLength(
+      final Stream<String> values,
+      final int maxLength,
+      final String message,
+      final DeploymentResource resource) {
+    return values
+        .filter(id -> id != null && id.length() > maxLength)
         .findFirst()
         .map(
-            name ->
+            id ->
                 Either.left(
-                    new Failure(
-                        String.format(
-                            "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
-                            engineConfiguration.getMaxNameFieldLength(),
-                            name,
-                            resource.getResourceName()))))
+                    new Failure(String.format(message, maxLength, id, resource.getResourceName()))))
         .orElse(NO_VALIDATION_ERROR);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import com.google.common.base.Strings;
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.dmn.ParsedDecision;
@@ -17,7 +18,7 @@ import io.camunda.zeebe.dmn.ParsedDecisionOutput;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.dmn.ParsedDecisionRule;
 import io.camunda.zeebe.dmn.impl.ParsedDmnScalaDrg;
-import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -59,19 +60,23 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   private final StateWriter stateWriter;
   private final ChecksumGenerator checksumGenerator;
   private final DecisionState decisionState;
-  private final EngineConfiguration engineConfiguration;
+
+  private final int maxIdLength;
+  private final int maxNameLength;
 
   public DmnResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
       final ChecksumGenerator checksumGenerator,
       final DecisionState decisionState,
-      final EngineConfiguration engineConfiguration) {
+      final int maxIdLength,
+      final int maxNameLength) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
     this.decisionState = decisionState;
-    this.engineConfiguration = engineConfiguration;
+    this.maxIdLength = maxIdLength;
+    this.maxNameLength = maxNameLength;
   }
 
   @Override
@@ -236,14 +241,14 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
     return checkFieldLength(
             Stream.of(decisionRequirementsId),
-            engineConfiguration.getMaxIdFieldLength(),
+            maxIdLength,
             "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
             valid ->
                 checkFieldLength(
                     Stream.of(decisionRequirementsName),
-                    engineConfiguration.getMaxNameFieldLength(),
+                    maxNameLength,
                     "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was '%s' in DRG '%s'",
                     resource));
   }
@@ -252,14 +257,14 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       final DeploymentResource resource, final ParsedDecision decision) {
     return checkFieldLength(
             decision.getId(),
-            engineConfiguration.getMaxIdFieldLength(),
+            maxIdLength,
             "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
             valid ->
                 checkFieldLength(
                     decision.getName(),
-                    engineConfiguration.getMaxNameFieldLength(),
+                    maxNameLength,
                     "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(valid -> checkDecisionTable(resource, decision));
@@ -273,7 +278,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
     return checkFieldLength(
             decision.getDecisionTable().getInputs().stream().map(ParsedDecisionInput::getId),
-            engineConfiguration.getMaxIdFieldLength(),
+            maxIdLength,
             "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
@@ -281,7 +286,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getInputs().stream()
                         .map(ParsedDecisionInput::getName),
-                    engineConfiguration.getMaxNameFieldLength(),
+                    maxNameLength,
                     "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
@@ -289,7 +294,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getOutputs().stream()
                         .map(ParsedDecisionOutput::getId),
-                    engineConfiguration.getMaxIdFieldLength(),
+                    maxIdLength,
                     "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
@@ -297,16 +302,38 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getOutputs().stream()
                         .map(ParsedDecisionOutput::getName),
-                    engineConfiguration.getMaxNameFieldLength(),
+                    maxNameLength,
                     "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
             valid ->
                 checkFieldLength(
-                    decision.getDecisionTable().getRules().stream().map(ParsedDecisionRule::getId),
-                    engineConfiguration.getMaxIdFieldLength(),
+                    decision.getDecisionTable().getRules().stream()
+                        .map(ParsedDecisionRule::getId)
+                        .filter(id -> !Strings.isNullOrEmpty(id)),
+                    maxIdLength,
                     "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
-                    resource));
+                    resource))
+        .flatMap(valid -> checkBlankRuleIds(resource, decision));
+  }
+
+  private Either<Failure, ?> checkBlankRuleIds(
+      final DeploymentResource resource, final ParsedDecision decision) {
+    final var hasBlankRuleIds =
+        decision.getDecisionTable().getRules().stream()
+            .anyMatch(rule -> Strings.isNullOrEmpty(rule.getId()));
+    if (hasBlankRuleIds) {
+      final var synthesizedRuleId = DecisionBehavior.synthesizeRuleId(decision.getId(), 9999, 9999);
+      final var maxLengthDecisionId =
+          maxIdLength - synthesizedRuleId.length() + decision.getId().length();
+      return checkFieldLength(
+          decision.getId(),
+          maxLengthDecisionId,
+          "A blank ruleId requires a decisionId having a max-id-length of %s characters, but was '%s' in resource '%s'. Either shorten the decisionId or set a ruleId explicitly",
+          resource);
+    } else {
+      return NO_VALIDATION_ERROR;
+    }
   }
 
   private Either<Failure, ?> checkDecisions(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -69,6 +69,8 @@ public final class DmnDeploymentTest {
       "/dmn/decision-table-with-long-output-name.dmn";
   private static final String DECISION_RULE_ID_LENGTH_EXCEEDED =
       "/dmn/decision-table-with-long-rule-id.dmn";
+  private static final String DECISION_RULE_ID_BLANK_EXCEEDED =
+      "/dmn/decision-table-with-blank-rule-id.dmn";
 
   private static final int MAX_ID_FIELD_LENGTH = 100;
   private static final int MAX_NAME_FIELD_LENGTH = 100;
@@ -840,6 +842,29 @@ public final class DmnDeploymentTest {
             String.format(
                 "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_rule_that_should_exceed_one_hundred_characters_for_testing' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DECISION_RULE_ID_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionRuleIdIsBlankAndDecisionIdExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_RULE_ID_BLANK_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "A blank ruleId requires a decisionId having a max-id-length of %s characters, but was 'this_is_a_creative_and_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test' in resource '%s'. Either shorten the decisionId or set a ruleId explicitly",
+                MAX_ID_FIELD_LENGTH - 29, DECISION_RULE_ID_BLANK_EXCEEDED));
   }
 
   private byte[] getChecksum(final String resourceName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -59,6 +59,16 @@ public final class DmnDeploymentTest {
   private static final String DECISION_ID_LENGTH_EXCEEDED = "/dmn/decision-table-with-long-ids.dmn";
   private static final String DECISION_NAME_LENGTH_EXCEEDED =
       "/dmn/decision-table-with-long-name.dmn";
+  private static final String DECISION_INPUT_ID_LENGTH_EXCEEDED =
+      "/dmn/decision-table-with-long-input-id.dmn";
+  private static final String DECISION_INPUT_NAME_LENGTH_EXCEEDED =
+      "/dmn/decision-table-with-long-input-name.dmn";
+  private static final String DECISION_OUTPUT_ID_LENGTH_EXCEEDED =
+      "/dmn/decision-table-with-long-output-id.dmn";
+  private static final String DECISION_OUTPUT_NAME_LENGTH_EXCEEDED =
+      "/dmn/decision-table-with-long-output-name.dmn";
+  private static final String DECISION_RULE_ID_LENGTH_EXCEEDED =
+      "/dmn/decision-table-with-long-rule-id.dmn";
 
   private static final int MAX_ID_FIELD_LENGTH = 50;
   private static final int MAX_NAME_FIELD_LENGTH = 50;
@@ -715,6 +725,121 @@ public final class DmnDeploymentTest {
             String.format(
                 "The name of a decision must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision table' in resource '%s'",
                 MAX_NAME_FIELD_LENGTH, DECISION_NAME_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionInputIdExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_INPUT_ID_LENGTH_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_input' in resource '%s'",
+                MAX_ID_FIELD_LENGTH, DECISION_INPUT_ID_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionInputNameExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_INPUT_NAME_LENGTH_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision input' in resource '%s'",
+                MAX_NAME_FIELD_LENGTH, DECISION_INPUT_NAME_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionOutputIdExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_OUTPUT_ID_LENGTH_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_output' in resource '%s'",
+                MAX_ID_FIELD_LENGTH, DECISION_OUTPUT_ID_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionOutputNameExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_OUTPUT_NAME_LENGTH_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision output' in resource '%s'",
+                MAX_NAME_FIELD_LENGTH, DECISION_OUTPUT_NAME_LENGTH_EXCEEDED));
+  }
+
+  @Test
+  public void shouldRejectIfDecisionRuleIdExceedsSize() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DECISION_RULE_ID_LENGTH_EXCEEDED)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_rule' in resource '%s'",
+                MAX_ID_FIELD_LENGTH, DECISION_RULE_ID_LENGTH_EXCEEDED));
   }
 
   private byte[] getChecksum(final String resourceName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -70,8 +70,8 @@ public final class DmnDeploymentTest {
   private static final String DECISION_RULE_ID_LENGTH_EXCEEDED =
       "/dmn/decision-table-with-long-rule-id.dmn";
 
-  private static final int MAX_ID_FIELD_LENGTH = 50;
-  private static final int MAX_NAME_FIELD_LENGTH = 50;
+  private static final int MAX_ID_FIELD_LENGTH = 100;
+  private static final int MAX_NAME_FIELD_LENGTH = 100;
 
   @Rule
   public final EngineRule engine =
@@ -654,7 +654,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_requirements_graph' in resource '%s'",
+                "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DRG_ID_LENGTH_EXCEEDED));
   }
 
@@ -677,7 +677,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was 'This is a very long name for a decision requirements graph' in DRG '%s'",
+                "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was 'This is an extremely beautiful and very long name for a decision table but it's worth it because we need it for a test' in DRG '%s'",
                 MAX_NAME_FIELD_LENGTH, DRG_NAME_LENGTH_EXCEEDED));
   }
 
@@ -700,7 +700,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision1' in resource '%s'",
+                "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DECISION_ID_LENGTH_EXCEEDED));
   }
 
@@ -723,7 +723,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a decision must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision table' in resource '%s'",
+                "The name of a decision must not be longer than the configured max-name-length of %s characters, but was 'This is an extremely beautiful and very long name for a decision table but it's worth it because we need it for a test' in resource '%s'",
                 MAX_NAME_FIELD_LENGTH, DECISION_NAME_LENGTH_EXCEEDED));
   }
 
@@ -746,7 +746,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_input' in resource '%s'",
+                "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_input_that_should_exceed_one_hundred_characters_for_testing' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DECISION_INPUT_ID_LENGTH_EXCEEDED));
   }
 
@@ -769,7 +769,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision input' in resource '%s'",
+                "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was 'This is an extremely beautiful and very long name for a decision input element that should exceed one hundred characters' in resource '%s'",
                 MAX_NAME_FIELD_LENGTH, DECISION_INPUT_NAME_LENGTH_EXCEEDED));
   }
 
@@ -792,7 +792,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_output' in resource '%s'",
+                "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_output_that_should_exceed_one_hundred_characters_for_testing' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DECISION_OUTPUT_ID_LENGTH_EXCEEDED));
   }
 
@@ -815,7 +815,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was 'This is an extreme and very long name for a decision output' in resource '%s'",
+                "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was 'This is an extremely beautiful and very long name for a decision output element that should exceed one hundred characters' in resource '%s'",
                 MAX_NAME_FIELD_LENGTH, DECISION_OUTPUT_NAME_LENGTH_EXCEEDED));
   }
 
@@ -838,7 +838,7 @@ public final class DmnDeploymentTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extreme_and_very_long_id_for_a_decision_rule' in resource '%s'",
+                "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was 'this_is_an_extremely_creative_and_very_long_id_for_a_decision_rule_that_should_exceed_one_hundred_characters_for_testing' in resource '%s'",
                 MAX_ID_FIELD_LENGTH, DECISION_RULE_ID_LENGTH_EXCEEDED));
   }
 

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-blank-rule-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-blank-rule-id.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="this_is_a_creative_and_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule>
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-ids.dmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
-  <decision id="this_is_an_extreme_and_very_long_id_for_a_decision1" name="Jedi or Sith">
+  <decision id="this_is_an_extremely_creative_and_very_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="this_is_an_extreme_and_very_long_id_for_a_decision1">
+      <dmndi:DMNShape dmnElementRef="this_is_an_extremely_creative_and_very_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-id.dmn
@@ -9,7 +9,7 @@
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
-      <input id="this_is_an_extreme_and_very_long_id_for_a_decision_input" label="Lightsaber color" biodi:width="192">
+      <input id="this_is_an_extremely_creative_and_very_long_id_for_a_decision_input_that_should_exceed_one_hundred_characters_for_testing" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-id.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="this_is_an_extreme_and_very_long_id_for_a_decision_input" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>
+

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-name.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="This is an extreme and very long name for a decision input" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>
+

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-input-name.dmn
@@ -9,7 +9,7 @@
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
-      <input id="Input_1" label="This is an extreme and very long name for a decision input" biodi:width="192">
+      <input id="Input_1" label="This is an extremely beautiful and very long name for a decision input element that should exceed one hundred characters" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-name.dmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
-  <decision id="jediOrSith" name="This is an extreme and very long name for a decision table">
+  <decision id="jediOrSith" name="This is an extremely beautiful and very long name for a decision table but it's worth it because we need it for a test">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-id.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="this_is_an_extreme_and_very_long_id_for_a_decision_output" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>
+

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-id.dmn
@@ -14,7 +14,7 @@
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="this_is_an_extreme_and_very_long_id_for_a_decision_output" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+      <output id="this_is_an_extremely_creative_and_very_long_id_for_a_decision_output_that_should_exceed_one_hundred_characters_for_testing" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-name.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="This is an extreme and very long name for a decision output" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>
+

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-name.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-output-name.dmn
@@ -14,7 +14,7 @@
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="This is an extreme and very long name for a decision output" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="This is an extremely beautiful and very long name for a decision output element that should exceed one hundred characters" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-rule-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-rule-id.dmn
@@ -19,7 +19,7 @@
           <text>"Jedi","Sith"</text>
         </outputValues>
       </output>
-      <rule id="this_is_an_extreme_and_very_long_id_for_a_decision_rule">
+      <rule id="this_is_an_extremely_creative_and_very_long_id_for_a_decision_rule_that_should_exceed_one_hundred_characters_for_testing">
         <inputEntry id="UnaryTests_0leuxqi">
           <text>"blue"</text>
         </inputEntry>

--- a/zeebe/engine/src/test/resources/dmn/decision-table-with-long-rule-id.dmn
+++ b/zeebe/engine/src/test/resources/dmn/decision-table-with-long-rule-id.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="this_is_an_extreme_and_very_long_id_for_a_decision_rule">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>
+

--- a/zeebe/engine/src/test/resources/dmn/drg-id-length-exceeded.dmn
+++ b/zeebe/engine/src/test/resources/dmn/drg-id-length-exceeded.dmn
@@ -5,7 +5,7 @@
   xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0"
   xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
-  id="this_is_an_extreme_and_very_long_id_for_a_decision_requirements_graph" name="force_users" namespace="http://camunda.org/schema/1.0/dmn"
+  id="this_is_an_extremely_creative_and_very_long_id_for_a_decision_but_it_is_worth_it_because_we_need_it_for_a_test" name="force_users" namespace="http://camunda.org/schema/1.0/dmn"
   exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <extensionElements>

--- a/zeebe/engine/src/test/resources/dmn/drg-name-length-exceeded.dmn
+++ b/zeebe/engine/src/test/resources/dmn/drg-name-length-exceeded.dmn
@@ -5,7 +5,9 @@
   xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0"
   xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
-  id="force_users" name="This is a very long name for a decision requirements graph" namespace="http://camunda.org/schema/1.0/dmn"
+  id="force_users"
+  name="This is an extremely beautiful and very long name for a decision table but it's worth it because we need it for a test"
+  namespace="http://camunda.org/schema/1.0/dmn"
   exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <extensionElements>


### PR DESCRIPTION
This PR adds length validation for ids and names in the context of decision tables. With this we make sure to not exceed the length restrictions in RDBMS.

- make DecisionTable and sub-elements like `input.id`, `input.name`, `output.id`, `output.name` and `rule.id` accessible in the `DmnResourceTransformer` for validation
- validate listed properties against length validation configuration
  - refactored the `DmnResourceTransformer` a bit to avoid code duplication

## Related issues

closes #45681 
