### PR TITLE
feat: adjust message for an empty state in the operations log

### DIFF
--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -99,7 +99,27 @@ describe('OperationsLog InstancesTable', () => {
     expect(screen.getByTestId('data-table-loader')).toBeInTheDocument();
   });
 
-  it('should render empty state when no operations are found', async () => {
+  it('should render empty state when no operations are found without filters', async () => {
+    mockQueryAuditLogs().withSuccess({
+      items: [],
+      page: {totalItems: 0},
+    });
+
+    render(<InstancesTable />, {
+      wrapper: Wrapper,
+    });
+
+    expect(
+      await screen.findByText('No operation log items yet'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Operations that you perform in UI or via the API will appear here.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render empty state when no operations are found with filters', async () => {
     mockQueryAuditLogs().withSuccess({
       items: [],
       page: {
@@ -110,8 +130,22 @@ describe('OperationsLog InstancesTable', () => {
       },
     });
 
+    const WrapperWithFilter: React.FC<{children: React.ReactNode}> = ({
+      children,
+    }) => {
+      return (
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={['/operations-log?operationType=CREATE']}>
+            <Routes>
+              <Route path="/operations-log" element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+    };
+
     render(<InstancesTable />, {
-      wrapper: Wrapper,
+      wrapper: WrapperWithFilter,
     });
 
     expect(

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.test.tsx
@@ -102,7 +102,12 @@ describe('OperationsLog InstancesTable', () => {
   it('should render empty state when no operations are found without filters', async () => {
     mockQueryAuditLogs().withSuccess({
       items: [],
-      page: {totalItems: 0},
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
     });
 
     render(<InstancesTable />, {
@@ -135,7 +140,9 @@ describe('OperationsLog InstancesTable', () => {
     }) => {
       return (
         <QueryClientProvider client={getMockQueryClient()}>
-          <MemoryRouter initialEntries={['/operations-log?operationType=CREATE']}>
+          <MemoryRouter
+            initialEntries={['/operations-log?operationType=CREATE']}
+          >
             <Routes>
               <Route path="/operations-log" element={children} />
             </Routes>

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -267,16 +267,27 @@ const InstancesTable: React.FC = observer(() => {
     return 'content';
   };
 
+  const getEmptyMessage = () => {
+    if (Object.keys(filterValues).length === 0) {
+      return {
+        message: 'No operation log items yet',
+        additionalInfo:
+          'Operations that you perform in UI or via the API will appear here.',
+      };
+    }
+    return {
+      message: 'No operations log found',
+      additionalInfo: 'Try adjusting your filters or check back later.',
+    };
+  };
+
   return (
     <Container>
       <BasePanelHeader title="Operations Log" count={data?.totalCount} />
       <PaginatedSortableTable
         state={getTableState()}
         rows={rows}
-        emptyMessage={{
-          message: 'No operations log found',
-          additionalInfo: 'Try adjusting your filters or check back later.',
-        }}
+        emptyMessage={getEmptyMessage()}
         headerColumns={headerColumns}
         pagination={{
           hasPreviousPage,

--- a/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
+++ b/operate/client/src/App/OperationsLog/InstancesTable/index.tsx
@@ -267,7 +267,7 @@ const InstancesTable: React.FC = observer(() => {
     return 'content';
   };
 
-  const getEmptyMessage = () => {
+  const emptyMessage = useMemo(() => {
     if (Object.keys(filterValues).length === 0) {
       return {
         message: 'No operation log items yet',
@@ -279,7 +279,7 @@ const InstancesTable: React.FC = observer(() => {
       message: 'No operations log found',
       additionalInfo: 'Try adjusting your filters or check back later.',
     };
-  };
+  }, [filterValues]);
 
   return (
     <Container>
@@ -287,7 +287,7 @@ const InstancesTable: React.FC = observer(() => {
       <PaginatedSortableTable
         state={getTableState()}
         rows={rows}
-        emptyMessage={getEmptyMessage()}
+        emptyMessage={emptyMessage}
         headerColumns={headerColumns}
         pagination={{
           hasPreviousPage,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a small condition to check whether filter values are present and displays a different message if so.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45203
