### PR TITLE
43063 by workers job stats rdbms impl

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobWorkerStatisticsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobWorkerStatisticsDbQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobWorkerStatisticsFilter;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobWorkerStatisticsDbQuery(
+    JobWorkerStatisticsFilter filter,
+    List<String> authorizedTenantIds,
+    DbQueryPage page,
+    DbQuerySorting<JobWorkerStatisticsEntity> sort) {
+
+  public static JobWorkerStatisticsDbQuery of(
+      final Function<JobWorkerStatisticsDbQuery.Builder, ObjectBuilder<JobWorkerStatisticsDbQuery>>
+          fn) {
+    return fn.apply(new JobWorkerStatisticsDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<JobWorkerStatisticsDbQuery> {
+    private JobWorkerStatisticsFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQueryPage page;
+    private DbQuerySorting<JobWorkerStatisticsEntity> sort;
+
+    public Builder filter(final JobWorkerStatisticsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<JobWorkerStatisticsFilter.Builder, ObjectBuilder<JobWorkerStatisticsFilter>>
+            fn) {
+      return filter(FilterBuilders.jobWorkerStatistics(fn));
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<JobWorkerStatisticsEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    @Override
+    public JobWorkerStatisticsDbQuery build() {
+      return new JobWorkerStatisticsDbQuery(
+          Objects.requireNonNull(filter, "filter must not be null"),
+          Objects.requireNonNullElse(authorizedTenantIds, Collections.emptyList()),
+          page,
+          sort);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobWorkerStatisticsDbResult.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/JobWorkerStatisticsDbResult.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import java.time.OffsetDateTime;
+
+public record JobWorkerStatisticsDbResult(
+    String worker,
+    Long createdCount,
+    OffsetDateTime lastCreatedAt,
+    Long completedCount,
+    OffsetDateTime lastCompletedAt,
+    Long failedCount,
+    OffsetDateTime lastFailedAt) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -12,8 +12,10 @@ import static java.util.Optional.ofNullable;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.db.rdbms.sql.columns.JobTypeStatisticsColumn;
+import io.camunda.db.rdbms.sql.columns.JobWorkerStatisticsColumn;
 import io.camunda.search.clients.reader.JobMetricsBatchReader;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
@@ -25,6 +27,7 @@ import io.camunda.search.query.JobTypeStatisticsQuery;
 import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.JobTypeStatisticsSort;
+import io.camunda.search.sort.JobWorkerStatisticsSort;
 import io.camunda.security.reader.ResourceAccessChecks;
 import java.util.Collections;
 import java.util.Optional;
@@ -42,18 +45,18 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
       JobTypeStatisticsSort.of(b -> b.jobType().asc());
 
   // Fixed sort: worker asc
-  //  private static final JobWorkerStatisticsSort JOB_WORKER_STATS_FIXED_SORT =
-  //      JobWorkerStatisticsSort.of(b -> b.worker().asc());
+  private static final JobWorkerStatisticsSort JOB_WORKER_STATS_FIXED_SORT =
+      JobWorkerStatisticsSort.of(b -> b.worker().asc());
 
   private final JobMetricsBatchMapper jobMetricsBatchMapper;
 
-  // private final AbstractEntityReader<JobWorkerStatisticsEntity> workerStatsReader;
+  private final AbstractEntityReader<JobWorkerStatisticsEntity> workerStatsReader;
 
   public JobMetricsBatchDbReader(
       final JobMetricsBatchMapper jobMetricsBatchMapper, final RdbmsReaderConfig readerConfig) {
     super(JobTypeStatisticsColumn.values(), readerConfig);
     this.jobMetricsBatchMapper = jobMetricsBatchMapper;
-    // workerStatsReader = new WorkerStatsReader(readerConfig);
+    workerStatsReader = new WorkerStatsReader(readerConfig);
   }
 
   @Override
@@ -124,52 +127,48 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
       final JobWorkerStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
     LOG.trace("[RDBMS DB] Search job worker statistics with {}", query);
-    // TODO enabled in a follow up PR
-    throw new UnsupportedOperationException("Job worker statistics is not yet supported");
-    //    if (shouldReturnEmptyResult(resourceAccessChecks)) {
-    //      return EmptyResults.JOB_WORKER_STATISTICS;
-    //    }
-    //    final var dbSort = workerStatsReader.convertSort(JOB_WORKER_STATS_FIXED_SORT);
-    //    final var dbPage =
-    //        workerStatsReader.convertPaging(
-    //            dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
-    //    final var dbQuery =
-    //        JobWorkerStatisticsDbQuery.of(
-    //            b ->
-    //                b.filter(query.filter())
-    //                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
-    //                    .sort(dbSort)
-    //                    .page(dbPage));
-    //
-    //    final var results = jobMetricsBatchMapper.jobWorkerStatistics(dbQuery);
-    //    final var entities =
-    //        results.stream()
-    //            .map(
-    //                result ->
-    //                    new JobWorkerStatisticsEntity(
-    //                        result.worker(),
-    //                        new StatusMetric(
-    //                            ofNullable(result.createdCount()).orElse(0L),
-    // result.lastCreatedAt()),
-    //                        new StatusMetric(
-    //                            ofNullable(result.completedCount()).orElse(0L),
-    //                            result.lastCompletedAt()),
-    //                        new StatusMetric(
-    //                            ofNullable(result.failedCount()).orElse(0L),
-    // result.lastFailedAt())))
-    //            .toList();
-    //
-    //    return workerStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return EmptyResults.JOB_WORKER_STATISTICS;
+    }
+    final var dbSort = workerStatsReader.convertSort(JOB_WORKER_STATS_FIXED_SORT);
+    final var dbPage =
+        workerStatsReader.convertPaging(
+            dbSort, Optional.ofNullable(query.page()).orElse(SearchQueryPage.DEFAULT));
+    final var dbQuery =
+        JobWorkerStatisticsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    final var results = jobMetricsBatchMapper.jobWorkerStatistics(dbQuery);
+    final var entities =
+        results.stream()
+            .map(
+                result ->
+                    new JobWorkerStatisticsEntity(
+                        result.worker(),
+                        new StatusMetric(
+                            ofNullable(result.createdCount()).orElse(0L), result.lastCreatedAt()),
+                        new StatusMetric(
+                            ofNullable(result.completedCount()).orElse(0L),
+                            result.lastCompletedAt()),
+                        new StatusMetric(
+                            ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt())))
+            .toList();
+
+    return workerStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
   }
 
-  //  /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */
-  //  private static final class WorkerStatsReader
-  //      extends AbstractEntityReader<JobWorkerStatisticsEntity> {
-  //
-  //    WorkerStatsReader(final RdbmsReaderConfig readerConfig) {
-  //      super(JobWorkerStatisticsColumn.values(), readerConfig);
-  //    }
-  //  }
+  /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */
+  private static final class WorkerStatsReader
+      extends AbstractEntityReader<JobWorkerStatisticsEntity> {
+
+    WorkerStatsReader(final RdbmsReaderConfig readerConfig) {
+      super(JobWorkerStatisticsColumn.values(), readerConfig);
+    }
+  }
 
   private static final class EmptyResults {
     private static final SearchQueryResult<JobTypeStatisticsEntity> JOB_TYPE_STATISTICS =

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMetricsBatchMapper.java
@@ -11,6 +11,8 @@ import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbQuery;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery;
+import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbResult;
 import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import java.util.List;
@@ -22,6 +24,8 @@ public interface JobMetricsBatchMapper {
   GlobalJobStatisticsDbResult globalJobStatistics(GlobalJobStatisticsDbQuery query);
 
   List<JobTypeStatisticsDbResult> jobTypeStatistics(JobTypeStatisticsDbQuery query);
+
+  List<JobWorkerStatisticsDbResult> jobWorkerStatistics(JobWorkerStatisticsDbQuery query);
 
   int cleanupMetrics(CleanupHistoryDto dto);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobWorkerStatisticsColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobWorkerStatisticsColumn.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
+
+public enum JobWorkerStatisticsColumn implements SearchColumn<JobWorkerStatisticsEntity> {
+  WORKER("worker");
+
+  private final String property;
+
+  JobWorkerStatisticsColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<JobWorkerStatisticsEntity> getEntityClass() {
+    return JobWorkerStatisticsEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -121,6 +121,61 @@
     </if>
   </sql>
 
+  <resultMap id="JobWorkerStatisticsResultMap"
+    type="io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbResult">
+    <constructor>
+      <arg column="WORKER" javaType="java.lang.String"/>
+      <arg column="CREATED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_CREATED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="COMPLETED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_COMPLETED_AT" javaType="java.time.OffsetDateTime"/>
+      <arg column="FAILED_COUNT" javaType="java.lang.Long"/>
+      <arg column="LAST_FAILED_AT" javaType="java.time.OffsetDateTime"/>
+    </constructor>
+  </resultMap>
+
+  <select id="jobWorkerStatistics"
+    parameterType="io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbQuery"
+    resultMap="JobWorkerStatisticsResultMap"
+    statementType="PREPARED">
+    SELECT
+      WORKER,
+      SUM(CREATED_COUNT) AS CREATED_COUNT,
+      MAX(LAST_CREATED_AT) AS LAST_CREATED_AT,
+      SUM(COMPLETED_COUNT) AS COMPLETED_COUNT,
+      MAX(LAST_COMPLETED_AT) AS LAST_COMPLETED_AT,
+      SUM(FAILED_COUNT) AS FAILED_COUNT,
+      MAX(LAST_FAILED_AT) AS LAST_FAILED_AT
+    FROM ${prefix}JOB_METRICS_BATCH
+    <trim prefix="WHERE" prefixOverrides="AND">
+      <include refid="io.camunda.db.rdbms.sql.JobMetricsBatchMapper.jobWorkerStatisticsFilter"/>
+      <trim prefix="AND" prefixOverrides="WHERE">
+        <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+      </trim>
+    </trim>
+    GROUP BY WORKER
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="jobWorkerStatisticsFilter">
+    <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+        #{tenantId}
+      </foreach>
+    </if>
+    <if test="filter.from != null">
+      AND START_TIME &gt;= #{filter.from}
+    </if>
+    <if test="filter.to != null">
+      AND END_TIME &lt;= #{filter.to}
+    </if>
+    <if test="filter.jobType != null">
+      AND JOB_TYPE = #{filter.jobType}
+    </if>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">
     INSERT INTO ${prefix}JOB_METRICS_BATCH (JOB_METRICS_BATCH_KEY,
                                             PARTITION_ID,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -15,9 +15,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.GlobalJobStatisticsDbResult;
 import io.camunda.db.rdbms.read.domain.JobTypeStatisticsDbResult;
+import io.camunda.db.rdbms.read.domain.JobWorkerStatisticsDbResult;
 import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
@@ -386,5 +388,301 @@ class JobMetricsBatchDbReaderTest {
 
     // then
     assertThat(result.items().getFirst().jobType()).isEqualTo(longJobTypeName);
+  }
+
+  // ===========================================================================
+  // Job Worker Statistics Tests
+  // ===========================================================================
+
+  @Test
+  void shouldReturnEmptyJobWorkerStatisticsWhenTenantCheckEnabledButNoTenants() {
+    // given
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.from(OffsetDateTime.now())
+                            .to(OffsetDateTime.now())
+                            .jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of()));
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+    verifyNoInteractions(jobMetricsBatchMapper);
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsFromMapper() {
+    // given
+    final var lastCreatedAt1 = OffsetDateTime.now().minusHours(1);
+    final var lastCompletedAt1 = OffsetDateTime.now().minusHours(2);
+    final var lastFailedAt1 = OffsetDateTime.now().minusHours(3);
+    final var lastCreatedAt2 = OffsetDateTime.now().minusHours(4);
+    final var lastCompletedAt2 = OffsetDateTime.now().minusHours(5);
+    final var lastFailedAt2 = OffsetDateTime.now().minusHours(6);
+
+    final var dbResult1 =
+        new JobWorkerStatisticsDbResult(
+            "worker-1", 100L, lastCreatedAt1, 80L, lastCompletedAt1, 5L, lastFailedAt1);
+    final var dbResult2 =
+        new JobWorkerStatisticsDbResult(
+            "worker-2", 50L, lastCreatedAt2, 40L, lastCompletedAt2, 2L, lastFailedAt2);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any()))
+        .thenReturn(List.of(dbResult1, dbResult2));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.from(OffsetDateTime.now())
+                            .to(OffsetDateTime.now())
+                            .jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+
+    final var item1 = result.items().get(0);
+    assertThat(item1.worker()).isEqualTo("worker-1");
+    assertThat(item1.created().count()).isEqualTo(100L);
+    assertThat(item1.created().lastUpdatedAt()).isEqualTo(lastCreatedAt1);
+    assertThat(item1.completed().count()).isEqualTo(80L);
+    assertThat(item1.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt1);
+    assertThat(item1.failed().count()).isEqualTo(5L);
+    assertThat(item1.failed().lastUpdatedAt()).isEqualTo(lastFailedAt1);
+
+    final var item2 = result.items().get(1);
+    assertThat(item2.worker()).isEqualTo("worker-2");
+    assertThat(item2.created().count()).isEqualTo(50L);
+    assertThat(item2.created().lastUpdatedAt()).isEqualTo(lastCreatedAt2);
+    assertThat(item2.completed().count()).isEqualTo(40L);
+    assertThat(item2.completed().lastUpdatedAt()).isEqualTo(lastCompletedAt2);
+    assertThat(item2.failed().count()).isEqualTo(2L);
+    assertThat(item2.failed().lastUpdatedAt()).isEqualTo(lastFailedAt2);
+  }
+
+  @Test
+  void shouldReturnEmptyJobWorkerStatisticsWhenCountIsZero() {
+    // given - mapper returns null (no data for this query)
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.from(OffsetDateTime.now())
+                            .to(OffsetDateTime.now())
+                            .jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullCountsInJobWorkerStatisticsDbResult() {
+    // given
+    final var dbResult =
+        new JobWorkerStatisticsDbResult("worker-1", null, null, null, null, null, null);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.from(OffsetDateTime.now())
+                            .to(OffsetDateTime.now())
+                            .jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).hasSize(1);
+
+    final var item = result.items().getFirst();
+    assertThat(item.worker()).isEqualTo("worker-1");
+    assertThat(item.created().count()).isZero();
+    assertThat(item.created().lastUpdatedAt()).isNull();
+    assertThat(item.completed().count()).isZero();
+    assertThat(item.completed().lastUpdatedAt()).isNull();
+    assertThat(item.failed().count()).isZero();
+    assertThat(item.failed().lastUpdatedAt()).isNull();
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsWithMultipleWorkers() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult1 = new JobWorkerStatisticsDbResult("worker-a", 100L, now, 90L, now, 5L, now);
+    final var dbResult2 = new JobWorkerStatisticsDbResult("worker-b", 50L, now, 45L, now, 2L, now);
+    final var dbResult3 = new JobWorkerStatisticsDbResult("worker-c", 25L, now, 20L, now, 1L, now);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any()))
+        .thenReturn(List.of(dbResult1, dbResult2, dbResult3));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isEqualTo(3L);
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items())
+        .extracting("worker")
+        .containsExactly("worker-a", "worker-b", "worker-c");
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsWithZeroFailedCount() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult =
+        new JobWorkerStatisticsDbResult("reliable-worker", 10L, now, 10L, now, 0L, now);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().worker()).isEqualTo("reliable-worker");
+    assertThat(result.items().getFirst().failed().count()).isZero();
+    assertThat(result.items().getFirst().completed().count()).isEqualTo(10L);
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsWithHighVolumeMetrics() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var dbResult =
+        new JobWorkerStatisticsDbResult(
+            "high-volume-worker", 1_000_000L, now, 950_000L, now, 50_000L, now);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(7)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().worker()).isEqualTo("high-volume-worker");
+    assertThat(result.items().getFirst().created().count()).isEqualTo(1_000_000L);
+    assertThat(result.items().getFirst().completed().count()).isEqualTo(950_000L);
+    assertThat(result.items().getFirst().failed().count()).isEqualTo(50_000L);
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsWithMixedTimestamps() {
+    // given
+    final var oldTimestamp = OffsetDateTime.now().minusDays(30);
+    final var recentTimestamp = OffsetDateTime.now().minusHours(1);
+
+    final var dbResult =
+        new JobWorkerStatisticsDbResult(
+            "worker-1", 100L, oldTimestamp, 80L, recentTimestamp, 5L, oldTimestamp);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b -> b.filter(f -> f.from(oldTimestamp).to(OffsetDateTime.now()).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    final var item = result.items().getFirst();
+    assertThat(item.created().lastUpdatedAt()).isEqualTo(oldTimestamp);
+    assertThat(item.completed().lastUpdatedAt()).isEqualTo(recentTimestamp);
+    assertThat(item.failed().lastUpdatedAt()).isEqualTo(oldTimestamp);
+  }
+
+  @Test
+  void shouldReturnEmptyJobWorkerStatisticsListWhenMapperReturnsEmptyList() {
+    // given
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of());
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b ->
+                b.filter(
+                    f ->
+                        f.from(OffsetDateTime.now())
+                            .to(OffsetDateTime.now())
+                            .jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.total()).isZero();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnJobWorkerStatisticsForLongWorkerNames() {
+    // given
+    final var now = OffsetDateTime.now();
+    final var longWorkerName =
+        "io.camunda.example.very.long.package.name.with.multiple.segments.MyVeryLongWorkerName";
+    final var dbResult =
+        new JobWorkerStatisticsDbResult(longWorkerName, 10L, now, 9L, now, 1L, now);
+
+    when(jobMetricsBatchMapper.jobWorkerStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var query =
+        JobWorkerStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobWorkerStatistics(query, resourceAccessChecks);
+
+    // then
+    assertThat(result.items().getFirst().worker()).isEqualTo(longWorkerName);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalJobStatisticsIT.java
@@ -29,13 +29,9 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "AWS_OS") // test is flaky on AWS OS
 public class GlobalJobStatisticsIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTypeStatisticsIT.java
@@ -30,13 +30,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "AWS_OS") // test is flaky on AWS OS
 public class JobTypeStatisticsIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobMetricsBatchFixtures.java
@@ -8,10 +8,14 @@
 package io.camunda.it.rdbms.db.fixtures;
 
 import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel;
 import io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel.Builder;
+import io.camunda.search.entities.GlobalJobStatisticsEntity;
+import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -71,5 +75,180 @@ public final class JobMetricsBatchFixtures extends CommonFixtures {
       rdbmsWriters.getJobMetricsBatchWriter().create(metric);
     }
     rdbmsWriters.flush();
+  }
+
+  /**
+   * Asserts that a {@link JobWorkerStatisticsEntity} exactly matches the counts and timestamps of a
+   * single {@link JobMetricsBatchDbModel}.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC to handle databases (e.g.
+   * MySQL/MariaDB) that return timestamps in local timezone.
+   */
+  public static void assertWorkerStats(
+      final JobWorkerStatisticsEntity stats, final JobMetricsBatchDbModel metric) {
+    assertThat(stats.created().count()).isEqualTo(metric.createdCount());
+    assertThat(stats.created().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCreatedAt()));
+    assertThat(stats.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCompletedAt()));
+    assertThat(stats.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastFailedAt()));
+  }
+
+  /**
+   * Asserts that a {@link JobWorkerStatisticsEntity} matches the aggregated result of a list of
+   * {@link JobMetricsBatchDbModel}: counts are summed, timestamps are the MAX across all models.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC.
+   */
+  public static void assertWorkerStats(
+      final JobWorkerStatisticsEntity stats, final List<JobMetricsBatchDbModel> metrics) {
+    assertThat(stats.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(stats.created().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCreatedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(stats.completed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCompletedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    assertThat(stats.failed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastFailedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+  }
+
+  /**
+   * Asserts that a {@link JobTypeStatisticsEntity} exactly matches the counts, timestamps and
+   * worker count of a single {@link JobMetricsBatchDbModel} (worker count is always 1 for a single
+   * model).
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC to handle databases (e.g.
+   * MySQL/MariaDB) that return timestamps in local timezone.
+   */
+  public static void assertJobTypeStats(
+      final JobTypeStatisticsEntity stats, final JobMetricsBatchDbModel metric) {
+    assertThat(stats.created().count()).isEqualTo(metric.createdCount());
+    assertThat(stats.created().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCreatedAt()));
+    assertThat(stats.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCompletedAt()));
+    assertThat(stats.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastFailedAt()));
+    assertThat(stats.workers()).isEqualTo(1);
+  }
+
+  /**
+   * Asserts that a {@link JobTypeStatisticsEntity} matches the aggregated result of a list of
+   * {@link JobMetricsBatchDbModel}: counts are summed, timestamps are the MAX, workers is the
+   * number of distinct worker names across the list.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC.
+   */
+  public static void assertJobTypeStats(
+      final JobTypeStatisticsEntity stats, final List<JobMetricsBatchDbModel> metrics) {
+    assertThat(stats.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(stats.created().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCreatedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(stats.completed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCompletedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    assertThat(stats.failed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastFailedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.workers())
+        .isEqualTo((int) metrics.stream().map(JobMetricsBatchDbModel::worker).distinct().count());
+  }
+
+  /**
+   * Asserts that a {@link GlobalJobStatisticsEntity} exactly matches the counts, timestamps and
+   * incompleteness of a single {@link JobMetricsBatchDbModel}.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC to handle databases (e.g.
+   * MySQL/MariaDB) that return timestamps in local timezone.
+   */
+  public static void assertGlobalStats(
+      final GlobalJobStatisticsEntity stats, final JobMetricsBatchDbModel metric) {
+    assertThat(stats.created().count()).isEqualTo(metric.createdCount());
+    assertThat(stats.created().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCreatedAt()));
+    assertThat(stats.completed().count()).isEqualTo(metric.completedCount());
+    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastCompletedAt()));
+    assertThat(stats.failed().count()).isEqualTo(metric.failedCount());
+    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(toUtc(metric.lastFailedAt()));
+    assertThat(stats.isIncomplete()).isEqualTo(metric.incompleteBatch());
+  }
+
+  /**
+   * Asserts that a {@link GlobalJobStatisticsEntity} matches the aggregated result of a list of
+   * {@link JobMetricsBatchDbModel}: counts are summed, timestamps are the MAX, and isIncomplete is
+   * true if any model in the list has incompleteBatch set.
+   *
+   * <p>Timestamps are compared after normalizing both sides to UTC.
+   */
+  public static void assertGlobalStats(
+      final GlobalJobStatisticsEntity stats, final List<JobMetricsBatchDbModel> metrics) {
+    assertThat(stats.created().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    assertThat(stats.created().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCreatedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.completed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
+    assertThat(stats.completed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastCompletedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.failed().count())
+        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    assertThat(stats.failed().lastUpdatedAt())
+        .isEqualTo(
+            metrics.stream()
+                .map(JobMetricsBatchDbModel::lastFailedAt)
+                .max(OffsetDateTime::compareTo)
+                .map(JobMetricsBatchFixtures::toUtc)
+                .orElseThrow());
+    assertThat(stats.isIncomplete())
+        .isEqualTo(metrics.stream().anyMatch(JobMetricsBatchDbModel::incompleteBatch));
+  }
+
+  private static OffsetDateTime toUtc(final OffsetDateTime timestamp) {
+    return timestamp == null ? null : timestamp.withOffsetSameInstant(UTC);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/jobmetrics/JobMetricsBatchIT.java
@@ -24,9 +24,11 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity.StatusMetric;
 import io.camunda.search.entities.JobTypeStatisticsEntity;
+import io.camunda.search.entities.JobWorkerStatisticsEntity;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
 import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.JobWorkerStatisticsQuery;
 import io.camunda.security.reader.AuthorizationCheck;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.security.reader.TenantCheck;
@@ -61,19 +63,6 @@ public class JobMetricsBatchIT {
    */
   private OffsetDateTime toUtc(final OffsetDateTime timestamp) {
     return timestamp == null ? null : timestamp.withOffsetSameInstant(UTC);
-  }
-
-  /**
-   * Normalizes a JobTypeStatisticsEntity to have all timestamps in UTC for comparison across
-   * different database types.
-   */
-  private JobTypeStatisticsEntity normalizeToUtc(final JobTypeStatisticsEntity entity) {
-    return new JobTypeStatisticsEntity(
-        entity.jobType(),
-        new StatusMetric(entity.created().count(), toUtc(entity.created().lastUpdatedAt())),
-        new StatusMetric(entity.completed().count(), toUtc(entity.completed().lastUpdatedAt())),
-        new StatusMetric(entity.failed().count(), toUtc(entity.failed().lastUpdatedAt())),
-        entity.workers());
   }
 
   private OffsetDateTime getMinStartTime(final List<JobMetricsBatchDbModel> metrics) {
@@ -128,31 +117,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - verify aggregation of both metrics
-    assertThat(actual.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
-    assertThat(toUtc(actual.created().lastUpdatedAt()))
-        .isEqualTo(
-            metrics.stream()
-                .map(JobMetricsBatchDbModel::lastCreatedAt)
-                .max(OffsetDateTime::compareTo)
-                .orElseThrow());
-    assertThat(actual.completed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
-    assertThat(toUtc(actual.completed().lastUpdatedAt()))
-        .isEqualTo(
-            metrics.stream()
-                .map(JobMetricsBatchDbModel::lastCompletedAt)
-                .max(OffsetDateTime::compareTo)
-                .orElseThrow());
-    assertThat(actual.failed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
-    assertThat(toUtc(actual.failed().lastUpdatedAt()))
-        .isEqualTo(
-            metrics.stream()
-                .map(JobMetricsBatchDbModel::lastFailedAt)
-                .max(OffsetDateTime::compareTo)
-                .orElseThrow());
-    assertThat(actual.isIncomplete()).isFalse();
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -177,12 +142,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - verify aggregation across tenants
-    assertThat(actual.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
-    assertThat(actual.completed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
-    assertThat(actual.failed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -207,12 +167,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - verify aggregation across job types
-    assertThat(actual.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
-    assertThat(actual.completed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
-    assertThat(actual.failed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -239,12 +194,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - verify aggregation across workers
-    assertThat(actual.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
-    assertThat(actual.completed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
-    assertThat(actual.failed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -275,12 +225,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - only middle batch data
-    assertThat(actual.created().count()).isEqualTo(metricMiddle.createdCount());
-    assertThat(actual.completed().count()).isEqualTo(metricMiddle.completedCount());
-    assertThat(actual.failed().count()).isEqualTo(metricMiddle.failedCount());
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metricMiddle.lastCreatedAt());
-    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metricMiddle.lastCompletedAt());
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metricMiddle.lastFailedAt());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metricMiddle);
   }
 
   @TestTemplate
@@ -308,13 +253,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - only JOB_TYPE_A data
-    assertThat(actual.created().count()).isEqualTo(metricJobTypeA.createdCount());
-    assertThat(actual.completed().count()).isEqualTo(metricJobTypeA.completedCount());
-    assertThat(actual.failed().count()).isEqualTo(metricJobTypeA.failedCount());
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metricJobTypeA.lastCreatedAt());
-    assertThat(toUtc(actual.completed().lastUpdatedAt()))
-        .isEqualTo(metricJobTypeA.lastCompletedAt());
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metricJobTypeA.lastFailedAt());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metricJobTypeA);
   }
 
   @TestTemplate
@@ -338,25 +277,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then - should return max timestamps
-    final var expectedMaxCreatedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastCreatedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-    final var expectedMaxCompletedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastCompletedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-    final var expectedMaxFailedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastFailedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(expectedMaxCreatedAt);
-    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(expectedMaxCompletedAt);
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(expectedMaxFailedAt);
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -450,9 +371,7 @@ public class JobMetricsBatchIT {
                 AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT1))));
 
     // then - only TENANT1 data
-    assertThat(actual.created().count()).isEqualTo(metricTenant1.createdCount());
-    assertThat(actual.completed().count()).isEqualTo(metricTenant1.completedCount());
-    assertThat(actual.failed().count()).isEqualTo(metricTenant1.failedCount());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metricTenant1);
   }
 
   @TestTemplate
@@ -537,9 +456,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
-    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
-    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
   @TestTemplate
@@ -561,13 +478,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metric.lastCreatedAt());
-    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
-    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metric.lastCompletedAt());
-    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metric.lastFailedAt());
-    assertThat(actual.isIncomplete()).isEqualTo(metric.incompleteBatch());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
   @TestTemplate
@@ -613,8 +524,7 @@ public class JobMetricsBatchIT {
                             f.from(getMinStartTime(metrics).minusMinutes(1))
                                 .to(getMaxEndTime(metrics).plusMinutes(1)))),
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
-    assertThat(actual.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metrics);
   }
 
   @TestTemplate
@@ -635,13 +545,7 @@ public class JobMetricsBatchIT {
             ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
 
     // then
-    assertThat(actual.isIncomplete()).isTrue();
-    assertThat(actual.created().count()).isEqualTo(metric.createdCount());
-    assertThat(toUtc(actual.created().lastUpdatedAt())).isEqualTo(metric.lastCreatedAt());
-    assertThat(actual.completed().count()).isEqualTo(metric.completedCount());
-    assertThat(toUtc(actual.completed().lastUpdatedAt())).isEqualTo(metric.lastCompletedAt());
-    assertThat(actual.failed().count()).isEqualTo(metric.failedCount());
-    assertThat(toUtc(actual.failed().lastUpdatedAt())).isEqualTo(metric.lastFailedAt());
+    JobMetricsBatchFixtures.assertGlobalStats(actual, metric);
   }
 
   @TestTemplate
@@ -820,25 +724,8 @@ public class JobMetricsBatchIT {
     assertThat(actual.items().get(0).jobType()).isEqualTo(JOB_TYPE_A);
     assertThat(actual.items().get(1).jobType()).isEqualTo(JOB_TYPE_B);
 
-    final var jobTypeA = normalizeToUtc(actual.items().get(0));
-    assertThat(jobTypeA.jobType()).isEqualTo(JOB_TYPE_A);
-    assertThat(jobTypeA.created().count()).isEqualTo(metricJobTypeA.createdCount());
-    assertThat(jobTypeA.created().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastCreatedAt());
-    assertThat(jobTypeA.completed().count()).isEqualTo(metricJobTypeA.completedCount());
-    assertThat(jobTypeA.completed().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastCompletedAt());
-    assertThat(jobTypeA.failed().count()).isEqualTo(metricJobTypeA.failedCount());
-    assertThat(jobTypeA.failed().lastUpdatedAt()).isEqualTo(metricJobTypeA.lastFailedAt());
-    assertThat(jobTypeA.workers()).isEqualTo(1);
-
-    final var jobTypeB = normalizeToUtc(actual.items().get(1));
-    assertThat(jobTypeB.jobType()).isEqualTo(JOB_TYPE_B);
-    assertThat(jobTypeB.created().count()).isEqualTo(metricJobTypeB.createdCount());
-    assertThat(jobTypeB.created().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastCreatedAt());
-    assertThat(jobTypeB.completed().count()).isEqualTo(metricJobTypeB.completedCount());
-    assertThat(jobTypeB.completed().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastCompletedAt());
-    assertThat(jobTypeB.failed().count()).isEqualTo(metricJobTypeB.failedCount());
-    assertThat(jobTypeB.failed().lastUpdatedAt()).isEqualTo(metricJobTypeB.lastFailedAt());
-    assertThat(jobTypeB.workers()).isEqualTo(1);
+    JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(0), metricJobTypeA);
+    JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(1), metricJobTypeB);
   }
 
   @TestTemplate
@@ -867,37 +754,8 @@ public class JobMetricsBatchIT {
     // then - aggregated across both batches
     assertThat(actual.total()).isEqualTo(1);
     assertThat(actual.items()).hasSize(1);
-
-    final var stats = normalizeToUtc(actual.items().get(0));
-    assertThat(stats.jobType()).isEqualTo(JOB_TYPE_A);
-    assertThat(stats.created().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::createdCount).sum());
-    assertThat(stats.completed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::completedCount).sum());
-    assertThat(stats.failed().count())
-        .isEqualTo(metrics.stream().mapToLong(JobMetricsBatchDbModel::failedCount).sum());
-
-    final var expectedLastCreatedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastCreatedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-    final var expectedLastCompletedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastCompletedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-    final var expectedLastFailedAt =
-        metrics.stream()
-            .map(JobMetricsBatchDbModel::lastFailedAt)
-            .max(OffsetDateTime::compareTo)
-            .orElseThrow();
-
-    assertThat(stats.created().lastUpdatedAt()).isEqualTo(expectedLastCreatedAt);
-    assertThat(stats.completed().lastUpdatedAt()).isEqualTo(expectedLastCompletedAt);
-    assertThat(stats.failed().lastUpdatedAt()).isEqualTo(expectedLastFailedAt);
-    final var workersNb = metrics.stream().map(JobMetricsBatchDbModel::worker).distinct().count();
-    assertThat(stats.workers()).isEqualTo(workersNb);
+    assertThat(actual.items().get(0).jobType()).isEqualTo(JOB_TYPE_A);
+    JobMetricsBatchFixtures.assertJobTypeStats(actual.items().get(0), metrics);
   }
 
   @TestTemplate
@@ -990,17 +848,7 @@ public class JobMetricsBatchIT {
     // then - only JOB_TYPE_A
     assertThat(actual.items()).hasSize(1);
     assertThat(actual.items().getFirst().jobType()).isEqualTo(JOB_TYPE_A);
-    assertThat(actual.items().getFirst().created().count())
-        .isEqualTo(metricJobTypeA.createdCount());
-    assertThat(actual.items().getFirst().completed().count())
-        .isEqualTo(metricJobTypeA.completedCount());
-    assertThat(actual.items().getFirst().failed().count()).isEqualTo(metricJobTypeA.failedCount());
-    assertThat(toUtc(actual.items().getFirst().completed().lastUpdatedAt()))
-        .isEqualTo(metricJobTypeA.lastCompletedAt());
-    assertThat(toUtc(actual.items().getFirst().created().lastUpdatedAt()))
-        .isEqualTo(metricJobTypeA.lastCreatedAt());
-    assertThat(toUtc(actual.items().getFirst().failed().lastUpdatedAt()))
-        .isEqualTo(metricJobTypeA.lastFailedAt());
+    JobMetricsBatchFixtures.assertJobTypeStats(actual.items().getFirst(), metricJobTypeA);
   }
 
   @TestTemplate
@@ -1071,5 +919,324 @@ public class JobMetricsBatchIT {
     assertThat(actual.items()).hasSize(2);
     final var jobTypes = actual.items().stream().map(JobTypeStatisticsEntity::jobType).toList();
     assertThat(jobTypes).containsExactly(JOB_TYPE_A, JOB_TYPE_B);
+  }
+
+  // ==========================================================================
+  // Job Worker Statistics Tests
+  // ==========================================================================
+
+  @TestTemplate
+  public void shouldAggregateJobStatisticsByWorker() {
+    // given
+    final var metricWorker1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricWorker2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_2));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricWorker1, metricWorker2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.total()).isEqualTo(2);
+    assertThat(actual.items()).hasSize(2);
+
+    // Results are ordered by WORKER ASC from SQL
+    final var workers = actual.items().stream().map(JobWorkerStatisticsEntity::worker).toList();
+    assertThat(workers).containsExactly(WORKER_1, WORKER_2);
+
+    JobMetricsBatchFixtures.assertWorkerStats(
+        actual.items().stream().filter(e -> WORKER_1.equals(e.worker())).findFirst().orElseThrow(),
+        metricWorker1);
+
+    JobMetricsBatchFixtures.assertWorkerStats(
+        actual.items().stream().filter(e -> WORKER_2.equals(e.worker())).findFirst().orElseThrow(),
+        metricWorker2);
+  }
+
+  @TestTemplate
+  public void shouldAggregateWorkerStatsAcrossMultipleBatches() {
+    // given - multiple batches for same worker
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metric3 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2, metric3);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - all batches aggregated into one worker entry
+    assertThat(actual.total()).isEqualTo(1);
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_1);
+    JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
+  }
+
+  @TestTemplate
+  public void shouldFilterWorkerStatsByJobType() {
+    // given - workers for different job types
+    final var metricWorkerA =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricWorkerB =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_B).worker(WORKER_2));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricWorkerA, metricWorkerB);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter by JOB_TYPE_A only
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only WORKER_1 (from JOB_TYPE_A)
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_1);
+    JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricWorkerA);
+  }
+
+  @TestTemplate
+  public void shouldFilterWorkerStatsByTimeRange() {
+    // given
+    final var metricOld =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.jobType(JOB_TYPE_A)
+                    .worker(WORKER_1)
+                    .startTime(NOW.minusMinutes(30))
+                    .endTime(NOW.minusMinutes(20)));
+
+    final var metricRecent =
+        JobMetricsBatchFixtures.createRandomized(
+            b ->
+                b.jobType(JOB_TYPE_A)
+                    .worker(WORKER_2)
+                    .startTime(NOW.minusMinutes(10))
+                    .endTime(NOW));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricOld, metricRecent);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - filter to only get the recent batch
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metricRecent.startTime().minusSeconds(1))
+                                .to(metricRecent.endTime().plusSeconds(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - only WORKER_2 (recent batch)
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_2);
+  }
+
+  @TestTemplate
+  public void shouldFilterWorkerStatsByAuthorizedTenants() {
+    // given
+    final var metricTenant1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricTenant2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT2).jobType(JOB_TYPE_A).worker(WORKER_2));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricTenant1, metricTenant2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - only authorize TENANT1
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of(TENANT1))));
+
+    // then - only WORKER_1 (TENANT1)
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_1);
+    JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metricTenant1);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyWorkerStatsWhenNoMetricsMatchFilter() {
+    // given
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when - query for a different time range
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(NOW.plusMinutes(1))
+                                .to(NOW.plusMinutes(10))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.items()).isEmpty();
+    assertThat(actual.total()).isZero();
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyWorkerStatsWhenJobTypeDoesNotMatch() {
+    // given
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when - query for a different job type
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1))
+                                .jobType(JOB_TYPE_B))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then
+    assertThat(actual.items()).isEmpty();
+    assertThat(actual.total()).isZero();
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyWorkerStatsWhenNoAuthorizedTenants() {
+    // given
+    final var metric =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+    JobMetricsBatchFixtures.createAndSaveMetric(rdbmsWriters, metric);
+
+    // when - authorize no tenants
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(metric.startTime().minusMinutes(1))
+                                .to(metric.endTime().plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of())));
+
+    // then
+    assertThat(actual.items()).isEmpty();
+    assertThat(actual.total()).isZero();
+  }
+
+  @TestTemplate
+  public void shouldReturnMaxLastUpdatedAtForWorkerStats() {
+    // given - multiple batches for the same worker
+    final var metric1 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metric2 =
+        JobMetricsBatchFixtures.createRandomized(b -> b.jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metric1, metric2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - should return max timestamps across both batches
+    assertThat(actual.items()).hasSize(1);
+    JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
+  }
+
+  @TestTemplate
+  public void shouldAggregateWorkerStatsAcrossMultipleTenants() {
+    // given - same worker, same job type, different tenants
+    final var metricTenant1 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT1).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final var metricTenant2 =
+        JobMetricsBatchFixtures.createRandomized(
+            b -> b.tenantId(TENANT2).jobType(JOB_TYPE_A).worker(WORKER_1));
+
+    final List<JobMetricsBatchDbModel> metrics = List.of(metricTenant1, metricTenant2);
+    JobMetricsBatchFixtures.createAndSaveMetrics(rdbmsWriters, metrics);
+
+    // when - both tenants authorized
+    final var actual =
+        jobMetricsBatchReader.getJobWorkerStatistics(
+            JobWorkerStatisticsQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.from(getMinStartTime(metrics).minusMinutes(1))
+                                .to(getMaxEndTime(metrics).plusMinutes(1))
+                                .jobType(JOB_TYPE_A))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    // then - WORKER_1 with combined counts from both tenants
+    assertThat(actual.items()).hasSize(1);
+    assertThat(actual.items().getFirst().worker()).isEqualTo(WORKER_1);
+    JobMetricsBatchFixtures.assertWorkerStats(actual.items().getFirst(), metrics);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GlobalJobStatisticsTenancyIT.java
@@ -29,10 +29,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class GlobalJobStatisticsTenancyIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTypeStatisticsTenancyIT.java
@@ -30,10 +30,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class JobTypeStatisticsTenancyIT {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobWorkerStatisticsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobWorkerStatisticsSort.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobWorkerStatisticsSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobWorkerStatisticsSort of(
+      final Function<JobWorkerStatisticsSort.Builder, ObjectBuilder<JobWorkerStatisticsSort>> fn) {
+    return SortOptionBuilders.jobWorkerStatistics(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<JobWorkerStatisticsSort.Builder>
+      implements ObjectBuilder<JobWorkerStatisticsSort> {
+
+    public Builder worker() {
+      currentOrdering = new FieldSorting("worker", null);
+      return this;
+    }
+
+    @Override
+    protected JobWorkerStatisticsSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobWorkerStatisticsSort build() {
+      return new JobWorkerStatisticsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -281,6 +281,15 @@ public final class SortOptionBuilders {
     return fn.apply(jobTypeStatistics()).build();
   }
 
+  public static JobWorkerStatisticsSort.Builder jobWorkerStatistics() {
+    return new JobWorkerStatisticsSort.Builder();
+  }
+
+  public static JobWorkerStatisticsSort jobWorkerStatistics(
+      final Function<JobWorkerStatisticsSort.Builder, ObjectBuilder<JobWorkerStatisticsSort>> fn) {
+    return fn.apply(jobWorkerStatistics()).build();
+  }
+
   public static CorrelatedMessageSubscriptionSort.Builder correlatedMessageSubscription() {
     return new CorrelatedMessageSubscriptionSort.Builder();
   }


### PR DESCRIPTION
## Description

This pull request introduces support for querying job worker statistics in the RDBMS batch metrics reader. The main changes add a new query and result type for job worker statistics, implement the necessary SQL mapping and result handling, and integrate these into the existing reader and mapper infrastructure.

**Support for job worker statistics queries:**

* Added new domain classes `JobWorkerStatisticsDbQuery` and `JobWorkerStatisticsDbResult` to represent queries and results for job worker statistics. [[1]](diffhunk://#diff-bb49823f195b5d5df8e2324298dfa1560133a66e3b825b2346547c666e9ad4e9R1-R72) [[2]](diffhunk://#diff-f456560add3ac482558dbc81df5f4e34d61059e75ec51a833ce7766c0c250317R1-R19)
* Introduced the `JobWorkerStatisticsColumn` enum for column mapping of job worker statistics entities.

**Integration into RDBMS reader and mapper:**

* Updated `JobMetricsBatchDbReader` to support `getJobWorkerStatistics`, including a dedicated inner reader and empty result handling for worker statistics queries. [[1]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R15-R30) [[2]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R47-R59) [[3]](diffhunk://#diff-77716966edb78e772fd6b5efb409e2dd7ecb9218d95b75f920835b3299700289R126-R179)
* Extended `JobMetricsBatchMapper` interface and its MyBatis XML mapping to support job worker statistics queries, including SQL result mapping and filtering logic. [[1]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R14-R15) [[2]](diffhunk://#diff-a4e0dee68facb952762b30e1eb6bd11a7fc75b15810b75258e90acd22a09f012R28-R29) [[3]](diffhunk://#diff-76bcc9d46c6f7e8b18ff6be8b66f8d6fed24f524445f0c27077b2d93ec2679a8R124-R178)

**Test support:**

* Updated test imports to include new job worker statistics query/result types.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43063
