### PR TITLE
feat: extend Camunda Nexus mirror to all artifactory repositories

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -190,7 +190,7 @@ runs:
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
           "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots"
+          "mirrorOf": "camunda-bpm,camunda-identity,zeebe,zeebe-snapshots"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{


### PR DESCRIPTION
## Description

Related to [INC-4582](https://camunda.slack.com/archives/C0AFCT4US93).

[Analysis](https://docs.google.com/spreadsheets/d/1WF3biggiFda-Vt0JTFzZ5zndw9S5KOot4xwFyHcJxTg/edit?gid=575738088#gid=575738088) shows that, in CI workflows, several dependencies are being downloaded directly from Artifactory (e.g., camunda-bpm). Since all Artifactory-related [repositories](https://github.com/camunda/camunda/blob/main/bom/pom.xml#L129-L213) are already proxied and available through Nexus, these dependencies should instead be resolved via Nexus. This will help reduce unnecessary traffic to Artifactory.

**Note:** Nexus includes the [internal](https://github.com/camunda/infra-core/blob/stage/terraform/artifactory/prod/virtual-repositories.tf#L39-L91) virtual Artifactory repository (which include camunda-bpm and camunda-identity) within its (internal) [group](https://github.com/camunda/infra-core/blob/stage/camunda-ci/terraform/nexus/modules/env-common/repositories.tf#L114-L149) used by CI.

e.g. for `org.camunda.bpm:camunda-bom:7.24.0`, the following works
- https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/camunda-bom/7.24.0/camunda-bom-7.24.0.pom
- https://repository.nexus.camunda.cloud/repository/internal/org/camunda/bpm/camunda-bom/7.24.0/camunda-bom-7.24.0.pom

A few workflows already use Nexus to mirror all repositories:
- [reate-urgent-hotfix-img.yml](https://github.com/camunda/camunda/blob/4d70e6fe6338d69cb59e9babdb83b90b4921e71b/.github/workflows/create-urgent-hotfix-img.yml#L176)
- [operate-docker-tests.yml,](https://github.com/camunda/camunda/blob/4d70e6fe6338d69cb59e9babdb83b90b4921e71b/.github/workflows/operate-docker-tests.yml#L100)
- [operate-e2e-tests.yml](https://github.com/camunda/camunda/blob/4d70e6fe6338d69cb59e9babdb83b90b4921e71b/.github/workflows/operate-e2e-tests.yml#L117)
- [tasklist-e2e-tests.yml](https://github.com/camunda/camunda/blob/4d70e6fe6338d69cb59e9babdb83b90b4921e71b/.github/workflows/tasklist-e2e-tests.yml#L122)

`ci:no-cache` label added to avoid github caching and download all dependencies.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
