### PR TITLE
fix: Add AWS Opensearch 3 Setup

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -13,6 +13,7 @@ on:
         options:
           - "2.17"
           - "2.19"
+          - "3.3"
   schedule:
     - cron: "0 4 * * Mon-Fri"
 
@@ -33,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: ${{ fromJSON(format('[{0}]', inputs.os_version || '"2.17", "2.19"')) }}
+        os_version: ${{ fromJSON(format('[{0}]', inputs.os_version || '"2.17", "2.19", "3.3"')) }}
         group:
         - os-exporter
         - search-client-os
@@ -81,6 +82,7 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_17_URL;
             secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_19_URL;
+            secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_3_URL;
       - name: Set temp GH envs
         id: temp-vars
         run: |
@@ -100,6 +102,10 @@ jobs:
           then
             echo "Using OS 2.19"
             OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_19_URL }};
+          elif [[ "${{ matrix.os_version }}" = "3.3" ]]
+          then
+            echo "Using OS 3.3"
+            OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_3_3_URL }};
           else
             echo "Incorrect on usupported version of OpenSearch"
             exit 1

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -11,7 +11,6 @@ on:
         description: Version of AWS OS
         type: choice
         options:
-          - "2.17"
           - "2.19"
           - "3.3"
   schedule:
@@ -34,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: ${{ fromJSON(format('[{0}]', inputs.os_version || '"2.17", "2.19", "3.3"')) }}
+        os_version: ${{ fromJSON(format('[{0}]', inputs.os_version || '"2.19", "3.3"')) }}
         group:
         - os-exporter
         - search-client-os
@@ -80,7 +79,6 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_17_URL;
             secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_2_19_URL;
             secret/data/products/camunda/ci/github-actions CAMUNDA_CI_OPENSEARCH_3_3_URL;
       - name: Set temp GH envs
@@ -94,11 +92,7 @@ jobs:
             echo "AWS_STS_REGIONAL_ENDPOINTS=$AWS_STS_REGIONAL_ENDPOINTS"
           } >> "$GITHUB_ENV"
 
-          if [[ "${{ matrix.os_version }}" = "2.17" ]]
-          then
-            echo "Using OS 2.17"
-            OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_17_URL }};
-          elif [[ "${{ matrix.os_version }}" = "2.19" ]]
+          if [[ "${{ matrix.os_version }}" = "2.19" ]]
           then
             echo "Using OS 2.19"
             OS_URL="https://"${{ steps.secrets.outputs.CAMUNDA_CI_OPENSEARCH_2_19_URL }};


### PR DESCRIPTION
## Description

Adding AWS OpenSearch 3 to our nightly test run and remove the older/unsupported 2.17 from the nightly list.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
