### PR TITLE
ci: extend zeebe testbench job execution time to 20 mins

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -30,7 +30,7 @@ jobs:
   testbench:
     name: Start a test in testbench
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The execution of the Zeebe testbench job has been flaky recently due to exceeding the execution time.
This PR extends the timeout to 20 mins. The changes will be backported to the [release-8.9.0-alpha5](https://github.com/camunda/camunda/tree/refs/heads/release-8.9.0-alpha5) branch, to unblock the upcoming release.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
