### PR TITLE
fix: added spring boot 4 dependencies to bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -102,6 +102,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-4-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-java</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -109,6 +115,12 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring-4</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the dedicated spring boot 4 dependencies to the bom

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
