### PR TITLE
feat: custom docker image camunda version

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,6 +1,8 @@
 ELASTICSEARCH_VERSION=8.19.10
 # this is the version of camunda/ zeebe
 CAMUNDA_VERSION=8.9.0-alpha4
+# docker images moved to a shortened tag, override compose with this value when using --docker
+CAMUNDA_DOCKER_VERSION=8.9.0-alpha4
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.9.0-alpha4
 # version of docker compose artifact (used for --docker option)

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -77,6 +77,7 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	composeCmd := exec.Command("docker", append([]string{"compose"}, args...)...)
 	composeCmd.Stdout = os.Stdout
 	composeCmd.Stderr = os.Stderr
+	composeCmd.Env = dockerCommandEnv(os.Environ())
 
 	err = composeCmd.Run()
 	if err != nil {
@@ -89,6 +90,27 @@ func runDockerCommand(composeExtractedFolder string, args ...string) error {
 	}
 
 	return nil
+}
+
+func dockerCommandEnv(baseEnv []string) []string {
+	dockerVersion := strings.TrimSpace(os.Getenv("CAMUNDA_DOCKER_VERSION"))
+	if dockerVersion == "" {
+		return baseEnv
+	}
+
+	env := append([]string(nil), baseEnv...)
+	return overrideEnvVar(env, "CAMUNDA_VERSION", dockerVersion)
+}
+
+func overrideEnvVar(env []string, key, value string) []string {
+	prefix := key + "="
+	for i := range env {
+		if strings.HasPrefix(env[i], prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
 }
 
 var helpTemplate = `Usage:

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -187,3 +187,32 @@ func TestValidatePort(t *testing.T) {
 		})
 	}
 }
+
+func TestDockerCommandEnvOverridesVersion(t *testing.T) {
+	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
+	base := []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT", "FOO=bar"}
+
+	result := dockerCommandEnv(base)
+
+	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
+	assert.Equal(t, []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT", "FOO=bar"}, base)
+}
+
+func TestDockerCommandEnvAddsVersionWhenMissing(t *testing.T) {
+	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
+	base := []string{"FOO=bar"}
+
+	result := dockerCommandEnv(base)
+
+	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
+	assert.Equal(t, []string{"FOO=bar"}, base)
+}
+
+func TestDockerCommandEnvNoOverrideWithoutDockerVersion(t *testing.T) {
+	t.Setenv("CAMUNDA_DOCKER_VERSION", "")
+	base := []string{"CAMUNDA_VERSION=8.9.0-SNAPSHOT"}
+
+	result := dockerCommandEnv(base)
+
+	assert.Equal(t, base, result)
+}


### PR DESCRIPTION
## Description

Orchestration changed place for docker images, prev. we have 8.9.0-SNAPSHOT maven and docker for camunda, not we have separately different names , maven still: 8.9.0-SNAPSHOT and dockerhub image now 8.9-SNAPSHOT. 
So, I introduced new var to support these 2 separate vars.

related to: #46712 
