### PR TITLE
feat: avoid duplicated sorting columns

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -25,6 +25,7 @@ import io.camunda.search.sort.SortOrder;
 import io.camunda.security.reader.ResourceAccessChecks;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,8 +63,15 @@ abstract class AbstractEntityReader<T> {
     final var builder = new DbQuerySorting.Builder<T>();
     final var discriminatorColumnList = new ArrayList<>(Arrays.asList(discriminatorColumns));
 
+    final var usedFields = new HashSet<String>();
+
     for (final FieldSorting fieldSorting : sortOption.getFieldSortings()) {
-      final var column = getSearchColumn(fieldSorting.field());
+      final String fieldName = fieldSorting.field();
+      if (!usedFields.add(fieldName)) {
+        continue; // skip duplicate field sorting
+      }
+
+      final var column = getSearchColumn(fieldName);
 
       // remove the column from the discriminator list to not sort double
       discriminatorColumnList.remove(column);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -171,4 +171,29 @@ class AbstractEntityReaderTest {
             new KeySetPaginationFieldEntry(
                 "PROCESS_INSTANCE_KEY", Operator.LOWER, entity.processInstanceKey()));
   }
+
+  @Test
+  void shouldConvertSortWithDuplicatedColumn() {
+    final var reader = new ProcessInstanceDbReader(null, TEST_CONFIG);
+
+    final var convertedSort =
+        reader.convertSort(
+            ProcessInstanceSort.of(
+                b ->
+                    b.processDefinitionName()
+                        .asc()
+                        .startDate()
+                        .desc()
+                        .processDefinitionName()
+                        .desc()),
+            ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY);
+
+    assertThat(convertedSort.orderings()).hasSize(3);
+    assertThat(convertedSort.orderings())
+        .containsExactly(
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC),
+            new SortingEntry<>(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC),
+            // Note: duplicated PROCESS_DEFINITION_NAME is ignored
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/globallistener/GlobalListenerSortIT.java
@@ -24,7 +24,6 @@ import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.util.ObjectBuilder;
 import java.util.Comparator;
 import java.util.function.Function;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,11 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class GlobalListenerSortIT {
-
-  @BeforeAll
-  public static void a() {
-    final int i = 0;
-  }
 
   @TestTemplate
   public void shouldSortByIdAsc(final CamundaRdbmsTestApplication testApplication) {
@@ -141,6 +135,32 @@ public class GlobalListenerSortIT {
         testApplication,
         b -> b.listenerType().desc(),
         Comparator.comparing(GlobalListenerEntity::listenerType).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortWhenCombiningWithDefaultSorting(
+      final CamundaRdbmsTestApplication testApplication) {
+    // When searching global listeners through API, a default sorting is applied:
+    // - afterNonGlobal asc
+    // - priority desc
+    // - listenerId asc
+    // Combining a user-provided sorting (in this case listenerId desc) with the default sorting
+    // should work without causing issues
+    testSorting(
+        testApplication,
+        b ->
+            b.listenerId()
+                .desc() // user-provided sorting
+                .afterNonGlobal()
+                .asc()
+                .priority()
+                .desc()
+                .listenerId()
+                .asc(), // default sorting (API)
+        Comparator.comparing(GlobalListenerEntity::listenerId)
+            .reversed()
+            .thenComparing(GlobalListenerEntity::afterNonGlobal)
+            .thenComparing(Comparator.comparing(GlobalListenerEntity::priority).reversed()));
   }
 
   private void testSorting(


### PR DESCRIPTION
When building the sorting parameters for RDBMS queries, the sorting options coming from the search layer are converted to DbQuerySorting, which are then used to build the ORDER BY clause of the final SQL query.

Since the sorting options can come from many sources, including user-provided parameters of exposed API, it is possible that some sorting fields are duplicated. Semantically this would not be a problem since ordering by the same field twice with differing priority is the same as just using ignoring any occurrence of the field after the first, however some RDBMSs (e.g. MSSQL) do not support having the same column multiple times in the ORDER BY clause.

To avoid related errors, it is enough to remove duplicated fields while converting from SortOption to DbQuerySorting.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46770
