### PR TITLE
ci: re enable Zeebe Update tests after version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,6 @@ jobs:
           ZEEBE_IT_DISTRIBUTED_MODULES: ${{ steps.set-constants.outputs.it_distributed }}
           ZEEBE_IT_ENGINE_MODULES: ${{ steps.set-constants.outputs.it_engine }}
           ZEEBE_IT_EXPORTER_MODULES: ${{ steps.set-constants.outputs.it_exporter }}
-          # TODO: disabled until 8.9.0 minor release is out
-          ZEEBE_QA_UPDATE_ENABLED: "false"
           # Opt-in to stress testing the integration-tests job via the PR label "ci:stress-test".
           STRESS_ENABLED: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') }}
         run: |
@@ -588,28 +586,23 @@ jobs:
               "owner": "CamundaEx",
               "module": "Testing",
               "stressRun": 1
+            },
+            {
+              "group": "qa-update",
+              "name": "Zeebe QA - Update",
+              "maven-modules": "zeebe/qa/update-tests",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 10,
+              "runs-on": "gcp-perf-core-8-default",
+              "docker-repository": "localhost:5000/camunda/zeebe",
+              "docker-file": "Dockerfile",
+              "owner": "Core Features",
+              "module": "Zeebe",
+              "stressRun": 1
             }
           ]
           EOF
           )
-
-          if [[ "${ZEEBE_QA_UPDATE_ENABLED}" == "true" ]]; then
-            base_matrix=$(jq -c '. + [
-              {
-                "group": "qa-update",
-                "name": "Zeebe QA - Update",
-                "maven-modules": "zeebe/qa/update-tests",
-                "maven-build-threads": 1,
-                "maven-test-fork-count": 10,
-                "runs-on": "gcp-perf-core-8-default",
-                "docker-repository": "localhost:5000/camunda/zeebe",
-                "docker-file": "Dockerfile",
-                "owner": "Core Features",
-                "module": "Zeebe",
-                "stressRun": 1
-              }
-            ]' <<< "${base_matrix}")
-          fi
 
           if [[ "${STRESS_ENABLED}" == "true" ]]; then
             zeebe_engine_template=$(jq -c '.[] | select(.group == "zeebe-engine-integration") | del(.stressRun)' <<< "${base_matrix}")

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NoSnapshotTest.java
@@ -10,9 +10,13 @@ package io.camunda.zeebe.test;
 import static io.camunda.zeebe.test.ContainerStateAssert.assertThat;
 import static io.camunda.zeebe.test.UpdateTestCaseProvider.PROCESS_ID;
 
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +31,14 @@ final class NoSnapshotTest {
 
   @BeforeAll
   static void setUp() {
+    final String previous = VersionUtil.getPreviousVersion();
+    final String current = VersionUtil.getVersion().replace("-SNAPSHOT", "");
+    final var result = VersionCompatibilityCheck.check(previous, current);
+
+    // Skip the test entirely for unsupported upgrades (e.g. skipped minor)
+    Assumptions.assumeTrue(
+        result instanceof Compatible,
+        () -> "Skipping NoSnapshotTest for unsupported upgrade path: " + result);
     network = Network.newNetwork();
   }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -88,7 +88,9 @@ final class RollingUpdateTest {
               node ->
                   node.withEnv(CREATE_SCHEMA_ENV_VAR, "false")
                       .withEnv(UNPROTECTED_API_ENV_VAR, "true")
-                      .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false"))
+                      .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
+                      .withEnv(
+                          "CAMUNDA_DATA_SECONDARYSTORAGE_AUTOCONFIGURECAMUNDAEXPORTER", "false"))
           .build();
 
   @SuppressWarnings("unused")
@@ -116,7 +118,7 @@ final class RollingUpdateTest {
     volumes.clear();
   }
 
-  @ParameterizedTest(name = "from {0} to {1}")
+  @ParameterizedTest(name = "from {0} to {1}", allowZeroInvocations = true)
   @MethodSource("versionMatrix")
   void shouldBeAbleToRestartContainerWithNewVersion(final String from, final String to) {
     // given
@@ -147,7 +149,7 @@ final class RollingUpdateTest {
     }
   }
 
-  @ParameterizedTest(name = "from {0} to {1}")
+  @ParameterizedTest(name = "from {0} to {1}", allowZeroInvocations = true)
   @MethodSource("versionMatrix")
   void shouldReplicateSnapshotAcrossVersions(final String from, final String to) {
     // given
@@ -214,7 +216,7 @@ final class RollingUpdateTest {
         .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(brokerId));
   }
 
-  @ParameterizedTest(name = "from {0} to {1}")
+  @ParameterizedTest(name = "from {0} to {1}", allowZeroInvocations = true)
   @MethodSource("versionMatrix")
   void shouldPerformRollingUpdate(final String from, final String to) {
     // given

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
@@ -11,6 +11,9 @@ import static io.camunda.zeebe.test.ContainerStateAssert.assertThat;
 import static io.camunda.zeebe.test.UpdateTestCaseProvider.PROCESS_ID;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck;
+import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Compatible;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,8 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,14 +33,20 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.Network;
 
 @ExtendWith(ContainerStateExtension.class)
-@Disabled(
-    "Requires 8.8 artifacts to be published to avoid NPE, see https://github.com/camunda/camunda/issues/37517")
 final class SnapshotTest {
 
   private static Network network;
 
   @BeforeAll
   static void setUp() {
+    final String previous = VersionUtil.getPreviousVersion();
+    final String current = VersionUtil.getVersion().replace("-SNAPSHOT", "");
+    final var result = VersionCompatibilityCheck.check(previous, current);
+
+    // Skip the test entirely for unsupported upgrades (e.g. skipped minor)
+    Assumptions.assumeTrue(
+        result instanceof Compatible,
+        () -> "Skipping SnapshotTest for unsupported upgrade path: " + result);
     network = Network.newNetwork();
   }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -194,12 +194,17 @@ final class VersionCompatibilityMatrix {
             .map(VersionInfo::version)
             .filter(version -> version.compareTo(current) < 0)
             .filter(version -> current.minor() - version.minor() == 1)
-            .filter(next -> isCompatible(current, next))
+            .filter(version -> isCompatible(version, current))
             .collect(StreamUtil.minMax(Comparator.comparing(SemanticVersion::patch)));
 
-    return Stream.of(
-        Arguments.of(minAndMaxPatch.min().toString(), "CURRENT"),
-        Arguments.of(minAndMaxPatch.max().toString(), "CURRENT"));
+    // If there are no compatible versions, returns an empty stream skipping the test
+    return Optional.ofNullable(minAndMaxPatch.min())
+        .map(
+            ignored ->
+                Stream.of(
+                    Arguments.of(minAndMaxPatch.min().toString(), "CURRENT"),
+                    Arguments.of(minAndMaxPatch.max().toString(), "CURRENT")))
+        .orElse(Stream.empty());
   }
 
   public Stream<Arguments> full() {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -128,6 +128,34 @@ class VersionCompatibilityMatrixTest {
   }
 
   @Test
+  void testFromFirstAndLastPatchToCurrentWithTwoMinorGap() {
+    // Simulates the case where the dev version (8.10.0-SNAPSHOT) is two minors ahead of the
+    // latest released minor (8.8.x) — e.g. when 8.9 was never released.
+    final var snapshotMatrix =
+        new VersionCompatibilityMatrix(
+            () ->
+                Stream.of(
+                    VersionInfo.of("8.7.0"),
+                    VersionInfo.of("8.8.0"),
+                    VersionInfo.of("8.8.1"),
+                    VersionInfo.of("8.8.2")),
+            new VersionCompatibilityConfig() {
+              @Override
+              public SemanticVersion getCurrentVersion() {
+                return SemanticVersion.parse("8.10.0-SNAPSHOT").orElseThrow();
+              }
+
+              @Override
+              public Optional<SemanticVersion> getPreviousMinorVersion() {
+                return SemanticVersion.parse("8.8.0");
+              }
+            });
+
+    // Should be empty -- intended
+    assertThat(snapshotMatrix.fromFirstAndLastPatchToCurrent().toList()).isEmpty();
+  }
+
+  @Test
   void testFromFirstAndLastPatchToCurrent() {
     final var paths =
         matrix

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -120,7 +120,14 @@ public interface BackupCompatibilityAcceptance {
         new TestStandaloneBroker().withUnifiedConfig(this::configureCurrentBackupStore)) {
       broker.start();
       final var backupActuator = BackupActuator.of(broker);
-      assertThat(backupActuator.list()).singleElement().returns(backupId, BackupInfo::getBackupId);
+      Awaitility.await("until backup from previous version is visible")
+          .atMost(Duration.ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertThat(backupActuator.list())
+                      .singleElement()
+                      .returns(backupId, BackupInfo::getBackupId));
 
       // when -- delete backup from previous version
       backupActuator.delete(backupId);


### PR DESCRIPTION
## Description

- Re enables `Zeebe QA - Update` tests after version bump
- `VersionCompatibilityMatrix` returns empty list on non-compatible versions
- Tweak `RollingUpdateTest` -- skip on non-compatible versions
- Tweak `NoSnapshotTest` -- skip on non-compatible versions
- Tweak `SnapshotTest` -- enable and skip on non-compatible versions

## Related issues
reverts https://github.com/camunda/camunda/pull/46223/changes/bf724988ecf614c7950f3ca71e6dc8df85360c64
slack discussion [here](https://camunda.slack.com/archives/C06UWQNCU7M/p1771508542181659)
