### PR TITLE
[Backport stable/8.9] fix: use local fonts for offline setup

### DIFF
--- a/optimize/c4/src/index.scss
+++ b/optimize/c4/src/index.scss
@@ -1,3 +1,3 @@
 @use "@carbon/react" as * with (
-	$font-path: "https://fonts.camunda.io"
+	$font-path: '@ibm/plex'
 );

--- a/optimize/client/src/style.scss
+++ b/optimize/client/src/style.scss
@@ -1,5 +1,5 @@
 @use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: "@ibm/plex"
 );
 
 @use '@carbon/react/scss/fonts/sans';


### PR DESCRIPTION
# Description
Backport of #46467 to `stable/8.9`.

relates to #45970