### PR TITLE
[backport stable/8.9] feat: add resource level authorization for resource type MESSAGE

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -102,6 +102,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             .permissionType(PermissionType.CREATE)
             .tenantId(command.getValue().getTenantId())
             .newResource()
+            .addResourceId(command.getValue().getName())
             .build();
     final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
     if (isAuthorized.isLeft()) {


### PR DESCRIPTION
## Description

Backport https://github.com/camunda/camunda/pull/42487

(manually created as backport action does not seem to work on contributions)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42473
