### PR TITLE
[Backport stable/8.9] fix: allow HTTP to be disabled in Optimize

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -111,6 +111,9 @@ public class OptimizeTomcatConfig {
                   configureHttpConnector(this);
                 }
               });
+        } else {
+          LOG.info(
+              "HTTP port is not configured. HTTP connector will not be started. Only HTTPS will be available.");
         }
       }
     };

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize;
 
 import static io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants.CONTEXT_PATH;
+import static io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants.HTTP_PORT_KEY;
 
 import io.camunda.optimize.rest.HealthRestService;
 import io.camunda.optimize.rest.LocalizationRestService;
@@ -24,6 +25,7 @@ import io.camunda.optimize.tomcat.ResponseTimezoneFilter;
 import io.camunda.optimize.tomcat.URLRedirectFilter;
 import java.util.Optional;
 import org.apache.catalina.connector.Connector;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.coyote.http2.Http2Protocol;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
@@ -94,21 +96,22 @@ public class OptimizeTomcatConfig {
           factory.setContextPath(contextPath.get());
         }
 
-        // NOTE: With the current implementation, we are always installing 2 connectors,
-        //   one for HTTP, one for HTTPs. The latter can be HTTP/1.1 or HTTP/2 depending
-        //   on the configuration.
-
+        // NOTE: With the current implementation, we install the mandatory HTTPS connector first,
+        // which can be HTTP/1.1 or HTTP/2 depending on the configuration, and then optionally add
+        // an HTTP connector if the HTTP port is configured.
         factory.addConnectorCustomizers(
             connector -> {
-              configureHttpConnector(connector);
+              configureHttpsConnector(connector);
             });
 
-        factory.addAdditionalConnectors(
-            new Connector() {
-              {
-                configureHttpsConnector(this);
-              }
-            });
+        if (getPort(HTTP_PORT_KEY) >= 0) {
+          factory.addAdditionalConnectors(
+              new Connector() {
+                {
+                  configureHttpConnector(this);
+                }
+              });
+        }
       }
     };
   }
@@ -157,7 +160,7 @@ public class OptimizeTomcatConfig {
 
   public int getPort(final String portType) {
     final String portProperty = environment.getProperty(portType);
-    if (portProperty != null) {
+    if (StringUtils.isNotBlank(portProperty)) {
       try {
         return Integer.parseInt(portProperty);
       } catch (final NumberFormatException exception) {
@@ -170,10 +173,7 @@ public class OptimizeTomcatConfig {
     }
 
     final Optional<Integer> httpPort = configurationService.getContainerHttpPort();
-    if (httpPort.isEmpty()) {
-      throw new OptimizeConfigurationException("HTTP port not configured");
-    }
-    return httpPort.get();
+    return httpPort.filter(port -> port > 0).orElse(-1);
   }
 
   public Optional<String> getContextPath() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeTomcatConfigTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.EnvironmentPropertiesConstants;
+import org.apache.catalina.connector.Connector;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+public class OptimizeTomcatConfigTest {
+  @Captor ArgumentCaptor<TomcatConnectorCustomizer> connectorCustomizerCaptor;
+  @Captor ArgumentCaptor<Connector> connectorCaptor;
+
+  @Mock private Environment environment;
+
+  @Mock private ConfigurationService configurationService;
+
+  @Mock private TomcatServletWebServerFactory factory;
+  @InjectMocks private OptimizeTomcatConfig optimizeTomcatConfig;
+
+  @Test
+  public void shouldAddConnectorsForHttpAndHttps() {
+    // when
+    when(environment.getProperty(anyString())).thenReturn("property");
+    when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("8090");
+    when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
+
+    when(configurationService.getContainerHost()).thenReturn("localhost");
+    // then
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    // verify HTTPS connector customizer is added with correct port
+    verify(factory).addConnectorCustomizers(connectorCustomizerCaptor.capture());
+    final Connector httpsConnector = new Connector();
+    final TomcatConnectorCustomizer connectorCustomizer = connectorCustomizerCaptor.getValue();
+    connectorCustomizer.customize(httpsConnector);
+    assertThat(httpsConnector.getPort()).isEqualTo(8091);
+    assertThat(httpsConnector.getScheme()).isEqualTo("https");
+    assertThat(httpsConnector.getSecure()).isTrue();
+
+    // verify HTTP connector is added with correct port
+    verify(factory).addAdditionalConnectors(connectorCaptor.capture());
+    final Connector httpConnector = connectorCaptor.getValue();
+    assertThat(httpConnector.getPort()).isEqualTo(8090);
+    assertThat(httpConnector.getScheme()).isEqualTo("http");
+    assertThat(httpConnector.getSecure()).isFalse();
+  }
+
+  @Test
+  public void shouldNotAddConnectorForEmptyHttpPort() {
+    // when
+    when(environment.getProperty(anyString())).thenReturn("property");
+    when(environment.getProperty(EnvironmentPropertiesConstants.HTTP_PORT_KEY)).thenReturn("");
+    when(environment.getProperty(EnvironmentPropertiesConstants.HTTPS_PORT_KEY)).thenReturn("8091");
+
+    when(configurationService.getContainerHost()).thenReturn("localhost");
+    // then
+    optimizeTomcatConfig.tomcatFactoryCustomizer().customize(factory);
+
+    // verify additional HTTP connector is not added
+    verify(factory, never()).addAdditionalConnectors(any());
+    // verify HTTPS connector customizer is added with correct port
+    verify(factory).addConnectorCustomizers(connectorCustomizerCaptor.capture());
+    final Connector httpsConnector = new Connector();
+    final TomcatConnectorCustomizer connectorCustomizer = connectorCustomizerCaptor.getValue();
+    connectorCustomizer.customize(httpsConnector);
+    assertThat(httpsConnector.getPort()).isEqualTo(8091);
+    assertThat(httpsConnector.getScheme()).isEqualTo("https");
+    assertThat(httpsConnector.getSecure()).isTrue();
+  }
+
+  @Test
+  public void shouldReturnNegativePortForNullHttpPort() {
+    // when
+    final String httpPortKey = EnvironmentPropertiesConstants.HTTP_PORT_KEY;
+    when(environment.getProperty(httpPortKey)).thenReturn(null);
+    // then
+    assertThat(optimizeTomcatConfig.getPort(httpPortKey)).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldReturnNegativePortForEmptyHttpPort() {
+    // when
+    final String httpPortKey = EnvironmentPropertiesConstants.HTTP_PORT_KEY;
+    when(environment.getProperty(httpPortKey)).thenReturn("");
+    // then
+    assertThat(optimizeTomcatConfig.getPort(httpPortKey)).isEqualTo(-1);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #46599 to `stable/8.9`.

relates to #44222