### PR TITLE
[CPT] New shared runtime

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(
     properties = {
+      "camunda.process-test.runtime-mode=managed",
       "camunda.process-test.connectors-enabled=true",
       "camunda.process-test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
     })

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/InvoiceApprovalIntegrationTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/InvoiceApprovalIntegrationTest.java
@@ -45,6 +45,7 @@ import org.wiremock.spring.EnableWireMock;
 @SpringBootTest(
     properties = {
       "camunda.client.worker.defaults.enabled=false", // disable job workers
+      "camunda.process-test.runtime-mode=managed",
       "camunda.process-test.connectors-enabled=true",
       "camunda.process-test.connectors-secrets.INVOICE_REJECTION_URL=http://host.testcontainers.internal:${wiremock.server.port}"
     })

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/MultiTenancyTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/MultiTenancyTest.java
@@ -26,7 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = {"camunda.process-test.multi-tenancy-enabled=true"})
+@SpringBootTest(
+    properties = {
+      "camunda.process-test.runtime-mode=managed",
+      "camunda.process-test.multi-tenancy-enabled=true"
+    })
 @CamundaSpringProcessTest
 public class MultiTenancyTest {
 

--- a/testing/camunda-process-test-example/src/test/resources/application.yml
+++ b/testing/camunda-process-test-example/src/test/resources/application.yml
@@ -1,3 +1,9 @@
+camunda:
+  process-test:
+    # Default: use a shared runtime for fast test execution
+    # Override to per test class to use a different configuration
+    runtime-mode: shared
+
 logging:
   level:
     root: info

--- a/testing/camunda-process-test-example/src/test/resources/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-example/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,1 @@
+runtimeMode=shared

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -540,7 +540,7 @@ public class CamundaProcessTestExtension
   }
 
   /**
-   * Configure the mode of the runtime (managed/remote).
+   * Configure the mode of the runtime (managed/remote/shared).
    *
    * @param runtimeMode the runtime mode to use
    * @return the extension builder

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestRuntimeMode.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestRuntimeMode.java
@@ -17,9 +17,18 @@ package io.camunda.process.test.api;
 
 /** The mode of the process test runtime. */
 public enum CamundaProcessTestRuntimeMode {
-  /** The runtime is managed internally by Camunda Process Test. */
+  /**
+   * The runtime is managed internally by Camunda Process Test. Each test class uses its own runtime
+   * instance with its own configuration.
+   */
   MANAGED,
 
   /** The runtime is managed remotely outside Camunda Process Test. */
-  REMOTE
+  REMOTE,
+
+  /**
+   * The runtime is managed internally by Camunda Process Test, but all test classes share the same
+   * runtime instance with the same configuration.
+   */
+  SHARED
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -73,7 +73,9 @@ public class CamundaProcessTestContainerRuntime
   private final boolean isMultiTenancyEnabled;
   private final boolean connectorsEnabled;
 
-  CamundaProcessTestContainerRuntime(
+  private boolean isStarted = false;
+
+  public CamundaProcessTestContainerRuntime(
       final CamundaProcessTestRuntimeBuilder builder, final ContainerFactory containerFactory) {
     this.containerFactory = containerFactory;
 
@@ -186,6 +188,8 @@ public class CamundaProcessTestContainerRuntime
     final Instant endTime = Instant.now();
     final Duration startupTime = Duration.between(startTime, endTime);
     LOGGER.info("Camunda container runtime started in {}", startupTime);
+
+    isStarted = true;
   }
 
   @Override
@@ -244,6 +248,10 @@ public class CamundaProcessTestContainerRuntime
     final Instant endTime = Instant.now();
     final Duration shutdownTime = Duration.between(startTime, endTime);
     LOGGER.info("Camunda container runtime stopped in {}", shutdownTime);
+  }
+
+  public boolean isStarted() {
+    return isStarted;
   }
 
   private static Slf4jLogConsumer createContainerLogger(final String name) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -279,6 +279,9 @@ public class CamundaProcessTestRuntimeBuilder {
         return new CamundaProcessTestContainerRuntime(this, containerFactory);
       case REMOTE:
         return new CamundaProcessTestRemoteRuntime(this);
+      case SHARED:
+        return new CamundaProcessTestSharedRuntime(
+            () -> new CamundaProcessTestContainerRuntime(this, containerFactory));
       default:
         LOGGER.warn("Unknown runtime mode: {}. Fall back to MANAGED runtime mode.", runtimeMode);
         return new CamundaProcessTestContainerRuntime(this, containerFactory);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntime.java
@@ -35,28 +35,25 @@ public class CamundaProcessTestSharedRuntime implements CamundaProcessTestRuntim
     initializeSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
   }
 
-  private static void initializeSharedRuntime(
+  private static synchronized void initializeSharedRuntime(
       final Supplier<CamundaProcessTestContainerRuntime> runtimeBuilder,
       final SharedRuntimeStorage sharedRuntimeStorage) {
 
-    final CamundaProcessTestContainerRuntime sharedRuntime = sharedRuntimeStorage.getRuntime();
+    CamundaProcessTestContainerRuntime sharedRuntime = sharedRuntimeStorage.getRuntime();
     if (sharedRuntime == null) {
       // Initialize the shared runtime only once, when the first test class is instantiated. The
       // next test classes will reuse the same runtime instance.
-      sharedRuntimeStorage.setRuntime(runtimeBuilder.get());
+      sharedRuntime = runtimeBuilder.get();
+      sharedRuntimeStorage.setRuntime(sharedRuntime);
+
+      // Register a shutdown hook to close the shared runtime when all tests are finished.
+      registerClosingRuntimeHook(sharedRuntime);
     }
   }
 
   @Override
   public void start() {
-    if (!getSharedRuntime().isStarted()) {
-      // Start the shared runtime only once, when the first test class is instantiated. The next
-      // test classes will reuse the same runtime instance, which is already started.
-      getSharedRuntime().start();
-
-      // Register a shutdown hook to close the shared runtime when all tests are finished.
-      registerClosingRuntimeHook();
-    }
+    startSharedRuntime();
   }
 
   @Override
@@ -84,14 +81,23 @@ public class CamundaProcessTestSharedRuntime implements CamundaProcessTestRuntim
     return getSharedRuntime().getCamundaClientBuilderFactory();
   }
 
-  private void registerClosingRuntimeHook() {
+  private synchronized void startSharedRuntime() {
+    if (!getSharedRuntime().isStarted()) {
+      // Start the shared runtime only once, when the first test class is instantiated. The next
+      // test classes will reuse the same runtime instance, which is already started.
+      getSharedRuntime().start();
+    }
+  }
+
+  private static void registerClosingRuntimeHook(
+      final CamundaProcessTestContainerRuntime sharedRuntime) {
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
                 () -> {
                   try {
-                    if (getSharedRuntime() != null) {
-                      getSharedRuntime().close();
+                    if (sharedRuntime.isStarted()) {
+                      sharedRuntime.close();
                     }
                   } catch (final Exception e) {
                     throw new RuntimeException("Failed to close shared runtime", e);

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntime.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import java.net.URI;
+import java.util.function.Supplier;
+
+public class CamundaProcessTestSharedRuntime implements CamundaProcessTestRuntime {
+
+  private final SharedRuntimeStorage sharedRuntimeStorage;
+
+  public CamundaProcessTestSharedRuntime(
+      final Supplier<CamundaProcessTestContainerRuntime> runtimeBuilder) {
+    this(runtimeBuilder, new StaticSharedRuntimeStorage());
+  }
+
+  CamundaProcessTestSharedRuntime(
+      final Supplier<CamundaProcessTestContainerRuntime> runtimeBuilder,
+      final SharedRuntimeStorage sharedRuntimeStorage) {
+    this.sharedRuntimeStorage = sharedRuntimeStorage;
+    initializeSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+  }
+
+  private static void initializeSharedRuntime(
+      final Supplier<CamundaProcessTestContainerRuntime> runtimeBuilder,
+      final SharedRuntimeStorage sharedRuntimeStorage) {
+
+    final CamundaProcessTestContainerRuntime sharedRuntime = sharedRuntimeStorage.getRuntime();
+    if (sharedRuntime == null) {
+      // Initialize the shared runtime only once, when the first test class is instantiated. The
+      // next test classes will reuse the same runtime instance.
+      sharedRuntimeStorage.setRuntime(runtimeBuilder.get());
+    }
+  }
+
+  @Override
+  public void start() {
+    if (!getSharedRuntime().isStarted()) {
+      // Start the shared runtime only once, when the first test class is instantiated. The next
+      // test classes will reuse the same runtime instance, which is already started.
+      getSharedRuntime().start();
+
+      // Register a shutdown hook to close the shared runtime when all tests are finished.
+      registerClosingRuntimeHook();
+    }
+  }
+
+  @Override
+  public URI getCamundaRestApiAddress() {
+    return getSharedRuntime().getCamundaRestApiAddress();
+  }
+
+  @Override
+  public URI getCamundaGrpcApiAddress() {
+    return getSharedRuntime().getCamundaGrpcApiAddress();
+  }
+
+  @Override
+  public URI getCamundaMonitoringApiAddress() {
+    return getSharedRuntime().getCamundaMonitoringApiAddress();
+  }
+
+  @Override
+  public URI getConnectorsRestApiAddress() {
+    return getSharedRuntime().getConnectorsRestApiAddress();
+  }
+
+  @Override
+  public CamundaClientBuilderFactory getCamundaClientBuilderFactory() {
+    return getSharedRuntime().getCamundaClientBuilderFactory();
+  }
+
+  private void registerClosingRuntimeHook() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    if (getSharedRuntime() != null) {
+                      getSharedRuntime().close();
+                    }
+                  } catch (final Exception e) {
+                    throw new RuntimeException("Failed to close shared runtime", e);
+                  }
+                }));
+  }
+
+  private CamundaProcessTestContainerRuntime getSharedRuntime() {
+    return sharedRuntimeStorage.getRuntime();
+  }
+
+  @Override
+  public void close() throws Exception {
+    // Do not close the shared runtime here, as it is shared across multiple test classes.
+  }
+
+  private static final class StaticSharedRuntimeStorage implements SharedRuntimeStorage {
+
+    private static CamundaProcessTestContainerRuntime sharedRuntime;
+
+    @Override
+    public CamundaProcessTestContainerRuntime getRuntime() {
+      return sharedRuntime;
+    }
+
+    @Override
+    public void setRuntime(final CamundaProcessTestContainerRuntime runtime) {
+      sharedRuntime = runtime;
+    }
+  }
+
+  /**
+   * Internal interface to abstract the storage of the shared runtime instance. This allows us to
+   * inject a mock implementation for testing purposes.
+   */
+  interface SharedRuntimeStorage {
+    CamundaProcessTestContainerRuntime getRuntime();
+
+    void setRuntime(CamundaProcessTestContainerRuntime runtime);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -231,6 +231,7 @@ public final class ContainerRuntimePropertiesUtil {
   private CamundaClientBuilder createCamundaClientBuilder() {
     switch (runtimeMode) {
       case MANAGED:
+      case SHARED:
         return CamundaClient.newClientBuilder();
       case REMOTE:
         return remoteRuntimeProperties.createCamundaClientBuilder();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/SharedRuntimeIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/SharedRuntimeIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class SharedRuntimeIT {
+
+  @RegisterExtension
+  private static final CamundaProcessTestExtension EXTENSION =
+      new CamundaProcessTestExtension().withRuntimeMode(CamundaProcessTestRuntimeMode.SHARED);
+
+  // to be injected
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @BeforeEach
+  void deployProcess() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.name("Task").zeebeJobType("task"))
+            .endEvent("end")
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+  }
+
+  @Test
+  void shouldCreateProcessInstance() {
+    // given
+    processTestContext.mockJobWorker("task").thenComplete();
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+
+    // then
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .isCompleted()
+        .hasCompletedElementsInOrder("start", "task", "end");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestSharedRuntimeTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestSharedRuntime.SharedRuntimeStorage;
+import java.net.URI;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CamundaProcessTestSharedRuntimeTest {
+
+  private static final URI GRPC_API_ADDRESS = URI.create("http://my-host:100");
+  private static final URI REST_API_ADDRESS = URI.create("http://my-host:101");
+  private static final URI MONITORING_API_ADDRESS = URI.create("http://my-host:103");
+  private static final URI CONNECTORS_REST_API_ADDRESS = URI.create("http://my-host:104");
+
+  @Mock private Supplier<CamundaProcessTestContainerRuntime> runtimeBuilder;
+  @Mock private CamundaProcessTestContainerRuntime containerRuntime;
+  @Mock private SharedRuntimeStorage sharedRuntimeStorage;
+  @Mock private CamundaClientBuilderFactory camundaClientBuilderFactory;
+
+  @Test
+  void shouldCreateRuntimeFromBuilder() {
+    // given/when
+    final CamundaProcessTestRuntime runtime =
+        CamundaProcessTestContainerRuntime.newBuilder()
+            .withRuntimeMode(CamundaProcessTestRuntimeMode.SHARED)
+            .build();
+
+    // then
+    assertThat(runtime).isInstanceOf(CamundaProcessTestSharedRuntime.class);
+  }
+
+  @Test
+  void shouldCreateContainerRuntime() {
+    // given
+    when(runtimeBuilder.get()).thenReturn(containerRuntime);
+
+    // when
+    new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+
+    // then
+    verify(runtimeBuilder).get();
+    verify(sharedRuntimeStorage).setRuntime(containerRuntime);
+  }
+
+  @Test
+  void shouldCreateContainerRuntimeOnlyOnce() {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+
+    // when
+    new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+
+    // then
+    verify(sharedRuntimeStorage).getRuntime();
+    verify(sharedRuntimeStorage, never()).setRuntime(any());
+    verify(runtimeBuilder, never()).get();
+  }
+
+  @Test
+  void shouldStartRuntime() {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+    when(containerRuntime.isStarted()).thenReturn(false);
+
+    // when
+    final CamundaProcessTestSharedRuntime sharedRuntime =
+        new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+    sharedRuntime.start();
+
+    // then
+    verify(containerRuntime).start();
+  }
+
+  @Test
+  void shouldStartRuntimeOnlyOnce() {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+    when(containerRuntime.isStarted()).thenReturn(true);
+
+    // when
+    final CamundaProcessTestSharedRuntime sharedRuntime =
+        new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+    sharedRuntime.start();
+
+    // then
+    verify(containerRuntime, never()).start();
+  }
+
+  @Test
+  void shouldNotCloseRuntime() throws Exception {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+
+    // when
+    final CamundaProcessTestSharedRuntime sharedRuntime =
+        new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+    sharedRuntime.start();
+    sharedRuntime.close();
+
+    // then
+    verify(containerRuntime, never()).close();
+  }
+
+  @Test
+  void shouldRetrieveAddressesFromRuntime() {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+    when(containerRuntime.getCamundaGrpcApiAddress()).thenReturn(GRPC_API_ADDRESS);
+    when(containerRuntime.getCamundaRestApiAddress()).thenReturn(REST_API_ADDRESS);
+    when(containerRuntime.getCamundaMonitoringApiAddress()).thenReturn(MONITORING_API_ADDRESS);
+    when(containerRuntime.getConnectorsRestApiAddress()).thenReturn(CONNECTORS_REST_API_ADDRESS);
+
+    // when
+    final CamundaProcessTestSharedRuntime sharedRuntime =
+        new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+    sharedRuntime.start();
+
+    // then
+    assertThat(sharedRuntime.getCamundaGrpcApiAddress()).isEqualTo(GRPC_API_ADDRESS);
+    assertThat(sharedRuntime.getCamundaRestApiAddress()).isEqualTo(REST_API_ADDRESS);
+    assertThat(sharedRuntime.getCamundaMonitoringApiAddress()).isEqualTo(MONITORING_API_ADDRESS);
+    assertThat(sharedRuntime.getConnectorsRestApiAddress()).isEqualTo(CONNECTORS_REST_API_ADDRESS);
+  }
+
+  @Test
+  void shouldRetrieveClientBuilderFromRuntime() {
+    // given
+    when(sharedRuntimeStorage.getRuntime()).thenReturn(containerRuntime);
+    when(containerRuntime.getCamundaClientBuilderFactory()).thenReturn(camundaClientBuilderFactory);
+
+    // when
+    final CamundaProcessTestSharedRuntime sharedRuntime =
+        new CamundaProcessTestSharedRuntime(runtimeBuilder, sharedRuntimeStorage);
+    sharedRuntime.start();
+
+    // then
+    assertThat(sharedRuntime.getCamundaClientBuilderFactory())
+        .isEqualTo(camundaClientBuilderFactory);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class ContainerRuntimePropertiesUtilTest {
 
@@ -392,6 +393,22 @@ public class ContainerRuntimePropertiesUtilTest {
     final List<Integer> expected = Arrays.asList(8080, 8081, 8088);
 
     assertThat(propertiesUtil.getCamundaExposedPorts()).containsAll(expected);
+  }
+
+  @ParameterizedTest
+  @EnumSource(CamundaProcessTestRuntimeMode.class)
+  void shouldReadRuntimeMode(final CamundaProcessTestRuntimeMode runtimeMode) {
+    final Properties properties = new Properties();
+    properties.put(
+        ContainerRuntimePropertiesUtil.PROPERTY_NAME_RUNTIME_MODE,
+        runtimeMode.name().toLowerCase());
+
+    // when
+    final ContainerRuntimePropertiesUtil propertiesUtil =
+        new ContainerRuntimePropertiesUtil(properties, emptyGitProperties);
+
+    // then
+    assertThat(propertiesUtil.getRuntimeMode()).isEqualTo(runtimeMode);
   }
 
   @Nested

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -39,7 +39,9 @@ public class CamundaSpringProcessTestRuntimeBuilder {
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
     runtimeBuilder.withRuntimeMode(runtimeMode);
 
-    if (runtimeMode == CamundaProcessTestRuntimeMode.MANAGED || runtimeMode == null) {
+    if (runtimeMode == null
+        || runtimeMode == CamundaProcessTestRuntimeMode.MANAGED
+        || runtimeMode == CamundaProcessTestRuntimeMode.SHARED) {
       configureManagedRuntime(runtimeBuilder, runtimeConfiguration, clientProperties);
 
     } else if (runtimeMode == CamundaProcessTestRuntimeMode.REMOTE) {

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringSharedRuntimeIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringSharedRuntimeIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {SpringSharedRuntimeIT.class},
+    properties = {"io.camunda.process.test.runtime-mode=shared"})
+@CamundaSpringProcessTest
+public class SpringSharedRuntimeIT {
+
+  @Autowired private CamundaClient client;
+  @Autowired private CamundaProcessTestContext processTestContext;
+
+  @BeforeEach
+  void deployProcess() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.name("Task").zeebeJobType("task"))
+            .endEvent("end")
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+  }
+
+  @Test
+  void shouldCreateProcessInstance() {
+    // given
+    processTestContext.mockJobWorker("task").thenComplete();
+
+    // when
+    final ProcessInstanceEvent processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+
+    // then
+    CamundaAssert.assertThatProcessInstance(processInstance)
+        .isCompleted()
+        .hasCompletedElementsInOrder("start", "task", "end");
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -37,6 +37,7 @@ import io.camunda.process.test.impl.runtime.CamundaProcessTestRemoteRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeBuilder;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestSharedRuntime;
 import io.camunda.process.test.impl.runtime.CamundaSpringProcessTestRuntimeBuilder;
 import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
 import java.net.URI;
@@ -45,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.util.unit.DataSize;
 
 public class CamundaSpringProcessTestRuntimeBuilderTest {
@@ -71,7 +74,26 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
 
     // then
     assertThat(camundaRuntime).isNotNull().isInstanceOf(CamundaProcessTestContainerRuntime.class);
+  }
 
+  @ParameterizedTest
+  @EnumSource(
+      value = CamundaProcessTestRuntimeMode.class,
+      names = {"MANAGED", "SHARED"})
+  void shouldBuildDefaultRuntime(final CamundaProcessTestRuntimeMode runtimeMode) {
+    // given
+    final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
+    final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
+        new CamundaProcessTestRuntimeConfiguration();
+    final CamundaClientProperties clientProperties = new CamundaClientProperties();
+
+    runtimeConfiguration.setRuntimeMode(runtimeMode);
+
+    // when
+    CamundaSpringProcessTestRuntimeBuilder.buildRuntime(
+        runtimeBuilder, runtimeConfiguration, clientProperties);
+
+    // then
     assertThat(runtimeBuilder.getCamundaDockerImageName())
         .isEqualTo(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME);
     assertThat(runtimeBuilder.getCamundaDockerImageVersion())
@@ -82,13 +104,18 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.isConnectorsEnabled()).isFalse();
   }
 
-  @Test
-  void shouldConfigureManagedCamundaRuntime() {
+  @ParameterizedTest
+  @EnumSource(
+      value = CamundaProcessTestRuntimeMode.class,
+      names = {"MANAGED", "SHARED"})
+  void shouldConfigureCamundaRuntime(final CamundaProcessTestRuntimeMode runtimeMode) {
     // given
     final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
     final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
         new CamundaProcessTestRuntimeConfiguration();
     final CamundaClientProperties clientProperties = new CamundaClientProperties();
+
+    runtimeConfiguration.setRuntimeMode(runtimeMode);
 
     final Map<String, String> camundaEnvVars =
         Map.ofEntries(entry("env-1", "test-1"), entry("env-2", "test-2"));
@@ -155,13 +182,18 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(cbf.getDefaultJobWorkerStreamEnabled()).isTrue();
   }
 
-  @Test
-  void shouldConfigureManagedConnectorsRuntime() {
+  @ParameterizedTest
+  @EnumSource(
+      value = CamundaProcessTestRuntimeMode.class,
+      names = {"MANAGED", "SHARED"})
+  void shouldConfigureConnectorsRuntime(final CamundaProcessTestRuntimeMode runtimeMode) {
     // given
     final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
     final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
         new CamundaProcessTestRuntimeConfiguration();
     final CamundaClientProperties clientProperties = new CamundaClientProperties();
+
+    runtimeConfiguration.setRuntimeMode(runtimeMode);
 
     final Map<String, String> connectorsEnvVars =
         Map.ofEntries(entry("env-1", "test-1"), entry("env-2", "test-2"));
@@ -321,6 +353,25 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         .isEqualTo(URI.create("https://my-cluster.my-region.zeebe.camunda.io:443"));
 
     assertThat(configuration.getCredentialsProvider()).isInstanceOf(OAuthCredentialsProvider.class);
+  }
+
+  @Test
+  void shouldBuildSharedRuntime() {
+    // given
+    final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
+    final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
+        new CamundaProcessTestRuntimeConfiguration();
+    final CamundaClientProperties clientProperties = new CamundaClientProperties();
+
+    runtimeConfiguration.setRuntimeMode(CamundaProcessTestRuntimeMode.SHARED);
+
+    // when
+    final CamundaProcessTestRuntime camundaRuntime =
+        CamundaSpringProcessTestRuntimeBuilder.buildRuntime(
+            runtimeBuilder, runtimeConfiguration, clientProperties);
+
+    // then
+    assertThat(camundaRuntime).isNotNull().isInstanceOf(CamundaProcessTestSharedRuntime.class);
   }
 
   private static CamundaClientConfiguration getCamundaClientConfiguration(


### PR DESCRIPTION
## Description

This PR introduces a new `SHARED` runtime mode for CPT, as an alternative to the existing `MANAGED` mode (one runtime per test class) and `REMOTE` mode (external runtime). In this mode, CPT creates one shared instance of a managed runtime and uses it for all test classes to avoid the runtime restarts between the test classes. 

The new shared runtime is not the new default runtime mode and must be enabled explicitly to avoid the risk of breaking existing user test cases with the update. An existing test case could break if it uses a different runtime configuration, such as enabled connectors or connector secrets.

If the shared runtime is used by default, a user can disable the shared runtime per test class by changing the runtime mode via:
- Java: `new CamundaProcessTestExtension().withRuntimeMode(MANAGED)`   
- Spring: `@SpringBootTest(properties = {"camunda.process-test.runtime-mode=managed"})`

This PR updates the CPT example module to use the shared runtime by default as a general recommendation and to reduce the test execution time. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #29131 
