### PR TITLE
refactor: use range metadata from runtime state for backup state API

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRangeStatus.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupRangeStatus.java
@@ -7,17 +7,18 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.util.Collections;
 import java.util.Set;
 
 public sealed interface BackupRangeStatus {
-  BackupStatus first();
+  CheckpointInfo first();
 
-  BackupStatus last();
+  CheckpointInfo last();
 
   Set<Long> missingCheckpoints();
 
-  record Complete(BackupStatus first, BackupStatus last) implements BackupRangeStatus {
+  record Complete(CheckpointInfo first, CheckpointInfo last) implements BackupRangeStatus {
 
     @Override
     public Set<Long> missingCheckpoints() {
@@ -29,10 +30,22 @@ public sealed interface BackupRangeStatus {
    * A backup range with deletions. Verification of all contained backups is required to determine
    * whether the range is effectively complete or not.
    */
-  record Incomplete(BackupStatus first, BackupStatus last, Set<Long> missingCheckpoints)
+  record Incomplete(CheckpointInfo first, CheckpointInfo last, Set<Long> missingCheckpoints)
       implements BackupRangeStatus {
     public Incomplete {
       missingCheckpoints = Set.copyOf(missingCheckpoints);
     }
   }
+
+  /**
+   * Checkpoint metadata for a range boundary. Contains the information needed to describe a
+   * checkpoint within a backup range without requiring a full {@link BackupStatus} lookup from the
+   * backup store.
+   */
+  record CheckpointInfo(
+      long checkpointId,
+      long checkpointPosition,
+      long checkpointTimestamp,
+      CheckpointType checkpointType,
+      long firstLogPosition) {}
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.metrics.BackupManagerMetrics;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -49,13 +51,17 @@ public final class BackupService extends Actor implements BackupManager {
       final Path segmentsDirectory,
       final JournalInfoProvider raftMetadataProvider,
       final MeterRegistry partitionRegistry,
-      final LogStreamWriter logStreamWriter) {
+      final LogStreamWriter logStreamWriter,
+      final DbBackupRangeState backupRangeState,
+      final DbCheckpointMetadataState checkpointMetadataState) {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
     metrics = new BackupManagerMetrics(partitionRegistry);
-    internalBackupManager = new BackupServiceImpl(backupStore, logStreamWriter);
+    internalBackupManager =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
     actorName = buildActorName("BackupService", partitionId);
     journalInfoProvider = raftMetadataProvider;
   }
@@ -209,7 +215,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public ActorFuture<Collection<BackupRangeStatus>> getBackupRangeStatus() {
-    return internalBackupManager.getBackupRangeStatus(partitionId, actor);
+    return internalBackupManager.getBackupRangeStatus(actor);
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -9,18 +9,17 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
-import io.camunda.zeebe.backup.api.BackupRange;
-import io.camunda.zeebe.backup.api.BackupRange.Complete;
-import io.camunda.zeebe.backup.api.BackupRange.Incomplete;
 import io.camunda.zeebe.backup.api.BackupRangeMarker;
 import io.camunda.zeebe.backup.api.BackupRangeMarker.Deletion;
 import io.camunda.zeebe.backup.api.BackupRangeStatus;
-import io.camunda.zeebe.backup.api.BackupRanges;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.processing.state.CheckpointMetadataValue;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
@@ -42,8 +41,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import org.agrona.collections.Hashing;
-import org.agrona.collections.Long2ObjectHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,11 +49,19 @@ final class BackupServiceImpl {
   private final Set<InProgressBackup> backupsInProgress = new HashSet<>();
   private final BackupStore backupStore;
   private final LogStreamWriter logStreamWriter;
+  private final DbBackupRangeState backupRangeState;
+  private final DbCheckpointMetadataState checkpointMetadataState;
   private ConcurrencyControl concurrencyControl;
 
-  BackupServiceImpl(final BackupStore backupStore, final LogStreamWriter logStreamWriter) {
+  BackupServiceImpl(
+      final BackupStore backupStore,
+      final LogStreamWriter logStreamWriter,
+      final DbBackupRangeState backupRangeState,
+      final DbCheckpointMetadataState checkpointMetadataState) {
     this.backupStore = backupStore;
     this.logStreamWriter = logStreamWriter;
+    this.backupRangeState = backupRangeState;
+    this.checkpointMetadataState = checkpointMetadataState;
   }
 
   void close() {
@@ -403,117 +408,51 @@ final class BackupServiceImpl {
   }
 
   ActorFuture<Collection<BackupRangeStatus>> getBackupRangeStatus(
-      final int partitionId, final ConcurrencyControl executor) {
+      final ConcurrencyControl executor) {
     LOG.atDebug().setMessage("Listing backup ranges").log();
     final ActorFuture<Collection<BackupRangeStatus>> future = executor.createFuture();
     executor.run(
-        () ->
-            backupStore
-                .rangeMarkers(partitionId)
-                .whenCompleteAsync(
-                    (markers, throwable) -> {
-                      if (throwable != null) {
-                        LOG.atError()
-                            .setMessage("Failed to retrieve range markers")
-                            .setCause(throwable)
-                            .log();
-                        future.completeExceptionally(throwable);
-                      } else {
-                        LOG.atTrace()
-                            .addKeyValue("markers", markers::size)
-                            .setMessage("Retrieved range markers")
-                            .log();
-                        getStatusForRanges(
-                            partitionId, BackupRanges.fromMarkers(markers), future, executor);
-                      }
-                    },
-                    executor));
+        () -> {
+          try {
+            final var ranges = backupRangeState.getAllRanges();
+            final var result = new ArrayList<BackupRangeStatus>(ranges.size());
+            for (final var range : ranges) {
+              final var firstMeta = checkpointMetadataState.getCheckpoint(range.start());
+              final var lastMeta = checkpointMetadataState.getCheckpoint(range.end());
+              if (firstMeta == null || lastMeta == null) {
+                LOG.atWarn()
+                    .addKeyValue("rangeStart", range.start())
+                    .addKeyValue("rangeEnd", range.end())
+                    .addKeyValue("firstMetaPresent", firstMeta != null)
+                    .addKeyValue("lastMetaPresent", lastMeta != null)
+                    .setMessage("Checkpoint metadata missing for range boundary, skipping range")
+                    .log();
+                continue;
+              }
+              final var first = toCheckpointInfo(range.start(), firstMeta);
+              final var last = toCheckpointInfo(range.end(), lastMeta);
+              result.add(new BackupRangeStatus.Complete(first, last));
+            }
+            future.complete(result);
+          } catch (final Exception e) {
+            LOG.atError()
+                .setMessage("Failed to read backup ranges from column families")
+                .setCause(e)
+                .log();
+            future.completeExceptionally(e);
+          }
+        });
     return future;
   }
 
-  private void getStatusForRanges(
-      final int partitionId,
-      final Collection<BackupRange> ranges,
-      final ActorFuture<Collection<BackupRangeStatus>> future,
-      final ConcurrencyControl executor) {
-    final var statuses = getBackupStatusForAllRanges(partitionId, ranges, executor);
-    final var result = new ArrayList<BackupRangeStatus>(ranges.size());
-    executor.runOnCompletion(
-        statuses.values(),
-        error -> {
-          if (error != null) {
-            LOG.atError()
-                .addKeyValue("ranges", ranges::size)
-                .setMessage("Failed to determine backup status for all ranges")
-                .setCause(error)
-                .log();
-            future.completeExceptionally(error);
-            return;
-          }
-          LOG.atTrace()
-              .addKeyValue("ranges", ranges::size)
-              .addKeyValue("statuses", statuses::size)
-              .setMessage("Resolved all backup statuses for ranges")
-              .log();
-          for (final var range : ranges) {
-            final var firstStatus = statuses.get(range.firstCheckpointId()).join().orElse(null);
-            final var lastStatus = statuses.get(range.lastCheckpointId()).join().orElse(null);
-            if (!isValidRange(range, firstStatus, lastStatus)) {
-              continue;
-            }
-            result.add(
-                switch (range) {
-                  case final Complete ignored ->
-                      new BackupRangeStatus.Complete(firstStatus, lastStatus);
-                  case final Incomplete incomplete ->
-                      new BackupRangeStatus.Incomplete(
-                          firstStatus, lastStatus, incomplete.deletedCheckpointIds());
-                });
-          }
-          future.complete(result);
-        });
-  }
-
-  private static boolean isValidRange(
-      final BackupRange range, final BackupStatus firstStatus, final BackupStatus lastStatus) {
-    if (firstStatus == null || lastStatus == null) {
-      LOG.atWarn()
-          .addKeyValue("range", range)
-          .addKeyValue("firstStatus", firstStatus)
-          .addKeyValue("lastStatus", lastStatus)
-          .setMessage("Did not find backup status for checkpoints in range, skipping range")
-          .log();
-      return false;
-    }
-    if (firstStatus.statusCode() != BackupStatusCode.COMPLETED
-        || lastStatus.statusCode() != BackupStatusCode.COMPLETED) {
-      LOG.atWarn()
-          .addKeyValue("range", range)
-          .addKeyValue("firstStatus", firstStatus)
-          .addKeyValue("lastStatus", lastStatus)
-          .setMessage("Backup status for range is not completed, skipping range")
-          .log();
-      return false;
-    }
-    return true;
-  }
-
-  private Long2ObjectHashMap<ActorFuture<Optional<BackupStatus>>> getBackupStatusForAllRanges(
-      final int partitionId,
-      final Collection<BackupRange> ranges,
-      final ConcurrencyControl executor) {
-    final var result =
-        new Long2ObjectHashMap<ActorFuture<Optional<BackupStatus>>>(
-            ranges.size() * 2, Hashing.DEFAULT_LOAD_FACTOR);
-    for (final BackupRange range : ranges) {
-      result.putIfAbsent(
-          range.firstCheckpointId(),
-          getBackupStatus(partitionId, range.firstCheckpointId(), executor));
-      result.putIfAbsent(
-          range.lastCheckpointId(),
-          getBackupStatus(partitionId, range.lastCheckpointId(), executor));
-    }
-    return result;
+  private static BackupRangeStatus.CheckpointInfo toCheckpointInfo(
+      final long checkpointId, final CheckpointMetadataValue meta) {
+    return new BackupRangeStatus.CheckpointInfo(
+        checkpointId,
+        meta.getCheckpointPosition(),
+        meta.getCheckpointTimestamp(),
+        meta.getCheckpointType(),
+        meta.getFirstLogPosition());
   }
 
   void createFailedBackup(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.collection;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +28,8 @@ import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupRangeMarker.End;
 import io.camunda.zeebe.backup.api.BackupRangeMarker.Start;
+import io.camunda.zeebe.backup.api.BackupRangeStatus;
+import io.camunda.zeebe.backup.api.BackupRangeStatus.CheckpointInfo;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -34,6 +37,10 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.processing.state.CheckpointMetadataValue;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState.BackupRange;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
@@ -597,6 +604,269 @@ class BackupServiceImplTest {
 
   private void mockSaveBackup() {
     when(backupStore.save(any())).thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  @Test
+  void shouldReturnEmptyCollectionWhenNoRangesExist() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+    when(backupRangeState.getAllRanges()).thenReturn(List.of());
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldReturnCompleteRangeStatus() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(1L, 5L)));
+
+    final var firstMeta = mockCheckpointMeta(100L, 1000L, CheckpointType.MANUAL_BACKUP, 50L);
+    final var lastMeta = mockCheckpointMeta(500L, 5000L, CheckpointType.SCHEDULED_BACKUP, 400L);
+
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(firstMeta);
+    when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(lastMeta);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .singleElement()
+        .isInstanceOf(BackupRangeStatus.Complete.class)
+        .satisfies(
+            status -> {
+              final var complete = (BackupRangeStatus.Complete) status;
+              assertThat(complete.first())
+                  .isEqualTo(
+                      new CheckpointInfo(1L, 100L, 1000L, CheckpointType.MANUAL_BACKUP, 50L));
+              assertThat(complete.last())
+                  .isEqualTo(
+                      new CheckpointInfo(5L, 500L, 5000L, CheckpointType.SCHEDULED_BACKUP, 400L));
+            });
+  }
+
+  @Test
+  void shouldReturnMultipleRangeStatuses() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges())
+        .thenReturn(List.of(new BackupRange(1L, 3L), new BackupRange(5L, 8L)));
+
+    final var meta1 = mockCheckpointMeta(100L, 1000L, CheckpointType.MANUAL_BACKUP, 50L);
+    final var meta3 = mockCheckpointMeta(300L, 3000L, CheckpointType.SCHEDULED_BACKUP, 200L);
+    final var meta5 = mockCheckpointMeta(500L, 5000L, CheckpointType.MANUAL_BACKUP, 400L);
+    final var meta8 = mockCheckpointMeta(800L, 8000L, CheckpointType.SCHEDULED_BACKUP, 700L);
+
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(meta1);
+    when(checkpointMetadataState.getCheckpoint(3L)).thenReturn(meta3);
+    when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(meta5);
+    when(checkpointMetadataState.getCheckpoint(8L)).thenReturn(meta8);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .hasSize(2)
+        .allSatisfy(status -> assertThat(status).isInstanceOf(BackupRangeStatus.Complete.class));
+  }
+
+  @Test
+  void shouldSkipRangeWhenFirstMetadataIsMissing() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(1L, 5L)));
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(null);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldSkipRangeWhenLastMetadataIsMissing() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(1L, 5L)));
+    final var firstMeta = mock(CheckpointMetadataValue.class);
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(firstMeta);
+    when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(null);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldSkipRangeWhenBothMetadataAreMissing() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(1L, 5L)));
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(null);
+    when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(null);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .isEmpty();
+  }
+
+  @Test
+  void shouldIncludeOnlyRangesWithValidMetadata() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges())
+        .thenReturn(List.of(new BackupRange(1L, 3L), new BackupRange(5L, 8L)));
+
+    // First range has missing metadata
+    when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(null);
+    when(checkpointMetadataState.getCheckpoint(3L)).thenReturn(null);
+
+    // Second range has valid metadata
+    final var meta5 = mockCheckpointMeta(500L, 5000L, CheckpointType.MANUAL_BACKUP, 400L);
+    final var meta8 = mockCheckpointMeta(800L, 8000L, CheckpointType.SCHEDULED_BACKUP, 700L);
+    when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(meta5);
+    when(checkpointMetadataState.getCheckpoint(8L)).thenReturn(meta8);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .singleElement()
+        .isInstanceOf(BackupRangeStatus.Complete.class)
+        .satisfies(
+            status -> {
+              final var complete = (BackupRangeStatus.Complete) status;
+              assertThat(complete.first().checkpointId()).isEqualTo(5L);
+              assertThat(complete.last().checkpointId()).isEqualTo(8L);
+            });
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenGetAllRangesThrows() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenThrow(new RuntimeException("DB error"));
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("DB error");
+  }
+
+  @Test
+  void shouldReturnSinglePointRangeWhenStartEqualsEnd() {
+    // given
+    final var backupRangeState = mock(DbBackupRangeState.class);
+    final var checkpointMetadataState = mock(DbCheckpointMetadataState.class);
+    final var service =
+        new BackupServiceImpl(
+            backupStore, logStreamWriter, backupRangeState, checkpointMetadataState);
+
+    when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(3L, 3L)));
+
+    final var meta = mockCheckpointMeta(300L, 3000L, CheckpointType.MANUAL_BACKUP, 200L);
+    when(checkpointMetadataState.getCheckpoint(3L)).thenReturn(meta);
+
+    // when
+    final var result = service.getBackupRangeStatus(concurrencyControl);
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofMillis(100))
+        .asInstanceOf(collection(BackupRangeStatus.class))
+        .singleElement()
+        .satisfies(
+            status -> {
+              final var complete = (BackupRangeStatus.Complete) status;
+              assertThat(complete.first()).isEqualTo(complete.last());
+              assertThat(complete.first().checkpointId()).isEqualTo(3L);
+            });
+  }
+
+  private CheckpointMetadataValue mockCheckpointMeta(
+      final long position,
+      final long timestamp,
+      final CheckpointType type,
+      final long firstLogPosition) {
+    final var meta = mock(CheckpointMetadataValue.class);
+    when(meta.getCheckpointPosition()).thenReturn(position);
+    when(meta.getCheckpointTimestamp()).thenReturn(timestamp);
+    when(meta.getCheckpointType()).thenReturn(type);
+    when(meta.getFirstLogPosition()).thenReturn(firstLogPosition);
+    return meta;
   }
 
   class ControllableInProgressBackup implements InProgressBackup {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -77,7 +77,7 @@ class BackupServiceImplTest {
 
   @BeforeEach
   void setup() {
-    backupService = new BackupServiceImpl(backupStore, logStreamWriter);
+    backupService = new BackupServiceImpl(backupStore, logStreamWriter, null, null);
 
     lenient()
         .when(notExistingBackupStatus.statusCode())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.management.BackupService;
 import io.camunda.zeebe.backup.management.NoopBackupManager;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
+import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointMetadataState;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -99,6 +101,11 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     // now because SegmentedJournal requires some information from RaftContext in its builder. Until
     // we can refactor SegmentedJournal and build it outside of raft, we have to do this in this
     // hacky way.
+    final var zeebeDb = context.getZeebeDb();
+    final var backupRangeState = new DbBackupRangeState(zeebeDb, zeebeDb.createContext());
+    final var checkpointMetadataState =
+        new DbCheckpointMetadataState(zeebeDb, zeebeDb.createContext());
+
     final BackupService backupManager =
         new BackupService(
             context.getNodeId(),
@@ -108,7 +115,9 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
             context.getRaftPartition().dataDirectory().toPath(),
             index -> context.getRaftPartition().getServer().getTailSegments(index),
             context.getPartitionTransitionMeterRegistry(),
-            context.getLogStream().newLogStreamWriter());
+            context.getLogStream().newLogStreamWriter(),
+            backupRangeState,
+            checkpointMetadataState);
 
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.backupapi;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupRangeStatus;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
@@ -270,8 +271,8 @@ public final class BackupApiRequestHandler
                           r ->
                               new PartitionBackupRange(
                                   partitionId,
-                                  fromBackupStatus(r.first()),
-                                  fromBackupStatus(r.last()),
+                                  fromCheckpointInfo(r.first()),
+                                  fromCheckpointInfo(r.last()),
                                   r.missingCheckpoints()))
                       .toList());
               result.complete(Either.right(responseWriter.withBackupRanges(response)));
@@ -280,24 +281,16 @@ public final class BackupApiRequestHandler
     return result;
   }
 
-  private CheckpointInfo fromBackupStatus(final BackupStatus backupStatus) {
-    if (backupStatus == null) {
+  private CheckpointInfo fromCheckpointInfo(final BackupRangeStatus.CheckpointInfo info) {
+    if (info == null) {
       return null;
     }
-
-    final var descriptor =
-        backupStatus
-            .descriptor()
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Expected a backup with descriptor: " + backupStatus));
     return new CheckpointInfo(
-        backupStatus.id().checkpointId(),
-        descriptor.firstLogPosition().orElse(-1L),
-        descriptor.checkpointPosition(),
-        descriptor.checkpointType(),
-        descriptor.checkpointTimestamp());
+        info.checkpointId(),
+        info.firstLogPosition(),
+        info.checkpointPosition(),
+        info.checkpointType(),
+        Instant.ofEpochMilli(info.checkpointTimestamp()));
   }
 
   private BackupListResponse buildBackupListResponse(final Collection<BackupStatus> backups) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -126,7 +126,9 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
                 // RaftPartitions implements this interface, but the RaftServer is not started
                 index -> CompletableFuture.completedFuture(journal.getTailSegments(index)),
                 meterRegistry,
-                (context, entries, source) -> Either.left(WriteFailure.CLOSED)));
+                (context, entries, source) -> Either.left(WriteFailure.CLOSED),
+                null,
+                null));
     actorScheduler.submitActor(backupService);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldInstallService;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -57,6 +58,9 @@ class BackupServiceTransitionStepTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   BrokerCfg brokerCfg;
 
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  ZeebeDb zeebeDb;
+
   @Mock ClusterCfg clusterCfg;
 
   @Mock RaftPartition raftPartition;
@@ -70,6 +74,7 @@ class BackupServiceTransitionStepTest {
     transitionContext.setBrokerCfg(brokerCfg);
     transitionContext.setRaftPartition(raftPartition);
     transitionContext.setLogStream(logStream);
+    transitionContext.setZeebeDb(zeebeDb);
 
     lenient().when(brokerCfg.getCluster().getPartitionsCount()).thenReturn(3);
     lenient()

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -547,13 +547,13 @@ final class BackupApiRequestHandlerTest {
     final long checkpointId2 = 20;
     final long checkpointId3 = 30;
 
-    final var status1 = createBackupStatus(checkpointId1);
-    final var status2 = createBackupStatus(checkpointId2);
-    final var status3 = createBackupStatus(checkpointId2);
-    final var status4 = createBackupStatus(checkpointId3);
+    final var info1 = createCheckpointInfo(checkpointId1);
+    final var info2 = createCheckpointInfo(checkpointId2);
+    final var info3 = createCheckpointInfo(checkpointId2);
+    final var info4 = createCheckpointInfo(checkpointId3);
 
-    final var range1 = new BackupRangeStatus.Complete(status1, status2);
-    final var range2 = new BackupRangeStatus.Incomplete(status3, status4, Set.of(25L));
+    final var range1 = new BackupRangeStatus.Complete(info1, info2);
+    final var range2 = new BackupRangeStatus.Incomplete(info3, info4, Set.of(25L));
 
     when(backupManager.getBackupRangeStatus())
         .thenReturn(CompletableActorFuture.completed(List.of(range1, range2)));
@@ -571,30 +571,24 @@ final class BackupApiRequestHandlerTest {
     assertThat(rangesResponse.getRanges())
         .containsExactlyInAnyOrder(
             new BackupRangesResponse.PartitionBackupRange(
-                1, toCheckpointInfo(status1), toCheckpointInfo(status2), Set.of()),
+                1, toResponseCheckpointInfo(info1), toResponseCheckpointInfo(info2), Set.of()),
             new BackupRangesResponse.PartitionBackupRange(
-                1, toCheckpointInfo(status3), toCheckpointInfo(status4), Set.of(25L)));
+                1, toResponseCheckpointInfo(info3), toResponseCheckpointInfo(info4), Set.of(25L)));
   }
 
-  private static BackupStatus createBackupStatus(final long checkpointId) {
-    return new BackupStatusImpl(
-        new BackupIdentifierImpl(1, 1, checkpointId),
-        Optional.of(
-            new BackupDescriptorImpl("s-id", 100, 3, "test", NOW, CheckpointType.MANUAL_BACKUP)),
-        io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
-        Optional.empty(),
-        Optional.of(NOW),
-        Optional.of(NOW));
+  private static BackupRangeStatus.CheckpointInfo createCheckpointInfo(final long checkpointId) {
+    return new BackupRangeStatus.CheckpointInfo(
+        checkpointId, 100L, NOW.toEpochMilli(), CheckpointType.MANUAL_BACKUP, -1L);
   }
 
-  private static CheckpointInfo toCheckpointInfo(final BackupStatus status) {
-    final var descriptor = status.descriptor().orElseThrow();
+  private static CheckpointInfo toResponseCheckpointInfo(
+      final BackupRangeStatus.CheckpointInfo info) {
     return new CheckpointInfo(
-        status.id().checkpointId(),
-        descriptor.firstLogPosition().orElse(-1L),
-        descriptor.checkpointPosition(),
-        descriptor.checkpointType(),
-        descriptor.checkpointTimestamp());
+        info.checkpointId(),
+        info.firstLogPosition(),
+        info.checkpointPosition(),
+        info.checkpointType(),
+        Instant.ofEpochMilli(info.checkpointTimestamp()));
   }
 
   private void handleRequest(final BackupRequest request) {

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -122,7 +122,9 @@ class PartitionRestoreServiceTest {
             // RaftPartitions implements this interface, but the RaftServer is not started
             index -> CompletableFuture.completedFuture(journal.getTailSegments(index)),
             meterRegistry,
-            (context, entries, source) -> Either.left(WriteFailure.CLOSED));
+            (context, entries, source) -> Either.left(WriteFailure.CLOSED),
+            null,
+            null);
     actorScheduler.submitActor(backupService);
   }
 


### PR DESCRIPTION
This updates the backup state API to retrieve range information from the column family directly instead of the marker files from the backup store.

Builds on top of #46622