### PR TITLE
refactor: Set Elasticsearch/Opensearch Dockerfile Version

### DIFF
--- a/.github/actions/compose/README.md
+++ b/.github/actions/compose/README.md
@@ -28,7 +28,7 @@ steps:
     compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
     project_name: elasticsearch
   env:
-    ELASTIC_VERSION: 8.13.0
+    ELASTIC_VERSION: 8.19.11
     ELASTIC_JVM_MEMORY: 1
     ELASTIC_HTTP_PORT: 9200
 ```

--- a/.github/actions/compose/docker-compose.elasticsearch.yml
+++ b/.github/actions/compose/docker-compose.elasticsearch.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   elasticsearch:
     container_name: elasticsearch-${ELASTIC_HTTP_PORT:-9200}
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.13.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/actions/compose/docker-compose.opensearch.yml
+++ b/.github/actions/compose/docker-compose.opensearch.yml
@@ -12,7 +12,7 @@ services:
     image: centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
     command: "sysctl -w vm.max_map_count=262144"
   opensearch:
-    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.17.0@sha256:7b9517dff561f54456fad947f11820fa595a340fd1034fc63d57b77f724b3f8f}
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.19.4@sha256:9e0b3b3b6805811bd63d9b9503ffe34a58ba33d03cc346000e318c6ff5c05bd9}
     container_name: opensearch-${OPENSEARCH_HTTP_PORT:-9200}
     depends_on:
       - fixsysctl

--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -1,7 +1,7 @@
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.16.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/actions/docker-logs/README.md
+++ b/.github/actions/docker-logs/README.md
@@ -25,7 +25,7 @@ steps:
     compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
     project_name: elasticsearch
   env:
-    ELASTIC_VERSION: 8.13.0
+    ELASTIC_VERSION: 8.19.11
     ELASTIC_JVM_MEMORY: 1
 ...
 - name: Docker log dump

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       start_period: 5s
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.18.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.11}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node
@@ -97,7 +97,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.17.0}
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.4}
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/docs/testing/acceptance.md
+++ b/docs/testing/acceptance.md
@@ -228,7 +228,7 @@ docker run -d -p 9200:9200 \
               -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!" \
               -e "OPENSEARCH_PASSWORD=changeme" \
               -e "DISABLE_SECURITY_PLUGIN=true" \
-              opensearchproject/opensearch:2.17.0
+              opensearchproject/opensearch:2.19.4
 ```
 
 To run with OpenSearch from your IDE, you have two options:

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     depends_on:
       - opensearch-init
     container_name: opensearch

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     container_name: opensearch
     environment:
       - cluster.name=opensearch

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
 
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     container_name: opensearch
     depends_on:
       - opensearch-init

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
@@ -62,7 +62,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class OpensearchConnectorIT extends OperateAbstractIT {
 
   private static final OpenSearchContainer<?> OPENSEARCH_CONTAINER =
-      new OpenSearchContainer<>("opensearchproject/opensearch:2.17.0")
+      new OpenSearchContainer<>("opensearchproject/opensearch:2.19.4")
           .withEnv(Map.of())
           .withExposedPorts(9200, 9205);
 

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,6 +1,6 @@
 testcontainers:
   elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
-  opensearch: "opensearchproject/opensearch:2.17.0"
+  opensearch: "opensearchproject/opensearch:2.19.4"
 
 # Unified Configuration
 camunda:

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,5 +1,5 @@
 testcontainers:
-  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.16.6"
+  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.11"
   opensearch: "opensearchproject/opensearch:2.19.4"
 
 # Unified Configuration

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.16.4}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
     container_name: elasticsearch
     profiles: ['cloud', 'self-managed', 'cloud:elasticsearch', 'self-managed:elasticsearch']
     environment:

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       timeout: 5s
       retries: 3
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.17.0}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
     container_name: opensearch
     profiles: ['cloud:opensearch', 'self-managed:opensearch']
     environment:

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -202,7 +202,7 @@ services:
       - optimize
     restart: always
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.17.0}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
     profiles: [ "opensearch" ]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -111,7 +111,7 @@ services:
       - identity-network
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.16.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -93,7 +93,7 @@ services:
       - localhost
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.16.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -183,7 +183,7 @@ services:
       - localhost
     restart: always
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.17.0}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
     profiles: ["opensearch"]
     container_name: opensearch
     environment:

--- a/optimize/docker-compose.yml
+++ b/optimize/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.16.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
     # By leaving the first profile entry blank, this container will also start if no profile is defined (default)
     profiles: ["", "elasticsearch", "setup-integration-test"]
     container_name: elasticsearch

--- a/optimize/docker-compose.yml
+++ b/optimize/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - /var/tmp:/var/tmp
   opensearch:
-    image: opensearchproject/opensearch:${OS_VERSION:-2.17.0}
+    image: opensearchproject/opensearch:${OS_VERSION:-2.19.4}
     profiles: ["opensearch", "setup-integration-test"]
     container_name: opensearch
     environment:

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -68,9 +68,9 @@
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->
     <elasticsearch.log4j.version>2.24.2</elasticsearch.log4j.version>
     <!-- The least supported opensearch version we should test against-->
-    <opensearch.test.version>2.17.0</opensearch.test.version>
+    <opensearch.test.version>2.19.4</opensearch.test.version>
     <!-- the opensearch version of the previous Optimize version -->
-    <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
+    <previous.optimize.opensearch.version>2.17.0</previous.optimize.opensearch.version>
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <quartz.version>2.5.2</quartz.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -62,9 +62,9 @@
     <version.elasticsearch>8.16.6</version.elasticsearch>
     <version.elasticsearch-java-client>8.19.11</version.elasticsearch-java-client>
     <!-- The least supported elasticsearch version we should test against-->
-    <elasticsearch.test.version>8.16.6</elasticsearch.test.version>
+    <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->
-    <previous.optimize.elasticsearch.version>8.13.0</previous.optimize.elasticsearch.version>
+    <previous.optimize.elasticsearch.version>8.16.6</previous.optimize.elasticsearch.version>
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->
     <elasticsearch.log4j.version>2.24.2</elasticsearch.log4j.version>
     <!-- The least supported opensearch version we should test against-->

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
   private static final OpenSearchContainer OPENSEARCH_CONTAINER =
-      new OpenSearchContainer("opensearchproject/opensearch:2.17.0");
+      new OpenSearchContainer("opensearchproject/opensearch:2.19.4");
 
   @Autowired
   @Qualifier("tasklistOsClient")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -52,7 +52,7 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
 
   static OpenSearchContainer opensearch =
       (OpenSearchContainer)
-          new OpenSearchContainer("opensearchproject/opensearch:2.17.0")
+          new OpenSearchContainer("opensearchproject/opensearch:2.19.4")
               // .withSecurityEnabled() // this should be uncommented to test SSL
               .withCopyFileToContainer(
                   MountableFile.forClasspathResource(CERTIFICATE_RESOURCE_PATH),

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -59,7 +59,7 @@ public class OpensearchConnectorIT {
 
   @Container
   private static final OpenSearchContainer<?> OPENSEARCH_CONTAINER =
-      new OpenSearchContainer<>("opensearchproject/opensearch:2.17.0")
+      new OpenSearchContainer<>("opensearchproject/opensearch:2.19.4")
           .withEnv(Map.of())
           .withExposedPorts(9200, 9205);
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -89,7 +89,7 @@ public class TestContainerUtil {
   private static final String DOCKER_ELASTICSEARCH_IMAGE_NAME =
       "docker.elastic.co/elasticsearch/elasticsearch";
   private static final String DOCKER_OPENSEARCH_IMAGE_NAME = "opensearchproject/opensearch";
-  private static final String DOCKER_OPENSEARCH_IMAGE_VERSION = "2.17.0";
+  private static final String DOCKER_OPENSEARCH_IMAGE_VERSION = "2.19.4";
   private static final String ZEEBE = "zeebe";
   private static final String KEYCLOAK_ZEEBE_SECRET = "zecret";
   private static final String USER_MEMBER_TYPE = "USER";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -21,7 +21,7 @@ public final class SupportedVersions {
    *
    * <p>To be used for client and server dependencies (e.g. in test container tests).
    */
-  public static final String SUPPORTED_OPENSEARCH_VERSION = "2.19.3";
+  public static final String SUPPORTED_OPENSEARCH_VERSION = "2.19.4";
 
   private SupportedVersions() {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/SupportedVersions.java
@@ -14,7 +14,7 @@ public final class SupportedVersions {
    *
    * <p>To be used for client and server dependencies (e.g. in test container tests).
    */
-  public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.16.6";
+  public static final String SUPPORTED_ELASTICSEARCH_VERSION = "8.19.11";
 
   /**
    * Official supported OpenSearch version.

--- a/zeebe/exporters/opensearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.4
     container_name: opensearch
     environment:
       - "discovery.type=single-node"

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -30,7 +30,7 @@ public final class TestSearchContainers {
           .withTag(
               Objects.requireNonNullElse(
                   org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
-                  "8.19.0"));
+                  "8.19.11"));
   private static final DockerImageName OPENSEARCH_IMAGE =
       DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.4");
   private static final DockerImageName POSTGRES_IMAGE =

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -32,7 +32,7 @@ public final class TestSearchContainers {
                   org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
                   "8.19.0"));
   private static final DockerImageName OPENSEARCH_IMAGE =
-      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.0");
+      DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.4");
   private static final DockerImageName POSTGRES_IMAGE =
       DockerImageName.parse("postgres").withTag("15.3-alpine");
   private static final DockerImageName MARIADB_IMAGE =


### PR DESCRIPTION
## Description

Set the correct Elasticsearch & OpenSearch docker image tag that we should used for testing. This is based on the lasted patch release of the earliest minor version we support.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
