### PR TITLE
Accurately mark history deletion batch operation items as complete

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -42,6 +42,8 @@ public interface BatchOperationMapper extends HistoryCleanupMapper {
 
   void incrementCompletedOperationsCount(String batchOperationKey);
 
+  void bulkIncrementCompletedOperationsCount(BatchOperationUpdateTotalCountDto dto);
+
   Long count(BatchOperationDbQuery query);
 
   List<BatchOperationDbModel> search(BatchOperationDbQuery query);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -34,6 +34,8 @@ public interface BatchOperationMapper extends HistoryCleanupMapper {
 
   void updateItemsWithState(BatchOperationItemStatusUpdateDto dto);
 
+  void completeBatchOperationItems(BatchOperationItemsCompletionDto dto);
+
   void incrementOperationsTotalCount(BatchOperationUpdateTotalCountDto dto);
 
   void incrementFailedOperationsCount(String batchOperationKey);
@@ -78,6 +80,11 @@ public interface BatchOperationMapper extends HistoryCleanupMapper {
       String batchOperationKey,
       BatchOperationEntity.BatchOperationItemState oldState,
       BatchOperationEntity.BatchOperationItemState newState) {}
+
+  record BatchOperationItemCompletionDto(String batchOperationKey, long itemKey) {}
+
+  record BatchOperationItemsCompletionDto(
+      List<BatchOperationItemCompletionDto> items, OffsetDateTime processedDate) {}
 
   record BatchOperationErrorsDto(String batchOperationKey, List<BatchOperationErrorDto> errors) {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionBatch.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/HistoryDeletionBatch.java
@@ -44,4 +44,19 @@ public record HistoryDeletionBatch(List<HistoryDeletionDbModel> historyDeletionM
         .map(HistoryDeletionDbModel::resourceKey)
         .toList();
   }
+
+  /**
+   * Gets models filtered by resource type and a set of resource keys.
+   *
+   * @param historyDeletionType The type of resource to filter by
+   * @param resourceKeys The specific resource keys to include
+   * @return List of models matching the type and the given resource keys
+   */
+  public List<HistoryDeletionDbModel> getModels(
+      final HistoryDeletionTypeDbModel historyDeletionType, final List<Long> resourceKeys) {
+    return historyDeletionModels.stream()
+        .filter(model -> model.resourceType().equals(historyDeletionType))
+        .filter(model -> resourceKeys.contains(model.resourceKey()))
+        .toList();
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -12,7 +12,9 @@ import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationActivateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationErrorsDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemCompletionDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemStatusUpdateDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsCompletionDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateTotalCountDto;
@@ -132,6 +134,31 @@ public class BatchOperationWriter implements RdbmsWriter {
               item.batchOperationKey(),
               "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementCompletedOperationsCount",
               item.batchOperationKey()));
+    }
+  }
+
+  /**
+   * Marks a batch of process instance batch operation items as completed in bulk, setting their
+   * state to COMPLETED and the processed date to the given end time. Items are split into blocks of
+   * {@code itemInsertBlockSize} to avoid generating excessively large SQL statements.
+   *
+   * @param items list of (batchOperationKey, itemKey) pairs identifying the items to complete
+   * @param processedDate the completion timestamp to set on each item
+   */
+  public void completeBatchOperationItems(
+      final List<BatchOperationItemCompletionDto> items, final OffsetDateTime processedDate) {
+    if (items.isEmpty()) {
+      return;
+    }
+    for (int i = 0; i < items.size(); i += itemInsertBlockSize) {
+      final var block = items.subList(i, Math.min(i + itemInsertBlockSize, items.size()));
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.BATCH_OPERATION,
+              WriteStatementType.UPDATE,
+              null,
+              "io.camunda.db.rdbms.sql.BatchOperationMapper.completeBatchOperationItems",
+              new BatchOperationItemsCompletionDto(block, processedDate)));
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -152,14 +152,19 @@ public class BatchOperationWriter implements RdbmsWriter {
     }
     for (int i = 0; i < items.size(); i += itemInsertBlockSize) {
       final var block = items.subList(i, Math.min(i + itemInsertBlockSize, items.size()));
-      executionQueue.executeInQueue(
-          new QueueItem(
-              ContextType.BATCH_OPERATION,
-              WriteStatementType.UPDATE,
-              null,
-              "io.camunda.db.rdbms.sql.BatchOperationMapper.completeBatchOperationItems",
-              new BatchOperationItemsCompletionDto(block, processedDate)));
+      mapper.completeBatchOperationItems(
+          new BatchOperationItemsCompletionDto(block, processedDate));
     }
+
+    items.stream()
+        .collect(
+            Collectors.groupingBy(
+                BatchOperationItemCompletionDto::batchOperationKey, Collectors.counting()))
+        .forEach(
+            (batchOperationKey, completedCount) ->
+                mapper.bulkIncrementCompletedOperationsCount(
+                    new BatchOperationUpdateTotalCountDto(
+                        batchOperationKey, completedCount.intValue())));
   }
 
   public void finish(final String batchOperationKey, final OffsetDateTime endDate) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -22,6 +22,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -43,13 +44,15 @@ public class HistoryDeletionService {
   private final HistoryDeletionConfig config;
   private final ExponentialBackoff exponentialBackoff;
   private Duration currentDelayBetweenRuns;
+  private final InstantSource clock;
 
   public HistoryDeletionService(
       final RdbmsWriters rdbmsWriters,
       final HistoryDeletionDbReader historyDeletionDbReader,
       final ProcessInstanceDbReader processInstanceDbReader,
       final DecisionInstanceDbReader decisionInstanceDbReader,
-      final HistoryDeletionConfig config) {
+      final HistoryDeletionConfig config,
+      final InstantSource clock) {
     this.rdbmsWriters = rdbmsWriters;
     this.historyDeletionDbReader = historyDeletionDbReader;
     this.processInstanceDbReader = processInstanceDbReader;
@@ -63,6 +66,7 @@ public class HistoryDeletionService {
             0.0); // Use 0.0 jitter for deterministic backoff and clamp to min delay to avoid
     // sub-min values
     currentDelayBetweenRuns = config.delayBetweenRuns();
+    this.clock = clock;
   }
 
   public Duration deleteHistory(final int partitionId) {
@@ -135,7 +139,8 @@ public class HistoryDeletionService {
     if (!completionItems.isEmpty()) {
       rdbmsWriters
           .getBatchOperationWriter()
-          .completeBatchOperationItems(completionItems, OffsetDateTime.now(ZoneOffset.UTC));
+          .completeBatchOperationItems(
+              completionItems, OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC));
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemCompletionDto;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionBatch;
@@ -21,6 +22,8 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.zeebe.util.ExponentialBackoff;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -109,10 +112,31 @@ public class HistoryDeletionService {
       rdbmsWriters.getProcessInstanceWriter().deleteByKeys(processInstanceKeys);
       scheduleAuditLogDataForDeletion(
           processInstanceKeys, HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
+      markBatchOperationItemsAsCompleted(
+          batch, processInstanceKeys, HistoryDeletionTypeDbModel.PROCESS_INSTANCE);
       return processInstanceKeys;
     }
 
     return List.of();
+  }
+
+  private void markBatchOperationItemsAsCompleted(
+      final HistoryDeletionBatch batch,
+      final List<Long> deletedKeys,
+      final HistoryDeletionTypeDbModel historyDeletionType) {
+    final var completionItems =
+        batch.getModels(historyDeletionType, deletedKeys).stream()
+            .map(
+                model ->
+                    new BatchOperationItemCompletionDto(
+                        String.valueOf(model.batchOperationKey()), model.resourceKey()))
+            .toList();
+
+    if (!completionItems.isEmpty()) {
+      rdbmsWriters
+          .getBatchOperationWriter()
+          .completeBatchOperationItems(completionItems, OffsetDateTime.now(ZoneOffset.UTC));
+    }
   }
 
   private List<Long> deleteProcessDefinitions(final HistoryDeletionBatch batch) {
@@ -142,7 +166,8 @@ public class HistoryDeletionService {
     rdbmsWriters.getDecisionInstanceWriter().deleteByKeys(decisionInstanceKeys);
     scheduleAuditLogDataForDeletion(
         decisionInstanceKeys, HistoryDeletionTypeDbModel.DECISION_INSTANCE);
-
+    markBatchOperationItemsAsCompleted(
+        batch, decisionInstanceKeys, HistoryDeletionTypeDbModel.DECISION_INSTANCE);
     return decisionInstanceKeys;
   }
 

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -262,6 +262,13 @@
     WHERE BATCH_OPERATION_KEY = #{id}
   </update>
 
+  <update id="bulkIncrementCompletedOperationsCount"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateTotalCountDto">
+    UPDATE ${prefix}BATCH_OPERATION
+    SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + #{operationsTotalCount}
+    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+  </update>
+
   <select id="count" resultType="java.lang.Long">
     SELECT COUNT(*) FROM (
       SELECT 1 as col

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -222,6 +222,17 @@
   </insert>
 
 
+  <update id="completeBatchOperationItems"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsCompletionDto">
+    UPDATE ${prefix}BATCH_OPERATION_ITEM
+    SET STATE = 'COMPLETED',
+        PROCESSED_DATE = #{processedDate, jdbcType=TIMESTAMP}
+    WHERE
+    <foreach collection="items" item="item" separator=" OR " open="(" close=")">
+      (BATCH_OPERATION_KEY = #{item.batchOperationKey} AND ITEM_KEY = #{item.itemKey})
+    </foreach>
+  </update>
+
   <update id="updateItemsWithState"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemStatusUpdateDto">
     UPDATE ${prefix}BATCH_OPERATION_ITEM

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -34,6 +34,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.query.SearchQueryResult;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,8 @@ public class HistoryDeletionServiceTest {
             historyDeletionDbReaderMock,
             processInstanceDbReaderMock,
             decisionInstanceDbReaderMock,
-            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, LIMIT));
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, LIMIT),
+            InstantSource.system());
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -8,11 +8,13 @@
 package io.camunda.db.rdbms.write.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -21,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemCompletionDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceDependantMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -504,6 +507,112 @@ public class HistoryDeletionServiceTest {
     verify(rdbmsWritersMock.getDecisionDefinitionWriter(), never())
         .deleteByDecisionRequirementsKeys(anyList(), anyInt());
     verify(rdbmsWritersMock.getDecisionRequirementsWriter(), never()).deleteByKeys(anyList());
+    verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
+  }
+
+  @Test
+  void shouldMarkProcessInstanceBatchOperationItemAsCompleted() {
+    // given
+    final var partitionId = 1;
+    final var processInstanceKey = 1L;
+    final var batchOperationKey = 2L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(processInstanceKey, HistoryDeletionTypeDbModel.PROCESS_INSTANCE))));
+    when(rdbmsWritersMock.getProcessInstanceDependantWriters()).thenReturn(Collections.emptyList());
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getBatchOperationWriter())
+        .completeBatchOperationItems(
+            argThat(
+                items ->
+                    items.size() == 1
+                        && items
+                            .getFirst()
+                            .equals(
+                                new BatchOperationItemCompletionDto(
+                                    String.valueOf(batchOperationKey), processInstanceKey))),
+            any());
+  }
+
+  @Test
+  void shouldMarkDecisionInstanceBatchOperationItemAsCompleted() {
+    // given
+    final var partitionId = 1;
+    final var decisionInstanceKey = 1L;
+    final var batchOperationKey = 2L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        decisionInstanceKey, HistoryDeletionTypeDbModel.DECISION_INSTANCE))));
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getBatchOperationWriter())
+        .completeBatchOperationItems(
+            argThat(
+                items ->
+                    items.size() == 1
+                        && items
+                            .getFirst()
+                            .equals(
+                                new BatchOperationItemCompletionDto(
+                                    String.valueOf(batchOperationKey), decisionInstanceKey))),
+            any());
+  }
+
+  @Test
+  void shouldNotDeleteFromHistoryDeletionTableIfMarkingProcessInstanceItemFails() {
+    // given
+    final var partitionId = 1;
+    final var processInstanceKey = 1L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(processInstanceKey, HistoryDeletionTypeDbModel.PROCESS_INSTANCE))));
+    when(rdbmsWritersMock.getProcessInstanceDependantWriters()).thenReturn(Collections.emptyList());
+    final var batchOperationWriterMock = rdbmsWritersMock.getBatchOperationWriter();
+    doThrow(new RuntimeException("marking failed"))
+        .when(batchOperationWriterMock)
+        .completeBatchOperationItems(anyList(), any());
+
+    // when / then
+    assertThatThrownBy(() -> historyDeletionService.deleteHistory(partitionId))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("marking failed");
+    verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
+  }
+
+  @Test
+  void shouldNotDeleteFromHistoryDeletionTableIfMarkingDecisionInstanceItemFails() {
+    // given
+    final var partitionId = 1;
+    final var decisionInstanceKey = 1L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        decisionInstanceKey, HistoryDeletionTypeDbModel.DECISION_INSTANCE))));
+    final var batchOperationWriterMock = rdbmsWritersMock.getBatchOperationWriter();
+    doThrow(new RuntimeException("marking failed"))
+        .when(batchOperationWriterMock)
+        .completeBatchOperationItems(anyList(), any());
+
+    // when / then
+    assertThatThrownBy(() -> historyDeletionService.deleteHistory(partitionId))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("marking failed");
     verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/historydeletion/HistoryDeletionServiceIT.java
@@ -18,6 +18,7 @@ import io.camunda.it.rdbms.db.history.ProcessInstanceHistory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +38,8 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
             rdbmsService.getHistoryDeletionDbReader(),
             rdbmsService.getProcessInstanceReader(),
             rdbmsService.getDecisionInstanceReader(),
-            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000));
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10000),
+            InstantSource.system());
 
     final long processInstanceKey = ProcessInstanceFixtures.nextKey();
     createRandomProcessWithRelevantRelatedData(
@@ -82,7 +84,8 @@ public class HistoryDeletionServiceIT extends ProcessInstanceHistory {
             rdbmsService.getHistoryDeletionDbReader(),
             rdbmsService.getProcessInstanceReader(),
             rdbmsService.getDecisionInstanceReader(),
-            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10));
+            new HistoryDeletionConfig(Duration.ofSeconds(1), Duration.ofMinutes(5), 100, 10),
+            InstantSource.system());
 
     final long processInstanceKey = ProcessInstanceFixtures.nextKey();
     createRandomProcessWithRelevantRelatedData(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -1271,8 +1271,8 @@ class RdbmsExporterIT {
     final var resourceKey = 1153L;
     final var deletionRecord =
         withBatchOperationReference(
-            FIXTURES.getHistoryDeletionRecord(
-                HistoryDeletionIntent.DELETED, resourceKey, HistoryDeletionType.PROCESS_INSTANCE),
+            FIXTURES.getRejectedHistoryDeletionRecord(
+                HistoryDeletionIntent.DELETE, resourceKey, HistoryDeletionType.PROCESS_INSTANCE),
             batchOperationKey);
 
     // when
@@ -1287,7 +1287,7 @@ class RdbmsExporterIT {
     assertThat(item.processInstanceKey()).isEqualTo(resourceKey);
     assertThat(item.rootProcessInstanceKey()).isNull();
     assertThat(item.operationType()).isEqualTo(BatchOperationType.DELETE_PROCESS_INSTANCE);
-    assertThat(item.state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(item.state()).isEqualTo(BatchOperationItemState.FAILED);
   }
 
   @Test
@@ -1301,8 +1301,8 @@ class RdbmsExporterIT {
     final var resourceKey = 1154L;
     final var deletionRecord =
         withBatchOperationReference(
-            FIXTURES.getHistoryDeletionRecord(
-                HistoryDeletionIntent.DELETED, resourceKey, HistoryDeletionType.DECISION_INSTANCE),
+            FIXTURES.getRejectedHistoryDeletionRecord(
+                HistoryDeletionIntent.DELETE, resourceKey, HistoryDeletionType.DECISION_INSTANCE),
             batchOperationKey);
 
     // when
@@ -1317,7 +1317,7 @@ class RdbmsExporterIT {
     assertThat(item.processInstanceKey()).isNull();
     assertThat(item.rootProcessInstanceKey()).isNull();
     assertThat(item.operationType()).isEqualTo(BatchOperationType.DELETE_DECISION_INSTANCE);
-    assertThat(item.state()).isEqualTo(BatchOperationItemState.COMPLETED);
+    assertThat(item.state()).isEqualTo(BatchOperationItemState.FAILED);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -565,7 +565,7 @@ public class RecordFixtures {
         .build();
   }
 
-  public ImmutableRecord<RecordValue> getHistoryDeletionRecord(
+  public ImmutableRecord<RecordValue> getRejectedHistoryDeletionRecord(
       final HistoryDeletionIntent intent,
       final long resourceKey,
       final HistoryDeletionType deletionType) {
@@ -578,6 +578,7 @@ public class RecordFixtures {
         .withPosition(nextPosition())
         .withPartitionId(1)
         .withTimestamp(System.currentTimeMillis())
+        .withRejectionType(RejectionType.INVALID_STATE)
         .withValue(
             ImmutableHistoryDeletionRecordValue.builder()
                 .from((ImmutableHistoryDeletionRecordValue) recordValueRecord.getValue())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationHandler.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 public abstract class AbstractOperationHandler<T extends ExporterEntity<T>, R extends RecordValue>
     implements ExportHandler<T, R> {
 
-  protected static final String ID_PATTERN = "%s_%s";
+  public static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
   protected final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
   private final OperationType relevantOperationType;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandler.java
@@ -53,8 +53,8 @@ public class DecisionInstanceHistoryDeletionOperationHandler
 
   @Override
   boolean isCompleted(final Record<HistoryDeletionRecordValue> record) {
-    return record.getValueType() == ValueType.HISTORY_DELETION
-        && record.getIntent().equals(HistoryDeletionIntent.DELETED);
+    // Completion is handled in the HistoryDeletionJob.
+    return false;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandler.java
@@ -53,8 +53,8 @@ public class ProcessInstanceHistoryDeletionOperationHandler
 
   @Override
   boolean isCompleted(final Record<HistoryDeletionRecordValue> record) {
-    return record.getValueType() == ValueType.HISTORY_DELETION
-        && record.getIntent().equals(HistoryDeletionIntent.DELETED);
+    // Completion is handled in the HistoryDeletionJob.
+    return false;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -284,13 +284,25 @@ public final class BackgroundTaskManagerFactory {
   private OpenSearchHistoryDeletionRepository createHistoryDeletionRepository(
       final OpenSearchAsyncClient asyncClient) {
     return new OpenSearchHistoryDeletionRepository(
-        resourceProvider, asyncClient, executor, logger, partitionId, config.getHistoryDeletion());
+        resourceProvider,
+        asyncClient,
+        executor,
+        logger,
+        partitionId,
+        config.getHistoryDeletion(),
+        clock);
   }
 
   private ElasticsearchHistoryDeletionRepository createHistoryDeletionRepository(
       final ElasticsearchAsyncClient asyncClient) {
     return new ElasticsearchHistoryDeletionRepository(
-        resourceProvider, asyncClient, executor, logger, partitionId, config.getHistoryDeletion());
+        resourceProvider,
+        asyncClient,
+        executor,
+        logger,
+        partitionId,
+        config.getHistoryDeletion(),
+        clock);
   }
 
   private OpensearchAuditLogArchiverRepository createAuditLogArchiverRepository(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -212,7 +212,7 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
   }
 
   @Override
-  public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+  public CompletableFuture<List<String>> completeOperations(final List<String> ids) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
 
     final var fieldsToUpdate =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepository.java
@@ -20,9 +20,15 @@ import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import java.time.InstantSource;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -41,6 +47,8 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
   private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
   private final HistoryDeletionConfiguration config;
+  private final InstantSource clock;
+  private final OperationTemplate operationIndexTemplateDescriptor;
 
   public ElasticsearchHistoryDeletionRepository(
       final ExporterResourceProvider resourceProvider,
@@ -48,7 +56,8 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
       final Executor executor,
       final Logger logger,
       final int partitionId,
-      final HistoryDeletionConfiguration config) {
+      final HistoryDeletionConfiguration config,
+      final InstantSource clock) {
     super(client, executor, logger);
     indexDescriptor =
         resourceProvider.getIndexDescriptors().stream()
@@ -62,8 +71,11 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
             .findFirst()
             .orElseThrow(
                 () -> new IllegalStateException("No AuditLogCleanupIndex descriptor found"));
+    operationIndexTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
     this.partitionId = partitionId;
     this.config = config;
+    this.clock = clock;
   }
 
   @Override
@@ -195,6 +207,44 @@ public class ElasticsearchHistoryDeletionRepository extends ElasticsearchReposit
                   entries.size(),
                   targetIndexName);
               return CompletableFuture.completedFuture(null);
+            },
+            executor);
+  }
+
+  @Override
+  public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+
+    final var fieldsToUpdate =
+        Map.of(
+            OperationTemplate.STATE,
+            OperationState.COMPLETED,
+            OperationTemplate.COMPLETED_DATE,
+            OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC));
+
+    ids.forEach(
+        id ->
+            bulkRequestBuilder.operations(
+                op ->
+                    op.update(
+                        u ->
+                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
+                                .id(id)
+                                .action(a -> a.doc(fieldsToUpdate))
+                                .retryOnConflict(3))));
+
+    return client
+        .bulk(bulkRequestBuilder.build())
+        .thenComposeAsync(
+            response -> {
+              if (response.errors()) {
+                final var errorMessage =
+                    "Bulk updating operations by ids '%s' failed with errors: %s"
+                        .formatted(ids, response.items());
+                logger.error(errorMessage);
+                return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+              }
+              return CompletableFuture.completedFuture(ids);
             },
             executor);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionBatch.java
@@ -31,4 +31,10 @@ public record HistoryDeletionBatch(List<HistoryDeletionEntity> historyDeletionEn
         .map(HistoryDeletionEntity::getId)
         .toList();
   }
+
+  List<HistoryDeletionEntity> getEntities(final HistoryDeletionType historyDeletionType) {
+    return historyDeletionEntities.stream()
+        .filter(entity -> entity.getResourceType().equals(historyDeletionType))
+        .toList();
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -187,16 +187,7 @@ public class HistoryDeletionJob implements BackgroundTask {
                   dependentSourceIdx, dependentIdFieldName, processInstanceKeys);
             })
         .thenCompose(
-            ignored -> {
-              final var operationIds =
-                  batch.getEntities(HistoryDeletionType.PROCESS_INSTANCE).stream()
-                      .map(
-                          entity ->
-                              AbstractOperationHandler.ID_PATTERN.formatted(
-                                  entity.getBatchOperationKey(), entity.getResourceKey()))
-                      .toList();
-              return deleterRepository.updateOperations(operationIds);
-            })
+            ignored -> markOperationAsCompleted(batch, HistoryDeletionType.PROCESS_INSTANCE))
         .thenApply(ignored -> batch.getHistoryDeletionIds(HistoryDeletionType.PROCESS_INSTANCE));
   }
 
@@ -244,17 +235,27 @@ public class HistoryDeletionJob implements BackgroundTask {
             DecisionInstanceTemplate.KEY,
             decisionInstances)
         .thenCompose(
-            ignored -> {
-              final var operationIds =
-                  batch.getEntities(HistoryDeletionType.DECISION_INSTANCE).stream()
-                      .map(
-                          entity ->
-                              AbstractOperationHandler.ID_PATTERN.formatted(
-                                  entity.getBatchOperationKey(), entity.getResourceKey()))
-                      .toList();
-              return deleterRepository.updateOperations(operationIds);
-            })
+            ignored -> markOperationAsCompleted(batch, HistoryDeletionType.DECISION_INSTANCE))
         .thenApply(ignored -> batch.getHistoryDeletionIds(HistoryDeletionType.DECISION_INSTANCE));
+  }
+
+  /**
+   * Marks the individual operations in the batch operation as completed
+   *
+   * @param batch the batch of entities to delete
+   * @param historyDeletionType the type of entities to mark as completed
+   * @return a future that becomes successful when the request to secondary storage succeeded.
+   */
+  private CompletableFuture<List<String>> markOperationAsCompleted(
+      final HistoryDeletionBatch batch, final HistoryDeletionType historyDeletionType) {
+    final var operationIds =
+        batch.getEntities(historyDeletionType).stream()
+            .map(
+                entity ->
+                    AbstractOperationHandler.ID_PATTERN.formatted(
+                        entity.getBatchOperationKey(), entity.getResourceKey()))
+            .toList();
+    return deleterRepository.updateOperations(operationIds);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -255,7 +255,7 @@ public class HistoryDeletionJob implements BackgroundTask {
                     AbstractOperationHandler.ID_PATTERN.formatted(
                         entity.getBatchOperationKey(), entity.getResourceKey()))
             .toList();
-    return deleterRepository.updateOperations(operationIds);
+    return deleterRepository.completeOperations(operationIds);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -243,6 +243,17 @@ public class HistoryDeletionJob implements BackgroundTask {
             decisionInstanceTemplate.getIndexPattern(),
             DecisionInstanceTemplate.KEY,
             decisionInstances)
+        .thenCompose(
+            ignored -> {
+              final var operationIds =
+                  batch.getEntities(HistoryDeletionType.DECISION_INSTANCE).stream()
+                      .map(
+                          entity ->
+                              AbstractOperationHandler.ID_PATTERN.formatted(
+                                  entity.getBatchOperationKey(), entity.getResourceKey()))
+                      .toList();
+              return deleterRepository.updateOperations(operationIds);
+            })
         .thenApply(ignored -> batch.getHistoryDeletionIds(HistoryDeletionType.DECISION_INSTANCE));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.historydeletion;
 
 import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -184,6 +185,17 @@ public class HistoryDeletionJob implements BackgroundTask {
               final var dependentIdFieldName = ListViewTemplate.PROCESS_INSTANCE_KEY;
               return deleterRepository.deleteDocumentsByField(
                   dependentSourceIdx, dependentIdFieldName, processInstanceKeys);
+            })
+        .thenCompose(
+            ignored -> {
+              final var operationIds =
+                  batch.getEntities(HistoryDeletionType.PROCESS_INSTANCE).stream()
+                      .map(
+                          entity ->
+                              AbstractOperationHandler.ID_PATTERN.formatted(
+                                  entity.getBatchOperationKey(), entity.getResourceKey()))
+                      .toList();
+              return deleterRepository.updateOperations(operationIds);
             })
         .thenApply(ignored -> batch.getHistoryDeletionIds(HistoryDeletionType.PROCESS_INSTANCE));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -71,7 +71,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    * @param ids the list of ids to mark as completed
    * @return a {@link CompletableFuture} containing the list of ids that were marked as completed
    */
-  CompletableFuture<List<String>> updateOperations(final List<String> ids);
+  CompletableFuture<List<String>> completeOperations(final List<String> ids);
 
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
@@ -99,7 +99,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+    public CompletableFuture<List<String>> completeOperations(final List<String> ids) {
       return CompletableFuture.completedFuture(List.of());
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -45,7 +45,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
    *
    * @param sourceIndexName The index to delete the documents from
    * @param ids The list of document IDs to delete
-   * @return a {@link CompletableFuture} containing th number of entities that were deleted
+   * @return a {@link CompletableFuture} containing the number of entities that were deleted
    */
   CompletableFuture<Integer> deleteDocumentsById(
       final String sourceIndexName, final List<String> ids);
@@ -62,6 +62,16 @@ public interface HistoryDeletionRepository extends AutoCloseable {
   CompletionStage<Void> createAuditLogCleanupEntries(
       final List<HistoryDeletionEntity> historyDeletionEntities,
       final Set<String> deletedResources);
+
+  /**
+   * Marks the individual operations of the batch operation as completed. The list of ids here
+   * should adhere to the pattern defined in {@link
+   * io.camunda.webapps.schema.descriptors.template.OperationTemplate}.
+   *
+   * @param ids the list of ids to mark as completed
+   * @return a {@link CompletableFuture} containing the list of ids that were marked as completed
+   */
+  CompletableFuture<List<String>> updateOperations(final List<String> ids);
 
   class NoopHistoryDeletionRepository implements HistoryDeletionRepository {
     @Override
@@ -86,6 +96,11 @@ public interface HistoryDeletionRepository extends AutoCloseable {
         final List<HistoryDeletionEntity> historyDeletionEntities,
         final Set<String> deletedResources) {
       return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+      return CompletableFuture.completedFuture(List.of());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionRepository.java
@@ -66,7 +66,7 @@ public interface HistoryDeletionRepository extends AutoCloseable {
   /**
    * Marks the individual operations of the batch operation as completed. The list of ids here
    * should adhere to the pattern defined in {@link
-   * io.camunda.webapps.schema.descriptors.template.OperationTemplate}.
+   * io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler#ID_PATTERN}.
    *
    * @param ids the list of ids to mark as completed
    * @return a {@link CompletableFuture} containing the list of ids that were marked as completed

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -220,7 +220,7 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
   }
 
   @Override
-  public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+  public CompletableFuture<List<String>> completeOperations(final List<String> ids) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
 
     final var fieldsToUpdate =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionRepository.java
@@ -12,11 +12,17 @@ import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
 import java.io.IOException;
+import java.time.InstantSource;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -43,6 +49,8 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
   private final IndexDescriptor auditLogCleanupIndex;
   private final int partitionId;
   private final HistoryDeletionConfiguration config;
+  private final InstantSource clock;
+  private final OperationTemplate operationIndexTemplateDescriptor;
 
   public OpenSearchHistoryDeletionRepository(
       final ExporterResourceProvider resourceProvider,
@@ -50,7 +58,8 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
       final Executor executor,
       final Logger logger,
       final int partitionId,
-      final HistoryDeletionConfiguration config) {
+      final HistoryDeletionConfiguration config,
+      final InstantSource clock) {
     super(client, executor, logger);
     indexDescriptor =
         resourceProvider.getIndexDescriptors().stream()
@@ -64,8 +73,11 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
             .findFirst()
             .orElseThrow(
                 () -> new IllegalStateException("No AuditLogCleanupIndex descriptor found"));
+    operationIndexTemplateDescriptor =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
     this.partitionId = partitionId;
     this.config = config;
+    this.clock = clock;
   }
 
   @Override
@@ -203,6 +215,46 @@ public class OpenSearchHistoryDeletionRepository extends OpensearchRepository
                           entries.size(),
                           targetIndexName);
                       return CompletableFuture.completedFuture(null);
+                    },
+                    executor));
+  }
+
+  @Override
+  public CompletableFuture<List<String>> updateOperations(final List<String> ids) {
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+
+    final var fieldsToUpdate =
+        Map.of(
+            OperationTemplate.STATE,
+            OperationState.COMPLETED,
+            OperationTemplate.COMPLETED_DATE,
+            OffsetDateTime.ofInstant(clock.instant(), ZoneOffset.UTC));
+
+    ids.forEach(
+        id ->
+            bulkRequestBuilder.operations(
+                op ->
+                    op.update(
+                        u ->
+                            u.index(operationIndexTemplateDescriptor.getFullQualifiedName())
+                                .id(id)
+                                .document(fieldsToUpdate)
+                                .retryOnConflict(3))));
+
+    return sendRequestAsync(
+        () ->
+            client
+                .bulk(bulkRequestBuilder.build())
+                .thenComposeAsync(
+                    response -> {
+                      if (response.errors()) {
+                        final var errorMessage =
+                            "Bulk updating operations by ids '%s' failed with errors: %s"
+                                .formatted(ids, response.items());
+                        logger.error(errorMessage);
+                        return CompletableFuture.failedFuture(new RuntimeException(errorMessage));
+                      }
+                      return CompletableFuture.completedFuture(ids);
                     },
                     executor));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -611,6 +611,23 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Override
+    @Test
+    void shouldHandleSuccessRecord() {
+      // We override the abstract test as this handler should not handle a success record.
+      final var record = createSuccessRecord();
+      assertThat(handler.handlesRecord(record)).isFalse();
+    }
+
+    @Override
+    @Test
+    void shouldUpdateEntityOnSuccess() {
+      // We don't want to test anything here. This handler is not supposed to handle the success
+      // record, and thus should not update the entity. Since the abstract test would fail, we need
+      // to override it with a NOOP implementation.
+      assert true;
+    }
+
+    @Override
     void shouldExtractCorrectItemKey() {
       final var record = createSuccessRecord();
       final var itemKey = handler.getItemKey(record);
@@ -667,6 +684,23 @@ class BatchOperationStatusHandlerTest {
 
     DecisionInstanceHistoryDeletionOperationHandlerTest() {
       super(new DecisionInstanceHistoryDeletionOperationHandler(indexName, batchOperationCache));
+    }
+
+    @Override
+    @Test
+    void shouldHandleSuccessRecord() {
+      // We override the abstract test as this handler should not handle a success record.
+      final var record = createSuccessRecord();
+      assertThat(handler.handlesRecord(record)).isFalse();
+    }
+
+    @Override
+    @Test
+    void shouldUpdateEntityOnSuccess() {
+      // We don't want to test anything here. This handler is not supposed to handle the success
+      // record, and thus should not update the entity. Since the abstract test would fail, we need
+      // to override it with a NOOP implementation.
+      assert true;
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/ElasticsearchHistoryDeletionRepositoryIT.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
+import java.time.InstantSource;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,8 @@ public class ElasticsearchHistoryDeletionRepositoryIT extends HistoryDeletionRep
         Runnable::run,
         LOGGER,
         partitionId,
-        config.getHistoryDeletion());
+        config.getHistoryDeletion(),
+        InstantSource.system());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJobTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
@@ -76,6 +77,8 @@ final class HistoryDeletionJobTest {
     job = new HistoryDeletionJob(dependants, executor, repository, LOGGER, resourceProvider);
     when(repository.createAuditLogCleanupEntries(anyList(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(repository.completeOperations(anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
   }
 
   @Test
@@ -1019,5 +1022,135 @@ final class HistoryDeletionJobTest {
             argThat(
                 deletedResources ->
                     deletedResources.size() == 1 && deletedResources.contains("id1")));
+  }
+
+  @Test
+  void shouldMarkProcessInstanceDeletionOperationsAsCompleted() {
+    // given
+    final var entity1 =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var entity2 =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(3L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity1, entity2))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .completeOperations(
+            List.of(
+                AbstractOperationHandler.ID_PATTERN.formatted(
+                    entity1.getBatchOperationKey(), entity1.getResourceKey()),
+                AbstractOperationHandler.ID_PATTERN.formatted(
+                    entity2.getBatchOperationKey(), entity2.getResourceKey())));
+  }
+
+  @Test
+  void shouldMarkDecisionInstanceDeletionOperationsAsCompleted() {
+    // given
+    final var entity1 =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    final var entity2 =
+        new HistoryDeletionEntity()
+            .setId("id2")
+            .setResourceKey(3L)
+            .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(
+            CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity1, entity2))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+
+    // when
+    job.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository)
+        .completeOperations(
+            List.of(
+                AbstractOperationHandler.ID_PATTERN.formatted(
+                    entity1.getBatchOperationKey(), entity1.getResourceKey()),
+                AbstractOperationHandler.ID_PATTERN.formatted(
+                    entity2.getBatchOperationKey(), entity2.getResourceKey())));
+  }
+
+  @Test
+  void shouldNotDeleteProcessInstanceFromDeletionIndexIfOperationCompletionMarkFailed() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.PROCESS_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+    when(repository.completeOperations(anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed marking")));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
+    verify(repository, never())
+        .deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any());
+  }
+
+  @Test
+  void shouldNotDeleteDecisionInstanceFromDeletionIndexIfOperationCompletionMarkFailed() {
+    // given
+    final var entity =
+        new HistoryDeletionEntity()
+            .setId("id1")
+            .setResourceKey(1L)
+            .setResourceType(HistoryDeletionType.DECISION_INSTANCE)
+            .setBatchOperationKey(2L)
+            .setPartitionId(1);
+    when(repository.getNextBatch())
+        .thenReturn(CompletableFuture.completedFuture(new HistoryDeletionBatch(List.of(entity))));
+    when(repository.deleteDocumentsByField(anyString(), anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+    when(repository.deleteDocumentsById(anyString(), anyList()))
+        .thenReturn(CompletableFuture.completedFuture(0));
+    when(repository.completeOperations(anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed marking")));
+
+    // when
+    job.execute().exceptionally(ex -> 0).toCompletableFuture().join();
+
+    // then
+    verify(repository, never())
+        .deleteDocumentsById(eq(historyDeletionIndex.getFullQualifiedName()), any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/historydeletion/OpenSearchHistoryDeletionIT.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import java.io.IOException;
+import java.time.InstantSource;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,8 @@ public class OpenSearchHistoryDeletionIT extends HistoryDeletionRepositoryIT {
         Runnable::run,
         LOGGER,
         partitionId,
-        config.getHistoryDeletion());
+        config.getHistoryDeletion(),
+        InstantSource.system());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -151,7 +151,8 @@ public class RdbmsExporterWrapper implements Exporter {
                 config.getHistoryDeletion().getDelayBetweenRuns(),
                 config.getHistoryDeletion().getMaxDelayBetweenRuns(),
                 config.getHistoryDeletion().getQueueBatchSize(),
-                config.getHistoryDeletion().getDependentRowLimit()));
+                config.getHistoryDeletion().getDependentRowLimit()),
+            context.clock());
     builder.historyDeletionService(historyDeletionService);
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/DecisionInstanceHistoryDeletionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/DecisionInstanceHistoryDeletionBatchOperationExportHandler.java
@@ -51,7 +51,8 @@ public class DecisionInstanceHistoryDeletionBatchOperationExportHandler
 
   @Override
   boolean isCompleted(final Record<HistoryDeletionRecordValue> record) {
-    return record.getIntent().equals(HistoryDeletionIntent.DELETED);
+    // Completion is handled in the HistoryDeletionService.
+    return false;
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceHistoryDeletionBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceHistoryDeletionBatchOperationExportHandler.java
@@ -51,7 +51,8 @@ public class ProcessInstanceHistoryDeletionBatchOperationExportHandler
 
   @Override
   boolean isCompleted(final Record<HistoryDeletionRecordValue> record) {
-    return record.getIntent().equals(HistoryDeletionIntent.DELETED);
+    // Completion is handled in the HistoryDeletionService.
+    return false;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Accurately reflect the operation items state. Only mark them as complete once they data is actually deleted.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46526
