### PR TITLE
fix: mark tenantId as nullable in cluster variable OpenAPI schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -400,7 +400,8 @@ components:
           $ref: '#/components/schemas/ClusterVariableScopeEnum'
         tenantId:
           type: string
-          description: Only provided if the cluster variable scope is TENANT.
+          nullable: true
+          description: Only provided if the cluster variable scope is TENANT. Null for global scope variables.
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false


### PR DESCRIPTION
## Description

Marks the `tenantId` field as `nullable: true` in the `ClusterVariableResultBase` OpenAPI schema to align with the actual API behavior.

## Context

PR #46183 changed serialization from `@JsonInclude(NON_NULL)` to `@JsonInclude(ALWAYS)`, which means the API now explicitly returns `tenantId: null` for global scope cluster variables instead of omitting the field.

However, the OpenAPI schema was not updated to reflect this change, causing validation failures in E2E tests that use `validateResponseShape()` to verify responses against the OpenAPI specification.

PR #46339 addressed this for other optional fields but missed cluster variables.

## Changes

- Added `nullable: true` to the `tenantId` field in `ClusterVariableResultBase` schema
- Updated field description to clarify: "Only provided if the cluster variable scope is TENANT. Null for global scope variables."

## Related Issues

Closes #46635
