### PR TITLE
Feat/set max field length rdbms

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -32,6 +32,12 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
    */
   private Integer queueMemoryLimit = RdbmsWriterConfig.DEFAULT_QUEUE_MEMORY_LIMIT;
 
+  /**
+   * The maximum length of varchar fields in the database. This is relevant for user defined string
+   * fields like ids and names.
+   */
+  private Integer maxVarcharFieldLength = RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH;
+
   /** Process definition cache configuration. Defines the size of the process definition cache. */
   private RdbmsCache processCache = new RdbmsCache();
 
@@ -175,5 +181,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setQuery(final RdbmsQuery query) {
     this.query = query;
+  }
+
+  public Integer getMaxVarcharFieldLength() {
+    return maxVarcharFieldLength;
+  }
+
+  public void setMaxVarcharFieldLength(final Integer maxVarcharFieldLength) {
+    this.maxVarcharFieldLength = maxVarcharFieldLength;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -878,6 +878,23 @@ public class BrokerBasedPropertiesOverride {
 
     final Rdbms database = secondaryStorage.getRdbms();
 
+    /* Limit */
+    override
+        .getExperimental()
+        .getEngine()
+        .getValidators()
+        .setMaxIdFieldLength(database.getMaxVarcharFieldLength());
+    override
+        .getExperimental()
+        .getEngine()
+        .getValidators()
+        .setMaxNameFieldLength(database.getMaxVarcharFieldLength());
+    override
+        .getExperimental()
+        .getEngine()
+        .getValidators()
+        .setMaxWorkerTypeLength(database.getMaxVarcharFieldLength());
+
     /* Load exporter config map */
 
     var exporter = override.getRdbmsExporter();

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -25,6 +25,8 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistElasticsearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.ValidatorsCfg;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -357,6 +359,18 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
       assertThat(searchEngineIndexProperties.getShardsByIndexName())
           .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
+    }
+
+    @Test
+    void testEngineValidatorsProperties() {
+      final ValidatorsCfg validators =
+          brokerBasedProperties.getExperimental().getEngine().getValidators();
+      assertThat(validators.getMaxIdFieldLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH);
+      assertThat(validators.getMaxNameFieldLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH);
+      assertThat(validators.getMaxWorkerTypeLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_WORKER_TYPE_LENGTH);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -25,6 +25,8 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistOpenSearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.ValidatorsCfg;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -348,6 +350,18 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_REPLICAS_BY_INDEX_NAME);
       assertThat(searchEngineIndexProperties.getShardsByIndexName())
           .isEqualTo(EXPECTED_SHARDS_BY_INDEX_NAME);
+    }
+
+    @Test
+    void testEngineValidatorsProperties() {
+      final ValidatorsCfg validators =
+          brokerBasedProperties.getExperimental().getEngine().getValidators();
+      assertThat(validators.getMaxIdFieldLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_ID_FIELD_LENGTH);
+      assertThat(validators.getMaxNameFieldLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_NAME_FIELD_LENGTH);
+      assertThat(validators.getMaxWorkerTypeLength())
+          .isEqualTo(EngineConfiguration.DEFAULT_MAX_WORKER_TYPE_LENGTH);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -15,11 +15,13 @@ import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverr
 import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.exporter.rdbms.ExporterConfiguration;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.broker.system.configuration.engine.ValidatorsCfg;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +105,7 @@ public class SecondaryStorageRdbmsTest {
         "camunda.data.secondary-storage.rdbms.exportBatchOperationItemsOnCreation=false",
         "camunda.data.secondary-storage.rdbms.batchOperationItemInsertBlockSize=1234",
         "camunda.data.secondary-storage.rdbms.insert-batching.max-audit-log-insert-batch-size=50",
+        "camunda.data.secondary-storage.rdbms.max-varchar-field-length=200",
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -184,6 +187,15 @@ public class SecondaryStorageRdbmsTest {
     }
 
     @Test
+    void testEngineValidatorsDefaults() {
+      final ValidatorsCfg validators =
+          brokerBasedProperties.getExperimental().getEngine().getValidators();
+      assertThat(validators.getMaxIdFieldLength()).isEqualTo(200);
+      assertThat(validators.getMaxNameFieldLength()).isEqualTo(200);
+      assertThat(validators.getMaxWorkerTypeLength()).isEqualTo(200);
+    }
+
+    @Test
     void testCamundaSearchEngineConnectProperties() {
       assertThat(searchEngineConnectProperties.getTypeEnum()).isEqualTo(DatabaseType.RDBMS);
       assertThat(searchEngineConnectProperties.getUrl()).isEqualTo("http://expected-url:4321");
@@ -213,6 +225,18 @@ public class SecondaryStorageRdbmsTest {
       assertThat(args.get("flushInterval")).isEqualTo(Duration.ofMillis(500));
       assertThat(args.get("exportBatchOperationItemsOnCreation")).isEqualTo(true);
       assertThat(args.get("batchOperationItemInsertBlockSize")).isEqualTo(10000);
+    }
+
+    @Test
+    void testEngineValidatorsDefaults() {
+      final ValidatorsCfg validators =
+          brokerBasedProperties.getExperimental().getEngine().getValidators();
+      assertThat(validators.getMaxIdFieldLength())
+          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
+      assertThat(validators.getMaxNameFieldLength())
+          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
+      assertThat(validators.getMaxWorkerTypeLength())
+          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -36,6 +36,7 @@ public record RdbmsWriterConfig(
   public static final int DEFAULT_QUEUE_SIZE = 1000;
   // Default memory limit: 20MB - aligned with CamundaExporter's default
   public static final int DEFAULT_QUEUE_MEMORY_LIMIT = 20;
+  public static final int DEFAULT_MAX_VARCHAR_FIELD_LENGTH = 400;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
   public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionCreateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionCreateIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@MultiDbTest
+public class ProcessDefinitionCreateIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void shouldRejectProcessDefinitionOnRdbmsWhenIdIsTooLong() {
+    final var processDefinition =
+        Bpmn.createExecutableProcess(
+                "p".repeat(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH + 1))
+            .name("my process")
+            .startEvent()
+            .endEvent()
+            .done();
+
+    assertThatThrownBy(
+            () -> {
+              camundaClient
+                  .newDeployResourceCommand()
+                  .addProcessModel(processDefinition, "process.bpmn")
+                  .execute();
+            })
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining(
+            "ERROR: IDs must not be longer than the configured max-id-length of %d characters"
+                .formatted(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH));
+  }
+}


### PR DESCRIPTION
This pull request introduces a configurable maximum length for varchar fields in the RDBMS configuration, ensuring that user-defined string fields (such as IDs and names) do not exceed database-imposed limits. It propagates this configuration to relevant validation logic and adds comprehensive tests to verify both configuration and enforcement, including an integration test that ensures process definitions with overly long IDs are correctly rejected.

**Configuration and Propagation of Max Varchar Length:**

* Added a new `maxVarcharFieldLength` field to the `Rdbms` configuration class, with getter and setter, defaulting to `RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH` (400). This value is now configurable via properties. [[1]](diffhunk://#diff-de3f11b851bcb595ee888adc031d9950d3ed5ecd412a9fdc8bd268c62e3a037bR35-R40) [[2]](diffhunk://#diff-de3f11b851bcb595ee888adc031d9950d3ed5ecd412a9fdc8bd268c62e3a037bR185-R192) [[3]](diffhunk://#diff-c358bca9c7ab2e42c95e2f92a432dc2b3edbff8138f82e366e34c347595af1c1R39)
* Updated the `BrokerBasedPropertiesOverride` logic to propagate the `maxVarcharFieldLength` setting to the engine's validators for ID, name, and worker type fields, ensuring consistent enforcement across the stack.

**Testing and Validation:**

* Extended existing configuration tests to verify that the `maxVarcharFieldLength` property is correctly set from configuration and defaults, and that it is applied to all relevant validator fields. [[1]](diffhunk://#diff-95cc4d44353480a777ae792e1f14e0f1067232338eafed666b6181426c78b69bR108) [[2]](diffhunk://#diff-95cc4d44353480a777ae792e1f14e0f1067232338eafed666b6181426c78b69bR187-R192) [[3]](diffhunk://#diff-95cc4d44353480a777ae792e1f14e0f1067232338eafed666b6181426c78b69bR225-R233)
* Added a new integration test (`ProcessDefinitionCreateIT`) that deploys a process definition with an ID exceeding the maximum allowed length, asserting that the deployment fails with the expected error message.## Description


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46672 
