### PR TITLE
[Backport release-8.9.0-alpha5] feat: route process instance requests with business ID to a stable partition

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker;
+
+import static io.camunda.zeebe.protocol.impl.PartitionUtil.getPartitionId;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
+import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import java.util.Optional;
+
+/**
+ * A dispatch strategy that deterministically routes a request to a partition based on a hash of the
+ * given key. This ensures that requests with the same key are always routed to the same partition,
+ * enabling per-partition uniqueness validation.
+ *
+ * <p>This strategy is used for message correlation (by correlation key) and process instance
+ * creation (by business ID).
+ */
+public final class HashBasedDispatchStrategy implements RequestDispatchStrategy {
+
+  private final String key;
+  private final String keyDescription;
+
+  /**
+   * Creates a new hash-based dispatch strategy.
+   *
+   * @param key the key to hash for partition selection
+   * @param keyDescription a human-readable description of the key (e.g., "correlation key",
+   *     "business id") used in error messages
+   */
+  public HashBasedDispatchStrategy(final String key, final String keyDescription) {
+    this.key = key;
+    this.keyDescription = keyDescription;
+  }
+
+  @Override
+  public int determinePartition(final BrokerTopologyManager topologyManager) {
+    return topologyManager
+        .getClusterConfiguration()
+        .routingState()
+        .map(this::fromRoutingState)
+        .or(() -> Optional.ofNullable(topologyManager.getTopology()).map(this::fromTopology))
+        .orElseThrow(
+            () ->
+                new NoTopologyAvailableException(
+                    "Expected to pick partition for request with %s '%s', but no topology is available"
+                        .formatted(keyDescription, key)));
+  }
+
+  private int fromRoutingState(final RoutingState routingState) {
+    return switch (routingState.messageCorrelation()) {
+      case HashMod(final int partitionCount) -> getPartitionId(wrapString(key), partitionCount);
+    };
+  }
+
+  private int fromTopology(final BrokerClusterState topology) {
+    final var partitionCount = topology.getPartitionsCount();
+    if (partitionCount == 0) {
+      throw new NoTopologyAvailableException(
+          "Expected to pick partition for request with %s '%s', but topology contains no partitions"
+              .formatted(keyDescription, key));
+    }
+    return getPartitionId(wrapString(key), partitionCount);
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
@@ -7,53 +7,24 @@
  */
 package io.camunda.zeebe.gateway.impl.broker;
 
-import static io.camunda.zeebe.protocol.impl.SubscriptionUtil.getSubscriptionPartitionId;
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
-import io.camunda.zeebe.dynamic.config.state.RoutingState;
-import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
-import java.util.Optional;
 
+/**
+ * Dispatch strategy for message publish and correlate requests. Delegates to {@link
+ * HashBasedDispatchStrategy} using the correlation key to deterministically route messages to the
+ * same partition.
+ */
 public final class PublishMessageDispatchStrategy implements RequestDispatchStrategy {
 
-  private final String correlationKey;
+  private final HashBasedDispatchStrategy delegate;
 
   public PublishMessageDispatchStrategy(final String correlationKey) {
-    this.correlationKey = correlationKey;
+    delegate = new HashBasedDispatchStrategy(correlationKey, "correlation key");
   }
 
   @Override
   public int determinePartition(final BrokerTopologyManager topologyManager) {
-    return topologyManager
-        .getClusterConfiguration()
-        .routingState()
-        .map(this::fromRoutingState)
-        .or(() -> Optional.ofNullable(topologyManager.getTopology()).map(this::fromTopology))
-        .orElseThrow(
-            () ->
-                new NoTopologyAvailableException(
-                    "Expected to pick partition for message with correlation key '%s', but no topology is available"
-                        .formatted(correlationKey)));
-  }
-
-  public int fromRoutingState(final RoutingState routingState) {
-    return switch (routingState.messageCorrelation()) {
-      case HashMod(final int partitionCount) ->
-          getSubscriptionPartitionId(wrapString(correlationKey), partitionCount);
-    };
-  }
-
-  public int fromTopology(final BrokerClusterState topology) {
-    final var partitionCount = topology.getPartitionsCount();
-    if (partitionCount == 0) {
-      throw new NoTopologyAvailableException(
-          "Expected to pick partition for message with correlation key '%s', but topology contains no partitions"
-              .formatted(correlationKey));
-    }
-    return getSubscriptionPartitionId(wrapString(correlationKey), partitionCount);
+    return delegate.determinePartition(topologyManager);
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -85,6 +85,17 @@ public final class RequestRetryHandler {
       return;
     }
 
+    // When the request specifies its own dispatch strategy (e.g., hash-based routing for business
+    // ID or correlation key), we must respect that strategy and send the request to that specific
+    // partition. Retrying on other partitions would violate the routing guarantee needed for
+    // per-partition uniqueness validation.
+    final var requestStrategy = request.requestDispatchStrategy();
+    if (requestStrategy.isPresent()) {
+      sendRequestToFixedPartition(
+          request, requestSender, requestStrategy.get(), responseConsumer, throwableConsumer);
+      return;
+    }
+
     sendRequestWithRetry(
         request,
         requestSender,
@@ -92,6 +103,38 @@ public final class RequestRetryHandler {
         responseConsumer,
         throwableConsumer,
         new ArrayList<>());
+  }
+
+  /**
+   * Sends a request to a fixed partition determined by the given dispatch strategy, without
+   * retrying on other partitions. This is used when the request must be routed to a specific
+   * partition (e.g., based on a business ID or correlation key hash) to preserve routing
+   * guarantees.
+   */
+  private <BrokerResponseT> void sendRequestToFixedPartition(
+      final BrokerRequest<BrokerResponseT> request,
+      final Function<
+              BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
+          requestSender,
+      final RequestDispatchStrategy strategy,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    try {
+      request.setPartitionId(strategy.determinePartition(topologyManager));
+    } catch (final Exception e) {
+      throwableConsumer.accept(e);
+      return;
+    }
+    requestSender
+        .apply(request)
+        .whenComplete(
+            (response, error) -> {
+              if (error == null) {
+                responseConsumer.accept(response.getKey(), response.getResponse());
+              } else {
+                throwableConsumer.accept(error);
+              }
+            });
   }
 
   private <BrokerResponseT> void sendRequestWithRetry(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequest.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.gateway.impl.broker.request;
 
+import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.gateway.impl.broker.HashBasedDispatchStrategy;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
@@ -16,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 
@@ -23,6 +26,7 @@ public class BrokerCreateProcessInstanceRequest
     extends BrokerExecuteCommand<ProcessInstanceCreationRecord> {
 
   private final ProcessInstanceCreationRecord requestDto = new ProcessInstanceCreationRecord();
+  private String businessId;
 
   public BrokerCreateProcessInstanceRequest() {
     super(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE);
@@ -102,7 +106,8 @@ public class BrokerCreateProcessInstanceRequest
   }
 
   public BrokerCreateProcessInstanceRequest setBusinessId(final String businessId) {
-    requestDto.setBusinessId(businessId);
+    this.businessId = businessId;
+    requestDto.setBusinessId(businessId != null ? businessId : "");
     return this;
   }
 
@@ -116,5 +121,13 @@ public class BrokerCreateProcessInstanceRequest
     final ProcessInstanceCreationRecord responseDto = new ProcessInstanceCreationRecord();
     responseDto.wrap(buffer);
     return responseDto;
+  }
+
+  @Override
+  public Optional<RequestDispatchStrategy> requestDispatchStrategy() {
+    if (businessId != null && !businessId.isEmpty()) {
+      return Optional.of(new HashBasedDispatchStrategy(businessId, "business id"));
+    }
+    return Optional.empty();
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
@@ -7,19 +7,23 @@
  */
 package io.camunda.zeebe.gateway.impl.broker.request;
 
+import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.gateway.impl.broker.HashBasedDispatchStrategy;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BrokerCreateProcessInstanceWithResultRequest
     extends BrokerExecuteCommand<ProcessInstanceResultRecord> {
   private final ProcessInstanceCreationRecord requestDto = new ProcessInstanceCreationRecord();
+  private String businessId;
 
   public BrokerCreateProcessInstanceWithResultRequest() {
     super(
@@ -53,7 +57,8 @@ public final class BrokerCreateProcessInstanceWithResultRequest
   }
 
   public BrokerCreateProcessInstanceWithResultRequest setBusinessId(final String businessId) {
-    requestDto.setBusinessId(businessId);
+    this.businessId = businessId;
+    requestDto.setBusinessId(businessId != null ? businessId : "");
     return this;
   }
 
@@ -100,6 +105,14 @@ public final class BrokerCreateProcessInstanceWithResultRequest
     final ProcessInstanceResultRecord responseDto = new ProcessInstanceResultRecord();
     responseDto.wrap(buffer);
     return responseDto;
+  }
+
+  @Override
+  public Optional<RequestDispatchStrategy> requestDispatchStrategy() {
+    if (businessId != null && !businessId.isEmpty()) {
+      return Optional.of(new HashBasedDispatchStrategy(businessId, "business id"));
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -21,11 +21,11 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   private final TestBrokerClusterState clusterState;
   private final ClusterConfiguration clusterConfiguration;
 
-  StubbedTopologyManager() {
+  public StubbedTopologyManager() {
     this(8);
   }
 
-  StubbedTopologyManager(final int partitionsCount) {
+  public StubbedTopologyManager(final int partitionsCount) {
     clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new TestBrokerClusterState(partitionsCount);
     clusterState.addBroker(0, "localhost:26501");

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.gateway.api.util.TestBrokerClusterState;
+import io.camunda.zeebe.protocol.impl.PartitionUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class HashBasedDispatchStrategyTest {
+
+  @Test
+  void shouldDispatchViaTopology() {
+    // given
+    final var businessId = "order-12345";
+    final var dispatchStrategy = new HashBasedDispatchStrategy(businessId, "business id");
+    final var partitionCount = 3;
+
+    // when -- No routing state in cluster configuration
+    final var topologyManager =
+        new TestTopologyManager(
+            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+
+    // then - the request is dispatched based on the partition count from the topology
+    assertThat(dispatchStrategy.determinePartition(topologyManager))
+        .isEqualTo(PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), partitionCount));
+  }
+
+  @Test
+  void shouldDispatchViaRoutingState() {
+    // given
+    final var businessId = "order-12345";
+    final var dispatchStrategy = new HashBasedDispatchStrategy(businessId, "business id");
+    final var partitionCount = 3;
+    final var messagePartitionCount = 2;
+
+    // when -- Routing state is available in cluster configuration
+    final var routingState =
+        new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
+    final var clusterConfiguration =
+        ClusterConfiguration.builder().version(1).routingState(Optional.of(routingState)).build();
+
+    final var topologyManager =
+        new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
+
+    // then - the request is dispatched based on the routing state
+    assertThat(dispatchStrategy.determinePartition(topologyManager))
+        .isEqualTo(
+            PartitionUtil.getPartitionId(BufferUtil.wrapString(businessId), messagePartitionCount));
+  }
+
+  @Test
+  void shouldAlwaysRouteToSamePartitionForSameKey() {
+    // given
+    final var businessId = "consistent-key";
+    final var partitionCount = 5;
+
+    final var topologyManager =
+        new TestTopologyManager(
+            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+
+    // when - we create multiple strategies with the same key
+    final var strategy1 = new HashBasedDispatchStrategy(businessId, "business id");
+    final var strategy2 = new HashBasedDispatchStrategy(businessId, "business id");
+
+    // then - both should route to the same partition
+    assertThat(strategy1.determinePartition(topologyManager))
+        .isEqualTo(strategy2.determinePartition(topologyManager));
+  }
+
+  @Test
+  void shouldRouteSameAsPublishMessageDispatchStrategy() {
+    // given - the same key used as both a correlation key and a business id
+    final var key = "shared-key";
+    final var partitionCount = 5;
+
+    final var topologyManager =
+        new TestTopologyManager(
+            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+
+    // when
+    final var hashBasedStrategy = new HashBasedDispatchStrategy(key, "business id");
+    final var messageStrategy = new PublishMessageDispatchStrategy(key);
+
+    // then - both strategies should route to the same partition for the same key
+    assertThat(hashBasedStrategy.determinePartition(topologyManager))
+        .isEqualTo(messageStrategy.determinePartition(topologyManager));
+  }
+
+  private record TestTopologyManager(
+      BrokerClusterState topology, ClusterConfiguration clusterConfiguration)
+      implements BrokerTopologyManager {
+
+    @Override
+    public BrokerClusterState getTopology() {
+      return topology;
+    }
+
+    @Override
+    public ClusterConfiguration getClusterConfiguration() {
+      return clusterConfiguration;
+    }
+
+    @Override
+    public void addTopologyListener(final BrokerTopologyListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeTopologyListener(final BrokerTopologyListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.net.ConnectException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class RequestRetryHandlerTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  private TestBrokerClient brokerClient;
+  private RequestRetryHandler retryHandler;
+
+  @BeforeEach
+  void setUp() {
+    final var topologyManager = new StubbedTopologyManager(PARTITION_COUNT);
+    brokerClient = new TestBrokerClient();
+    retryHandler = new RequestRetryHandler(brokerClient, topologyManager);
+  }
+
+  @Test
+  void shouldSendToFixedPartitionWhenDispatchStrategyIsPresent() {
+    // given - a request with a specific dispatch strategy targeting partition 2
+    final int targetPartition = 2;
+    final var request = new TestBrokerRequest(Optional.of(__ -> targetPartition));
+    brokerClient.setResponse(new BrokerResponse<>("result", targetPartition, 1));
+
+    // when
+    final var result = new AtomicReference<String>();
+    retryHandler.sendRequest(request, (key, response) -> result.set(response), error -> {});
+
+    // then - the request was sent to the fixed partition
+    assertThat(request.getPartitionId()).isEqualTo(targetPartition);
+    assertThat(result.get()).isEqualTo("result");
+  }
+
+  @Test
+  void shouldNotRetryOnOtherPartitionsWhenDispatchStrategyIsPresent() {
+    // given - a request with a specific dispatch strategy that fails with a retryable error
+    final int targetPartition = 2;
+    final var request = new TestBrokerRequest(Optional.of(__ -> targetPartition));
+    brokerClient.setError(new ConnectException("connection refused"));
+
+    // when
+    final var error = new AtomicReference<Throwable>();
+    retryHandler.sendRequest(request, (key, response) -> {}, error::set);
+
+    // then - the error is propagated without retrying on other partitions
+    assertThat(error.get()).isInstanceOf(ConnectException.class);
+    assertThat(brokerClient.sendCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldRetryOnOtherPartitionsWhenNoDispatchStrategy() {
+    // given - a request without a dispatch strategy that fails with a retryable error
+    final var request = new TestBrokerRequest(Optional.empty());
+    brokerClient.setError(new ConnectException("connection refused"));
+
+    // when
+    final var error = new AtomicReference<Throwable>();
+    retryHandler.sendRequest(request, (key, response) -> {}, error::set);
+
+    // then - the request was retried on all partitions
+    assertThat(brokerClient.sendCount.get()).isEqualTo(PARTITION_COUNT);
+  }
+
+  @Test
+  void shouldPropagateStrategyExceptionWhenDispatchStrategyFails() {
+    // given - a request whose dispatch strategy throws
+    final var request =
+        new TestBrokerRequest(
+            Optional.of(
+                __ -> {
+                  throw new RuntimeException("no topology");
+                }));
+
+    // when
+    final var error = new AtomicReference<Throwable>();
+    retryHandler.sendRequest(request, (key, response) -> {}, error::set);
+
+    // then - the exception from the strategy is propagated
+    assertThat(error.get()).isInstanceOf(RuntimeException.class).hasMessage("no topology");
+    assertThat(brokerClient.sendCount.get()).isEqualTo(0);
+  }
+
+  private static final class TestBrokerClient implements BrokerClient {
+    final AtomicInteger sendCount = new AtomicInteger(0);
+    private BrokerResponse<String> response;
+    private Throwable error;
+
+    void setResponse(final BrokerResponse<String> response) {
+      this.response = response;
+      error = null;
+    }
+
+    void setError(final Throwable error) {
+      this.error = error;
+      response = null;
+    }
+
+    @Override
+    public Collection<ActorFuture<Void>> start() {
+      return java.util.List.of();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> CompletableFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
+      sendCount.incrementAndGet();
+      if (error != null) {
+        return CompletableFuture.failedFuture(error);
+      }
+      return CompletableFuture.completedFuture((BrokerResponse<T>) response);
+    }
+
+    @Override
+    public <T> CompletableFuture<BrokerResponse<T>> sendRequest(
+        final BrokerRequest<T> request, final java.time.Duration requestTimeout) {
+      return sendRequest(request);
+    }
+
+    @Override
+    public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
+        final BrokerRequest<T> request) {
+      return sendRequest(request);
+    }
+
+    @Override
+    public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
+        final BrokerRequest<T> request, final java.time.Duration requestTimeout) {
+      return sendRequest(request);
+    }
+
+    @Override
+    public <T> void sendRequestWithRetry(
+        final BrokerRequest<T> request,
+        final BrokerResponseConsumer<T> responseConsumer,
+        final Consumer<Throwable> throwableConsumer) {
+      sendRequest(request)
+          .whenComplete(
+              (resp, err) -> {
+                if (err != null) {
+                  throwableConsumer.accept(err);
+                } else {
+                  responseConsumer.accept(resp.getKey(), resp.getResponse());
+                }
+              });
+    }
+
+    @Override
+    public BrokerTopologyManager getTopologyManager() {
+      return null;
+    }
+
+    @Override
+    public void subscribeJobAvailableNotification(
+        final String topic, final Consumer<String> handler) {}
+  }
+
+  private static class TestBrokerRequest extends BrokerExecuteCommand<String> {
+    private final Optional<RequestDispatchStrategy> strategy;
+
+    TestBrokerRequest(final Optional<RequestDispatchStrategy> strategy) {
+      super(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE);
+      this.strategy = strategy;
+    }
+
+    @Override
+    public BufferWriter getRequestWriter() {
+      return null;
+    }
+
+    @Override
+    protected String toResponseDto(final DirectBuffer buffer) {
+      return null;
+    }
+
+    @Override
+    public Optional<RequestDispatchStrategy> requestDispatchStrategy() {
+      return strategy;
+    }
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequestTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceRequestTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.impl.broker.HashBasedDispatchStrategy;
+import org.junit.jupiter.api.Test;
+
+final class BrokerCreateProcessInstanceRequestTest {
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenNoBusinessId() {
+    // given
+    final var request = new BrokerCreateProcessInstanceRequest();
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenBusinessIdIsNull() {
+    // given
+    final var request = new BrokerCreateProcessInstanceRequest();
+    request.setBusinessId(null);
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenBusinessIdIsEmpty() {
+    // given
+    final var request = new BrokerCreateProcessInstanceRequest();
+    request.setBusinessId("");
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnHashBasedDispatchStrategyWhenBusinessIdIsSet() {
+    // given
+    final var request = new BrokerCreateProcessInstanceRequest();
+    request.setBusinessId("order-12345");
+
+    // when/then
+    assertThat(request.requestDispatchStrategy())
+        .isPresent()
+        .get()
+        .isInstanceOf(HashBasedDispatchStrategy.class);
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequestTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequestTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.impl.broker.HashBasedDispatchStrategy;
+import org.junit.jupiter.api.Test;
+
+final class BrokerCreateProcessInstanceWithResultRequestTest {
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenNoBusinessId() {
+    // given
+    final var request = new BrokerCreateProcessInstanceWithResultRequest();
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenBusinessIdIsNull() {
+    // given
+    final var request = new BrokerCreateProcessInstanceWithResultRequest();
+    request.setBusinessId(null);
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyDispatchStrategyWhenBusinessIdIsEmpty() {
+    // given
+    final var request = new BrokerCreateProcessInstanceWithResultRequest();
+    request.setBusinessId("");
+
+    // when/then
+    assertThat(request.requestDispatchStrategy()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnHashBasedDispatchStrategyWhenBusinessIdIsSet() {
+    // given
+    final var request = new BrokerCreateProcessInstanceWithResultRequest();
+    request.setBusinessId("order-12345");
+
+    // when/then
+    assertThat(request.requestDispatchStrategy())
+        .isPresent()
+        .get()
+        .isInstanceOf(HashBasedDispatchStrategy.class);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/PartitionUtil.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/PartitionUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
+import org.agrona.DirectBuffer;
+
+/**
+ * Utility for deterministically mapping a key to a partition ID based on hashing. This is used to
+ * ensure that the same key always maps to the same partition, enabling per-partition uniqueness
+ * validation and consistent routing across scaling operations.
+ */
+public final class PartitionUtil {
+
+  private PartitionUtil() {}
+
+  /**
+   * Computes a hash code for the given key buffer, equivalent to {@link String#hashCode()}.
+   *
+   * @param key the key buffer to hash
+   * @return the hash code
+   */
+  static int hashCode(final DirectBuffer key) {
+    int hashCode = 0;
+
+    for (int i = 0, length = key.capacity(); i < length; i++) {
+      hashCode = 31 * hashCode + key.getByte(i);
+    }
+    return hashCode;
+  }
+
+  /**
+   * Deterministically maps a key to a partition ID by hashing the key and applying modulo over the
+   * partition count.
+   *
+   * @param key the key buffer to hash
+   * @param partitionCount the total number of partitions
+   * @return a partition ID in the range [{@link
+   *     io.camunda.zeebe.protocol.Protocol#START_PARTITION_ID}, {@code START_PARTITION_ID +
+   *     partitionCount})
+   */
+  public static int getPartitionId(final DirectBuffer key, final int partitionCount) {
+    final int hashCode = hashCode(key);
+    return Math.abs(hashCode % partitionCount) + START_PARTITION_ID;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/SubscriptionUtil.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/SubscriptionUtil.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.protocol.impl;
 
-import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
-
 import org.agrona.DirectBuffer;
 
 public final class SubscriptionUtil {
@@ -20,13 +18,7 @@ public final class SubscriptionUtil {
    * @return the hash code of the subscription
    */
   static int getSubscriptionHashCode(final DirectBuffer correlationKey) {
-    // is equal to java.lang.String#hashCode
-    int hashCode = 0;
-
-    for (int i = 0, length = correlationKey.capacity(); i < length; i++) {
-      hashCode = 31 * hashCode + correlationKey.getByte(i);
-    }
-    return hashCode;
+    return PartitionUtil.hashCode(correlationKey);
   }
 
   /**
@@ -38,8 +30,6 @@ public final class SubscriptionUtil {
    */
   public static int getSubscriptionPartitionId(
       final DirectBuffer correlationKey, final int partitionCount) {
-    final int hashCode = getSubscriptionHashCode(correlationKey);
-    // partition ids range from START_PARTITION_ID .. START_PARTITION_ID + partitionCount
-    return Math.abs(hashCode % partitionCount) + START_PARTITION_ID;
+    return PartitionUtil.getPartitionId(correlationKey, partitionCount);
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/PartitionUtilTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/PartitionUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl;
+
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class PartitionUtilTest {
+
+  @Test
+  void shouldComputeHashCode() {
+    assertThat(PartitionUtil.hashCode(wrapString("a"))).isEqualTo(97);
+    assertThat(PartitionUtil.hashCode(wrapString("b"))).isEqualTo(98);
+    assertThat(PartitionUtil.hashCode(wrapString("c"))).isEqualTo(99);
+    assertThat(PartitionUtil.hashCode(wrapString("foobar"))).isEqualTo(-1268878963);
+  }
+
+  @Test
+  void shouldGetZeroHashCodeIfEmpty() {
+    assertThat(PartitionUtil.hashCode(new UnsafeBuffer())).isEqualTo(0);
+  }
+
+  @Test
+  void shouldGetPartitionIdForCorrelationKey() {
+    assertThat(PartitionUtil.getPartitionId(wrapString("a"), 10)).isEqualTo(7 + START_PARTITION_ID);
+    assertThat(PartitionUtil.getPartitionId(wrapString("b"), 3)).isEqualTo(2 + START_PARTITION_ID);
+    assertThat(PartitionUtil.getPartitionId(wrapString("c"), 11)).isEqualTo(0 + START_PARTITION_ID);
+    assertThat(PartitionUtil.getPartitionId(wrapString("foobar"), 100))
+        .isEqualTo(63 + START_PARTITION_ID);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #46554 to `release-8.9.0-alpha5`.

relates to #44979