### PR TITLE
fix: set key on history deletion request

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeleteHistoryRequest.java
@@ -24,6 +24,7 @@ public class BrokerDeleteHistoryRequest extends BrokerExecuteCommand<HistoryDele
   }
 
   public BrokerDeleteHistoryRequest setResourceKey(final long resourceKey) {
+    request.setKey(resourceKey);
     requestDto.setResourceKey(resourceKey);
     return this;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The key is used to determine the partition that should receive the command. We need to ensure we set this properly, as if it's null the command would be distributed round-robin. As a result process instance existence checks would sometimes fail, and sometimes succeed, depending on the partition that received the command.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46675 
