### PR TITLE
Element instance search incident API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/.gitignore
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /test-results/
 /jsonReports/
+/json-report/
 /playwright-report/
 /html-report/
 /playwright/.cache/

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callErrorProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callErrorProcess.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="42a5e63" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="callProcessWithAnError" name="Call Process With Error" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a3emhl" sourceRef="StartEvent_1" targetRef="Activity_1uxd8yb" />
+    <bpmn:endEvent id="Event_0gfc9mn">
+      <bpmn:incoming>Flow_1l13cvl</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1l13cvl" sourceRef="Activity_1uxd8yb" targetRef="Event_0gfc9mn" />
+    <bpmn:callActivity id="Activity_1uxd8yb" name="Call Activity with error">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=assert(bar, bar != null)" target="whof" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="calledErrorProcess" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1l13cvl</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="callProcessWithAnError">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gfc9mn_di" bpmnElement="Event_0gfc9mn">
+        <dc:Bounds x="492" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hersz0_di" bpmnElement="Activity_1uxd8yb">
+        <dc:Bounds x="310" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="310" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l13cvl_di" bpmnElement="Flow_1l13cvl">
+        <di:waypoint x="410" y="117" />
+        <di:waypoint x="492" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/calledErrorProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/calledErrorProcess.bpmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="9ee7886" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:process id="calledErrorProcess" name="calledErrorProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_08ekq79</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_01dkgxo" name="IO Mapping Failing task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="meow" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=assert(foo, foo != null)" target="meow" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0va2p2y</bpmn:incoming>
+      <bpmn:outgoing>Flow_01l3eeq</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_08ekq79" sourceRef="StartEvent_1" targetRef="Gateway_0wcfjtw" />
+    <bpmn:parallelGateway id="Gateway_0wcfjtw">
+      <bpmn:incoming>Flow_08ekq79</bpmn:incoming>
+      <bpmn:outgoing>Flow_0va2p2y</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1k693y6</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0va2p2y" sourceRef="Gateway_0wcfjtw" targetRef="Activity_01dkgxo" />
+    <bpmn:sequenceFlow id="Flow_1k693y6" sourceRef="Gateway_0wcfjtw" targetRef="Activity_0zud03c" />
+    <bpmn:sequenceFlow id="Flow_01l3eeq" sourceRef="Activity_01dkgxo" targetRef="Gateway_0h5q0a5" />
+    <bpmn:parallelGateway id="Gateway_0h5q0a5">
+      <bpmn:incoming>Flow_01l3eeq</bpmn:incoming>
+      <bpmn:incoming>Flow_1c7g3fg</bpmn:incoming>
+      <bpmn:outgoing>Flow_084yr2u</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1c7g3fg" sourceRef="Activity_0zud03c" targetRef="Gateway_0h5q0a5" />
+    <bpmn:endEvent id="Event_0dswctz">
+      <bpmn:incoming>Flow_084yr2u</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_084yr2u" sourceRef="Gateway_0h5q0a5" targetRef="Event_0dswctz" />
+    <bpmn:serviceTask id="Activity_0zud03c" name="Job To Fail Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="meow" retries="=1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1k693y6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c7g3fg</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="calledErrorProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="22" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13ejzna_di" bpmnElement="Activity_01dkgxo">
+        <dc:Bounds x="210" y="0" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0arkkoh_di" bpmnElement="Gateway_0wcfjtw">
+        <dc:Bounds x="115" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jjf4e8_di" bpmnElement="Gateway_0h5q0a5">
+        <dc:Bounds x="353" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dswctz_di" bpmnElement="Event_0dswctz">
+        <dc:Bounds x="452" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_142cejn_di" bpmnElement="Activity_0zud03c">
+        <dc:Bounds x="210" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_08ekq79_di" bpmnElement="Flow_08ekq79">
+        <di:waypoint x="58" y="118" />
+        <di:waypoint x="115" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0va2p2y_di" bpmnElement="Flow_0va2p2y">
+        <di:waypoint x="140" y="93" />
+        <di:waypoint x="140" y="40" />
+        <di:waypoint x="210" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k693y6_di" bpmnElement="Flow_1k693y6">
+        <di:waypoint x="140" y="143" />
+        <di:waypoint x="140" y="190" />
+        <di:waypoint x="210" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01l3eeq_di" bpmnElement="Flow_01l3eeq">
+        <di:waypoint x="310" y="40" />
+        <di:waypoint x="378" y="40" />
+        <di:waypoint x="378" y="93" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7g3fg_di" bpmnElement="Flow_1c7g3fg">
+        <di:waypoint x="310" y="190" />
+        <di:waypoint x="378" y="190" />
+        <di:waypoint x="378" y="143" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_084yr2u_di" bpmnElement="Flow_084yr2u">
+        <di:waypoint x="403" y="118" />
+        <di:waypoint x="452" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -1,0 +1,454 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deploy,
+} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertForbiddenRequest,
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  expectProcessInstanceCanBeFound,
+  activateJobToObtainAValidJobKey,
+  grantUserResourceAuthorization,
+  createUser,
+} from '@requestHelpers';
+import {sleep} from 'utils/sleep';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe('Element Instance Incident Search API', () => {
+  const state: Record<string, unknown> = {};
+  const processInstanceKeys: string[] = [];
+  const expectedIncidentTypes = ['JOB_NO_RETRIES', 'IO_MAPPING_ERROR'];
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Deploy processes and create instance', async () => {
+      const deployment1 = await deploy([
+        './resources/calledErrorProcess.bpmn',
+      ]);
+      state['processDefinitionKeyCalled'] =
+        deployment1.processes[0].processDefinitionKey;
+      await deploy(['./resources/callErrorProcess.bpmn']);
+      await createInstances('callProcessWithAnError', 1, 1).then(
+        (instances) => {
+          console.log(instances[0].processInstanceKey);
+          state.processInstanceKey = instances[0].processInstanceKey;
+          state.processDefinitionKey = instances[0].processDefinitionKey;
+          processInstanceKeys.push(instances[0].processInstanceKey);
+          console.log(`State: ${JSON.stringify(state)}`);
+        },
+      );
+      await sleep(5000);
+    });
+
+    await test.step('Verify instance is created and search by processInstanceKey and element type returns element instance', async () => {
+      await expectProcessInstanceCanBeFound(
+        request,
+        state.processInstanceKey as string,
+      );
+
+      await expect(async () => {
+        const res = await request.post(buildUrl('/element-instances/search'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: state.processInstanceKey,
+              type: 'CALL_ACTIVITY',
+            },
+          },
+        });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/element-instances/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const body = await res.json();
+        expect(body.page.totalItems).toEqual(1);
+        expect(body.items[0].processInstanceKey).toEqual(
+          state.processInstanceKey,
+        );
+        expect(body.items[0].type).toEqual('CALL_ACTIVITY');
+        state.elementInstanceKey = body.items[0].elementInstanceKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Fail job on called process', async () => {
+      const jobKey = await activateJobToObtainAValidJobKey(request, 'meow');
+      const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
+        headers: jsonHeaders(),
+        data: {
+          retries: 0,
+          errorMessage: 'Simulated failure',
+        },
+      });
+
+      await assertStatusCode(failRes, 204);
+    });
+  });
+
+  test.afterAll(async () => {
+    for (const instance of processInstanceKeys) {
+      await cancelProcessInstance(instance as string);
+    }
+  });
+
+  test('Search for incidents of a specific element instance - Multiple Results - Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(2);
+      body.items.forEach((item: Record<string, string>) => {
+        expect(expectedIncidentTypes).toContain(item.errorType);
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - filtered by errorType - Single Result - Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              errorType: 'IO_MAPPING_ERROR',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(1);
+      expect(body.items[0].errorType).toEqual('IO_MAPPING_ERROR');
+      expect(body.items[0].processDefinitionKey).toEqual(
+        state.processDefinitionKeyCalled,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - filtered by processDefinitionKey and state - Single Result - Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionKey: state.processDefinitionKeyCalled,
+              state: 'ACTIVE',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(2);
+      body.items.forEach((item: Record<string, string>) => {
+        expect(item.processDefinitionKey).toEqual(
+          state.processDefinitionKeyCalled,
+        );
+        expect(item.state).toEqual('ACTIVE');
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  //Skipped due to bug 46661: https://github.com/camunda/camunda/issues/46661
+  test.skip('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
+    request,
+  }) => {
+    const errorMessage1 =
+      "Assertion failure on evaluate the expression '{meow:assert(foo, foo != null)}': The condition is not fulfilled The evaluation reported the following warnings:\n[NO_VARIABLE_FOUND] No variable found with name 'foo'\n[NO_VARIABLE_FOUND] No variable found with name 'foo'\n[ASSERT_FAILURE] The condition is not fulfilled";
+    const errorMessage2 = 'Simulated failure';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            sort: [
+              {
+                field: 'errorMessage',
+                order: 'ASC',
+              },
+            ],
+            filter: {
+              processDefinitionKey: state.processDefinitionKeyCalled,
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(2);
+      expect(body.items[0].errorMessage).toEqual(errorMessage2);
+      expect(body.items[1].errorMessage).toEqual(errorMessage1);
+      body.items.forEach((item: Record<string, string>) => {
+        expect(item.processDefinitionKey).toEqual(
+          state.processDefinitionKeyCalled,
+        );
+      });
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Empty Result - Success', async ({
+    request,
+  }) => {
+    const notExistingProcessInstanceKey = '9999999999999';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: notExistingProcessInstanceKey,
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: `/element-instances/{elementInstanceKey}/incidents/search`,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toEqual(0);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Wrong Filter Value - Bad Request', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey: 'notANumber',
+            },
+          },
+        },
+      );
+      await assertBadRequest(res, 'For input string: \"notANumber\"');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Wrong Filter Field - Bad Request', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKeyyyy: '21312312',
+            },
+          },
+        },
+      );
+      await assertBadRequest(
+        res,
+        'Request property [filter.processInstanceKeyyyy] cannot be parsed',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Not Existing Element Instance Key - Not Found', async ({
+    request,
+  }) => {
+    const notExistingElementInstanceKey = '9999999999999';
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${notExistingElementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {},
+        },
+      );
+      await assertNotFoundRequest(
+        res,
+        `Element Instance with key '${notExistingElementInstanceKey}' not found`,
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Unauthorized', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: {},
+          data: {},
+        },
+      );
+      await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search for incidents of a specific element instance - Forbidden', async ({
+    request,
+  }) => {
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+    await test.step('Setup - Create user for authorization tests', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+
+    await test.step('Attempt to search element instance incidents without proper authorization', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(
+            `/element-instances/${state.elementInstanceKey}/incidents/search`,
+          ),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {},
+          },
+        );
+        await assertForbiddenRequest(
+          res,
+          "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'",
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Cleanup - delete user', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  //Skipped due to bug 39372: https://github.com/camunda/camunda/issues/39372
+  test.skip('Search for incidents of a specific element instance - with invalid pagination parameters', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/element-instances/${state.elementInstanceKey}/incidents/search`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            page: {
+              limit: -1,
+            },
+          },
+        },
+      );
+      await assertBadRequest(res, 'Sort field must not be null.');
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/usersCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/usersCleanup.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {APIRequestContext} from '@playwright/test';
 import {jsonHeaders, buildUrl} from './http';
 


### PR DESCRIPTION
## Description

This PR introduces Element instance search incident API tests including:

- Search for incidents of a specific element instance - Multiple Results - Success
- Search for incidents of a specific element instance - filtered by errorType - Single Result - Success
- Search for incidents of a specific element instance - filtered by processDefinitionKey and state - Single Result - Success
- Search for incidents of a specific element instance - ascending order by errorMessage - Success <- skipped due to #46661 
- Search for incidents of a specific element instance - Empty Result - Success
- Search for incidents of a specific element instance - Wrong Filter Value - Bad Request
- Search for incidents of a specific element instance - Wrong Filter Field - Bad Request
- Search for incidents of a specific element instance - Not Existing Element Instance Key - Not Found
- Search for incidents of a specific element instance - Unauthorized
- Search for incidents of a specific element instance - Forbidden
- Search for incidents of a specific element instance - with invalid pagination parameters <- skipped due to #39372

and also new processes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## On demand workflow
Was [all green](https://github.com/camunda/camunda/actions/runs/22435370156/job/64963918015)
