### PR TITLE
feat: validate length of a resource name #45678

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NamedBpmnElementValidatorsArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/NamedBpmnElementValidatorsArchTest.java
@@ -18,7 +18,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
-import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import io.camunda.zeebe.model.bpmn.instance.NamedBpmnElement;
 import io.camunda.zeebe.model.bpmn.instance.dc.Font;
 import io.camunda.zeebe.model.bpmn.instance.di.Diagram;
@@ -81,7 +81,7 @@ public class NamedBpmnElementValidatorsArchTest {
 
       // Use reflection to call getValidators and extract registered types
       final var validators =
-          ZeebeConfigurationValidators.getValidators(BpmnValidatorConfig.builder().build());
+          ZeebeConfigurationValidators.getValidators(ValidationConfig.builder().build());
 
       final Set<String> registeredTypes =
           validators.stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -123,7 +124,12 @@ public final class DeploymentCreateProcessor
             expressionProcessor,
             keyGenerator,
             featureFlags,
-            config,
+            ValidationConfig.builder()
+                .withMaxIdFieldLength(config.getMaxIdFieldLength())
+                .withMaxNameFieldLength(config.getMaxNameFieldLength())
+                .withMaxWorkerTypeLength(config.getMaxWorkerTypeLength())
+                .withValidatorResultsOutputMaxSize(config.getValidatorsResultsOutputMaxSize())
+                .build(),
             clock,
             expressionLanguageMetrics);
     startEventSubscriptionManager =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
-import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import java.time.InstantSource;
 
 public final class BpmnFactory {
@@ -42,7 +42,7 @@ public final class BpmnFactory {
   public static BpmnValidator createValidator(
       final InstantSource clock,
       final ExpressionProcessor expressionProcessor,
-      final BpmnValidatorConfig config,
+      final ValidationConfig config,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
     return new BpmnValidator(
         createExpressionLanguage(new ZeebeFeelEngineClock(clock), expressionLanguageMetrics),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeConfigurationValidators.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
-import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import io.camunda.zeebe.model.bpmn.instance.CallableElement;
 import io.camunda.zeebe.model.bpmn.instance.Category;
 import io.camunda.zeebe.model.bpmn.instance.Collaboration;
@@ -45,8 +45,7 @@ import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 
 public final class ZeebeConfigurationValidators {
 
-  public static Collection<ModelElementValidator<?>> getValidators(
-      final BpmnValidatorConfig config) {
+  public static Collection<ModelElementValidator<?>> getValidators(final ValidationConfig config) {
     return List.of(
         new IdLengthValidator(config.maxIdFieldLength()),
         new NameLengthValidator<>(CallableElement.class, config.maxNameFieldLength()),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
@@ -59,27 +58,18 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final ProcessState processState,
       final ExpressionProcessor expressionProcessor,
       final boolean enableStraightThroughProcessingLoopDetector,
-      final EngineConfiguration config,
+      final ValidationConfig config,
       final InstantSource clock,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
     bpmnTransformer =
         BpmnFactory.createTransformer(
-            clock, expressionLanguageMetrics, config.getMaxNameFieldLength());
+            clock, expressionLanguageMetrics, config.maxNameFieldLength());
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
     this.processState = processState;
     validator =
-        BpmnFactory.createValidator(
-            clock,
-            expressionProcessor,
-            BpmnValidatorConfig.builder()
-                .withMaxIdFieldLength(config.getMaxIdFieldLength())
-                .withMaxNameFieldLength(config.getMaxNameFieldLength())
-                .withMaxWorkerTypeLength(config.getMaxWorkerTypeLength())
-                .withValidatorResultsOutputMaxSize(config.getValidatorsResultsOutputMaxSize())
-                .build(),
-            expressionLanguageMetrics);
+        BpmnFactory.createValidator(clock, expressionProcessor, config, expressionLanguageMetrics);
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
@@ -29,7 +29,7 @@ public final class BpmnValidator {
   public BpmnValidator(
       final ExpressionLanguage expressionLanguage,
       final ExpressionProcessor expressionProcessor,
-      final BpmnValidatorConfig config) {
+      final ValidationConfig config) {
     final var designTimeAspectValidator =
         new ValidationVisitor(ZeebeDesignTimeValidators.VALIDATORS);
     final var runtimeAspectValidator =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -175,8 +175,8 @@ public final class DeploymentTransformer {
     if (resourceName.length() > config.maxNameFieldLength()) {
       errors.append(
           String.format(
-              "\n- Resource name '%s' exceeds maximum length of %d characters",
-              resourceName, config.maxNameFieldLength()));
+              "\n- Resource name '%s' exceeds maximum length of %d characters as it has a length of %d characters",
+              resourceName, config.maxNameFieldLength(), resourceName.length()));
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
 import static java.util.Map.entry;
 
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -38,7 +37,7 @@ public final class DeploymentTransformer {
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private static final DeploymentResourceTransformer UNKNOWN_RESOURCE =
       new UnknownResourceTransformer();
-  private final EngineConfiguration config;
+  private final ValidationConfig config;
   private final Map<String, DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   // internal changes during processing
@@ -51,7 +50,7 @@ public final class DeploymentTransformer {
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator,
       final FeatureFlags featureFlags,
-      final EngineConfiguration config,
+      final ValidationConfig config,
       final InstantSource clock,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
     this.config = config;
@@ -73,8 +72,7 @@ public final class DeploymentTransformer {
             stateWriter,
             checksumGenerator,
             processingState.getDecisionState(),
-            config.getMaxIdFieldLength(),
-            config.getMaxNameFieldLength());
+            config);
 
     final var formResourceTransformer =
         new FormResourceTransformer(
@@ -174,11 +172,11 @@ public final class DeploymentTransformer {
     final var resourceName = deploymentResource.getResourceName();
     final var transformer = getResourceTransformer(resourceName);
 
-    if (resourceName.length() > config.getMaxNameFieldLength()) {
+    if (resourceName.length() > config.maxNameFieldLength()) {
       errors.append(
           String.format(
               "\n- Resource name '%s' exceeds maximum length of %d characters",
-              resourceName, config.getMaxNameFieldLength()));
+              resourceName, config.maxNameFieldLength()));
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -38,6 +38,7 @@ public final class DeploymentTransformer {
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private static final DeploymentResourceTransformer UNKNOWN_RESOURCE =
       new UnknownResourceTransformer();
+  private final EngineConfiguration config;
   private final Map<String, DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   // internal changes during processing
@@ -53,6 +54,7 @@ public final class DeploymentTransformer {
       final EngineConfiguration config,
       final InstantSource clock,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
+    this.config = config;
 
     final var bpmnResourceTransformer =
         new BpmnResourceTransformer(
@@ -171,6 +173,14 @@ public final class DeploymentTransformer {
       final StringBuilder errors) {
     final var resourceName = deploymentResource.getResourceName();
     final var transformer = getResourceTransformer(resourceName);
+
+    if (resourceName.length() > config.getMaxNameFieldLength()) {
+      errors.append(
+          String.format(
+              "\n- Resource name '%s' exceeds maximum length of %d characters",
+              resourceName, config.getMaxNameFieldLength()));
+      return false;
+    }
 
     try {
       final var result = transformer.createMetadata(deploymentResource, deploymentEvent, context);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -61,22 +61,19 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   private final ChecksumGenerator checksumGenerator;
   private final DecisionState decisionState;
 
-  private final int maxIdLength;
-  private final int maxNameLength;
+  private final ValidationConfig config;
 
   public DmnResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
       final ChecksumGenerator checksumGenerator,
       final DecisionState decisionState,
-      final int maxIdLength,
-      final int maxNameLength) {
+      final ValidationConfig config) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
     this.decisionState = decisionState;
-    this.maxIdLength = maxIdLength;
-    this.maxNameLength = maxNameLength;
+    this.config = config;
   }
 
   @Override
@@ -241,14 +238,14 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
     return checkFieldLength(
             Stream.of(decisionRequirementsId),
-            maxIdLength,
+            config.maxIdFieldLength(),
             "The ID of a DRG must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
             valid ->
                 checkFieldLength(
                     Stream.of(decisionRequirementsName),
-                    maxNameLength,
+                    config.maxNameFieldLength(),
                     "The name of a DRG must not be longer than the configured max-name-length of %s characters, but was '%s' in DRG '%s'",
                     resource));
   }
@@ -257,14 +254,14 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       final DeploymentResource resource, final ParsedDecision decision) {
     return checkFieldLength(
             decision.getId(),
-            maxIdLength,
+            config.maxIdFieldLength(),
             "The ID of a decision must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
             valid ->
                 checkFieldLength(
                     decision.getName(),
-                    maxNameLength,
+                    config.maxNameFieldLength(),
                     "The name of a decision must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(valid -> checkDecisionTable(resource, decision));
@@ -278,7 +275,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
     return checkFieldLength(
             decision.getDecisionTable().getInputs().stream().map(ParsedDecisionInput::getId),
-            maxIdLength,
+            config.maxIdFieldLength(),
             "The ID of a decision input must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
             resource)
         .flatMap(
@@ -286,7 +283,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getInputs().stream()
                         .map(ParsedDecisionInput::getName),
-                    maxNameLength,
+                    config.maxNameFieldLength(),
                     "The name of a decision input must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
@@ -294,7 +291,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getOutputs().stream()
                         .map(ParsedDecisionOutput::getId),
-                    maxIdLength,
+                    config.maxIdFieldLength(),
                     "The ID of a decision output must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
@@ -302,7 +299,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 checkFieldLength(
                     decision.getDecisionTable().getOutputs().stream()
                         .map(ParsedDecisionOutput::getName),
-                    maxNameLength,
+                    config.maxNameFieldLength(),
                     "The name of a decision output must not be longer than the configured max-name-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(
@@ -311,7 +308,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                     decision.getDecisionTable().getRules().stream()
                         .map(ParsedDecisionRule::getId)
                         .filter(id -> !Strings.isNullOrEmpty(id)),
-                    maxIdLength,
+                    config.maxIdFieldLength(),
                     "The ID of a decision rule must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
                     resource))
         .flatMap(valid -> checkBlankRuleIds(resource, decision));
@@ -325,7 +322,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     if (hasBlankRuleIds) {
       final var synthesizedRuleId = DecisionBehavior.synthesizeRuleId(decision.getId(), 9999, 9999);
       final var maxLengthDecisionId =
-          maxIdLength - synthesizedRuleId.length() + decision.getId().length();
+          config.maxIdFieldLength() - synthesizedRuleId.length() + decision.getId().length();
       return checkFieldLength(
           decision.getId(),
           maxLengthDecisionId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -37,14 +36,14 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   private final StateWriter stateWriter;
   private final ChecksumGenerator checksumGenerator;
   private final FormState formState;
-  private final EngineConfiguration config;
+  private final ValidationConfig config;
 
   public FormResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
       final ChecksumGenerator checksumGenerator,
       final FormState formState,
-      final EngineConfiguration config) {
+      final ValidationConfig config) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
@@ -134,11 +133,11 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   private Either<Failure, ?> checkForFormIdLength(
       final String formId, final DeploymentResource resource) {
 
-    if (formId != null && formId.length() > config.getMaxIdFieldLength()) {
+    if (formId != null && formId.length() > config.maxIdFieldLength()) {
       final var failureMessage =
           String.format(
               "The ID of a form must not be longer than the configured max-id-length of %s characters, but was '%s' in resource '%s'",
-              config.getMaxIdFieldLength(), formId, resource.getResourceName());
+              config.maxIdFieldLength(), formId, resource.getResourceName());
       return Either.left(new Failure(failureMessage));
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ValidationConfig.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ValidationConfig.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.engine.EngineConfiguration;
 
-public record BpmnValidatorConfig(
+public record ValidationConfig(
     int maxIdFieldLength,
     int maxNameFieldLength,
     int maxWorkerTypeLength,
@@ -20,7 +20,7 @@ public record BpmnValidatorConfig(
     return new Builder();
   }
 
-  public static class Builder implements ObjectBuilder<BpmnValidatorConfig> {
+  public static class Builder implements ObjectBuilder<ValidationConfig> {
     private int maxIdFieldLength = EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH;
     private int maxNameFieldLength = EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH;
     private int maxWorkerTypeLength = EngineConfiguration.DEFAULT_MAX_WORKER_TYPE_LENGTH;
@@ -48,8 +48,8 @@ public record BpmnValidatorConfig(
     }
 
     @Override
-    public BpmnValidatorConfig build() {
-      return new BpmnValidatorConfig(
+    public ValidationConfig build() {
+      return new ValidationConfig(
           maxIdFieldLength, maxNameFieldLength, maxWorkerTypeLength, validatorResultsOutputMaxSize);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -628,6 +628,35 @@ public class DeploymentRejectionTest {
   }
 
   @Test
+  public void shouldRejectDeploymentResourceNameExceedsLengthLimit() {
+    final var resourceName = "a".repeat(MAX_NAME_FIELD_LENGTH - 4) + ".bpmn";
+
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("startEvent")
+            .serviceTask("serviceTask", t -> t.zeebeJobType("workerType"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource(resourceName, process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .startsWith("Expected to deploy new resources, but encountered the following errors:")
+        .contains(
+            "- Resource name '%s' exceeds maximum length of %d characters"
+                .formatted(resourceName, MAX_WORKER_TYPE_LENGTH));
+  }
+
+  @Test
   public void shouldNotRejectDeploymentForBindingTypeDeploymentIfTargetIdIsExpression() {
     // given
     final var process =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -653,7 +653,7 @@ public class DeploymentRejectionTest {
         .startsWith("Expected to deploy new resources, but encountered the following errors:")
         .contains(
             "- Resource name '%s' exceeds maximum length of %d characters"
-                .formatted(resourceName, MAX_WORKER_TYPE_LENGTH));
+                .formatted(resourceName, MAX_NAME_FIELD_LENGTH));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
-import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidatorConfig;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import io.camunda.zeebe.engine.processing.expression.ScopedEvaluationContext;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -91,7 +91,7 @@ public class ProcessValidationUtil {
                     ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor),
                     ZeebeDesignTimeValidators.VALIDATORS,
                     ZeebeConfigurationValidators.getValidators(
-                        BpmnValidatorConfig.builder()
+                        ValidationConfig.builder()
                             .withMaxIdFieldLength(MAX_ID_FIELD_LENGTH)
                             .withMaxNameFieldLength(MAX_NAME_FIELD_LENGTH)
                             .withMaxWorkerTypeLength(MAX_WORKER_TYPE_LENGTH)


### PR DESCRIPTION
## Description

This PR adds validation of the resourceName of all deployment resources (BPMN, DMN, Form).

I also had to refactor the `DeploymentRejectionTest` to now use 100 chars and not 50 because the resourceNames were longer.

## Related issues

closes #45678 
