### PR TITLE
fix: Fix flaky ClusterMultiplePartitionsBatchOperationIT

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -38,7 +38,8 @@ public class DefaultExecutionQueue implements ExecutionQueue {
   private static final Set<Pattern> IGNORE_EMPTY_UPDATES =
       Set.of(
           Pattern.compile(".*update.*HistoryCleanupDate$"),
-          Pattern.compile("io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists"));
+          Pattern.compile("io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists"),
+          Pattern.compile("io.camunda.db.rdbms.sql.BatchOperationMapper.activate"));
 
   private final SqlSessionFactory sessionFactory;
   private final List<PreFlushListener> preFlushListeners = new ArrayList<>();

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -92,6 +92,7 @@
     SET STATE      = 'ACTIVE',
         START_DATE = #{startDate, jdbcType=TIMESTAMP}
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+      AND STATE != 'COMPLETED'
   </update>
 
   <update id="updateCompleted"

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -412,6 +412,7 @@ class DefaultExecutionQueueTest {
     "foo.updateHistoryCleanupDate,true",
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.updateHistoryCleanupDate,true",
     "io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists,true",
+    "io.camunda.db.rdbms.sql.BatchOperationMapper.activate,true",
     "some.other.Statement,false"
   })
   void shouldIgnoreWhenNoRowsAffectedMatchesPatterns(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes the flaky test `ClusterMultiplePartitionsBatchOperationIT`, and potentially a bug, that causes the batch operate state to stay in `ACTIVE` state even when completed.
I think we have the same issue for Elasticsearch/Opensearch. However, `ClusterMultiplePartitionsBatchOperationIT` runs only for RDBMS, for unknown reason. The test is flaky with ES/OS in local

**Changes:**
* Add a state guard to the batch operation activate SQL statement to prevent a late INITIALIZED export from overwriting a terminal COMPLETED state back to ACTIVE
* In a multi-partition setup, each partition independently exports `INITIALIZED` events. If a slow partition's exporter flushes after the BO lead partition has already marked the batch operation as `COMPLETED`, this overwrites the state back to ACTIVE
* The fix adds `AND STATE != 'COMPLETED'` to the WHERE clause and registers the statement in `IGNORE_EMPTY_UPDATES` since the guarded update may now legitimately affect 0 rows

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
