### PR TITLE
feat: add sticky header to filters in identity operations log

### DIFF
--- a/identity/client/src/pages/operations-log/List.tsx
+++ b/identity/client/src/pages/operations-log/List.tsx
@@ -21,6 +21,7 @@ import {
   Grid,
   ColumnRightPadding,
   CenteredRow,
+  StickySection,
 } from "./components/styled";
 import {
   Button,
@@ -29,7 +30,6 @@ import {
   Dropdown,
   Heading,
   MultiSelect,
-  Section,
   Stack,
   TextInput,
 } from "@carbon/react";
@@ -180,7 +180,7 @@ const List: FC = () => {
       />
       <Grid condensed fullWidth>
         <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>
-          <Section level={4}>
+          <StickySection level={4}>
             <Stack gap={5}>
               <Heading>{t("filter")}</Heading>
               <MultiSelect
@@ -296,7 +296,7 @@ const List: FC = () => {
                 </Button>
               </CenteredRow>
             </Stack>
-          </Section>
+          </StickySection>
         </ColumnRightPadding>
         <Column sm={4} md={5} lg={12} xlg={13}>
           <EntityList

--- a/identity/client/src/pages/operations-log/components/styled.tsx
+++ b/identity/client/src/pages/operations-log/components/styled.tsx
@@ -11,7 +11,7 @@ import {
   CheckmarkOutline as BaseCheckmarkOutline,
   ErrorOutline as BaseErrorOutline,
 } from "@carbon/react/icons";
-import { Column, Grid as CarbonGrid } from "@carbon/react";
+import { Column, Grid as CarbonGrid, Section } from "@carbon/react";
 import { styles } from "@carbon/elements";
 
 const OperationLogName = styled.div`
@@ -50,6 +50,11 @@ const OwnerInfo = styled.div`
   white-space: nowrap;
 `;
 
+const StickySection = styled(Section)`
+  position: sticky;
+  top: 0;
+`;
+
 export {
   OperationLogName,
   SuccessIcon,
@@ -59,4 +64,5 @@ export {
   CenteredRow,
   PropertyText,
   OwnerInfo,
+  StickySection,
 };


### PR DESCRIPTION
## Description

Add position sticky to filters column

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #45199
