### PR TITLE
fix: clear deployment values on stop to prevent accumulation across test runs

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
@@ -102,7 +102,7 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
 
   @Override
   public void stop(final CamundaClient client) {
-    // noop for deployment
+    deploymentValues.clear();
   }
 
   private void overrideFromProperties(final DeploymentValue deploymentValue) {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentAnnotationProcessorTest.java
@@ -256,6 +256,37 @@ public class DeploymentAnnotationProcessorTest {
             });
   }
 
+  @Test
+  public void shouldClearDeploymentValuesOnStop() throws IOException {
+    // given
+    when(deploymentValueExtractor.apply(any()))
+        .thenAnswer(r -> AnnotationUtil.getDeploymentValues(r.getArgument(0)));
+    final BeanInfo classInfo = beanInfo(new WithSingleClassPathResource());
+
+    final Resource resource = mock(FileSystemResource.class);
+    when(resource.getFilename()).thenReturn("1.bpmn");
+    when(client.newDeployResourceCommand()).thenReturn(deployStep1);
+    when(resourcePatternResolver.getResources(anyString())).thenReturn(new Resource[] {resource});
+    when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
+    when(deployStep2.execute()).thenReturn(deploymentEvent);
+    when(deploymentEvent.getProcesses()).thenReturn(Collections.singletonList(getProcess()));
+
+    // when - simulate two lifecycle rounds (as with @RepeatedTest)
+    deploymentAnnotationProcessor.configureFor(classInfo);
+    deploymentAnnotationProcessor.start(client);
+
+    // stop should clear the deployment values
+    deploymentAnnotationProcessor.stop(client);
+
+    // configure and start again (second test run)
+    deploymentAnnotationProcessor.configureFor(classInfo);
+    deploymentAnnotationProcessor.start(client);
+
+    // then - deploy should have been called exactly once per lifecycle round, not accumulating
+    verify(deployStep2, times(2)).execute();
+    verify(deployStep1, times(2)).addResourceStream(any(), eq("1.bpmn"));
+  }
+
   private Process getProcess() {
     return new Process() {
       @Override

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.processor;
+
+import static io.camunda.client.spring.testsupport.BeanInfoUtil.beanInfo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.jobhandling.CommandExceptionHandlingStrategy;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.jobhandling.ManagedJobWorker;
+import io.camunda.client.jobhandling.parameter.ParameterResolverStrategy;
+import io.camunda.client.jobhandling.result.ResultProcessorStrategy;
+import io.camunda.client.metrics.MetricsRecorder;
+import io.camunda.client.spring.annotation.processor.JobWorkerAnnotationProcessor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class JobWorkerAnnotationProcessorTest {
+
+  @Mock private CamundaClient client;
+
+  @Mock private JobWorkerManager jobWorkerManager;
+
+  @Mock private CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
+
+  @Mock private MetricsRecorder metricsRecorder;
+
+  @Mock private ParameterResolverStrategy parameterResolverStrategy;
+
+  @Mock private ResultProcessorStrategy resultProcessorStrategy;
+
+  @InjectMocks private JobWorkerAnnotationProcessor jobWorkerAnnotationProcessor;
+
+  @Test
+  public void shouldClearManagedJobWorkersOnStop() {
+    // given - simulate two lifecycle rounds (as with @RepeatedTest)
+    jobWorkerAnnotationProcessor.configureFor(beanInfo(new WithJobWorker()));
+    jobWorkerAnnotationProcessor.start(client);
+
+    // verify first round created exactly one job worker
+    verify(jobWorkerManager, times(1))
+        .createJobWorker(eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor));
+
+    // when - stop should clear the managed job workers
+    jobWorkerAnnotationProcessor.stop(client);
+
+    // configure and start again (second test run)
+    jobWorkerAnnotationProcessor.configureFor(beanInfo(new WithJobWorker()));
+    jobWorkerAnnotationProcessor.start(client);
+
+    // then - createJobWorker should have been called exactly once per lifecycle round (2 total),
+    // not accumulating (which would be 3 if the list wasn't cleared)
+    verify(jobWorkerManager, times(2))
+        .createJobWorker(eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor));
+  }
+
+  private static final class WithJobWorker {
+    @JobWorker
+    public void myWorker() {}
+  }
+}


### PR DESCRIPTION
## Description

DeploymentAnnotationProcessor.stop() was a no-op, causing deploymentValues to accumulate on each onStart/onStop lifecycle cycle. In repeated tests (@RepeatedTest), this led to N redundant deployments on iteration N.

This mirrors the fix applied to JobWorkerAnnotationProcessor in 56608fb6a6e, which added managedJobWorkers.clear() to its stop() method.

Also adds regression tests for both processors to guard against this pattern.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46638
