### PR TITLE
fix: cache JSON value in VariableRecord to avoid redundant MsgPack-to-JSON conversions

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -51,6 +51,12 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
+  /**
+   * Cached JSON representation of the value. Lazily computed on first call to {@link #getValue()}
+   * and invalidated when the underlying value changes via {@link #setValue} or {@link #wrap}.
+   */
+  private String cachedJsonValue;
+
   public VariableRecord() {
     super(9);
     declareProperty(nameProp)
@@ -65,13 +71,22 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   }
 
   @Override
+  public void reset() {
+    super.reset();
+    cachedJsonValue = null;
+  }
+
+  @Override
   public String getName() {
     return BufferUtil.bufferAsString(nameProp.getValue());
   }
 
   @Override
   public String getValue() {
-    return MsgPackConverter.convertToJson(valueProp.getValue());
+    if (cachedJsonValue == null) {
+      cachedJsonValue = MsgPackConverter.convertToJson(valueProp.getValue());
+    }
+    return cachedJsonValue;
   }
 
   @Override
@@ -136,6 +151,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value) {
     valueProp.setValue(value);
+    cachedJsonValue = null;
     return this;
   }
 
@@ -146,6 +162,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value, final int offset, final int length) {
     valueProp.setValue(value, offset, length);
+    cachedJsonValue = null;
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
@@ -133,36 +133,4 @@ final class VariableRecordTest {
     record.setRootProcessInstanceKey(4L);
     return record;
   }
-
-  @Test
-  void shouldReturnCachedInstanceAcrossMultipleHandlerSimulation() {
-    // given - simulating the exporter scenario where multiple handlers call getValue()
-    final var record = new VariableRecord();
-    final byte[] msgPack = MsgPackConverter.convertToMsgPack("\"some-large-variable-value\"");
-    record.setValue(new UnsafeBuffer(msgPack));
-
-    // when - simulate multiple handlers calling getValue() as happens during export
-    // Handler 1: VariableHandler calls getValue() for length check and assignment
-    final String handler1LengthCheck = record.getValue();
-    final String handler1Assignment = record.getValue();
-
-    // Handler 2: UserTaskVariableHandler calls getValue() for its setVariableValues
-    final String handler2LengthCheck = record.getValue();
-    final String handler2Assignment = record.getValue();
-
-    // Handler 3: UserTaskVariableHandler creates a second entity and calls again
-    final String handler3LengthCheck = record.getValue();
-    final String handler3Assignment = record.getValue();
-
-    // Handler 4: ListViewVariableFromVariableHandler calls getValue()
-    final String handler4Assignment = record.getValue();
-
-    // then - all 7 calls should return the exact same String instance
-    assertThat(handler1Assignment).isSameAs(handler1LengthCheck);
-    assertThat(handler2LengthCheck).isSameAs(handler1LengthCheck);
-    assertThat(handler2Assignment).isSameAs(handler1LengthCheck);
-    assertThat(handler3LengthCheck).isSameAs(handler1LengthCheck);
-    assertThat(handler3Assignment).isSameAs(handler1LengthCheck);
-    assertThat(handler4Assignment).isSameAs(handler1LengthCheck);
-  }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
@@ -15,11 +15,23 @@ import org.junit.jupiter.api.Test;
 
 final class VariableRecordTest {
 
+  private static final String JSON_VALUE = "{\"key\":\"value\"}";
+  private static final String JSON_VALUE_1 = "{\"key\":\"value1\"}";
+  private static final String JSON_VALUE_2 = "{\"key\":\"value2\"}";
+  private static final String JSON_NEW_VALUE = "{\"key\":\"newValue\"}";
+  private static final String VARIABLE_NAME = "myVar";
+  private static final String BPMN_PROCESS_ID = "process";
+  private static final String TENANT_ID = "<default>";
+  private static final long SCOPE_KEY = 1L;
+  private static final long PROCESS_INSTANCE_KEY = 2L;
+  private static final long PROCESS_DEFINITION_KEY = 3L;
+  private static final long ROOT_PROCESS_INSTANCE_KEY = 4L;
+
   @Test
   void shouldCacheJsonValueOnRepeatedGetValueCalls() {
     // given
     final var record = new VariableRecord();
-    final byte[] msgPack = MsgPackConverter.convertToMsgPack("{\"key\":\"value\"}");
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack(JSON_VALUE);
     record.setValue(new UnsafeBuffer(msgPack));
 
     // when
@@ -28,7 +40,7 @@ final class VariableRecordTest {
     final String thirdCall = record.getValue();
 
     // then - all calls should return the exact same String instance (not just equal strings)
-    assertThat(firstCall).isEqualTo("{\"key\":\"value\"}");
+    assertThat(firstCall).isEqualTo(JSON_VALUE);
     assertThat(secondCall).isSameAs(firstCall);
     assertThat(thirdCall).isSameAs(firstCall);
   }
@@ -37,19 +49,19 @@ final class VariableRecordTest {
   void shouldInvalidateCacheWhenSetValueIsCalled() {
     // given
     final var record = new VariableRecord();
-    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack("{\"key\":\"value1\"}");
+    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack(JSON_VALUE_1);
     record.setValue(new UnsafeBuffer(msgPack1));
 
     final String firstValue = record.getValue();
-    assertThat(firstValue).isEqualTo("{\"key\":\"value1\"}");
+    assertThat(firstValue).isEqualTo(JSON_VALUE_1);
 
     // when - setting a new value should invalidate the cache
-    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"value2\"}");
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack(JSON_VALUE_2);
     record.setValue(new UnsafeBuffer(msgPack2));
 
     // then
     final String secondValue = record.getValue();
-    assertThat(secondValue).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(secondValue).isEqualTo(JSON_VALUE_2);
     assertThat(secondValue).isNotSameAs(firstValue);
   }
 
@@ -57,20 +69,20 @@ final class VariableRecordTest {
   void shouldInvalidateCacheWhenSetValueWithOffsetIsCalled() {
     // given
     final var record = new VariableRecord();
-    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack("{\"key\":\"value1\"}");
+    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack(JSON_VALUE_1);
     record.setValue(new UnsafeBuffer(msgPack1));
 
     final String firstValue = record.getValue();
-    assertThat(firstValue).isEqualTo("{\"key\":\"value1\"}");
+    assertThat(firstValue).isEqualTo(JSON_VALUE_1);
 
     // when - setting a new value with offset should invalidate the cache
-    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"value2\"}");
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack(JSON_VALUE_2);
     final var buffer = new UnsafeBuffer(msgPack2);
     record.setValue(buffer, 0, buffer.capacity());
 
     // then
     final String secondValue = record.getValue();
-    assertThat(secondValue).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(secondValue).isEqualTo(JSON_VALUE_2);
     assertThat(secondValue).isNotSameAs(firstValue);
   }
 
@@ -78,33 +90,33 @@ final class VariableRecordTest {
   void shouldInvalidateCacheWhenRecordIsReset() {
     // given
     final var record = new VariableRecord();
-    final byte[] msgPack = MsgPackConverter.convertToMsgPack("{\"key\":\"value\"}");
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack(JSON_VALUE);
     record.setValue(new UnsafeBuffer(msgPack));
 
     final String cachedValue = record.getValue();
-    assertThat(cachedValue).isEqualTo("{\"key\":\"value\"}");
+    assertThat(cachedValue).isEqualTo(JSON_VALUE);
 
     // when - reset the record and set a new value
     record.reset();
-    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"newValue\"}");
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack(JSON_NEW_VALUE);
     record.setValue(new UnsafeBuffer(msgPack2));
 
     // then - the cache should be invalidated and a fresh conversion should happen
     final String afterReset = record.getValue();
-    assertThat(afterReset).isEqualTo("{\"key\":\"newValue\"}");
+    assertThat(afterReset).isEqualTo(JSON_NEW_VALUE);
     assertThat(afterReset).isNotSameAs(cachedValue);
   }
 
   @Test
   void shouldInvalidateCacheWhenRecordIsWrapped() {
     // given
-    final var record = createFullRecord("{\"key\":\"value1\"}");
+    final var record = createFullRecord(JSON_VALUE_1);
 
     final String cachedValue = record.getValue();
-    assertThat(cachedValue).isEqualTo("{\"key\":\"value1\"}");
+    assertThat(cachedValue).isEqualTo(JSON_VALUE_1);
 
     // when - serialize and re-wrap with different data (simulates how the engine reuses records)
-    final var record2 = createFullRecord("{\"key\":\"value2\"}");
+    final var record2 = createFullRecord(JSON_VALUE_2);
     final var writeBuffer2 = new UnsafeBuffer(new byte[record2.getLength()]);
     record2.write(writeBuffer2, 0);
 
@@ -116,7 +128,7 @@ final class VariableRecordTest {
 
     // then - the value should reflect the new data, not the cached one
     final String afterWrap = record.getValue();
-    assertThat(afterWrap).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(afterWrap).isEqualTo(JSON_VALUE_2);
     assertThat(afterWrap).isNotSameAs(cachedValue);
   }
 
@@ -124,13 +136,13 @@ final class VariableRecordTest {
     final var record = new VariableRecord();
     final byte[] msgPack = MsgPackConverter.convertToMsgPack(jsonValue);
     record.setValue(new UnsafeBuffer(msgPack));
-    record.setName(new UnsafeBuffer("myVar".getBytes()));
-    record.setScopeKey(1L);
-    record.setProcessInstanceKey(2L);
-    record.setProcessDefinitionKey(3L);
-    record.setBpmnProcessId(new UnsafeBuffer("process".getBytes()));
-    record.setTenantId("<default>");
-    record.setRootProcessInstanceKey(4L);
+    record.setName(new UnsafeBuffer(VARIABLE_NAME.getBytes()));
+    record.setScopeKey(SCOPE_KEY);
+    record.setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    record.setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+    record.setBpmnProcessId(new UnsafeBuffer(BPMN_PROCESS_ID.getBytes()));
+    record.setTenantId(TENANT_ID);
+    record.setRootProcessInstanceKey(ROOT_PROCESS_INSTANCE_KEY);
     return record;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecordTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class VariableRecordTest {
+
+  @Test
+  void shouldCacheJsonValueOnRepeatedGetValueCalls() {
+    // given
+    final var record = new VariableRecord();
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack("{\"key\":\"value\"}");
+    record.setValue(new UnsafeBuffer(msgPack));
+
+    // when
+    final String firstCall = record.getValue();
+    final String secondCall = record.getValue();
+    final String thirdCall = record.getValue();
+
+    // then - all calls should return the exact same String instance (not just equal strings)
+    assertThat(firstCall).isEqualTo("{\"key\":\"value\"}");
+    assertThat(secondCall).isSameAs(firstCall);
+    assertThat(thirdCall).isSameAs(firstCall);
+  }
+
+  @Test
+  void shouldInvalidateCacheWhenSetValueIsCalled() {
+    // given
+    final var record = new VariableRecord();
+    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack("{\"key\":\"value1\"}");
+    record.setValue(new UnsafeBuffer(msgPack1));
+
+    final String firstValue = record.getValue();
+    assertThat(firstValue).isEqualTo("{\"key\":\"value1\"}");
+
+    // when - setting a new value should invalidate the cache
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"value2\"}");
+    record.setValue(new UnsafeBuffer(msgPack2));
+
+    // then
+    final String secondValue = record.getValue();
+    assertThat(secondValue).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(secondValue).isNotSameAs(firstValue);
+  }
+
+  @Test
+  void shouldInvalidateCacheWhenSetValueWithOffsetIsCalled() {
+    // given
+    final var record = new VariableRecord();
+    final byte[] msgPack1 = MsgPackConverter.convertToMsgPack("{\"key\":\"value1\"}");
+    record.setValue(new UnsafeBuffer(msgPack1));
+
+    final String firstValue = record.getValue();
+    assertThat(firstValue).isEqualTo("{\"key\":\"value1\"}");
+
+    // when - setting a new value with offset should invalidate the cache
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"value2\"}");
+    final var buffer = new UnsafeBuffer(msgPack2);
+    record.setValue(buffer, 0, buffer.capacity());
+
+    // then
+    final String secondValue = record.getValue();
+    assertThat(secondValue).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(secondValue).isNotSameAs(firstValue);
+  }
+
+  @Test
+  void shouldInvalidateCacheWhenRecordIsReset() {
+    // given
+    final var record = new VariableRecord();
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack("{\"key\":\"value\"}");
+    record.setValue(new UnsafeBuffer(msgPack));
+
+    final String cachedValue = record.getValue();
+    assertThat(cachedValue).isEqualTo("{\"key\":\"value\"}");
+
+    // when - reset the record and set a new value
+    record.reset();
+    final byte[] msgPack2 = MsgPackConverter.convertToMsgPack("{\"key\":\"newValue\"}");
+    record.setValue(new UnsafeBuffer(msgPack2));
+
+    // then - the cache should be invalidated and a fresh conversion should happen
+    final String afterReset = record.getValue();
+    assertThat(afterReset).isEqualTo("{\"key\":\"newValue\"}");
+    assertThat(afterReset).isNotSameAs(cachedValue);
+  }
+
+  @Test
+  void shouldInvalidateCacheWhenRecordIsWrapped() {
+    // given
+    final var record = createFullRecord("{\"key\":\"value1\"}");
+
+    final String cachedValue = record.getValue();
+    assertThat(cachedValue).isEqualTo("{\"key\":\"value1\"}");
+
+    // when - serialize and re-wrap with different data (simulates how the engine reuses records)
+    final var record2 = createFullRecord("{\"key\":\"value2\"}");
+    final var writeBuffer2 = new UnsafeBuffer(new byte[record2.getLength()]);
+    record2.write(writeBuffer2, 0);
+
+    // populate cache on record before wrapping
+    record.getValue();
+
+    // wrap with the new data
+    record.wrap(writeBuffer2, 0, record2.getLength());
+
+    // then - the value should reflect the new data, not the cached one
+    final String afterWrap = record.getValue();
+    assertThat(afterWrap).isEqualTo("{\"key\":\"value2\"}");
+    assertThat(afterWrap).isNotSameAs(cachedValue);
+  }
+
+  private VariableRecord createFullRecord(final String jsonValue) {
+    final var record = new VariableRecord();
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack(jsonValue);
+    record.setValue(new UnsafeBuffer(msgPack));
+    record.setName(new UnsafeBuffer("myVar".getBytes()));
+    record.setScopeKey(1L);
+    record.setProcessInstanceKey(2L);
+    record.setProcessDefinitionKey(3L);
+    record.setBpmnProcessId(new UnsafeBuffer("process".getBytes()));
+    record.setTenantId("<default>");
+    record.setRootProcessInstanceKey(4L);
+    return record;
+  }
+
+  @Test
+  void shouldReturnCachedInstanceAcrossMultipleHandlerSimulation() {
+    // given - simulating the exporter scenario where multiple handlers call getValue()
+    final var record = new VariableRecord();
+    final byte[] msgPack = MsgPackConverter.convertToMsgPack("\"some-large-variable-value\"");
+    record.setValue(new UnsafeBuffer(msgPack));
+
+    // when - simulate multiple handlers calling getValue() as happens during export
+    // Handler 1: VariableHandler calls getValue() for length check and assignment
+    final String handler1LengthCheck = record.getValue();
+    final String handler1Assignment = record.getValue();
+
+    // Handler 2: UserTaskVariableHandler calls getValue() for its setVariableValues
+    final String handler2LengthCheck = record.getValue();
+    final String handler2Assignment = record.getValue();
+
+    // Handler 3: UserTaskVariableHandler creates a second entity and calls again
+    final String handler3LengthCheck = record.getValue();
+    final String handler3Assignment = record.getValue();
+
+    // Handler 4: ListViewVariableFromVariableHandler calls getValue()
+    final String handler4Assignment = record.getValue();
+
+    // then - all 7 calls should return the exact same String instance
+    assertThat(handler1Assignment).isSameAs(handler1LengthCheck);
+    assertThat(handler2LengthCheck).isSameAs(handler1LengthCheck);
+    assertThat(handler2Assignment).isSameAs(handler1LengthCheck);
+    assertThat(handler3LengthCheck).isSameAs(handler1LengthCheck);
+    assertThat(handler3Assignment).isSameAs(handler1LengthCheck);
+    assertThat(handler4Assignment).isSameAs(handler1LengthCheck);
+  }
+}

--- a/zeebe/protocol-test-util/pom.xml
+++ b/zeebe/protocol-test-util/pom.xml
@@ -47,11 +47,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-msgpack-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.test.broker.protocol;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
-import io.camunda.zeebe.msgpack.property.BaseProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
@@ -18,6 +17,8 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -76,8 +77,10 @@ final class ImplRecordValuePopulator {
           populateArrayProperty(field, implInstance, random);
         } else if (fieldType.equals(ObjectProperty.class)) {
           populateObjectProperty(field, implInstance, random);
-        } else if (!BaseProperty.class.isAssignableFrom(fieldType)) {
-          // Skip non-property fields (e.g. caches, internal state, MsgPackWriter/Reader)
+        } else if (fieldType.equals(MsgPackWriter.class)
+            || fieldType.equals(MsgPackReader.class)
+            || fieldType.equals(String.class)) {
+          // Skip other msgpack types that are more complex
         } else {
           throw new IllegalArgumentException(
               "Unsupported field type: "
@@ -155,14 +158,8 @@ final class ImplRecordValuePopulator {
       throws IllegalAccessException {
     final BinaryProperty binaryProperty = (BinaryProperty) field.get(implInstance);
     if (binaryProperty != null) {
-      // Encode as valid MsgPack so that getters calling MsgPackConverter.convertToJson() work
-      final Map<String, Object> randomMap = new HashMap<>();
-      final int size = random.nextInt(1, 5); // 1-4 entries
-      for (int i = 0; i < size; i++) {
-        randomMap.put("key" + i, random.nextObject(String.class));
-      }
-      final byte[] msgPackBytes = MsgPackConverter.convertToMsgPack(randomMap);
-      binaryProperty.setValue(BufferUtil.wrapArray(msgPackBytes));
+      final String randomString = random.nextObject(String.class);
+      binaryProperty.setValue(BufferUtil.wrapString(randomString));
     }
   }
 

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.broker.protocol;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BaseProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
@@ -17,8 +18,6 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
-import io.camunda.zeebe.msgpack.spec.MsgPackReader;
-import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -77,10 +76,8 @@ final class ImplRecordValuePopulator {
           populateArrayProperty(field, implInstance, random);
         } else if (fieldType.equals(ObjectProperty.class)) {
           populateObjectProperty(field, implInstance, random);
-        } else if (fieldType.equals(MsgPackWriter.class)
-            || fieldType.equals(MsgPackReader.class)
-            || fieldType.equals(String.class)) {
-          // Skip other msgpack types that are more complex
+        } else if (!BaseProperty.class.isAssignableFrom(fieldType)) {
+          // Skip non-property fields (e.g. caches, internal state, MsgPackWriter/Reader)
         } else {
           throw new IllegalArgumentException(
               "Unsupported field type: "

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ImplRecordValuePopulator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.broker.protocol;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BaseProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
@@ -17,8 +18,6 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
-import io.camunda.zeebe.msgpack.spec.MsgPackReader;
-import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -77,8 +76,8 @@ final class ImplRecordValuePopulator {
           populateArrayProperty(field, implInstance, random);
         } else if (fieldType.equals(ObjectProperty.class)) {
           populateObjectProperty(field, implInstance, random);
-        } else if (fieldType.equals(MsgPackWriter.class) || fieldType.equals(MsgPackReader.class)) {
-          // Skip other msgpack types that are more complex
+        } else if (!BaseProperty.class.isAssignableFrom(fieldType)) {
+          // Skip non-property fields (e.g. caches, internal state, MsgPackWriter/Reader)
         } else {
           throw new IllegalArgumentException(
               "Unsupported field type: "
@@ -156,8 +155,14 @@ final class ImplRecordValuePopulator {
       throws IllegalAccessException {
     final BinaryProperty binaryProperty = (BinaryProperty) field.get(implInstance);
     if (binaryProperty != null) {
-      final String randomString = random.nextObject(String.class);
-      binaryProperty.setValue(BufferUtil.wrapString(randomString));
+      // Encode as valid MsgPack so that getters calling MsgPackConverter.convertToJson() work
+      final Map<String, Object> randomMap = new HashMap<>();
+      final int size = random.nextInt(1, 5); // 1-4 entries
+      for (int i = 0; i < size; i++) {
+        randomMap.put("key" + i, random.nextObject(String.class));
+      }
+      final byte[] msgPackBytes = MsgPackConverter.convertToMsgPack(randomMap);
+      binaryProperty.setValue(BufferUtil.wrapArray(msgPackBytes));
     }
   }
 


### PR DESCRIPTION
## Summary

- Cache the JSON string returned by `VariableRecord.getValue()` to eliminate redundant MsgPack-to-JSON conversions during export, where multiple handlers call `getValue()` 7-10 times per record
- Add cache invalidation in `setValue()`, `setValue(offset, length)`, and `reset()` (also covers `wrap()`)

## Problem

During export, a single `VARIABLE` record is dispatched to multiple handlers (`VariableHandler`, `UserTaskVariableHandler`, `ListViewVariableFromVariableHandler`) that collectively call `getValue()` 7-10 times. Each call performed a full MsgPack-to-JSON conversion including `byte[]` copies, `ByteArrayInputStream`/`ByteArrayOutputStream` allocations, and Jackson `JsonParser`/`JsonGenerator` instantiation. This was visible as a significant allocation hotspot in flamegraphs.

closes #45807