### PR TITLE
[Backport stable/8.8] fix: clear deployment values on stop to prevent accumulation across test runs

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
@@ -77,7 +77,7 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
 
   @Override
   public void stop(final CamundaClient client) {
-    // noop for deployment
+    deploymentValues.clear();
   }
 
   private DeploymentEvent deploy(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
@@ -97,5 +97,6 @@ public class JobWorkerAnnotationProcessor extends AbstractCamundaAnnotationProce
   @Override
   public void stop(final CamundaClient camundaClient) {
     jobWorkerManager.closeAllOpenWorkers();
+    jobWorkerValues.clear();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentPostProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentPostProcessorTest.java
@@ -170,6 +170,35 @@ public class DeploymentPostProcessorTest {
             });
   }
 
+  @Test
+  public void shouldClearDeploymentValuesOnStop() {
+    // given
+    final BeanInfo classInfo = beanInfo(new WithSingleClassPathResource());
+
+    final Resource resource = mock(FileSystemResource.class);
+    when(resource.getFilename()).thenReturn("1.bpmn");
+    when(client.newDeployResourceCommand()).thenReturn(deployStep1);
+    when(deploymentPostProcessor.getResources(anyString())).thenReturn(new Resource[] {resource});
+    when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
+    when(deployStep2.execute()).thenReturn(deploymentEvent);
+    when(deploymentEvent.getProcesses()).thenReturn(Collections.singletonList(getProcess()));
+
+    // when - simulate two lifecycle rounds (as with @RepeatedTest)
+    deploymentPostProcessor.configureFor(classInfo);
+    deploymentPostProcessor.start(client);
+
+    // stop should clear the deployment values
+    deploymentPostProcessor.stop(client);
+
+    // configure and start again (second test run)
+    deploymentPostProcessor.configureFor(classInfo);
+    deploymentPostProcessor.start(client);
+
+    // then - deploy should have been called exactly once per lifecycle round, not accumulating
+    verify(deployStep2, times(2)).execute();
+    verify(deployStep1, times(2)).addResourceStream(any(), eq("1.bpmn"));
+  }
+
   private Process getProcess() {
     return new Process() {
       @Override

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.processor;
+
+import static io.camunda.client.spring.testsupport.BeanInfoUtil.beanInfo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.annotation.customizer.JobWorkerValueCustomizer;
+import io.camunda.client.annotation.value.JobWorkerValue;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.spring.annotation.processor.JobWorkerAnnotationProcessor;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class JobWorkerAnnotationProcessorTest {
+
+  @Mock private CamundaClient client;
+
+  @Mock private JobWorkerManager jobWorkerManager;
+
+  @Test
+  public void shouldClearJobWorkerValuesOnStop() {
+    // given
+    final JobWorkerAnnotationProcessor processor =
+        new JobWorkerAnnotationProcessor(
+            jobWorkerManager, Collections.<JobWorkerValueCustomizer>emptyList());
+
+    // simulate two lifecycle rounds (as with @RepeatedTest)
+    processor.configureFor(beanInfo(new WithJobWorker()));
+    processor.start(client);
+
+    // verify first round opened exactly one job worker
+    verify(jobWorkerManager, times(1)).openWorker(eq(client), any(JobWorkerValue.class));
+
+    // when - stop should clear the job worker values
+    processor.stop(client);
+
+    // configure and start again (second test run)
+    processor.configureFor(beanInfo(new WithJobWorker()));
+    processor.start(client);
+
+    // then - openWorker should have been called exactly once per lifecycle round (2 total),
+    // not accumulating (which would be 3 if the list wasn't cleared)
+    verify(jobWorkerManager, times(2)).openWorker(eq(client), any(JobWorkerValue.class));
+  }
+
+  private static final class WithJobWorker {
+    @JobWorker
+    public void myWorker() {}
+  }
+}


### PR DESCRIPTION
# Description
Backport of #46732 to `stable/8.8`.

relates to #46638