### PR TITLE
feat: add context to the expression eval API

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -461,7 +461,10 @@ public class RequestMapper {
   }
 
   public static Either<ProblemDetail, ExpressionEvaluationRequest> toExpressionEvaluationRequest(
-      final String expression, final String tenantId, final boolean isMultiTenancyEnabled) {
+      final String expression,
+      final String tenantId,
+      final Map<String, Object> context,
+      final boolean isMultiTenancyEnabled) {
     final var validator =
         validateTenantId(tenantId, isMultiTenancyEnabled, "Expression Evaluation");
     if (expression == null || expression.isBlank()) {
@@ -472,7 +475,7 @@ public class RequestMapper {
               INVALID_ARGUMENT.name()));
     }
     return validator.map(
-        validTenantId -> new ExpressionEvaluationRequest(expression, validTenantId));
+        validTenantId -> new ExpressionEvaluationRequest(expression, validTenantId, context));
   }
 
   public static Either<ProblemDetail, DeployResourcesRequest> toDeployResourceRequest(

--- a/service/src/main/java/io/camunda/service/ExpressionServices.java
+++ b/service/src/main/java/io/camunda/service/ExpressionServices.java
@@ -13,6 +13,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerExpressionEvaluationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public final class ExpressionServices extends ApiServices<ExpressionServices> {
@@ -49,5 +50,6 @@ public final class ExpressionServices extends ApiServices<ExpressionServices> {
             .setTenantId(request.tenantId()));
   }
 
-  public record ExpressionEvaluationRequest(String expression, String tenantId) {}
+  public record ExpressionEvaluationRequest(
+      String expression, String tenantId, Map<String, Object> context) {}
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -46,6 +46,11 @@ components:
           type: string
           description: Required when the expression references tenant-scoped cluster variables
           example: "tenant_123"
+        context:
+          type: object
+          description: Optional context variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.
+          additionalProperties:
+            example: { "x": 10, "y": 20 }
     ExpressionEvaluationResult:
       type: object
       required:

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -49,8 +49,11 @@ components:
         context:
           type: object
           description: Optional context variables for expression evaluation. These variables are only used for the current evaluation and do not persist beyond it.
-          additionalProperties:
-            example: { "x": 10, "y": 20 }
+          example:
+            x: 10
+            y: 20
+          additionalProperties: true
+          nullable: true
     ExpressionEvaluationResult:
       type: object
       required:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
@@ -43,7 +43,10 @@ public class ExpressionController {
   public CompletableFuture<ResponseEntity<Object>> evaluateExpression(
       @RequestBody final ExpressionEvaluationRequest request) {
     return RequestMapper.toExpressionEvaluationRequest(
-            request.getExpression(), request.getTenantId(), multiTenancyCfg.isChecksEnabled())
+            request.getExpression(),
+            request.getTenantId(),
+            request.getContext(),
+            multiTenancyCfg.isChecksEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateExpression);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.ExpressionServices.ExpressionEvaluationRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,55 @@ public class ExpressionControllerTest extends RestControllerTest {
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.expression()).isEqualTo("=x + y");
     assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithContext() {
+    // given
+    final var expressionRecord = mock(ExpressionRecord.class);
+    when(expressionRecord.getExpression()).thenReturn("=x + y");
+    when(expressionRecord.getResultValue()).thenReturn("10");
+    when(expressionRecord.getWarnings()).thenReturn(List.of());
+
+    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(expressionRecord));
+
+    final var request =
+        """
+        {
+            "expression": "=x + y",
+            "tenantId": "tenant1",
+            "context": {
+                "x": 4,
+                "y": 6
+            }
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(EXPRESSION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+                "expression": "=x + y",
+                "result": "10",
+                "warnings": []
+            }""",
+            JsonCompareMode.STRICT);
+
+    verify(expressionServices).evaluateExpression(requestCaptor.capture());
+    final var capturedRequest = requestCaptor.getValue();
+    assertThat(capturedRequest.expression()).isEqualTo("=x + y");
+    assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+    assertThat(capturedRequest.context()).isEqualTo(Map.of("x", 4, "y", 6));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the first part of the changes for #46332

- Modified the API definition to support `context` in the FEEL evaluation request
- Modified the controller/request mapper to pass the context

Broker changes in the next PR   

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46333 
