### PR TITLE
refactor: update operate null checks

### DIFF
--- a/operate/client/src/App/Dashboard/IncidentsByError/Details.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/Details.tsx
@@ -87,7 +87,7 @@ const Details: React.FC<Props> = ({
         const normalizedTenantId = tenantId ?? DEFAULT_TENANT;
         const tenantName =
           tenantsById[normalizedTenantId] ?? normalizedTenantId;
-        const name = processDefinitionName || processDefinitionId;
+        const name = processDefinitionName ?? processDefinitionId;
 
         return (
           <Li key={`${processDefinitionKey}-${normalizedTenantId}`}>

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/Details.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/Details.tsx
@@ -132,7 +132,7 @@ const Details: React.FC<Props> = ({
                   });
                 }}
                 title={getAccordionItemTitle({
-                  processName: processDefinitionName || processName,
+                  processName: processDefinitionName ?? processName,
                   instancesCount: totalInstancesCount,
                   version: processDefinitionVersion,
                   ...(isMultiTenancyEnabled
@@ -147,7 +147,7 @@ const Details: React.FC<Props> = ({
                     type: 'process',
                     size: 'small',
                     text: getAccordionItemLabel({
-                      name: processDefinitionName || processName,
+                      name: processDefinitionName ?? processName,
                       instancesCount: totalInstancesCount,
                       version: processDefinitionVersion,
                       ...(isMultiTenancyEnabled

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/createMetadataJson.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/createMetadataJson.ts
@@ -85,8 +85,8 @@ export function createMetadataJson(
     calledProcessDefinitionName:
       calledProcessInstance?.processDefinitionName ?? null,
     calledDecisionDefinitionName:
-      calledDecisionInstance?.decisionDefinitionName ||
-      calledDecisionDefinition?.name ||
+      calledDecisionInstance?.decisionDefinitionName ??
+      calledDecisionDefinition?.name ??
       null,
     jobRetries: job?.retries ?? null,
     jobDeadline: job?.deadline ?? null,
@@ -100,16 +100,16 @@ export function createMetadataJson(
     type: elementInstance.type,
     elementInstanceState: elementInstance.state,
     userTaskState: userTaskState,
-    startDate: elementInstance.startDate || '',
-    endDate: elementInstance.endDate || null,
+    startDate: elementInstance.startDate ?? '',
+    endDate: elementInstance.endDate ?? null,
     processDefinitionId: elementInstance.processDefinitionId,
     processInstanceKey: elementInstance.processInstanceKey,
     processDefinitionKey: elementInstance.processDefinitionKey,
     hasIncident: elementInstance.hasIncident,
     tenantId: elementInstance.tenantId,
     elementType: elementInstance.type,
-    incidentErrorType: incident?.errorTypeName || null,
-    incidentErrorMessage: incident?.errorMessage || null,
+    incidentErrorType: incident?.errorTypeName ?? null,
+    incidentErrorMessage: incident?.errorMessage ?? null,
     calledProcessInstanceKey: calledProcessInstance?.processInstanceKey ?? null,
     calledDecisionInstanceKey:
       calledDecisionInstance?.decisionEvaluationInstanceKey ?? null,

--- a/operate/client/src/modules/queries/processInstance/useProcessTitle.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessTitle.ts
@@ -15,7 +15,7 @@ const processTitleParser = (processInstance: ProcessInstance): string => {
 
   return PAGE_TITLE.INSTANCE(
     processInstance.processInstanceKey,
-    processDefinitionName || processDefinitionId || '',
+    processDefinitionName ?? processDefinitionId ?? '',
   );
 };
 

--- a/operate/client/src/modules/queries/processInstance/useProcessTitle.ts
+++ b/operate/client/src/modules/queries/processInstance/useProcessTitle.ts
@@ -15,7 +15,7 @@ const processTitleParser = (processInstance: ProcessInstance): string => {
 
   return PAGE_TITLE.INSTANCE(
     processInstance.processInstanceKey,
-    processDefinitionName ?? processDefinitionId ?? '',
+    processDefinitionName ?? processDefinitionId,
   );
 };
 


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/46183 made all optional fields return as null. With that change some checks need to be updated since the API can now return nullfor these fields (not just omit them), empty string is a valid distinct value that should NOT be treated as falsy

## Related issues

related to #46370 
