### PR TITLE
[Backport stable/8.9] fix: added spring boot 4 dependencies to bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -102,6 +102,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-4-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-java</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -109,6 +115,12 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring-4</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
# Description
Backport of #46659 to `stable/8.9`.

relates to 