### PR TITLE
[Backport stable/8.9] fix(rdbms): preserve "null" string value for NULL-typed variables instead of storing SQL NULL

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -106,7 +106,7 @@ public record ClusterVariableDbModel(
         case LONG -> getLongModel();
         case DOUBLE -> getDoubleModel();
         case BOOLEAN -> getModel(ValueTypeEnum.BOOLEAN, mapBoolean(value));
-        case NULL -> getModel(ValueTypeEnum.NULL, null);
+        case NULL -> getModel(ValueTypeEnum.NULL, value);
         default -> getModel(ValueTypeEnum.STRING, value);
       };
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -167,7 +167,7 @@ public record VariableDbModel(
         case LONG -> getLongModel();
         case DOUBLE -> getDoubleModel();
         case BOOLEAN -> getModel(ValueTypeEnum.BOOLEAN, mapBoolean(value));
-        case NULL -> getModel(ValueTypeEnum.NULL, null);
+        case NULL -> getModel(ValueTypeEnum.NULL, value);
         default -> getModel(ValueTypeEnum.STRING, value);
       };
     }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.ClusterVariableScope;
+import io.camunda.search.entities.ValueTypeEnum;
+import org.junit.jupiter.api.Test;
+
+public class ClusterVariableDbModelTest {
+
+  @Test
+  public void shouldSetCorrectTypeAndValueForNullValue() {
+    // given
+    final ClusterVariableDbModel.ClusterVariableDbModelBuilder builder =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder();
+
+    // when
+    final ClusterVariableDbModel model =
+        builder
+            .name("test")
+            .value("null")
+            .tenantId("tenant1")
+            .scope(ClusterVariableScope.GLOBAL)
+            .build();
+
+    // then
+    assertThat(model.type()).isEqualTo(ValueTypeEnum.NULL);
+    assertThat(model.doubleValue()).isNull();
+    assertThat(model.longValue()).isNull();
+    assertThat(model.value()).isEqualTo("null");
+  }
+
+  @Test
+  public void shouldSetCorrectTypeAndValueForLongValue() {
+    // given
+    final ClusterVariableDbModel.ClusterVariableDbModelBuilder builder =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder();
+
+    // when
+    final ClusterVariableDbModel model =
+        builder
+            .name("test")
+            .value("123456")
+            .tenantId("tenant1")
+            .scope(ClusterVariableScope.GLOBAL)
+            .build();
+
+    // then
+    assertThat(model.type()).isEqualTo(ValueTypeEnum.LONG);
+    assertThat(model.doubleValue()).isNull();
+    assertThat(model.longValue()).isEqualTo(123456L);
+    assertThat(model.value()).isEqualTo("123456");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/VariableDbModelTest.java
@@ -155,6 +155,32 @@ public class VariableDbModelTest {
   }
 
   @Test
+  public void shouldSetCorrectTypeAndValueForNullValue() {
+    // given
+    final VariableDbModel.VariableDbModelBuilder builder =
+        new VariableDbModel.VariableDbModelBuilder();
+
+    // when
+    final VariableDbModel model =
+        builder
+            .variableKey(1L)
+            .name("test")
+            .value("null")
+            .scopeKey(2L)
+            .processInstanceKey(3L)
+            .rootProcessInstanceKey(4L)
+            .tenantId("tenant1")
+            .elementInstanceKey(5L)
+            .build();
+
+    // then
+    assertThat(model.type()).isEqualTo(ValueTypeEnum.NULL);
+    assertThat(model.doubleValue()).isNull();
+    assertThat(model.longValue()).isNull();
+    assertThat(model.value()).isEqualTo("null");
+  }
+
+  @Test
   public void shouldSetCorrectTypeAndValueForNonNumericValue() {
     // given
     final VariableDbModel.VariableDbModelBuilder builder =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNullValueSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNullValueSearchIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.io.InputStream;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class VariableNullValueSearchIT {
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final InputStream process =
+        VariableNullValueSearchIT.class.getResourceAsStream("/process/bpm_variable_test.bpmn");
+    deployProcessAndWaitForIt(
+        camundaClient, Bpmn.readModelFromStream(process), "bpm_variable_test.bpmn");
+  }
+
+  @Test
+  void shouldReturnJsonNullLiteralForProcessVariableValue() {
+    // given
+    final var variableName = "nullVar_" + UUID.randomUUID().toString().replace("-", "");
+    final var processInstance =
+        startProcessInstance(
+            camundaClient, "bpmProcessVariable", "{\"%s\":null}".formatted(variableName));
+
+    // when / then
+    Awaitility.await("should index null variable value")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  camundaClient
+                      .newVariableSearchRequest()
+                      .filter(
+                          f ->
+                              f.name(variableName)
+                                  .processInstanceKey(processInstance.getProcessInstanceKey()))
+                      .send()
+                      .join();
+              assertThat(searchResult.items()).hasSize(1);
+              assertThat(searchResult.items().getFirst().getValue()).isEqualTo("null");
+            });
+  }
+}


### PR DESCRIPTION
# Description
Backport of #46401 to `stable/8.9`.

relates to camunda/camunda#46399