### PR TITLE
[Backport stable/8.9] fix: update flaky test on main

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TaskPanelPage.ts
@@ -43,7 +43,7 @@ class TaskPanelPageV1 {
     await this.availableTasks
       .getByText(name, {exact: true})
       .nth(0)
-      .click({timeout: 10000});
+      .click({timeout: 30000});
   }
 
   async filterBy(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -126,7 +126,6 @@ test.describe('task details page', () => {
   });
 
   test('assign and unassign task', async ({
-    page,
     taskPanelPageV1,
     taskDetailsPageV1,
   }) => {


### PR DESCRIPTION
# Description
Backport of #46625 to `stable/8.9`.
[Test run](https://github.com/camunda/camunda/actions/runs/22347623908/job/64675471679)
❗ Failing v2 tests are due to [this issue](https://camunda.slack.com/archives/C08MRKHJ0CD/p1771831048856029), aslo there is a flaky API test that will investigate in a separate PR
relates to 