### PR TITLE
fix: do not push jobs when TIMEOUT

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -58,7 +58,7 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
     if (state == State.ACTIVATED && hasTimedOut(job)) {
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
       jobMetrics.countJobEvent(JobAction.TIMED_OUT, job.getJobKind(), job.getType());
-      jobActivationBehavior.publishWork(jobKey, job);
+      jobActivationBehavior.notifyJobAvailableAsSideEffect(job);
     } else {
       final var reason =
           switch (state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -172,24 +172,23 @@ public class ActivatableJobsPushTest {
   }
 
   @Test
-  public void shouldPushWhenJobTimesOut() {
+  public void shouldNotifyInsteadOfPushWhenJobTimesOut() {
     // given
-    final int activationCount = 2;
     final long jobKey = createJob(jobType, PROCESS_ID, variables);
+    jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).await();
+
+    // when - job times out
     ENGINE.increaseTime(
         Duration.ofMillis(timeout).plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
-
-    // when
-    // job times out
     jobRecords(TIMED_OUT).withType(jobType).await();
 
-    // then
-    assertEventOrder(
-        "Expect that the job is re-activated after job was timed out",
-        JOB_AND_JOB_BATCH_TYPES,
-        JobIntent.TIMED_OUT,
-        JobBatchIntent.ACTIVATED);
-    assertActivatedJobsPushed(jobKey, activationCount);
+    // then - the job was NOT re-pushed to the stream after timeout
+    // only the initial push from job creation should exist
+    assertThat(jobStream.getActivatedJobs()).hasSize(1);
+
+    // and the job is still available for activation via polling
+    final var activateResponse = ENGINE.jobs().withType(jobType).activate();
+    assertThat(activateResponse.getValue().getJobKeys()).contains(jobKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.agrona.DirectBuffer;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -176,6 +177,9 @@ public class ActivatableJobsPushTest {
     // given
     final long jobKey = createJob(jobType, PROCESS_ID, variables);
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).await();
+    // initial push to the stream
+    Awaitility.await("Job is pushed")
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
 
     // when - job times out
     ENGINE.increaseTime(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -180,6 +180,7 @@ public class ActivatableJobsPushTest {
     // initial push to the stream
     Awaitility.await("Job is pushed")
         .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    assertThat(JOB_STREAMER.notificationsForJob(jobType)).isEqualTo(0);
 
     // when - job times out
     ENGINE.increaseTime(
@@ -191,6 +192,8 @@ public class ActivatableJobsPushTest {
     assertThat(jobStream.getActivatedJobs()).hasSize(1);
 
     // and the job is still available for activation via polling
+    Awaitility.await("job is being notified")
+        .untilAsserted(() -> assertThat(JOB_STREAMER.notificationsForJob(jobType)).isEqualTo(1));
     final var activateResponse = ENGINE.jobs().withType(jobType).activate();
     assertThat(activateResponse.getValue().getJobKeys()).contains(jobKey);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingJobStreamer.java
@@ -27,7 +27,8 @@ public class RecordingJobStreamer implements JobStreamer {
 
   @Override
   public void notifyWorkAvailable(final String jobType) {
-    final AtomicInteger counter = jobNotifications.getOrDefault(jobType, new AtomicInteger(0));
+    final AtomicInteger counter =
+        jobNotifications.computeIfAbsent(jobType, key -> new AtomicInteger(0));
     counter.getAndIncrement();
   }
 
@@ -39,6 +40,10 @@ public class RecordingJobStreamer implements JobStreamer {
             .filter(jobStream -> predicate.test(jobStream.getProperties()))
             .findAny()
             .get());
+  }
+
+  public int notificationsForJob(final String jobType) {
+    return Optional.ofNullable(jobNotifications.get(jobType)).map(AtomicInteger::get).orElse(0);
   }
 
   public void clearStreams() {


### PR DESCRIPTION
When a job times out it's pushed immediately again. This can create a vicious cycle where the jobs are pushed over and over again. If there's no worker capacity signalled through the grpc backpressure they will be yielded back to the engine and then set as "ACTIVATABLE". If they're not yielded, but they are still not completed before the timeout, they will pushed again on timeout.
The second case is problematic as it's quite difficult to exit this situation until the rate of jobs created decreases. This might decrease fairness as jobs pushed might get prioritized over the older ones, but we're already doing this on YIELD, so it's probably ok.

A valid solution to this would be to add backpressure mechanism between gateway and broker and process the jobs in creation order in a FIFO like manner

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #35047
closes #42244
