### PR TITLE
43064 by workers job stats client impl

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -181,6 +181,7 @@ import io.camunda.client.api.statistics.request.GlobalJobStatisticsRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByErrorRequest;
 import io.camunda.client.api.statistics.request.JobTypeStatisticsRequest;
+import io.camunda.client.api.statistics.request.JobWorkerStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionElementStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
@@ -1023,6 +1024,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   JobTypeStatisticsRequest newJobTypeStatisticsRequest(
       final OffsetDateTime from, final OffsetDateTime to);
+
+  /**
+   * Executes a request to query job statistics grouped by worker for a specific job type.
+   *
+   * <pre>
+   * camundaClient
+   *  .newJobWorkerStatisticsRequest(OffsetDateTime.now().minusDays(1), OffsetDateTime.now(), "fetch-customer-data")
+   *  .send();
+   * </pre>
+   *
+   * @param from the start of the time range (inclusive)
+   * @param to the end of the time range (inclusive)
+   * @param jobType the job type to return worker statistics for
+   * @return a builder for the job worker statistics request
+   */
+  JobWorkerStatisticsRequest newJobWorkerStatisticsRequest(
+      final OffsetDateTime from, final OffsetDateTime to, final String jobType);
 
   /**
    * Executes a search request to query process instance sequence flows.

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/request/JobWorkerStatisticsRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/request/JobWorkerStatisticsRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.request;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.request.TypedPageableRequest;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
+
+/**
+ * Request to query job statistics grouped by worker for a specific job type. Supports pagination.
+ */
+public interface JobWorkerStatisticsRequest
+    extends FinalCommandStep<JobWorkerStatistics>,
+        TypedPageableRequest<JobWorkerStatisticsRequest> {}

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobWorkerStatistics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobWorkerStatistics.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.response;
+
+import io.camunda.client.api.search.response.SearchResponse;
+
+/** Response for job worker statistics query. Contains a list of statistics grouped by worker. */
+public interface JobWorkerStatistics extends SearchResponse<JobWorkerStatisticsItem> {}

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobWorkerStatisticsItem.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/response/JobWorkerStatisticsItem.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.response;
+
+/** Statistics for a specific worker within a job type. */
+public interface JobWorkerStatisticsItem {
+
+  /**
+   * Returns the worker identifier.
+   *
+   * @return the worker name
+   */
+  String getWorker();
+
+  /**
+   * Returns the metric for jobs in CREATED state.
+   *
+   * @return the created jobs metric
+   */
+  JobStatusMetric getCreated();
+
+  /**
+   * Returns the metric for jobs in COMPLETED state.
+   *
+   * @return the completed jobs metric
+   */
+  JobStatusMetric getCompleted();
+
+  /**
+   * Returns the metric for jobs in FAILED state.
+   *
+   * @return the failed jobs metric
+   */
+  JobStatusMetric getFailed();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -192,6 +192,7 @@ import io.camunda.client.api.statistics.request.GlobalJobStatisticsRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequest;
 import io.camunda.client.api.statistics.request.IncidentProcessInstanceStatisticsByErrorRequest;
 import io.camunda.client.api.statistics.request.JobTypeStatisticsRequest;
+import io.camunda.client.api.statistics.request.JobWorkerStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionElementStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
@@ -366,6 +367,7 @@ import io.camunda.client.impl.statistics.request.GlobalJobStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.IncidentProcessInstanceStatisticsByDefinitionRequestImpl;
 import io.camunda.client.impl.statistics.request.IncidentProcessInstanceStatisticsByErrorRequestImpl;
 import io.camunda.client.impl.statistics.request.JobTypeStatisticsRequestImpl;
+import io.camunda.client.impl.statistics.request.JobWorkerStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionElementStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequestImpl;
@@ -941,6 +943,13 @@ public final class CamundaClientImpl implements CamundaClient {
   public JobTypeStatisticsRequest newJobTypeStatisticsRequest(
       final OffsetDateTime from, final OffsetDateTime to) {
     return new JobTypeStatisticsRequestImpl(httpClient, config.getJsonMapper(), from, to);
+  }
+
+  @Override
+  public JobWorkerStatisticsRequest newJobWorkerStatisticsRequest(
+      final OffsetDateTime from, final OffsetDateTime to, final String jobType) {
+    return new JobWorkerStatisticsRequestImpl(
+        httpClient, config.getJsonMapper(), from, to, jobType);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/request/JobWorkerStatisticsRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/request/JobWorkerStatisticsRequestImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.statistics.request.JobWorkerStatisticsRequest;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.statistics.response.StatisticsResponseMapper;
+import io.camunda.client.protocol.rest.CursorForwardPagination;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsFilter;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsQuery;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsQueryResult;
+import io.camunda.client.protocol.rest.SearchQueryPageRequest;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class JobWorkerStatisticsRequestImpl
+    extends TypedSearchRequestPropertyProvider<JobWorkerStatisticsQuery>
+    implements JobWorkerStatisticsRequest {
+
+  private final JobWorkerStatisticsQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public JobWorkerStatisticsRequestImpl(
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper,
+      final OffsetDateTime from,
+      final OffsetDateTime to,
+      final String jobType) {
+    request = new JobWorkerStatisticsQuery();
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+
+    request.setFilter(
+        new JobWorkerStatisticsFilter()
+            .from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(from))
+            .to(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(to))
+            .jobType(jobType));
+  }
+
+  @Override
+  public FinalCommandStep<JobWorkerStatistics> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<JobWorkerStatistics> send() {
+    final HttpCamundaFuture<JobWorkerStatistics> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/jobs/statistics/by-workers",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        JobWorkerStatisticsQueryResult.class,
+        StatisticsResponseMapper::toJobWorkerStatisticsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  protected JobWorkerStatisticsQuery getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public JobWorkerStatisticsRequest page(final SearchRequestPage value) {
+    final SearchQueryPageRequest page = provideSearchRequestProperty(value);
+    request.setPage(new CursorForwardPagination().limit(page.getLimit()).after(page.getAfter()));
+    return this;
+  }
+
+  @Override
+  public JobWorkerStatisticsRequest page(final java.util.function.Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobWorkerStatisticsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobWorkerStatisticsImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.response;
+
+import io.camunda.client.api.search.response.SearchResponsePage;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
+import io.camunda.client.api.statistics.response.JobWorkerStatisticsItem;
+import java.util.List;
+import java.util.Objects;
+
+public class JobWorkerStatisticsImpl implements JobWorkerStatistics {
+  private final List<JobWorkerStatisticsItem> items;
+  private final SearchResponsePage page;
+
+  public JobWorkerStatisticsImpl(
+      final List<JobWorkerStatisticsItem> items, final SearchResponsePage page) {
+    this.items = items;
+    this.page = page;
+  }
+
+  @Override
+  public List<JobWorkerStatisticsItem> items() {
+    return items;
+  }
+
+  @Override
+  public SearchResponsePage page() {
+    return page;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, page);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final JobWorkerStatisticsImpl that = (JobWorkerStatisticsImpl) obj;
+    return Objects.equals(items, that.items) && Objects.equals(page, that.page);
+  }
+
+  @Override
+  public String toString() {
+    return "JobWorkerStatisticsImpl{" + "items=" + items + ", page=" + page + '}';
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobWorkerStatisticsItemImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/JobWorkerStatisticsItemImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.response;
+
+import io.camunda.client.api.statistics.response.JobStatusMetric;
+import io.camunda.client.api.statistics.response.JobWorkerStatisticsItem;
+import java.util.Objects;
+
+public class JobWorkerStatisticsItemImpl implements JobWorkerStatisticsItem {
+
+  private final String worker;
+  private final JobStatusMetric created;
+  private final JobStatusMetric completed;
+  private final JobStatusMetric failed;
+
+  public JobWorkerStatisticsItemImpl(
+      final String worker,
+      final JobStatusMetric created,
+      final JobStatusMetric completed,
+      final JobStatusMetric failed) {
+    this.worker = worker;
+    this.created = created;
+    this.completed = completed;
+    this.failed = failed;
+  }
+
+  @Override
+  public String getWorker() {
+    return worker;
+  }
+
+  @Override
+  public JobStatusMetric getCreated() {
+    return created;
+  }
+
+  @Override
+  public JobStatusMetric getCompleted() {
+    return completed;
+  }
+
+  @Override
+  public JobStatusMetric getFailed() {
+    return failed;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(worker, created, completed, failed);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JobWorkerStatisticsItemImpl that = (JobWorkerStatisticsItemImpl) o;
+    return Objects.equals(worker, that.worker)
+        && Objects.equals(created, that.created)
+        && Objects.equals(completed, that.completed)
+        && Objects.equals(failed, that.failed);
+  }
+
+  @Override
+  public String toString() {
+    return "JobWorkerStatisticsItemImpl{"
+        + "worker='"
+        + worker
+        + '\''
+        + ", created="
+        + created
+        + ", completed="
+        + completed
+        + ", failed="
+        + failed
+        + '}';
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
@@ -26,6 +26,8 @@ import io.camunda.client.api.statistics.response.IncidentProcessInstanceStatisti
 import io.camunda.client.api.statistics.response.JobStatusMetric;
 import io.camunda.client.api.statistics.response.JobTypeStatistics;
 import io.camunda.client.api.statistics.response.JobTypeStatisticsItem;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
+import io.camunda.client.api.statistics.response.JobWorkerStatisticsItem;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceStatistics;
 import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceVersionStatistics;
 import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
@@ -38,6 +40,7 @@ import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.GlobalJobStatisticsQueryResult;
 import io.camunda.client.protocol.rest.IncidentProcessInstanceStatisticsByErrorQueryResult;
 import io.camunda.client.protocol.rest.JobTypeStatisticsQueryResult;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceVersionStatisticsQueryResult;
@@ -203,5 +206,23 @@ public class StatisticsResponseMapper {
     final OffsetDateTime lastUpdatedAt =
         ParseUtil.parseOffsetDateTimeOrNull(metric.getLastUpdatedAt());
     return new JobStatusMetricImpl(ofNullable(metric.getCount()).orElse(0L), lastUpdatedAt);
+  }
+
+  public static JobWorkerStatistics toJobWorkerStatisticsResponse(
+      final JobWorkerStatisticsQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<JobWorkerStatisticsItem> items =
+        toSearchResponseInstances(
+            response.getItems(), StatisticsResponseMapper::toJobWorkerStatisticsItem);
+    return new JobWorkerStatisticsImpl(items, page);
+  }
+
+  private static JobWorkerStatisticsItem toJobWorkerStatisticsItem(
+      final io.camunda.client.protocol.rest.JobWorkerStatisticsItem item) {
+    return new JobWorkerStatisticsItemImpl(
+        item.getWorker(),
+        toJobStatusMetric(item.getCreated()),
+        toJobStatusMetric(item.getCompleted()),
+        toJobStatusMetric(item.getFailed()));
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/job/JobWorkerStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobWorkerStatisticsTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsItem;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsQuery;
+import io.camunda.client.protocol.rest.JobWorkerStatisticsQueryResult;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.StatusMetric;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class JobWorkerStatisticsTest extends ClientRestTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
+  private static final OffsetDateTime FROM = NOW.minusDays(1);
+  private static final OffsetDateTime TO = NOW.plusDays(1);
+  private static final String JOB_TYPE = "fetch-customer-data";
+
+  @Test
+  void shouldGetJobWorkerStatisticsWithEmptyQuery() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getJobWorkerStatisticsUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldGetJobWorkerStatistics() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    final JobWorkerStatistics result =
+        client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getJobWorkerStatisticsUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+
+    assertThat(result).isNotNull();
+    assertThat(result.items()).hasSize(2);
+
+    // Verify first worker
+    assertThat(result.items().get(0).getWorker()).isEqualTo("worker-1");
+    assertThat(result.items().get(0).getCreated().getCount()).isEqualTo(100L);
+    assertThat(result.items().get(0).getCompleted().getCount()).isEqualTo(80L);
+    assertThat(result.items().get(0).getFailed().getCount()).isEqualTo(5L);
+
+    // Verify second worker
+    assertThat(result.items().get(1).getWorker()).isEqualTo("worker-2");
+    assertThat(result.items().get(1).getCreated().getCount()).isEqualTo(50L);
+    assertThat(result.items().get(1).getCompleted().getCount()).isEqualTo(45L);
+    assertThat(result.items().get(1).getFailed().getCount()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldGetJobWorkerStatisticsWithPagination() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createPaginatedResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    client
+        .newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE)
+        .page(p -> p.limit(10).after("cursor123"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    final String body = request.getBodyAsString();
+    assertThat(body).contains("\"page\"");
+    assertThat(body).contains("\"limit\":10");
+    assertThat(body).contains("\"after\":\"cursor123\"");
+  }
+
+  @Test
+  void shouldSendCorrectRequestBodyWithTimeRangeAndJobType() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+
+    final String body = request.getBodyAsString();
+    assertThat(body)
+        .contains("\"from\":\"" + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(FROM) + "\"");
+    assertThat(body)
+        .contains("\"to\":\"" + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(TO) + "\"");
+    assertThat(body).contains("\"jobType\":\"" + JOB_TYPE + "\"");
+  }
+
+  @Test
+  void shouldIncludeJobTypeInFilter() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    client.newJobWorkerStatisticsRequest(FROM, TO, "process-payment").send().join();
+
+    // then
+    final JobWorkerStatisticsQuery request =
+        gatewayService.getLastRequest(JobWorkerStatisticsQuery.class);
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getJobType()).isEqualTo("process-payment");
+  }
+
+  @Test
+  void shouldIncludePageInRequestBody() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createPaginatedResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).page(p -> p.limit(5)).send().join();
+
+    // then
+    final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
+    final String requestBody = lastRequest.getBodyAsString();
+
+    assertThat(requestBody).contains("\"page\"");
+    assertThat(requestBody).contains("\"limit\":5");
+  }
+
+  @Test
+  void shouldHandleEmptyResults() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createEmptyResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    final JobWorkerStatistics result =
+        client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldHandleNullMetrics() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createResponseWithNullMetrics();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    final JobWorkerStatistics result =
+        client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).getCreated().getCount()).isZero();
+    assertThat(result.items().get(0).getCompleted().getCount()).isZero();
+    assertThat(result.items().get(0).getFailed().getCount()).isZero();
+    assertThat(result.items().get(0).getCreated().getLastUpdatedAt()).isNull();
+  }
+
+  @Test
+  void shouldReturnPaginatedResponse() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createPaginatedResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    final JobWorkerStatistics result =
+        client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.page().totalItems()).isEqualTo(3L);
+    assertThat(result.page().endCursor()).isEqualTo("cursor123");
+  }
+
+  @Test
+  void shouldVerifyResultsAreOrderedByWorker() {
+    // given
+    final JobWorkerStatisticsQueryResult response = createTestResponse();
+    gatewayService.onJobWorkerStatisticsRequest(response);
+
+    // when
+    final JobWorkerStatistics result =
+        client.newJobWorkerStatisticsRequest(FROM, TO, JOB_TYPE).send().join();
+
+    // then - results are ordered as returned by the API (worker ASC from SQL)
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().get(0).getWorker()).isEqualTo("worker-1");
+    assertThat(result.items().get(1).getWorker()).isEqualTo("worker-2");
+  }
+
+  // -----------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------
+
+  private JobWorkerStatisticsQueryResult createTestResponse() {
+    final JobWorkerStatisticsQueryResult response = new JobWorkerStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(
+        Arrays.asList(
+            createWorkerItem("worker-1", 100L, 80L, 5L),
+            createWorkerItem("worker-2", 50L, 45L, 2L)));
+    return response;
+  }
+
+  private JobWorkerStatisticsQueryResult createPaginatedResponse() {
+    final JobWorkerStatisticsQueryResult response = new JobWorkerStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse().totalItems(3L).endCursor("cursor123"));
+    response.setItems(
+        Arrays.asList(
+            createWorkerItem("worker-1", 100L, 80L, 5L),
+            createWorkerItem("worker-2", 50L, 45L, 2L),
+            createWorkerItem("worker-3", 30L, 25L, 1L)));
+    return response;
+  }
+
+  private JobWorkerStatisticsQueryResult createEmptyResponse() {
+    final JobWorkerStatisticsQueryResult response = new JobWorkerStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    response.setItems(Collections.emptyList());
+    return response;
+  }
+
+  private JobWorkerStatisticsQueryResult createResponseWithNullMetrics() {
+    final JobWorkerStatisticsQueryResult response = new JobWorkerStatisticsQueryResult();
+    response.setPage(new SearchQueryPageResponse());
+    final JobWorkerStatisticsItem item = new JobWorkerStatisticsItem();
+    item.setWorker("worker-1");
+    response.setItems(Collections.singletonList(item));
+    return response;
+  }
+
+  private JobWorkerStatisticsItem createWorkerItem(
+      final String worker,
+      final long createdCount,
+      final long completedCount,
+      final long failedCount) {
+    final JobWorkerStatisticsItem item = new JobWorkerStatisticsItem();
+    item.setWorker(worker);
+    item.setCreated(createStatusMetric(createdCount));
+    item.setCompleted(createStatusMetric(completedCount));
+    item.setFailed(createStatusMetric(failedCount));
+    return item;
+  }
+
+  private StatusMetric createStatusMetric(final long count) {
+    final StatusMetric metric = new StatusMetric();
+    metric.setCount(count);
+    metric.setLastUpdatedAt(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.now()));
+    return metric;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -124,6 +124,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/incidents/statistics/process-instances-by-error";
   private static final String URL_GLOBAL_JOB_STATISTICS = REST_API_PATH + "/jobs/statistics/global";
   private static final String URL_JOB_TYPE_STATISTICS = REST_API_PATH + "/jobs/statistics/by-types";
+  private static final String URL_JOB_WORKER_STATISTICS =
+      REST_API_PATH + "/jobs/statistics/by-workers";
 
   /**
    * @return the topology request URL
@@ -462,6 +464,10 @@ public class RestGatewayPaths {
 
   public static String getJobTypeStatisticsUrl() {
     return URL_JOB_TYPE_STATISTICS;
+  }
+
+  public static String getJobWorkerStatisticsUrl() {
+    return URL_JOB_WORKER_STATISTICS;
   }
 
   public static String getResourceDeletionUrl(final long resourceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -493,6 +493,13 @@ public class RestGatewayService {
         response);
   }
 
+  public void onJobWorkerStatisticsRequest(
+      final io.camunda.client.protocol.rest.JobWorkerStatisticsQueryResult response) {
+    register(
+        WireMock.post(WireMock.urlPathEqualTo(RestGatewayPaths.getJobWorkerStatisticsUrl())),
+        response);
+  }
+
   public void onStatusRequestHealthy() {
     onStatusRequest(204);
   }

--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -174,6 +174,7 @@
     <if test="filter.jobType != null">
       AND JOB_TYPE = #{filter.jobType}
     </if>
+    AND WORKER IS NOT NULL
   </sql>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobMetricsBatchDbModel">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobWorkerStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobWorkerStatisticsIT.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
+import static io.camunda.it.util.TestHelper.activateAndFailJobs;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForJobWorkerStatistics;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.JobState;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class JobWorkerStatisticsIT {
+
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthenticatedAccess()
+          .withProperty(
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
+
+  private static final String ADMIN = "admin";
+  private static final String JOB_TYPE_A = "taskA";
+  private static final String JOB_TYPE_B = "taskB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+  private static final String WORKER_1 = "worker-1";
+  private static final String WORKER_2 = "worker-2";
+  private static final String WORKER_3 = "worker-3";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @BeforeAll
+  static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws InterruptedException {
+    // Deploy a process with sequential service tasks (taskA -> taskB -> taskC)
+    deployResource(adminClient, "process/service_tasks_v1.bpmn");
+
+    // Start 4 process instances to create 4 taskA jobs
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+    startProcessInstance(adminClient, PROCESS_ID);
+
+    // Wait for 4 taskA jobs to be available
+    waitForJobs(adminClient, f -> f.type(JOB_TYPE_A), 4);
+
+    // worker-1 completes 2 taskA jobs -> creates 2 taskB jobs
+    activateAndCompleteJobs(adminClient, JOB_TYPE_A, WORKER_1, 2);
+    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).type(JOB_TYPE_A), 2);
+
+    // worker-2 fails 1 taskA job
+    activateAndFailJobs(adminClient, JOB_TYPE_A, WORKER_2, 1, "Intentional failure for test");
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_A), 1);
+
+    // Wait for the 2 taskB jobs to be available (created after taskA completions)
+    waitForJobs(adminClient, f -> f.type(JOB_TYPE_B).state(JobState.CREATED), 2);
+
+    // worker-1 completes 1 taskB job
+    activateAndCompleteJobs(adminClient, JOB_TYPE_B, WORKER_1, 1);
+    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).type(JOB_TYPE_B), 1);
+
+    // worker-3 fails 1 taskB job
+    activateAndFailJobs(adminClient, JOB_TYPE_B, WORKER_3, 1, "Intentional failure for test");
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_B), 1);
+
+    // Wait for metrics to be exported: taskA has worker-1 and worker-2; taskB has worker-1 and
+    // worker-3
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).hasSizeGreaterThanOrEqualTo(2));
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> assertThat(stats.items()).hasSizeGreaterThanOrEqualTo(2));
+  }
+
+  @Test
+  void shouldReturnWorkerStatisticsForJobTypeA(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // taskA: worker-1 completed 2, worker-2 failed 1, 1 job still created
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          // Results sorted by worker ASC
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(2L);
+          assertThat(worker1Stats.getCompleted().getLastUpdatedAt()).isNotNull();
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+          assertThat(worker1Stats.getFailed().getLastUpdatedAt()).isNull();
+
+          final var worker2Stats = stats.items().get(1);
+          assertThat(worker2Stats.getWorker()).isEqualTo(WORKER_2);
+          assertThat(worker2Stats.getCompleted().getCount()).isZero();
+          assertThat(worker2Stats.getCompleted().getLastUpdatedAt()).isNull();
+          assertThat(worker2Stats.getFailed().getCount()).isEqualTo(1L);
+          assertThat(worker2Stats.getFailed().getLastUpdatedAt()).isNotNull();
+        });
+  }
+
+  @Test
+  void shouldReturnWorkerStatisticsForJobTypeB(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // taskB: worker-1 completed 1, worker-3 failed 1
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          // Results sorted by worker ASC: worker-1 < worker-3
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(worker1Stats.getCompleted().getLastUpdatedAt()).isNotNull();
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+          assertThat(worker1Stats.getFailed().getLastUpdatedAt()).isNull();
+
+          final var worker3Stats = stats.items().get(1);
+          assertThat(worker3Stats.getWorker()).isEqualTo(WORKER_3);
+          assertThat(worker3Stats.getCompleted().getCount()).isZero();
+          assertThat(worker3Stats.getCompleted().getLastUpdatedAt()).isNull();
+          assertThat(worker3Stats.getFailed().getCount()).isEqualTo(1L);
+          assertThat(worker3Stats.getFailed().getLastUpdatedAt()).isNotNull();
+        });
+  }
+
+  @Test
+  void shouldNotShowTaskAWorkersForTaskBQuery(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // worker-2 only processed taskA jobs — must not appear in taskB worker stats
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> assertThat(stats.items()).extracting("worker").doesNotContain(WORKER_2));
+  }
+
+  @Test
+  void shouldNotShowTaskBWorkersForTaskAQuery(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // worker-3 only processed taskB jobs — must not appear in taskA worker stats
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).extracting("worker").doesNotContain(WORKER_3));
+  }
+
+  @Test
+  void shouldShowWorker1InBothJobTypeQueries(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // worker-1 processed both taskA (2 completed) and taskB (1 completed) — must appear in both
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          final var worker1Stats =
+              stats.items().stream()
+                  .filter(w -> WORKER_1.equals(w.getWorker()))
+                  .findFirst()
+                  .orElseThrow();
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(2L);
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+        });
+
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          final var worker1Stats =
+              stats.items().stream()
+                  .filter(w -> WORKER_1.equals(w.getWorker()))
+                  .findFirst()
+                  .orElseThrow();
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentJobType(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        "non-existent-job-type",
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldPaginateWorkerStatisticsForTaskA(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var endCursor = new AtomicReference<>("");
+
+    // First page: worker-1 (ORDER BY worker ASC)
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // Second page: worker-2
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_2);
+        });
+  }
+
+  @Test
+  void shouldPaginateWorkerStatisticsForTaskB(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var endCursor = new AtomicReference<>("");
+
+    // First page: worker-1 (ORDER BY worker ASC)
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        p -> p.limit(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // Second page: worker-3
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_3);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyWhenTimeRangeExcludesAllMetrics(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(30),
+        NOW.minusDays(29),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByWorkerForTaskA(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          assertThat(stats.items().get(1).getWorker()).isEqualTo(WORKER_2);
+        });
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByWorkerForTaskB(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          assertThat(stats.items().get(1).getWorker()).isEqualTo(WORKER_3);
+        });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobWorkerStatisticsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobWorkerStatisticsTenancyIT.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobsForTenant;
+import static io.camunda.it.util.TestHelper.activateAndFailJobsForTenant;
+import static io.camunda.it.util.TestHelper.createTenant;
+import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
+import static io.camunda.it.util.TestHelper.waitForJobWorkerStatistics;
+import static io.camunda.it.util.TestHelper.waitForJobs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.JobState;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class JobWorkerStatisticsTenancyIT {
+
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+  public static final Duration EXPORT_INTERVAL = Duration.ofSeconds(2);
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess()
+          .withProperty(
+              "zeebe.broker.experimental.engine.jobMetrics.exportInterval", EXPORT_INTERVAL);
+
+  private static final String ADMIN = "admin";
+  private static final String USER_TENANT_A = "userTenantA";
+  private static final String USER_TENANT_B = "userTenantB";
+  private static final String USER_NO_TENANT = "userNoTenant";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+  private static final String JOB_TYPE_A = "taskA";
+  private static final String JOB_TYPE_B = "taskB";
+  private static final String PROCESS_ID = "service_tasks_v1";
+  // TENANT_A uses two workers; TENANT_B uses one worker
+  private static final String WORKER_1 = "worker-1";
+  private static final String WORKER_2 = "worker-2";
+  private static final String WORKER_3 = "worker-3";
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_TENANT_A_USER =
+      new TestUser(USER_TENANT_A, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_TENANT_B_USER =
+      new TestUser(USER_TENANT_B, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_NO_TENANT_USER =
+      new TestUser(USER_NO_TENANT, "password", List.of());
+
+  @BeforeAll
+  static void setup(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws InterruptedException {
+    // Create tenants and assign users
+    createTenant(adminClient, TENANT_A, TENANT_A, ADMIN, USER_TENANT_A);
+    createTenant(adminClient, TENANT_B, TENANT_B, ADMIN, USER_TENANT_B);
+
+    // Deploy processes for each tenant
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);
+    deployResourceForTenant(adminClient, "process/service_tasks_v1.bpmn", TENANT_B);
+
+    // TENANT_A: 3 instances -> 3 taskA jobs; TENANT_B: 1 instance -> 1 taskA job
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_B);
+
+    // Wait for jobs
+    waitForJobs(adminClient, f -> f.tenantId(TENANT_A).type(JOB_TYPE_A), 3);
+    waitForJobs(adminClient, f -> f.tenantId(TENANT_B).type(JOB_TYPE_A), 1);
+
+    // TENANT_A: worker-1 completes 2 taskA jobs -> creates 2 taskB jobs
+    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_A, TENANT_A, WORKER_1, 2);
+    waitForJobs(adminClient, f -> f.state(JobState.COMPLETED).tenantId(TENANT_A), 2);
+
+    // TENANT_A: worker-2 fails 1 taskA job
+    activateAndFailJobsForTenant(
+        adminClient, JOB_TYPE_A, TENANT_A, WORKER_2, 1, "Intentional failure");
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).tenantId(TENANT_A), 1);
+
+    // TENANT_B: worker-1 fails 1 taskA job (no taskB created in TENANT_B)
+    activateAndFailJobsForTenant(
+        adminClient, JOB_TYPE_A, TENANT_B, WORKER_1, 1, "Intentional failure");
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).tenantId(TENANT_B), 1);
+
+    // Wait for 2 taskB jobs in TENANT_A (created after the 2 taskA completions)
+    waitForJobs(adminClient, f -> f.tenantId(TENANT_A).type(JOB_TYPE_B).state(JobState.CREATED), 2);
+
+    // TENANT_A: worker-1 completes 1 taskB job
+    activateAndCompleteJobsForTenant(adminClient, JOB_TYPE_B, TENANT_A, WORKER_1, 1);
+    waitForJobs(
+        adminClient, f -> f.state(JobState.COMPLETED).type(JOB_TYPE_B).tenantId(TENANT_A), 1);
+
+    // TENANT_A: worker-3 fails 1 taskB job
+    activateAndFailJobsForTenant(
+        adminClient, JOB_TYPE_B, TENANT_A, WORKER_3, 1, "Intentional failure");
+    waitForJobs(adminClient, f -> f.state(JobState.FAILED).type(JOB_TYPE_B).tenantId(TENANT_A), 1);
+
+    // Wait for metrics export
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).hasSizeGreaterThanOrEqualTo(2));
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> assertThat(stats.items()).hasSizeGreaterThanOrEqualTo(2));
+  }
+
+  @Test
+  void shouldReturnAllWorkersForAllTenants(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    // Admin (taskA): worker-1 completed 2 (TENANT_A), worker-2 failed 1 (TENANT_A),
+    //                worker-1 failed 1 (TENANT_B) => worker-1: 2 completed + 1 failed, worker-2: 1
+    // failed
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(2L);
+          assertThat(worker1Stats.getFailed().getCount()).isEqualTo(1L);
+
+          final var worker2Stats = stats.items().get(1);
+          assertThat(worker2Stats.getWorker()).isEqualTo(WORKER_2);
+          assertThat(worker2Stats.getCompleted().getCount()).isZero();
+          assertThat(worker2Stats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnAllWorkersForTaskBForAdmin(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // Admin (taskB, TENANT_A only): worker-1 completed 1, worker-3 failed 1
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+
+          final var worker3Stats = stats.items().get(1);
+          assertThat(worker3Stats.getWorker()).isEqualTo(WORKER_3);
+          assertThat(worker3Stats.getCompleted().getCount()).isZero();
+          assertThat(worker3Stats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTenantAWorkersForTaskAForTenantAUser(
+      @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
+    // TENANT_A (taskA): worker-1 completed 2, worker-2 failed 1 — no TENANT_B data
+    waitForJobWorkerStatistics(
+        userTenantAClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(2L);
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+
+          final var worker2Stats = stats.items().get(1);
+          assertThat(worker2Stats.getWorker()).isEqualTo(WORKER_2);
+          assertThat(worker2Stats.getCompleted().getCount()).isZero();
+          assertThat(worker2Stats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTenantAWorkersForTaskBForTenantAUser(
+      @Authenticated(USER_TENANT_A) final CamundaClient userTenantAClient) {
+    // TENANT_A (taskB): worker-1 completed 1, worker-3 failed 1
+    waitForJobWorkerStatistics(
+        userTenantAClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isEqualTo(1L);
+          assertThat(worker1Stats.getFailed().getCount()).isZero();
+
+          final var worker3Stats = stats.items().get(1);
+          assertThat(worker3Stats.getWorker()).isEqualTo(WORKER_3);
+          assertThat(worker3Stats.getCompleted().getCount()).isZero();
+          assertThat(worker3Stats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnOnlyTenantBWorkersForTenantBUser(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // TENANT_B (taskA): only worker-1 failed 1 job
+    waitForJobWorkerStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+
+          final var worker1Stats = stats.items().get(0);
+          assertThat(worker1Stats.getWorker()).isEqualTo(WORKER_1);
+          assertThat(worker1Stats.getCompleted().getCount()).isZero();
+          assertThat(worker1Stats.getFailed().getCount()).isEqualTo(1L);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyTaskBForTenantBUser(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // TENANT_B has no taskB activity — no taskA was completed in TENANT_B
+    waitForJobWorkerStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldNotSeeWorker2OrWorker3ForTenantBUser(
+      @Authenticated(USER_TENANT_B) final CamundaClient userTenantBClient) {
+    // worker-2 and worker-3 only processed TENANT_A jobs
+    waitForJobWorkerStatistics(
+        userTenantBClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).extracting("worker").doesNotContain(WORKER_2, WORKER_3));
+  }
+
+  @Test
+  void shouldReturnEmptyForUserWithNoTenantAccess(
+      @Authenticated(USER_NO_TENANT) final CamundaClient userNoTenantClient) {
+    waitForJobWorkerStatistics(
+        userNoTenantClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldPaginateTaskAWorkerStatistics(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var endCursor = new AtomicReference<>("");
+
+    // First page: worker-1
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // Second page: worker-2
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_2);
+        });
+  }
+
+  @Test
+  void shouldPaginateTaskBWorkerStatistics(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var endCursor = new AtomicReference<>("");
+
+    // First page: worker-1
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        p -> p.limit(1),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          endCursor.set(stats.page().endCursor());
+        });
+
+    // Second page: worker-3
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        p -> p.limit(1).after(endCursor.get()),
+        stats -> {
+          assertThat(stats.items()).hasSize(1);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_3);
+        });
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentJobTypeAcrossTenants(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        "non-existent-job-type",
+        stats -> assertThat(stats.items()).isEmpty());
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByWorkerForTaskA(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_A,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          assertThat(stats.items().get(1).getWorker()).isEqualTo(WORKER_2);
+        });
+  }
+
+  @Test
+  void shouldVerifyResultsAreSortedByWorkerForTaskB(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    waitForJobWorkerStatistics(
+        adminClient,
+        NOW.minusDays(1),
+        NOW.plusDays(1),
+        JOB_TYPE_B,
+        stats -> {
+          assertThat(stats.items()).hasSize(2);
+          assertThat(stats.items().get(0).getWorker()).isEqualTo(WORKER_1);
+          assertThat(stats.items().get(1).getWorker()).isEqualTo(WORKER_3);
+        });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -49,6 +49,7 @@ import io.camunda.client.api.search.response.Tenant;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.statistics.response.GlobalJobStatistics;
 import io.camunda.client.api.statistics.response.JobTypeStatistics;
+import io.camunda.client.api.statistics.response.JobWorkerStatistics;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -967,6 +968,56 @@ public final class TestHelper {
                   camundaClient
                       .newJobTypeStatisticsRequest(startTime, endTime)
                       .filter(filterFn)
+                      .page(pageFn);
+
+              assertThat(request.send().join()).satisfies(fnRequirements);
+            });
+  }
+
+  /**
+   * Waits for job worker statistics to be exported and match the given requirements.
+   *
+   * @param camundaClient the Camunda client
+   * @param startTime the start time for the statistics query
+   * @param endTime the end time for the statistics query
+   * @param jobType the job type to query worker statistics for
+   * @param fnRequirements the assertions to apply to the statistics
+   */
+  public static void waitForJobWorkerStatistics(
+      final CamundaClient camundaClient,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
+      final String jobType,
+      final Consumer<JobWorkerStatistics> fnRequirements) {
+    waitForJobWorkerStatistics(camundaClient, startTime, endTime, jobType, p -> {}, fnRequirements);
+  }
+
+  /**
+   * Waits for job worker statistics to be exported and match the given requirements, with
+   * pagination.
+   *
+   * @param camundaClient the Camunda client
+   * @param startTime the start time for the statistics query
+   * @param endTime the end time for the statistics query
+   * @param jobType the job type to query worker statistics for
+   * @param pageFn the page consumer to apply
+   * @param fnRequirements the assertions to apply to the statistics
+   */
+  public static void waitForJobWorkerStatistics(
+      final CamundaClient camundaClient,
+      final OffsetDateTime startTime,
+      final OffsetDateTime endTime,
+      final String jobType,
+      final Consumer<SearchRequestPage> pageFn,
+      final Consumer<JobWorkerStatistics> fnRequirements) {
+    Awaitility.await("should export job worker metrics to secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var request =
+                  camundaClient
+                      .newJobWorkerStatisticsRequest(startTime, endTime, jobType)
                       .page(pageFn);
 
               assertThat(request.send().join()).satisfies(fnRequirements);

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobWorkerStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobWorkerStatisticsQuery.java
@@ -8,6 +8,7 @@
 package io.camunda.search.query;
 
 import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.JobWorkerStatisticsAggregation;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -37,9 +38,7 @@ public record JobWorkerStatisticsQuery(JobWorkerStatisticsFilter filter, SearchQ
 
   @Override
   public AggregationBase aggregation() {
-    // TODO enabled in a future PR, once the aggregation implementation is completed
-    // return new JobWorkerStatisticsAggregation(page);
-    return null;
+    return new JobWorkerStatisticsAggregation(page);
   }
 
   public static final class Builder


### PR DESCRIPTION
## Description

This pull request introduces a new feature to the Java client, enabling users to query job statistics grouped by worker for a specific job type. It adds a new API endpoint, request/response types, and implementation classes to support this functionality, including pagination and integration with the existing statistics infrastructure.

**New Job Worker Statistics Feature:**

* Added a new request interface `JobWorkerStatisticsRequest` and its implementation `JobWorkerStatisticsRequestImpl`, allowing users to query job statistics grouped by worker for a given job type and time range, with pagination support. [[1]](diffhunk://#diff-f70a3e6cd4d52e09f85064041f8bb086f06c25d1a59b67c9f521ffb6650bc3f1R1-R27) [[2]](diffhunk://#diff-0b66f20d19d9537be4844eb68163b1746f7aabedfb8ccea86be85dbc83196c3eR1-R103)
* Introduced a new response interface `JobWorkerStatistics` and its implementation `JobWorkerStatisticsImpl`, representing the paginated list of worker statistics. [[1]](diffhunk://#diff-8a848c40e61a01c45f1ce1d337859295c7ed446f370785687bbd73814cb1f0aaR1-R21) [[2]](diffhunk://#diff-203772e5ac9409ace51a15c18cb3eb757fd7231c98de738c99ae2e9c428a80ffR1-R65)
* Added a new response item interface `JobWorkerStatisticsItem` and its implementation `JobWorkerStatisticsItemImpl`, encapsulating metrics for created, completed, and failed jobs per worker. [[1]](diffhunk://#diff-75f4b52021978bb6aa64f8404483da8e086acaab2a12bfbe01e2959eec8fc2edR1-R48) [[2]](diffhunk://#diff-4bc8aa99b1f88774a46adadb1339a01dbff22dc4a28b328b9a35702dc9dc6b68R1-R94)

**API and Integration Updates:**

* Updated `CamundaClient` and `CamundaClientImpl` to expose the new `newJobWorkerStatisticsRequest` method, making the new statistics endpoint available to users. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR1028-R1044) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R948-R954)
* Extended the `StatisticsResponseMapper` to convert protocol responses to the new response types, ensuring seamless integration with the existing response mapping system.

**Dependency and Import Adjustments:**

* Added necessary imports in various files to support the new request and response types, ensuring proper compilation and modularity. [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR184) [[2]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R195) [[3]](diffhunk://#diff-2884eafcbed15b7a71340ac204ab639273cd477bb54b0114c8487f5fdcffc189R370) [[4]](diffhunk://#diff-15258458de0c634b01308a375c589bbbcbeae4ccab4250fdddfc742090a5eafdR29-R30) [[5]](diffhunk://#diff-15258458de0c634b01308a375c589bbbcbeae4ccab4250fdddfc742090a5eafdR43)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/43064
