### PR TITLE
ci: configure secondary storage for preview envs

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -11,7 +11,7 @@ global:
     camunda.cloud/managed-by: Helm
     camunda.cloud/source: argocd
     team: monorepo-devops
-  
+
   image:
     pullSecrets:
     - name: dockerhub-registry
@@ -42,6 +42,10 @@ global:
 
   # Camunda 8 Self-Managed global configurations
   elasticsearch:
+    # Required so the orchestration chart renders the `camunda.data.secondary-storage.elasticsearch`
+    # block (url, credentials, etc.). Without this, embedded Operate/Tasklist may fall back
+    # to their defaults (e.g. `http://localhost:9200`).
+    enabled: true
     # necessary due to name override bugs
     url:
       host: elasticsearch
@@ -204,6 +208,10 @@ camunda-platform:
         freeSpace:
           processing: 110MB
           replication: 10MB
+      secondaryStorage:
+        type: elasticsearch
+        elasticsearch:
+          url: http://elasticsearch:9200
     resources:
       limits:
         cpu: "1"
@@ -273,7 +281,7 @@ camunda-platform:
     enabled: true
     fullnameOverride: identity-keycloak
     extraEnvVars:
-    # Required as TLS is enabled 
+    # Required as TLS is enabled
     - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
       value: "true"
     resources:


### PR DESCRIPTION
## Description

Fix the failing [smoke tests](https://github.com/camunda/camunda/actions/runs/22295318979) that indicate the preview envs are not working. ([Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1771829453400789))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
