### PR TITLE
fix: Set Correct Min & Max Elastic/OpenSearch Versions

### DIFF
--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -22,11 +22,17 @@ inputs:
     elasticsearch9-tests-flaky:
         description: 'Flaky tests from the Elasticsearch 9 integration tests job'
         required: true
-    opensearch-tests-result:
-        description: 'Result of the OpenSearch integration tests job'
+    opensearch2-tests-result:
+        description: 'Result of the OpenSearch 2 integration tests job'
         required: true
-    opensearch-tests-flaky:
-        description: 'Flaky tests from the OpenSearch integration tests job'
+    opensearch2-tests-flaky:
+        description: 'Flaky tests from the OpenSearch 2 integration tests job'
+        required: true
+    opensearch3-tests-result:
+        description: 'Result of the OpenSearch 3 integration tests job'
+        required: true
+    opensearch3-tests-flaky:
+        description: 'Flaky tests from the OpenSearch 3 integration tests job'
         required: true
     rdbms-h2-tests-result:
         description: 'Result of the RDBMS H2 integration tests job'
@@ -84,7 +90,8 @@ runs:
         collect_from_single_job "general-unit-tests" "${{ inputs.general-unit-tests-result }}" "${{ inputs.general-unit-tests-flaky }}"
         collect_from_single_job "elasticsearch8-integration-tests" "${{ inputs.elasticsearch8-tests-result }}" "${{ inputs.elasticsearch8-tests-flaky }}"
         collect_from_single_job "elasticsearch9-integration-tests" "${{ inputs.elasticsearch9-tests-result }}" "${{ inputs.elasticsearch9-tests-flaky }}"
-        collect_from_single_job "opensearch-integration-tests" "${{ inputs.opensearch-tests-result }}" "${{ inputs.opensearch-tests-flaky }}"
+        collect_from_single_job "opensearch2-integration-tests" "${{ inputs.opensearch2-tests-result }}" "${{ inputs.opensearch2-tests-flaky }}"
+        collect_from_single_job "opensearch3-integration-tests" "${{ inputs.opensearch3-tests-result }}" "${{ inputs.opensearch3-tests-flaky }}"
         collect_from_single_job "rdbms-h2-integration-tests" "${{ inputs.rdbms-h2-tests-result }}" "${{ inputs.rdbms-h2-tests-flaky }}"
         collect_from_single_job "rdbms-integration-tests" "${{ inputs.rdbms-tests-result }}" "${{ inputs.rdbms-tests-flaky }}"
         collect_from_single_job "docker-checks" "${{ inputs.docker-checks-result }}" "${{ inputs.docker-checks-flaky }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,14 +494,14 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   elasticsearch8-integration-tests:
-    name: "Database Integration Tests / Elasticsearch"
+    name: "Database Integration Tests / Elasticsearch 8"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
       database-type: "elasticsearch"
-      database-image-version: "8.18.4"
+      database-image-version: "8.19.11"
       database-name: "Elasticsearch 8"
       it-database-type: "es"
 
@@ -513,22 +513,36 @@ jobs:
     secrets: inherit
     with:
       database-type: "elasticsearch"
-      database-image-version: "9.2.4"
+      database-image-version: "9.2.5"
       database-name: "Elasticsearch 9"
       it-database-type: "es"
       job-name-suffix: "9"
 
-  opensearch-integration-tests:
-    name: "Database Integration Tests / Opensearch"
+  opensearch2-integration-tests:
+    name: "Database Integration Tests / Opensearch 2"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     secrets: inherit
     with:
       database-type: "opensearch"
-      database-image-version: "2.17.0"
+      database-image-version: "2.19.4"
       database-name: "OpenSearch 2"
       it-database-type: "os"
+      job-name-suffix: "2"
+
+  opensearch3-integration-tests:
+    name: "Database Integration Tests / Opensearch 3"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    secrets: inherit
+    with:
+      database-type: "opensearch"
+      database-image-version: "3.4.0"
+      database-name: "OpenSearch 3"
+      it-database-type: "os"
+      job-name-suffix: "3"
 
   rdbms-h2-integration-tests:
     name: "Database Integration Tests / RDBMS H2"
@@ -549,7 +563,7 @@ jobs:
     secrets: inherit
     with:
       database-type: "elasticsearch"
-      database-image-version: "8.18.4"
+      database-image-version: "8.19.11"
       database-name: "Elasticsearch 8"
       it-database-type: "es"
       maven-profiles: "history"
@@ -564,7 +578,7 @@ jobs:
     secrets: inherit
     with:
       database-type: "opensearch"
-      database-image-version: "2.17.0"
+      database-image-version: "2.19.4"
       database-name: "OpenSearch 2"
       it-database-type: "os"
       maven-profiles: "history"
@@ -979,7 +993,7 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
-      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.16.4
+      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
       DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
       - uses: actions/checkout@v6
@@ -1091,7 +1105,8 @@ jobs:
       - elasticsearch9-integration-tests
       - general-unit-tests
       - integration-tests
-      - opensearch-integration-tests
+      - opensearch2-integration-tests
+      - opensearch3-integration-tests
       - rdbms-h2-integration-tests
       - rdbms-integration-tests
       - zeebe-unit-tests
@@ -1122,8 +1137,10 @@ jobs:
           elasticsearch8-tests-flaky: ${{ needs.elasticsearch8-integration-tests.outputs.flakyTests }}
           elasticsearch9-tests-result: ${{ needs.elasticsearch9-integration-tests.result }}
           elasticsearch9-tests-flaky: ${{ needs.elasticsearch9-integration-tests.outputs.flakyTests }}
-          opensearch-tests-result: ${{ needs.opensearch-integration-tests.result }}
-          opensearch-tests-flaky: ${{ needs.opensearch-integration-tests.outputs.flakyTests }}
+          opensearch2-tests-result: ${{ needs.opensearch2-integration-tests.result }}
+          opensearch2-tests-flaky: ${{ needs.opensearch2-integration-tests.outputs.flakyTests }}
+          opensearch3-tests-result: ${{ needs.opensearch3-integration-tests.result }}
+          opensearch3-tests-flaky: ${{ needs.opensearch3-integration-tests.outputs.flakyTests }}
           rdbms-h2-tests-result: ${{ needs.rdbms-h2-integration-tests.result }}
           rdbms-h2-tests-flaky: ${{ needs.rdbms-h2-integration-tests.outputs.flakyTests }}
           rdbms-tests-result: ${{ needs.rdbms-integration-tests.result }}
@@ -1393,7 +1410,8 @@ jobs:
       - maven-spotless-linter
       - openapi-lint
       - opensearch-history-tests
-      - opensearch-integration-tests
+      - opensearch2-integration-tests
+      - opensearch3-integration-tests
       - operate-ci
       - optimize-ci
       - protobuf-checks

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -31,19 +31,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Elasticsearch 8 - Supported versions: 8.16.6 (min) to 8.19.10 (max)
-          - database-name: "Elasticsearch 8.16.6"
+          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.11 (max)
+          - database-name: "Elasticsearch 8.19.0"
             database-type: "elasticsearch"
-            database-image-version: "8.16.6"
+            database-image-version: "8.19.0"
             it-database-type: "es"
-          - database-name: "Elasticsearch 8.19.10"
+            job-name-suffix: "8"
+          - database-name: "Elasticsearch 8.19.11"
             database-type: "elasticsearch"
-            database-image-version: "8.19.10"
+            database-image-version: "8.19.11"
             it-database-type: "es"
-          # Elasticsearch 9 - Supported versions: 9.0.0 (min) to 9.3.0 (max)
-          - database-name: "Elasticsearch 9.0.0"
+            job-name-suffix: "8"
+          # Elasticsearch 9 - Supported versions: 9.2.0 (min) to 9.3.0 (max)
+          - database-name: "Elasticsearch 9.2.0"
             database-type: "elasticsearch"
-            database-image-version: "9.0.0"
+            database-image-version: "9.2.0"
             it-database-type: "es"
             job-name-suffix: "9"
           - database-name: "Elasticsearch 9.3.0"
@@ -51,15 +53,28 @@ jobs:
             database-image-version: "9.3.0"
             it-database-type: "es"
             job-name-suffix: "9"
-          # OpenSearch 2 - Supported versions: 2.17.0 (min) to 2.19.4 (max)
-          - database-name: "OpenSearch 2.17.0"
+          # OpenSearch 2 - Supported versions: 2.19.0 (min) to 2.19.4 (max)
+          - database-name: "OpenSearch 2.19.0"
             database-type: "opensearch"
-            database-image-version: "2.17.0"
+            database-image-version: "2.19.0"
             it-database-type: "os"
+            job-name-suffix: "2"
           - database-name: "OpenSearch 2.19.4"
             database-type: "opensearch"
             database-image-version: "2.19.4"
             it-database-type: "os"
+            job-name-suffix: "2"
+          # OpenSearch 3 - Supported versions: 3.4.0 (min) to 3.5.0 (max)
+          - database-name: "OpenSearch 3.4.0"
+            database-type: "opensearch"
+            database-image-version: "3.4.0"
+            it-database-type: "os"
+            job-name-suffix: "3"
+          - database-name: "OpenSearch 3.5.0"
+            database-type: "opensearch"
+            database-image-version: "3.5.0"
+            it-database-type: "os"
+            job-name-suffix: "3"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:


### PR DESCRIPTION

## Description

Set the correct min/max elasticsearch and opensearch versions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
