### PR TITLE
Propagate business id to all element instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -657,7 +657,7 @@ public final class BpmnStateTransitionBehavior {
   }
 
   public long createChildProcessInstance(
-      final DeployedProcess process, final BpmnElementContext context, final String businessId) {
+      final DeployedProcess process, final BpmnElementContext context) {
 
     final var processInstanceKey = keyGenerator.nextKey();
 
@@ -673,7 +673,7 @@ public final class BpmnStateTransitionBehavior {
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(context.getTenantId())
         .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
-        .setBusinessId(businessId);
+        .setBusinessId(context.getBusinessId());
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -97,12 +97,8 @@ public final class CallActivityProcessor
               final var activated =
                   stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
-              final var processInstance =
-                  stateBehavior.getElementInstance(context.getProcessInstanceKey());
-              final String businessId = processInstance.getValue().getBusinessId();
-
               final var childProcessInstanceKey =
-                  stateTransitionBehavior.createChildProcessInstance(process, context, businessId);
+                  stateTransitionBehavior.createChildProcessInstance(process, context);
 
               final var propagateAllParentVariablesEnabled =
                   element.isPropagateAllParentVariablesEnabled();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
@@ -1313,6 +1314,51 @@ public final class CallActivityTest {
         .allSatisfy(
             instance ->
                 assertThat(instance.getRootProcessInstanceKey()).isEqualTo(rootInstanceKey));
+  }
+
+  @Test
+  public void shouldInheritBusinessIdFromParentProcessInstance() {
+    final String processUnderTestId = helper.getBpmnProcessId() + "_underTest";
+    final String processWithCallActivityId = helper.getBpmnProcessId() + "_callActivity";
+    final String businessId = "biz-123";
+
+    // given:
+    // - two processes: process under test and call activity process
+    // - and an instance of the process under test with a business id
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processUnderTestId)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processWithCallActivityId)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(processUnderTestId))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var parentProcessInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processWithCallActivityId)
+            .withBusinessId(businessId)
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withBpmnProcessId(processUnderTestId)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expect the called process instance to inherit the business id from the call activity instance")
+        .hasBusinessId(businessId);
   }
 
   private void deployDefaultParentAndChildProcess() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceBusinessIdUniquenessTest.java
@@ -312,51 +312,6 @@ public final class CreateProcessInstanceBusinessIdUniquenessTest {
   }
 
   @Test
-  public void shouldInheritBusinessIdFromParentProcessInstance() {
-    final String processUnderTestId = helper.getBpmnProcessId() + "_underTest";
-    final String processWithCallActivityId = helper.getBpmnProcessId() + "_callActivity";
-    final String businessId = "biz-123";
-
-    // given:
-    // - two processes: process under test and call activity process
-    // - and an instance of the process under test with a business id
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processUnderTestId)
-                .startEvent()
-                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
-                .endEvent()
-                .done())
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processWithCallActivityId)
-                .startEvent()
-                .callActivity("call", c -> c.zeebeProcessId(processUnderTestId))
-                .endEvent()
-                .done())
-        .deploy();
-
-    // when
-    final var parentProcessInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(processWithCallActivityId)
-            .withBusinessId(businessId)
-            .create();
-
-    // then
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withBpmnProcessId(processUnderTestId)
-                .withParentProcessInstanceKey(parentProcessInstanceKey)
-                .getFirst()
-                .getValue())
-        .describedAs(
-            "Expect the called process instance to inherit the business id from the call activity instance")
-        .hasBusinessId(businessId);
-  }
-
-  @Test
   public void shouldAllowMultipleChildProcessInstancesWithSameBusinessId() {
     final String parentProcessId = helper.getBpmnProcessId() + "_parent";
     final String childProcessId = helper.getBpmnProcessId() + "_child";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceTest.java
@@ -281,14 +281,24 @@ public final class CreateProcessInstanceTest {
         ENGINE.processInstance().ofBpmnProcessId(processId).withBusinessId(businessId).create();
 
     // then
-    final Record<ProcessInstanceRecordValue> processActivated =
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withElementType(BpmnElementType.PROCESS)
-            .getFirst();
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withInstanceKey(processInstanceKey)
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .getFirst()
+                .getValue()
+                .getBusinessId())
+        .describedAs("Should create process instance with the given business id")
+        .isEqualTo(businessId);
 
-    assertThat(processActivated.getValue().getBusinessId()).isEqualTo(businessId);
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .map(Record::getValue)
+        .map(ProcessInstanceRecordValue::getBusinessId)
+        .describedAs("Should propagate business id to all process instance records")
+        .containsOnly(businessId);
   }
 
   @Test

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -200,8 +200,6 @@ public interface ProcessInstanceRecordValue
    * user-defined string identifier that can be used to identify a process instance within the scope
    * of a process definition.
    *
-   * <p>The business id is set only on elements of type PROCESS.
-   *
    * <p>Once set, it remains immutable throughout the instance's lifecycle.
    *
    * <p>It can be used to enforce idempotency when creating process instances.


### PR DESCRIPTION
## Description

Propagate the `businessId` to all element instances in `PROCESS_INSTANCE` records, not just elements of type `PROCESS`.

### Background

Previously, we wanted the `businessId` to only be set on `PROCESS_INSTANCE` records of element type `PROCESS` to limit performance impact. However, propagating `businessId` to downstream records (e.g. `JOB`, `USER_TASK`, `DECISION`, `MESSAGE_SUBSCRIPTION`, `INCIDENT`, `VARIABLE`) would require looking up the process instance's element instance for every process instance — including those without a `businessId` set. This would negatively impact the performance of **all** process instances.

### Approach

Instead, this PR propagates the `businessId` like any other element instance property (similar to `processId`), so it is available on all element instances. This way:

- The performance impact is limited to only process instances that have a `businessId` set.
- The design is consistent with how `processId` and `elementId` are already propagated.
- No additional lookups are required when accessing `businessId` from child elements or call activities.

### Changes

- **`BpmnStateTransitionBehavior`**: Simplified `createChildProcessInstance` by removing the explicit `businessId` parameter. The business ID is now read directly from the `BpmnElementContext`, since it's available on all element instances.
- **`CallActivityProcessor`**: Removed the unnecessary lookup of the process instance element just to retrieve the `businessId`. The context already carries it.
- **`ProcessInstanceRecordValue`**: Removed the Javadoc comment stating that business ID is only set on elements of type `PROCESS`.
- **Tests**: Updated `CreateProcessInstanceTest` to assert that `businessId` is propagated to **all** `PROCESS_INSTANCE` records (not just `ELEMENT_ACTIVATED` of type `PROCESS`). Moved the call activity business ID inheritance test from `CreateProcessInstanceBusinessIdUniquenessTest` to `CallActivityTest` where it belongs.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46688