### PR TITLE
refactor: update operate nullable fields

### DIFF
--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
@@ -66,7 +66,8 @@ const DecisionPanel: React.FC<DecisionPanelProps> = (props) => {
     >
       {decisionInstance?.state === 'FAILED' && (
         <IncidentBanner data-testid="incident-banner">
-          {decisionInstance.evaluationFailure}
+          {decisionInstance.evaluationFailure ??
+            'Evaluation failed with unknown error'}
         </IncidentBanner>
       )}
       <DiagramShell status={getStatus()}>

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
@@ -92,9 +92,9 @@ const InputsAndOutputs: React.FC<InputAndOutputProps> = ({
 
     return decisionInstance.matchedRules.flatMap((rule) => {
       return rule.evaluatedOutputs.map<RowProps>((output) => ({
-        key: `${output.outputId}--${rule.ruleId}`,
+        key: `${output.outputId}--${rule.ruleId ?? 'no-rule-id'}`,
         columns: [
-          {cellContent: rule.ruleIndex},
+          {cellContent: rule.ruleIndex ?? '--'},
           {cellContent: output.outputName},
           {cellContent: output.outputValue},
         ],

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
@@ -167,7 +167,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
                     {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
                   </Link>
                 ),
-              jobKey: incident.jobKey ?? '--',
+              jobKey: incident.jobKey || '--',
               creationTime: formatDate(incident.creationTime),
               errorMessage: (
                 <FlexContainer>

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
@@ -167,7 +167,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
                     {`${incident.elementId} - ${incident.processDefinitionName} - ${incident.processInstanceKey}`}
                   </Link>
                 ),
-              jobKey: incident.jobKey || '--',
+              jobKey: incident.jobKey ?? '--',
               creationTime: formatDate(incident.creationTime),
               errorMessage: (
                 <FlexContainer>


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/46183 made all optional fields return as null. With that change some nullable fields has to be updated since the API can now return null for these fields (not just omit them), empty string is a valid distinct value that should NOT be treated as falsy

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to https://github.com/camunda/camunda/pull/46370
