### PR TITLE
[Backport stable/8.9] fix: mark tenantId as nullable in cluster variable OpenAPI schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -400,7 +400,8 @@ components:
           $ref: '#/components/schemas/ClusterVariableScopeEnum'
         tenantId:
           type: string
-          description: Only provided if the cluster variable scope is TENANT.
+          nullable: true
+          description: Only provided if the cluster variable scope is TENANT. Null for global scope variables.
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false


### PR DESCRIPTION
# Description
Backport of #46646 to `stable/8.9`.

relates to #46183 #46339 #46635